### PR TITLE
fix(trading-signals-docs): Remove basePath/assetPrefix for root domain deployment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,3 +6,7 @@
 - Use native ESM features instead of legacy workarounds
 - Use `import.meta.dirname` instead of `dirname(fileURLToPath(import.meta.url))` (available since Node.js 21.2)
 - Use `import.meta.filename` instead of `fileURLToPath(import.meta.url)` when a file path is needed
+
+## Commit & PR Conventions
+
+- Use the actual package name in the scope brackets of commit/PR titles, e.g. `fix(trading-signals-docs):` not `fix(docs):`

--- a/packages/trading-signals-docs/next.config.ts
+++ b/packages/trading-signals-docs/next.config.ts
@@ -1,21 +1,9 @@
 import type {NextConfig} from 'next';
 
-const isCI = process.env.CI === 'true';
-// GitHub Pages will serve from https://<user>.github.io/<repo>
-// This docs site lives under the repo "trading-signals"
-const repoName = 'trading-signals';
-
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   output: 'export',
   trailingSlash: true,
-  // Configure basePath and assetPrefix only in CI (GitHub Pages) to keep local dev URLs clean
-  ...(isCI
-    ? {
-        basePath: `/${repoName}`,
-        assetPrefix: `/${repoName}/`,
-      }
-    : {}),
   transpilePackages: ['trading-strategies', '@typedtrader/exchange'],
   images: {
     unoptimized: true,


### PR DESCRIPTION
## Summary

- Removed the CI-conditional `basePath` and `assetPrefix` from `next.config.ts`
- Docs are now served from the root of typedtrader.com, so the `/trading-signals/` subpath prefix is no longer needed