### PR TITLE
feat(messaging): Add /health command

### DIFF
--- a/packages/messaging/src/command/health.ts
+++ b/packages/messaging/src/command/health.ts
@@ -28,7 +28,7 @@ export const health = async () => {
   return lines.join('\n');
 };
 
-function formatBytes(bytes: number): string {
+function formatBytes(bytes: number) {
   const mb = bytes / 1024 / 1024;
   if (mb >= 1024) {
     return `${(mb / 1024).toFixed(1)} GB`;

--- a/packages/messaging/src/command/health.ts
+++ b/packages/messaging/src/command/health.ts
@@ -1,0 +1,37 @@
+import os from 'node:os';
+
+export const health = async () => {
+  const mem = process.memoryUsage();
+  const totalMem = os.totalmem();
+  const freeMem = os.freemem();
+  const usedMem = totalMem - freeMem;
+  const memPercent = ((usedMem / totalMem) * 100).toFixed(1);
+
+  const cpus = os.cpus();
+  const cpuAvg =
+    cpus.reduce((acc, cpu) => {
+      const total = Object.values(cpu.times).reduce((a, b) => a + b, 0);
+      const idle = cpu.times.idle;
+      return acc + ((total - idle) / total) * 100;
+    }, 0) / cpus.length;
+
+  const heapPercent = ((mem.heapUsed / mem.heapTotal) * 100).toFixed(1);
+  const rssPercent = ((mem.rss / totalMem) * 100).toFixed(1);
+
+  const lines = [
+    `🖥 CPU Usage: ${cpuAvg.toFixed(1)}% (${cpus.length} cores)`,
+    `💾 System RAM: ${memPercent}% (${formatBytes(usedMem)} / ${formatBytes(totalMem)})`,
+    `📦 Process RSS: ${rssPercent}% (${formatBytes(mem.rss)} / ${formatBytes(totalMem)})`,
+    `📦 Process Heap: ${heapPercent}% (${formatBytes(mem.heapUsed)} / ${formatBytes(mem.heapTotal)})`,
+  ];
+
+  return lines.join('\n');
+};
+
+function formatBytes(bytes: number): string {
+  const mb = bytes / 1024 / 1024;
+  if (mb >= 1024) {
+    return `${(mb / 1024).toFixed(1)} GB`;
+  }
+  return `${mb.toFixed(1)} MB`;
+}

--- a/packages/messaging/src/command/index.ts
+++ b/packages/messaging/src/command/index.ts
@@ -3,6 +3,7 @@ export {accountList} from './account/accountList.js';
 export {accountRemove} from './account/accountRemove.js';
 export {accountTime} from './account/accountTime.js';
 export {candle} from './candle.js';
+export {health} from './health.js';
 export {price} from './price.js';
 export {time} from './time.js';
 export {uptime} from './uptime.js';

--- a/packages/messaging/src/startServer.ts
+++ b/packages/messaging/src/startServer.ts
@@ -4,6 +4,7 @@ import {
   accountRemove,
   accountTime,
   candle,
+  health,
   price,
   reportAdd,
   reportList,
@@ -77,6 +78,10 @@ function registerCommands(platform: MessagingPlatform, monitors: Monitors): void
 
   platform.registerCommand('time', async ctx => {
     await ctx.reply(await time());
+  });
+
+  platform.registerCommand('health', async ctx => {
+    await ctx.reply(await health());
   });
 
   platform.registerCommand('uptime', async ctx => {


### PR DESCRIPTION
## Summary

- Adds a `/health` command to the Telegram bot that reports CPU usage, system RAM, process RSS, and heap memory usage
- Output shows percentages with fixed values in parentheses for quick at-a-glance monitoring