### PR TITLE
fix replace feature in TR

### DIFF
--- a/src/TR/TR.test.ts
+++ b/src/TR/TR.test.ts
@@ -42,15 +42,17 @@ describe('TR', () => {
     it('calculates the True Range (TR)', () => {
       const tr = new TR();
       const fasterTR = new FasterTR();
-      for (const candle of candles) {
+
+      candles.forEach((candle, i) => {
         tr.update(candle);
         fasterTR.update(candle);
         if (tr.isStable && fasterTR.isStable) {
-          const expected = expectations.shift();
+          const expected = expectations[i]; // .shift();
           expect(tr.getResult().toFixed(2)).toBe(expected!);
           expect(fasterTR.getResult().toFixed(2)).toBe(expected!);
         }
-      }
+      });
+
       expect(tr.isStable).toBe(true);
       expect(fasterTR.isStable).toBe(true);
 
@@ -62,6 +64,42 @@ describe('TR', () => {
 
       expect(tr.highest?.toFixed(2)).toBe('2.00');
       expect(fasterTR.highest?.toFixed(2)).toBe('2.00');
+    });
+
+    it('should replace recently added values', () => {
+      const tr = new TR();
+      const fasterTR = new FasterTR();
+
+      // Update candles except last one.
+      candles.slice(-1).forEach((candle, i) => {
+        tr.update(candle);
+        fasterTR.update(candle);
+      });
+
+      const expected = expectations.at(-1);
+      const lastCandle = candles.at(-1)!;
+      const otherCandle = {close: 84.55, high: 84.84, low: 84.15};
+
+      // Add the last candle
+      tr.update(lastCandle);
+      fasterTR.update(lastCandle);
+
+      expect(tr.getResult().toFixed(2)).toBe(expected);
+      expect(fasterTR.getResult().toFixed(2)).toBe(expected);
+
+      // Replace the last candle with some other candle.
+      tr.update(otherCandle, true);
+      fasterTR.update(otherCandle, true);
+
+      expect(tr.getResult().toFixed(2)).not.toBe(expected);
+      expect(fasterTR.getResult().toFixed(2)).not.toBe(expected);
+
+      // Replace other candle again with the last candle.
+      tr.update(lastCandle, true);
+      fasterTR.update(lastCandle, true);
+
+      expect(tr.getResult().toFixed(2)).toBe(expected);
+      expect(fasterTR.getResult().toFixed(2)).toBe(expected);
     });
   });
 });

--- a/src/TR/TR.test.ts
+++ b/src/TR/TR.test.ts
@@ -71,7 +71,7 @@ describe('TR', () => {
       const fasterTR = new FasterTR();
 
       // Update candles except last one.
-      candles.slice(-1).forEach((candle, i) => {
+      candles.slice(-1).forEach(candle => {
         tr.update(candle);
         fasterTR.update(candle);
       });

--- a/src/TR/TR.ts
+++ b/src/TR/TR.ts
@@ -15,33 +15,50 @@ import {getMaximum, HighLowClose, HighLowCloseNumber} from '../util/index.js';
  */
 export class TR extends BigIndicatorSeries<HighLowClose> {
   private previousCandle?: HighLowClose;
+  private twoPreviousCandle?: HighLowClose;
 
   update(candle: HighLowClose, replace: boolean = false): Big {
     const high = new Big(candle.high);
     const highLow = high.minus(candle.low);
+
+    if (this.previousCandle && replace) {
+      this.previousCandle = this.twoPreviousCandle;
+    }
+
     if (this.previousCandle) {
       const highClose = high.minus(this.previousCandle.close).abs();
       const lowClose = new Big(candle.low).minus(this.previousCandle.close).abs();
+      this.twoPreviousCandle = this.previousCandle;
       this.previousCandle = candle;
       return this.setResult(getMaximum([highLow, highClose, lowClose]), replace);
     }
+    this.twoPreviousCandle = this.previousCandle;
     this.previousCandle = candle;
+
     return this.setResult(highLow, replace);
   }
 }
 
 export class FasterTR extends NumberIndicatorSeries<HighLowCloseNumber> {
   private previousCandle?: HighLowCloseNumber;
+  private twoPreviousCandle?: HighLowCloseNumber;
 
   update(candle: HighLowCloseNumber, replace: boolean = false): number {
     const {high, low} = candle;
     const highLow = high - low;
+
+    if (this.previousCandle && replace) {
+      this.previousCandle = this.twoPreviousCandle;
+    }
+
     if (this.previousCandle) {
       const highClose = Math.abs(high - this.previousCandle.close);
       const lowClose = Math.abs(low - this.previousCandle.close);
+      this.twoPreviousCandle = this.previousCandle;
       this.previousCandle = candle;
       return this.setResult(Math.max(highLow, highClose, lowClose), replace);
     }
+    this.twoPreviousCandle = this.previousCandle;
     this.previousCandle = candle;
     return this.setResult(highLow, replace);
   }


### PR DESCRIPTION
The replace feature in the `update` of the `TR` indicator was not working correctly, because it does not handle `previousCandle` when replacing the result.

I added a new attribute to store two previous candles that replace the previous candle when `replace` is `true`. I also included a test to ensure that replace feature is working as expected.