### PR TITLE
Types are optional.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
     "url": "https://github.com/bennycode/trading-signals/issues"
   },
   "dependencies": {
-    "@types/big.js": "6.1.2",
     "big.js": "6.1.1"
   },
   "description": "Technical indicators to run technical analysis with JavaScript / TypeScript.",
   "devDependencies": {
+    "@types/big.js": "6.1.2",
     "@types/jasmine": "3.9.1",
     "@typescript-eslint/eslint-plugin": "4.32.0",
     "@typescript-eslint/parser": "4.32.0",


### PR DESCRIPTION
If someone wants to use types to use trading-signals with big numbers, they need to add the types dependency themselves.