### PR TITLE
Assert MACD isStable after age has passed all intervals

### DIFF
--- a/src/MACD/MACD.ts
+++ b/src/MACD/MACD.ts
@@ -30,7 +30,7 @@ export class MACD {
   }
 
   get isStable(): boolean {
-    return this.age >= this.config.longInterval;
+    return this.age >= Math.max(this.config.longInterval, this.config.shortInterval, this.config.signalInterval);
   }
 
   update(_price: BigSource): void {


### PR DESCRIPTION
The MACD indicator should only be stable after all intervals have expired. It must wait until the age reaches the largest of the intervals.

This allows for any intervals, like (26, 12, 9) or (5, 2, 9), etc.