### PR TITLE
feat(messaging, trading-strategies): Improve Telegram report delivery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1235,6 +1235,12 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/@grammyjs/types": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@grammyjs/types/-/types-3.26.0.tgz",
+      "integrity": "sha512-jlnyfxfev/2o68HlvAGRocAXgdPPX5QabG7jZlbqC2r9DZyWBfzTlg+nu3O3Fy4EhgLWu28hZ/8wr7DsNamP9A==",
+      "license": "MIT"
+    },
     "node_modules/@highcharts/react": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@highcharts/react/-/react-4.2.1.tgz",
@@ -4271,12 +4277,6 @@
         "tailwindcss": "4.2.2"
       }
     },
-    "node_modules/@telegraf/types": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@telegraf/types/-/types-7.1.0.tgz",
-      "integrity": "sha512-kGevOIbpMcIlCDeorKGpwZmdH7kHbqlk/Yj6dEpJMKEQw5lk0KVQY0OLXaCswy8GqlIVLd5625OB+rAntP9xVw==",
-      "license": "MIT"
-    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
@@ -5828,28 +5828,6 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
-    },
-    "node_modules/buffer-alloc": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-alloc-unsafe": "^1.1.0",
-        "buffer-fill": "^1.0.0"
-      }
-    },
-    "node_modules/buffer-alloc-unsafe": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-      "license": "MIT"
-    },
-    "node_modules/buffer-fill": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-      "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
-      "license": "MIT"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -8641,6 +8619,21 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
+    "node_modules/grammy": {
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/grammy/-/grammy-1.42.0.tgz",
+      "integrity": "sha512-1AdCge+AkjSdp2FwfICSFnVbl8Mq3KVHJDy+DgTI9+D6keJ0zWALPRKas5jv/8psiCzL4N2cEOcGW7O45Kn39g==",
+      "license": "MIT",
+      "dependencies": {
+        "@grammyjs/types": "3.26.0",
+        "abort-controller": "^3.0.0",
+        "debug": "^4.4.3",
+        "node-fetch": "^2.7.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || >=14.13.1"
+      }
+    },
     "node_modules/handlebars": {
       "version": "4.7.9",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
@@ -11035,15 +11028,6 @@
         "node": "*"
       }
     },
-    "node_modules/mri": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
-      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -13371,15 +13355,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/safe-compare": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/safe-compare/-/safe-compare-1.1.4.tgz",
-      "integrity": "sha512-b9wZ986HHCo/HbKrRpBJb2kqXMK9CEWIE1egeEvZsYn69ay3kdfl9nG3RyOcR+jInTDf7a86WQ1d4VJX7goSSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-alloc": "^1.2.0"
-      }
-    },
     "node_modules/safe-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
@@ -13396,15 +13371,6 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "devOptional": true,
       "license": "MIT"
-    },
-    "node_modules/sandwich-stream": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/sandwich-stream/-/sandwich-stream-2.0.2.tgz",
-      "integrity": "sha512-jLYV0DORrzY3xaz/S9ydJL6Iz7essZeAfnAavsJ+zsJGZ1MOnsS52yRjU3uF3pJa/lla7+wisp//fxOwOH8SKQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 0.10"
-      }
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -14026,37 +13992,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/telegraf": {
-      "version": "4.16.3",
-      "resolved": "https://registry.npmjs.org/telegraf/-/telegraf-4.16.3.tgz",
-      "integrity": "sha512-yjEu2NwkHlXu0OARWoNhJlIjX09dRktiMQFsM678BAH/PEPVwctzL67+tvXqLCRQQvm3SDtki2saGO9hLlz68w==",
-      "license": "MIT",
-      "dependencies": {
-        "@telegraf/types": "^7.1.0",
-        "abort-controller": "^3.0.0",
-        "debug": "^4.3.4",
-        "mri": "^1.2.0",
-        "node-fetch": "^2.7.0",
-        "p-timeout": "^4.1.0",
-        "safe-compare": "^1.1.4",
-        "sandwich-stream": "^2.0.2"
-      },
-      "bin": {
-        "telegraf": "lib/cli.mjs"
-      },
-      "engines": {
-        "node": "^12.20.0 || >=14.13.1"
-      }
-    },
-    "node_modules/telegraf/node_modules/p-timeout": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-4.1.0.tgz",
-      "integrity": "sha512-+/wmHtzJuWii1sXn3HCuH/FTwGhrp4tmJTxSKJbfS+vkipci6osxXM5mY0jUiRzWKMTgUT8l7HFbeSwZAynqHw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/text-extensions": {
@@ -15940,11 +15875,11 @@
         "better-sqlite3": "^12.8.0",
         "better-sqlite3-multiple-ciphers": "^12.8.0",
         "drizzle-orm": "^0.45.2",
+        "grammy": "^1.42.0",
         "moment": "^2.30.1",
         "moment-duration-format": "^2.3.2",
         "moment-timezone": "^0.6.1",
         "ms": "4.0.0-nightly.202508271359",
-        "telegraf": "^4.16.3",
         "trading-strategies": "0.3.5"
       },
       "devDependencies": {

--- a/packages/messaging/README.md
+++ b/packages/messaging/README.md
@@ -1,6 +1,6 @@
 # @typedtrader/messaging
 
-Messaging interface for controlling personal trading bots remotely via [Telegram](https://core.telegram.org/bots) (using [Telegraf](https://telegraf.js.org/)).
+Messaging interface for controlling personal trading bots remotely via [Telegram](https://core.telegram.org/bots) (using [grammY](https://grammy.dev/)).
 
 ## Features
 

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -12,8 +12,8 @@
     "moment": "^2.30.1",
     "moment-duration-format": "^2.3.2",
     "moment-timezone": "^0.6.1",
+    "grammy": "^1.42.0",
     "ms": "4.0.0-nightly.202508271359",
-    "telegraf": "^4.16.3",
     "trading-strategies": "0.3.5"
   },
   "description": "Trading bot via messaging service.",

--- a/packages/messaging/src/platform/TelegramPlatform.test.ts
+++ b/packages/messaging/src/platform/TelegramPlatform.test.ts
@@ -2,13 +2,15 @@ import {describe, it, expect, vi, beforeEach} from 'vitest';
 import {TelegramPlatform} from './TelegramPlatform.js';
 
 const mockSendMessage = vi.fn();
-const mockGetMe = vi.fn().mockResolvedValue({username: 'testbot'});
-const mockLaunch = vi.fn().mockResolvedValue(undefined);
+const mockInit = vi.fn();
+const mockStart = vi.fn().mockReturnValue(new Promise(() => {}));
 const mockStop = vi.fn();
 const mockCommand = vi.fn();
-const mockAction = vi.fn();
+const mockCallbackQuery = vi.fn();
+const botInfo = {username: 'testbot'};
 
 vi.mock('trading-strategies', () => ({
+  MESSAGE_BREAK: '\f',
   getAvailableReportNames: vi.fn().mockReturnValue([]),
 }));
 
@@ -16,29 +18,24 @@ vi.mock('../command/report/reportAdd.js', () => ({
   reportAdd: vi.fn(),
 }));
 
-vi.mock('telegraf', () => {
-  function Telegraf() {
+vi.mock('grammy', () => {
+  function Bot() {
     return {
       command: mockCommand,
-      action: mockAction,
-      launch: mockLaunch,
+      callbackQuery: mockCallbackQuery,
+      init: mockInit,
+      start: mockStart,
       stop: mockStop,
-      telegram: {
+      api: {
         sendMessage: mockSendMessage,
-        getMe: mockGetMe,
+      },
+      get botInfo() {
+        return botInfo;
       },
     };
   }
 
-  return {
-    Telegraf,
-    Markup: {
-      inlineKeyboard: vi.fn().mockReturnValue({}),
-      button: {
-        callback: vi.fn().mockReturnValue({}),
-      },
-    },
-  };
+  return {Bot};
 });
 
 describe('TelegramPlatform', () => {
@@ -91,31 +88,39 @@ describe('TelegramPlatform', () => {
 
       platform.registerCommand('reportadd', vi.fn());
 
-      // reportadd uses bot.command and bot.action, not the generic handler path
+      // reportadd uses bot.command and bot.callbackQuery, not the generic handler path
       expect(mockCommand).toHaveBeenCalledWith('reportadd', expect.any(Function));
-      expect(mockAction).toHaveBeenCalledWith(expect.any(RegExp), expect.any(Function));
+      expect(mockCallbackQuery).toHaveBeenCalledWith(expect.any(RegExp), expect.any(Function));
     });
   });
 
   describe('sendMessage', () => {
-    it('strips the telegram: prefix and sends with MarkdownV2', async () => {
+    it('strips the telegram: prefix and sends as HTML', async () => {
       const platform = new TelegramPlatform('bot-token');
 
       await platform.sendMessage('telegram:123456', 'Hello!');
 
-      expect(mockSendMessage).toHaveBeenCalledWith('123456', 'Hello!', {parse_mode: 'MarkdownV2'});
+      expect(mockSendMessage).toHaveBeenCalledWith('123456', 'Hello!', {parse_mode: 'HTML'});
     });
 
-    it('falls back to plain text when MarkdownV2 fails', async () => {
+    it('converts **bold** markdown to <b> HTML tags', async () => {
+      const platform = new TelegramPlatform('bot-token');
+
+      await platform.sendMessage('telegram:123456', '**Report:** 5 items');
+
+      expect(mockSendMessage).toHaveBeenCalledWith('123456', '<b>Report:</b> 5 items', {parse_mode: 'HTML'});
+    });
+
+    it('falls back to plain text when HTML parsing fails', async () => {
       const platform = new TelegramPlatform('bot-token');
 
       mockSendMessage.mockRejectedValueOnce(new Error('Bad Request: can\'t parse entities'));
 
-      await platform.sendMessage('telegram:123456', 'Hello <world>!');
+      await platform.sendMessage('telegram:123456', 'Hello world');
 
       expect(mockSendMessage).toHaveBeenCalledTimes(2);
-      expect(mockSendMessage).toHaveBeenNthCalledWith(1, '123456', 'Hello <world>!', {parse_mode: 'MarkdownV2'});
-      expect(mockSendMessage).toHaveBeenNthCalledWith(2, '123456', 'Hello <world>!');
+      expect(mockSendMessage).toHaveBeenNthCalledWith(1, '123456', 'Hello world', {parse_mode: 'HTML'});
+      expect(mockSendMessage).toHaveBeenNthCalledWith(2, '123456', 'Hello world');
     });
 
     it('passes the raw chat ID when no prefix is present', async () => {
@@ -123,29 +128,30 @@ describe('TelegramPlatform', () => {
 
       await platform.sendMessage('789', 'Hello!');
 
-      expect(mockSendMessage).toHaveBeenCalledWith('789', 'Hello!', {parse_mode: 'MarkdownV2'});
+      expect(mockSendMessage).toHaveBeenCalledWith('789', 'Hello!', {parse_mode: 'HTML'});
     });
   });
 
   describe('start', () => {
-    it('populates platformInfo before launching the bot', async () => {
+    it('initializes the bot and populates platformInfo before starting polling', async () => {
       const platform = new TelegramPlatform('bot-token');
 
       const callOrder: string[] = [];
-      mockGetMe.mockImplementation(async () => {
-        callOrder.push('getMe');
-        return {username: 'testbot'};
+      mockInit.mockImplementation(async () => {
+        callOrder.push('init');
       });
-      mockLaunch.mockImplementation(async () => {
-        callOrder.push('launch');
+      mockStart.mockImplementationOnce(() => {
+        callOrder.push('start');
+        return new Promise(() => {});
       });
 
       await platform.start();
 
-      expect(callOrder).toEqual(['getMe', 'launch']);
+      expect(callOrder).toEqual(['init', 'start']);
+      expect(mockStart).toHaveBeenCalledWith({drop_pending_updates: true});
       expect(platform.platformInfo).toEqual({
         botAddress: '@testbot',
-        sdkVersion: 'Telegraf',
+        sdkVersion: 'grammY',
       });
     });
   });
@@ -158,7 +164,7 @@ describe('TelegramPlatform', () => {
 
       platform.registerCommand('help', handler);
 
-      // Retrieve the Telegraf command callback registered during registerCommand
+      // Retrieve the grammY command callback registered during registerCommand
       const registeredCallback = mockCommand.mock.calls[0][1];
 
       const ctxUnauthorized = {

--- a/packages/messaging/src/platform/TelegramPlatform.ts
+++ b/packages/messaging/src/platform/TelegramPlatform.ts
@@ -1,7 +1,8 @@
-import {Markup, Telegraf} from 'telegraf';
-import type {Context} from 'telegraf';
+import {Bot} from 'grammy';
+import type {Context} from 'grammy';
 import {getAvailableReportNames, reportRequiresAccount} from 'trading-strategies';
 import type {CommandHandler, MessageContext, MessagingPlatform, PlatformInfo} from './MessagingPlatform.js';
+import {markdownToTelegramHtml, splitForTelegram} from './telegramMarkdown.js';
 import {reportAdd} from '../command/report/reportAdd.js';
 import {Account} from '../database/models/Account.js';
 import type {ReportScheduler} from '../service/ReportScheduler.js';
@@ -12,23 +13,34 @@ const ACCOUNT_CALLBACK_PREFIX = 'reportaccount:';
 const MODE_CALLBACK_PREFIX = 'reportmode:';
 const INTERVAL_CALLBACK_PREFIX = 'reportinterval:';
 
+interface InlineButton {
+  text: string;
+  callback_data: string;
+}
+
+function inlineKeyboard(rows: InlineButton[][]) {
+  return {reply_markup: {inline_keyboard: rows}};
+}
+
 async function replyWithMarkdown(ctx: Context, text: string): Promise<void> {
-  try {
-    await ctx.reply(text, {parse_mode: 'MarkdownV2'});
-  } catch {
-    await ctx.reply(text);
+  for (const chunk of splitForTelegram(text)) {
+    try {
+      await ctx.reply(markdownToTelegramHtml(chunk), {parse_mode: 'HTML'});
+    } catch {
+      await ctx.reply(chunk);
+    }
   }
 }
 
 export class TelegramPlatform implements MessagingPlatform {
-  #bot: Telegraf;
+  #bot: Bot;
   #ownerIds: string[];
   #commands: Map<string, CommandHandler> = new Map();
   #platformInfo: PlatformInfo = {botAddress: '', sdkVersion: ''};
   #reportScheduler?: ReportScheduler;
 
   constructor(botToken: string, ownerIds?: string) {
-    this.#bot = new Telegraf(botToken);
+    this.#bot = new Bot(botToken);
     this.#ownerIds = ownerIds ? ownerIds.split(',').map(id => id.trim()) : [];
   }
 
@@ -64,7 +76,7 @@ export class TelegramPlatform implements MessagingPlatform {
       }
 
       // Extract text after the /command
-      const text = ctx.message.text;
+      const text = ctx.message?.text ?? '';
       const commandEnd = text.indexOf(' ');
       const content = commandEnd === -1 ? '' : text.slice(commandEnd + 1);
 
@@ -100,14 +112,16 @@ export class TelegramPlatform implements MessagingPlatform {
         return;
       }
 
-      const buttons = available.map(name => [Markup.button.callback(name, `${REPORT_CALLBACK_PREFIX}${name}`)]);
+      const rows: InlineButton[][] = available.map(name => [
+        {text: name, callback_data: `${REPORT_CALLBACK_PREFIX}${name}`},
+      ]);
 
-      await ctx.reply('Select a report to run:', Markup.inlineKeyboard(buttons));
+      await ctx.reply('Select a report to run:', inlineKeyboard(rows));
     });
 
     // Step 2: User selected a report — if it needs an account, ask for one; otherwise ask run mode
-    this.#bot.action(new RegExp(`^${REPORT_CALLBACK_PREFIX}(.+)$`), async ctx => {
-      await ctx.answerCbQuery();
+    this.#bot.callbackQuery(new RegExp(`^${REPORT_CALLBACK_PREFIX}(.+)$`), async ctx => {
+      await ctx.answerCallbackQuery();
 
       const reportName = ctx.match[1];
       const senderId = ctx.from?.id?.toString();
@@ -122,29 +136,29 @@ export class TelegramPlatform implements MessagingPlatform {
           return;
         }
 
-        const buttons = userAccounts.map(acc => [
-          Markup.button.callback(
-            `${acc.name} (${acc.exchange}${acc.isPaper ? ' paper' : ''})`,
-            `${ACCOUNT_CALLBACK_PREFIX}${acc.id}:${reportName}`
-          ),
+        const rows: InlineButton[][] = userAccounts.map(acc => [
+          {
+            text: `${acc.name} (${acc.exchange}${acc.isPaper ? ' paper' : ''})`,
+            callback_data: `${ACCOUNT_CALLBACK_PREFIX}${acc.id}:${reportName}`,
+          },
         ]);
 
-        await ctx.editMessageText(`Report: ${reportName}\nSelect an account:`, Markup.inlineKeyboard(buttons));
+        await ctx.editMessageText(`Report: ${reportName}\nSelect an account:`, inlineKeyboard(rows));
         return;
       }
 
       await ctx.editMessageText(
         `Report: ${reportName}\nRun once or schedule recurring?`,
-        Markup.inlineKeyboard([
-          [Markup.button.callback('Run once', `${MODE_CALLBACK_PREFIX}once:${reportName}`)],
-          [Markup.button.callback('Schedule recurring', `${MODE_CALLBACK_PREFIX}schedule:${reportName}`)],
+        inlineKeyboard([
+          [{text: 'Run once', callback_data: `${MODE_CALLBACK_PREFIX}once:${reportName}`}],
+          [{text: 'Schedule recurring', callback_data: `${MODE_CALLBACK_PREFIX}schedule:${reportName}`}],
         ])
       );
     });
 
     // Step 2b: User selected an account — ask run mode
-    this.#bot.action(new RegExp(`^${ACCOUNT_CALLBACK_PREFIX}(\\d+):(.+)$`), async ctx => {
-      await ctx.answerCbQuery();
+    this.#bot.callbackQuery(new RegExp(`^${ACCOUNT_CALLBACK_PREFIX}(\\d+):(.+)$`), async ctx => {
+      await ctx.answerCallbackQuery();
 
       const accountId = ctx.match[1];
       const reportName = ctx.match[2];
@@ -154,16 +168,16 @@ export class TelegramPlatform implements MessagingPlatform {
 
       await ctx.editMessageText(
         `Report: ${reportName} (account ${accountId})\nRun once or schedule recurring?`,
-        Markup.inlineKeyboard([
-          [Markup.button.callback('Run once', `${MODE_CALLBACK_PREFIX}once:${reportWithAccount}`)],
-          [Markup.button.callback('Schedule recurring', `${MODE_CALLBACK_PREFIX}schedule:${reportWithAccount}`)],
+        inlineKeyboard([
+          [{text: 'Run once', callback_data: `${MODE_CALLBACK_PREFIX}once:${reportWithAccount}`}],
+          [{text: 'Schedule recurring', callback_data: `${MODE_CALLBACK_PREFIX}schedule:${reportWithAccount}`}],
         ])
       );
     });
 
     // Step 3a: Run once
-    this.#bot.action(new RegExp(`^${MODE_CALLBACK_PREFIX}once:(.+)$`), async ctx => {
-      await ctx.answerCbQuery();
+    this.#bot.callbackQuery(new RegExp(`^${MODE_CALLBACK_PREFIX}once:(.+)$`), async ctx => {
+      await ctx.answerCallbackQuery();
 
       const reportInput = ctx.match[1];
       const senderId = ctx.from?.id?.toString();
@@ -178,32 +192,32 @@ export class TelegramPlatform implements MessagingPlatform {
     });
 
     // Step 3b: Schedule — ask for interval
-    this.#bot.action(new RegExp(`^${MODE_CALLBACK_PREFIX}schedule:(.+)$`), async ctx => {
-      await ctx.answerCbQuery();
+    this.#bot.callbackQuery(new RegExp(`^${MODE_CALLBACK_PREFIX}schedule:(.+)$`), async ctx => {
+      await ctx.answerCallbackQuery();
 
       const reportInput = ctx.match[1];
       const reportName = reportInput.split(' ')[0];
 
       await ctx.editMessageText(
         `Report: ${reportName}\nSelect interval:`,
-        Markup.inlineKeyboard([
+        inlineKeyboard([
           [
-            Markup.button.callback('1m', `${INTERVAL_CALLBACK_PREFIX}1m:${reportInput}`),
-            Markup.button.callback('1h', `${INTERVAL_CALLBACK_PREFIX}1h:${reportInput}`),
-            Markup.button.callback('6h', `${INTERVAL_CALLBACK_PREFIX}6h:${reportInput}`),
+            {text: '1m', callback_data: `${INTERVAL_CALLBACK_PREFIX}1m:${reportInput}`},
+            {text: '1h', callback_data: `${INTERVAL_CALLBACK_PREFIX}1h:${reportInput}`},
+            {text: '6h', callback_data: `${INTERVAL_CALLBACK_PREFIX}6h:${reportInput}`},
           ],
           [
-            Markup.button.callback('12h', `${INTERVAL_CALLBACK_PREFIX}12h:${reportInput}`),
-            Markup.button.callback('1d', `${INTERVAL_CALLBACK_PREFIX}1d:${reportInput}`),
-            Markup.button.callback('1w', `${INTERVAL_CALLBACK_PREFIX}1w:${reportInput}`),
+            {text: '12h', callback_data: `${INTERVAL_CALLBACK_PREFIX}12h:${reportInput}`},
+            {text: '1d', callback_data: `${INTERVAL_CALLBACK_PREFIX}1d:${reportInput}`},
+            {text: '1w', callback_data: `${INTERVAL_CALLBACK_PREFIX}1w:${reportInput}`},
           ],
         ])
       );
     });
 
     // Step 4: Schedule with chosen interval
-    this.#bot.action(new RegExp(`^${INTERVAL_CALLBACK_PREFIX}([^:]+):(.+)$`), async ctx => {
-      await ctx.answerCbQuery();
+    this.#bot.callbackQuery(new RegExp(`^${INTERVAL_CALLBACK_PREFIX}([^:]+):(.+)$`), async ctx => {
+      await ctx.answerCallbackQuery();
 
       const interval = ctx.match[1];
       const reportInput = ctx.match[2];
@@ -230,27 +244,33 @@ export class TelegramPlatform implements MessagingPlatform {
       console.warn('Warning: TELEGRAM_OWNER_IDS is not set. Everyone can message the bot via Telegram.');
     }
 
-    const botInfo = await this.#bot.telegram.getMe();
+    await this.#bot.init();
     this.#platformInfo = {
-      botAddress: `@${botInfo.username}`,
-      sdkVersion: 'Telegraf',
+      botAddress: `@${this.#bot.botInfo.username}`,
+      sdkVersion: 'grammY',
     };
 
-    await this.#bot.launch({dropPendingUpdates: true});
+    // bot.start() resolves only when the bot is stopped, so we don't await it —
+    // we want start() to return to the caller once polling is running.
+    this.#bot.start({drop_pending_updates: true}).catch((err: unknown) => {
+      console.error('Telegram bot polling error:', err);
+    });
 
     console.log(`Telegram bot started as ${this.#platformInfo.botAddress}.`);
   }
 
   async stop(): Promise<void> {
-    this.#bot.stop();
+    await this.#bot.stop();
   }
 
   async sendMessage(userId: string, text: string): Promise<void> {
     const chatId = userId.replace(PLATFORM_PREFIX, '');
-    try {
-      await this.#bot.telegram.sendMessage(chatId, text, {parse_mode: 'MarkdownV2'});
-    } catch {
-      await this.#bot.telegram.sendMessage(chatId, text);
+    for (const chunk of splitForTelegram(text)) {
+      try {
+        await this.#bot.api.sendMessage(chatId, markdownToTelegramHtml(chunk), {parse_mode: 'HTML'});
+      } catch {
+        await this.#bot.api.sendMessage(chatId, chunk);
+      }
     }
   }
 

--- a/packages/messaging/src/platform/telegramMarkdown.test.ts
+++ b/packages/messaging/src/platform/telegramMarkdown.test.ts
@@ -18,6 +18,23 @@ describe('markdownToTelegramHtml', () => {
   it('leaves plain text untouched', () => {
     expect(markdownToTelegramHtml('no formatting here')).toBe('no formatting here');
   });
+
+  it('wraps fenced code blocks in <pre>', () => {
+    const input = 'Header\n```\nRank  Stock\n  1  AAPL\n```\nFooter';
+    expect(markdownToTelegramHtml(input)).toBe('Header\n<pre>Rank  Stock\n  1  AAPL</pre>\nFooter');
+  });
+
+  it('escapes HTML entities inside code blocks', () => {
+    expect(markdownToTelegramHtml('```\nA & <B>\n```')).toBe('<pre>A &amp; &lt;B&gt;</pre>');
+  });
+
+  it('does not apply **bold** conversion inside code blocks', () => {
+    expect(markdownToTelegramHtml('```\n**not bold**\n```')).toBe('<pre>**not bold**</pre>');
+  });
+
+  it('ignores an optional language tag on the opening fence', () => {
+    expect(markdownToTelegramHtml('```js\nconst x = 1;\n```')).toBe('<pre>const x = 1;</pre>');
+  });
 });
 
 describe('splitForTelegram', () => {

--- a/packages/messaging/src/platform/telegramMarkdown.test.ts
+++ b/packages/messaging/src/platform/telegramMarkdown.test.ts
@@ -1,0 +1,86 @@
+import {describe, expect, it} from 'vitest';
+import {MESSAGE_BREAK} from 'trading-strategies';
+import {markdownToTelegramHtml, splitForTelegram} from './telegramMarkdown.js';
+
+describe('markdownToTelegramHtml', () => {
+  it('converts **bold** to <b>', () => {
+    expect(markdownToTelegramHtml('**Report:** done')).toBe('<b>Report:</b> done');
+  });
+
+  it('escapes &, <, > to HTML entities', () => {
+    expect(markdownToTelegramHtml('A & B <tag>')).toBe('A &amp; B &lt;tag&gt;');
+  });
+
+  it('escapes HTML before applying bold so ** inside tags does not break', () => {
+    expect(markdownToTelegramHtml('**A & B**')).toBe('<b>A &amp; B</b>');
+  });
+
+  it('leaves plain text untouched', () => {
+    expect(markdownToTelegramHtml('no formatting here')).toBe('no formatting here');
+  });
+});
+
+describe('splitForTelegram', () => {
+  it('returns a single chunk when the text fits', () => {
+    expect(splitForTelegram('short text', 100)).toEqual(['short text']);
+  });
+
+  it('splits at paragraph boundaries when possible', () => {
+    const text = 'A'.repeat(50) + '\n\n' + 'B'.repeat(50) + '\n\n' + 'C'.repeat(50);
+    const chunks = splitForTelegram(text, 60);
+    expect(chunks).toEqual(['A'.repeat(50), 'B'.repeat(50), 'C'.repeat(50)]);
+  });
+
+  it('merges small paragraphs into one chunk when they fit together', () => {
+    const text = 'small\n\nparagraphs\n\nhere';
+    expect(splitForTelegram(text, 100)).toEqual([text]);
+  });
+
+  it('falls back to line splitting when a paragraph exceeds the limit', () => {
+    const paragraph = Array.from({length: 5}, (_, i) => `line ${i + 1}`).join('\n');
+    // "line 1\nline 2\nline 3\nline 4\nline 5" is 34 chars, each line is 6
+    const chunks = splitForTelegram(paragraph, 15);
+    expect(chunks).toEqual(['line 1\nline 2', 'line 3\nline 4', 'line 5']);
+  });
+
+  it('hard-splits a single line that exceeds the limit', () => {
+    expect(splitForTelegram('X'.repeat(10), 4)).toEqual(['XXXX', 'XXXX', 'XX']);
+  });
+
+  it('honors MESSAGE_BREAK markers as forced section splits', () => {
+    const text = `**Section 1**\nline a\n${MESSAGE_BREAK}\n**Section 2**\nline b\n${MESSAGE_BREAK}\n**Section 3**\nline c`;
+    expect(splitForTelegram(text)).toEqual([
+      '**Section 1**\nline a',
+      '**Section 2**\nline b',
+      '**Section 3**\nline c',
+    ]);
+  });
+
+  it('still size-splits within a section that exceeds the limit after a forced break', () => {
+    const bigSection = Array.from({length: 10}, (_, i) => `line ${i + 1}`).join('\n');
+    const text = `small${MESSAGE_BREAK}${bigSection}`;
+    const chunks = splitForTelegram(text, 20);
+    expect(chunks[0]).toBe('small');
+    expect(chunks.length).toBeGreaterThan(2);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(20);
+    }
+  });
+
+  it('drops empty sections produced by consecutive markers', () => {
+    const text = `a${MESSAGE_BREAK}${MESSAGE_BREAK}b`;
+    expect(splitForTelegram(text)).toEqual(['a', 'b']);
+  });
+
+  it('keeps chunks under the default Telegram limit for a realistic report', () => {
+    // Simulate a report with 100 numbered items in a single paragraph, each ~60 chars.
+    // Total ~6000 chars, forcing a split.
+    const lines = Array.from({length: 100}, (_, i) => `${i + 1}. Some Company Name (TICKER) — detail one, detail two`);
+    const longReport = '**Header**\n' + lines.join('\n');
+    const chunks = splitForTelegram(longReport);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(3900);
+    }
+  });
+});

--- a/packages/messaging/src/platform/telegramMarkdown.ts
+++ b/packages/messaging/src/platform/telegramMarkdown.ts
@@ -1,0 +1,96 @@
+import {MESSAGE_BREAK} from 'trading-strategies';
+
+const HTML_ESCAPES: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+};
+
+/**
+ * Convert the minimal markdown used by reports into Telegram HTML parse mode:
+ * `**bold**` becomes `<b>bold</b>`, and `&`, `<`, `>` are escaped to entities.
+ * Everything else passes through as plain text.
+ */
+export function markdownToTelegramHtml(markdown: string): string {
+  return markdown.replace(/[&<>]/g, ch => HTML_ESCAPES[ch]).replace(/\*\*(.+?)\*\*/g, '<b>$1</b>');
+}
+
+/**
+ * Telegram rejects text messages longer than 4096 characters. We use 3900 to
+ * leave headroom for the `**` → `<b>` expansion performed by
+ * {@link markdownToTelegramHtml}.
+ */
+const TELEGRAM_MAX_CHUNK = 3900;
+
+/**
+ * Split a long markdown message into chunks that fit Telegram's per-message
+ * limit. Forced section breaks from {@link MESSAGE_BREAK} are honored first;
+ * within each section, splits prefer paragraph (`\n\n`) boundaries, then line
+ * (`\n`) boundaries, and only hard-split a single line as a last resort.
+ */
+export function splitForTelegram(markdown: string, maxLength = TELEGRAM_MAX_CHUNK): string[] {
+  // Honor forced section breaks first. Strip the surrounding newlines that end
+  // up around the marker after line-join so each section starts cleanly.
+  const sections = markdown
+    .split(MESSAGE_BREAK)
+    .map(section => section.replace(/^\n+|\n+$/g, ''))
+    .filter(section => section.length > 0);
+
+  if (sections.length > 1) {
+    return sections.flatMap(section => splitSectionForTelegram(section, maxLength));
+  }
+
+  return splitSectionForTelegram(sections[0] ?? '', maxLength);
+}
+
+function splitSectionForTelegram(markdown: string, maxLength: number): string[] {
+  if (markdown.length === 0) {
+    return [];
+  }
+  if (markdown.length <= maxLength) {
+    return [markdown];
+  }
+
+  const chunks: string[] = [];
+  let current = '';
+
+  const flush = () => {
+    if (current) {
+      chunks.push(current);
+      current = '';
+    }
+  };
+
+  const tryAppend = (piece: string, separator: string): boolean => {
+    const candidate = current ? current + separator + piece : piece;
+    if (candidate.length <= maxLength) {
+      current = candidate;
+      return true;
+    }
+    return false;
+  };
+
+  for (const paragraph of markdown.split('\n\n')) {
+    if (tryAppend(paragraph, '\n\n')) continue;
+    flush();
+    if (paragraph.length <= maxLength) {
+      current = paragraph;
+      continue;
+    }
+    // Paragraph too big on its own — fall back to per-line splitting
+    for (const line of paragraph.split('\n')) {
+      if (tryAppend(line, '\n')) continue;
+      flush();
+      if (line.length <= maxLength) {
+        current = line;
+      } else {
+        // Single line exceeds the limit — hard split
+        for (let i = 0; i < line.length; i += maxLength) {
+          chunks.push(line.slice(i, i + maxLength));
+        }
+      }
+    }
+  }
+  flush();
+  return chunks;
+}

--- a/packages/messaging/src/platform/telegramMarkdown.ts
+++ b/packages/messaging/src/platform/telegramMarkdown.ts
@@ -10,6 +10,14 @@ function escapeHtml(text: string): string {
   return text.replace(/[&<>]/g, ch => HTML_ESCAPES[ch]);
 }
 
+function trimNewlines(text: string): string {
+  let start = 0;
+  let end = text.length;
+  while (start < end && text[start] === '\n') start++;
+  while (end > start && text[end - 1] === '\n') end--;
+  return text.slice(start, end);
+}
+
 function convertOutsideCode(text: string): string {
   return escapeHtml(text).replace(/\*\*(.+?)\*\*/g, '<b>$1</b>');
 }
@@ -33,7 +41,7 @@ export function markdownToTelegramHtml(markdown: string): string {
     if (match.index > lastIndex) {
       parts.push(convertOutsideCode(markdown.slice(lastIndex, match.index)));
     }
-    const code = match[1].replace(/^\n+|\n+$/g, '');
+    const code = trimNewlines(match[1]);
     parts.push(`<pre>${escapeHtml(code)}</pre>`);
     lastIndex = match.index + match[0].length;
   }
@@ -63,7 +71,7 @@ export function splitForTelegram(markdown: string, maxLength = TELEGRAM_MAX_CHUN
   // up around the marker after line-join so each section starts cleanly.
   const sections = markdown
     .split(MESSAGE_BREAK)
-    .map(section => section.replace(/^\n+|\n+$/g, ''))
+    .map(trimNewlines)
     .filter(section => section.length > 0);
 
   if (sections.length > 1) {

--- a/packages/messaging/src/platform/telegramMarkdown.ts
+++ b/packages/messaging/src/platform/telegramMarkdown.ts
@@ -6,13 +6,43 @@ const HTML_ESCAPES: Record<string, string> = {
   '>': '&gt;',
 };
 
+function escapeHtml(text: string): string {
+  return text.replace(/[&<>]/g, ch => HTML_ESCAPES[ch]);
+}
+
+function convertOutsideCode(text: string): string {
+  return escapeHtml(text).replace(/\*\*(.+?)\*\*/g, '<b>$1</b>');
+}
+
 /**
  * Convert the minimal markdown used by reports into Telegram HTML parse mode:
- * `**bold**` becomes `<b>bold</b>`, and `&`, `<`, `>` are escaped to entities.
- * Everything else passes through as plain text.
+ *
+ * - `**bold**` → `<b>bold</b>`
+ * - fenced code blocks (```` ``` ````) → `<pre>...</pre>` (monospace, preserves whitespace)
+ * - `&`, `<`, `>` escaped to entities
+ *
+ * Other markdown is passed through as plain text.
  */
 export function markdownToTelegramHtml(markdown: string): string {
-  return markdown.replace(/[&<>]/g, ch => HTML_ESCAPES[ch]).replace(/\*\*(.+?)\*\*/g, '<b>$1</b>');
+  const parts: string[] = [];
+  const codeBlockRegex = /```(?:\w*\n)?([\s\S]*?)```/g;
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = codeBlockRegex.exec(markdown)) !== null) {
+    if (match.index > lastIndex) {
+      parts.push(convertOutsideCode(markdown.slice(lastIndex, match.index)));
+    }
+    const code = match[1].replace(/^\n+|\n+$/g, '');
+    parts.push(`<pre>${escapeHtml(code)}</pre>`);
+    lastIndex = match.index + match[0].length;
+  }
+
+  if (lastIndex < markdown.length) {
+    parts.push(convertOutsideCode(markdown.slice(lastIndex)));
+  }
+
+  return parts.join('');
 }
 
 /**

--- a/packages/trading-strategies/README.md
+++ b/packages/trading-strategies/README.md
@@ -94,6 +94,30 @@ type Config = MultiIndicatorConfluenceConfig; // z.infer<typeof MultiIndicatorCo
 - `SELL_LIMIT`: Sell when price reaches specified limit
 - `NONE`: No action recommended
 
+## Market Regimes
+
+No strategy works in every market. Classifying the current market state — the **regime** — helps decide which strategy is actually applicable right now. A useful model crosses **direction** (is price going up, down, or nowhere?) with **volatility** (how much is it moving?):
+
+|                  | Low volatility                                   | High volatility                                 |
+| ---------------- | ------------------------------------------------ | ----------------------------------------------- |
+| **Uptrending**   | **Smooth uptrend** — trend-following longs       | **Volatile uptrend** — breakout longs, wide stops |
+| **Downtrending** | **Smooth downtrend** — trend-following shorts    | **Volatile downtrend** — breakout shorts        |
+| **Ranging**      | **Tight range** — wait / accumulate              | **Wide range** — mean reversion, scalping       |
+
+Splitting direction into *up* / *down* / *ranging* (instead of a single *directional* axis) matters because long-only strategies only apply to uptrends, short strategies only to downtrends, and mean reversion works very differently in a sideways range than inside a trend.
+
+In practice this maps cleanly onto measurements that are cheap to compute from daily candles:
+
+- **Direction strength:** the [Efficiency Ratio](https://www.investopedia.com/articles/trading/07/kama.asp) (ER) — close to `1` means a clean directional move, close to `0` means pure noise. Pair it with the sign of the long-window slope (or a moving-average crossover) to decide *up* vs. *down*.
+- **Volatility:** average daily range relative to price (ATR%).
+
+A seventh bucket worth naming is **noise** — price movement with neither direction nor meaningful range. No strategy has an edge there; the right move is to stay out.
+
+Two distinct things use this concept:
+
+1. **Strategies** declare which regime(s) they target as static metadata, so you can answer *"given today's market for AAPL, which of my strategies are applicable?"*.
+2. **Stocks** get a *dynamic* regime label computed from recent price action, so the same stock can be classified differently across time windows.
+
 ## Backtesting
 
 Always backtest your strategies with historical data before deploying them in live trading. A good strategy should:

--- a/packages/trading-strategies/src/report-scalp-scanner/ScalpScannerReport.ts
+++ b/packages/trading-strategies/src/report-scalp-scanner/ScalpScannerReport.ts
@@ -28,9 +28,6 @@ interface ScanResult {
   er: number;
   atrPct: number;
   suggestedOffset: string;
-  priceStart: number;
-  priceEnd: number;
-  netChangePct: number;
 }
 
 interface DailyBar {
@@ -87,9 +84,6 @@ export class ScalpScannerReport extends Report<ScalpScannerConfig> {
       }
 
       const erValue = er.getResultOrThrow();
-      const firstClose = daily[0].close;
-      const lastClose = daily[daily.length - 1].close;
-      const netChangePct = ((lastClose / firstClose) - 1) * 100;
 
       // Compute ATR% for context
       const exchangeCandles = daily.map((bar, i) => ({
@@ -123,9 +117,6 @@ export class ScalpScannerReport extends Report<ScalpScannerConfig> {
         er: erValue,
         atrPct,
         suggestedOffset: offsetStr,
-        priceStart: firstClose,
-        priceEnd: lastClose,
-        netChangePct,
       });
     }
 
@@ -216,21 +207,19 @@ export class ScalpScannerReport extends Report<ScalpScannerConfig> {
       ...trendingTop.map(r => formatSymbolWithName(r.symbol, names, tableNameMax).length)
     );
 
-    const formatNet = (pct: number): string => (pct >= 0 ? '+' : '') + pct.toFixed(1) + '%';
-
     // Message 1: header + top scalp-friendly table
     lines.push(`**Scalp Scanner: ${total} stocks analyzed**`);
     lines.push(`Lookback: ${this.config.lookbackDays} trading days | ER threshold: ${this.config.erThreshold}`);
     lines.push('');
     lines.push(`**Top ${scalpFriendlyTop.length} Scalp-Friendly Stocks (lowest ER = most choppy)**`);
     lines.push('```');
-    lines.push(`Rank  ${'Stock'.padEnd(stockColWidth)}  ER     ATR%    Offset   Net      Price`);
-    lines.push(`----  ${'-'.repeat(stockColWidth)}  -----  ------  -------  -------  --------`);
+    lines.push(`Rank  ${'Stock'.padEnd(stockColWidth)}  ER     ATR%    Offset`);
+    lines.push(`----  ${'-'.repeat(stockColWidth)}  -----  ------  -------`);
     for (let i = 0; i < scalpFriendlyTop.length; i++) {
       const r = scalpFriendlyTop[i];
       const stock = formatSymbolWithName(r.symbol, names, tableNameMax).padEnd(stockColWidth);
       lines.push(
-        `${String(i + 1).padStart(4)}  ${stock}  ${r.er.toFixed(2).padStart(5)}  ${(r.atrPct.toFixed(1) + '%').padStart(6)}  ${r.suggestedOffset.padStart(7)}  ${formatNet(r.netChangePct).padStart(7)}  ${('$' + r.priceEnd.toFixed(2)).padStart(8)}`
+        `${String(i + 1).padStart(4)}  ${stock}  ${r.er.toFixed(2).padStart(5)}  ${(r.atrPct.toFixed(1) + '%').padStart(6)}  ${r.suggestedOffset.padStart(7)}`
       );
     }
     lines.push('```');
@@ -239,13 +228,13 @@ export class ScalpScannerReport extends Report<ScalpScannerConfig> {
     lines.push(MESSAGE_BREAK);
     lines.push(`**Top ${trendingTop.length} Trending Stocks (highest ER = most directional)**`);
     lines.push('```');
-    lines.push(`Rank  ${'Stock'.padEnd(stockColWidth)}  ER     ATR%    Net      Price`);
-    lines.push(`----  ${'-'.repeat(stockColWidth)}  -----  ------  -------  --------`);
+    lines.push(`Rank  ${'Stock'.padEnd(stockColWidth)}  ER     ATR%`);
+    lines.push(`----  ${'-'.repeat(stockColWidth)}  -----  ------`);
     for (let i = 0; i < trendingTop.length; i++) {
       const r = trendingTop[i];
       const stock = formatSymbolWithName(r.symbol, names, tableNameMax).padEnd(stockColWidth);
       lines.push(
-        `${String(i + 1).padStart(4)}  ${stock}  ${r.er.toFixed(2).padStart(5)}  ${(r.atrPct.toFixed(1) + '%').padStart(6)}  ${formatNet(r.netChangePct).padStart(7)}  ${('$' + r.priceEnd.toFixed(2)).padStart(8)}`
+        `${String(i + 1).padStart(4)}  ${stock}  ${r.er.toFixed(2).padStart(5)}  ${(r.atrPct.toFixed(1) + '%').padStart(6)}`
       );
     }
     lines.push('```');
@@ -257,7 +246,7 @@ export class ScalpScannerReport extends Report<ScalpScannerConfig> {
     if (picks.length > 0) {
       lines.push(`**Top Picks for Scalping (low ER + ATR >= 2%):**`);
       for (const r of picks) {
-        lines.push(`- ${formatSymbolWithName(r.symbol, names)} (ER: ${r.er.toFixed(2)}, ATR: ${r.atrPct.toFixed(1)}%, offset: ${r.suggestedOffset}, price: $${r.priceEnd.toFixed(2)})`);
+        lines.push(`- ${formatSymbolWithName(r.symbol, names)} (ER: ${r.er.toFixed(2)}, ATR: ${r.atrPct.toFixed(1)}%, offset: ${r.suggestedOffset})`);
       }
     } else {
       lines.push(`No strong scalp candidates found (need low ER + ATR >= 2%).`);

--- a/packages/trading-strategies/src/report-scalp-scanner/ScalpScannerReport.ts
+++ b/packages/trading-strategies/src/report-scalp-scanner/ScalpScannerReport.ts
@@ -200,7 +200,7 @@ export class ScalpScannerReport extends Report<ScalpScannerConfig> {
     const scalpFriendlyTop = scalpFriendly.slice(0, top);
     const trendingTop = trending.slice(0, top);
 
-    const tableNameMax = 22;
+    const tableNameMax = 12;
     const stockColWidth = Math.max(
       'Stock'.length,
       ...scalpFriendlyTop.map(r => formatSymbolWithName(r.symbol, names, tableNameMax).length),

--- a/packages/trading-strategies/src/report-scalp-scanner/ScalpScannerReport.ts
+++ b/packages/trading-strategies/src/report-scalp-scanner/ScalpScannerReport.ts
@@ -209,29 +209,46 @@ export class ScalpScannerReport extends Report<ScalpScannerConfig> {
     const scalpFriendlyTop = scalpFriendly.slice(0, top);
     const trendingTop = trending.slice(0, top);
 
-    // Message 1: header + top scalp-friendly
+    const tableNameMax = 22;
+    const stockColWidth = Math.max(
+      'Stock'.length,
+      ...scalpFriendlyTop.map(r => formatSymbolWithName(r.symbol, names, tableNameMax).length),
+      ...trendingTop.map(r => formatSymbolWithName(r.symbol, names, tableNameMax).length)
+    );
+
+    const formatNet = (pct: number): string => (pct >= 0 ? '+' : '') + pct.toFixed(1) + '%';
+
+    // Message 1: header + top scalp-friendly table
     lines.push(`**Scalp Scanner: ${total} stocks analyzed**`);
     lines.push(`Lookback: ${this.config.lookbackDays} trading days | ER threshold: ${this.config.erThreshold}`);
     lines.push('');
     lines.push(`**Top ${scalpFriendlyTop.length} Scalp-Friendly Stocks (lowest ER = most choppy)**`);
+    lines.push('```');
+    lines.push(`Rank  ${'Stock'.padEnd(stockColWidth)}  ER     ATR%    Offset   Net      Price`);
+    lines.push(`----  ${'-'.repeat(stockColWidth)}  -----  ------  -------  -------  --------`);
     for (let i = 0; i < scalpFriendlyTop.length; i++) {
       const r = scalpFriendlyTop[i];
-      const netChange = (r.netChangePct >= 0 ? '+' : '') + r.netChangePct.toFixed(1);
+      const stock = formatSymbolWithName(r.symbol, names, tableNameMax).padEnd(stockColWidth);
       lines.push(
-        `${i + 1}. ${formatSymbolWithName(r.symbol, names)} — ER: ${r.er.toFixed(2)}, ATR: ${r.atrPct.toFixed(1)}%, offset: ${r.suggestedOffset}, net: ${netChange}%, price: $${r.priceEnd.toFixed(2)}`
+        `${String(i + 1).padStart(4)}  ${stock}  ${r.er.toFixed(2).padStart(5)}  ${(r.atrPct.toFixed(1) + '%').padStart(6)}  ${r.suggestedOffset.padStart(7)}  ${formatNet(r.netChangePct).padStart(7)}  ${('$' + r.priceEnd.toFixed(2)).padStart(8)}`
       );
     }
+    lines.push('```');
 
-    // Message 2: top trending
+    // Message 2: top trending table
     lines.push(MESSAGE_BREAK);
     lines.push(`**Top ${trendingTop.length} Trending Stocks (highest ER = most directional)**`);
+    lines.push('```');
+    lines.push(`Rank  ${'Stock'.padEnd(stockColWidth)}  ER     ATR%    Net      Price`);
+    lines.push(`----  ${'-'.repeat(stockColWidth)}  -----  ------  -------  --------`);
     for (let i = 0; i < trendingTop.length; i++) {
       const r = trendingTop[i];
-      const netChange = (r.netChangePct >= 0 ? '+' : '') + r.netChangePct.toFixed(1);
+      const stock = formatSymbolWithName(r.symbol, names, tableNameMax).padEnd(stockColWidth);
       lines.push(
-        `${i + 1}. ${formatSymbolWithName(r.symbol, names)} — ER: ${r.er.toFixed(2)}, ATR: ${r.atrPct.toFixed(1)}%, net: ${netChange}%, price: $${r.priceEnd.toFixed(2)}`
+        `${String(i + 1).padStart(4)}  ${stock}  ${r.er.toFixed(2).padStart(5)}  ${(r.atrPct.toFixed(1) + '%').padStart(6)}  ${formatNet(r.netChangePct).padStart(7)}  ${('$' + r.priceEnd.toFixed(2)).padStart(8)}`
       );
     }
+    lines.push('```');
 
     // Message 3: top picks + summary + disclaimer
     lines.push(MESSAGE_BREAK);

--- a/packages/trading-strategies/src/report-scalp-scanner/ScalpScannerReport.ts
+++ b/packages/trading-strategies/src/report-scalp-scanner/ScalpScannerReport.ts
@@ -2,10 +2,11 @@ import {z} from 'zod';
 import {AlpacaAPI} from '@typedtrader/exchange';
 import type {Bar} from '@typedtrader/exchange';
 import {ER} from 'trading-signals';
-import {Report} from '../report/Report.js';
+import {MESSAGE_BREAK, Report} from '../report/Report.js';
 import {SP500_TICKERS} from '../report-sp500-momentum/sp500Tickers.js';
 import {ScalpStrategy} from '../strategy-scalp/ScalpStrategy.js';
 import {suggestScalpOffset} from '../strategy-scalp/suggestScalpOffset.js';
+import {fetchUsEquityNames, formatSymbolWithName} from '../util/formatSymbolWithName.js';
 
 export const ScalpScannerSchema = z.object({
   /** Alpaca API key */
@@ -60,7 +61,10 @@ export class ScalpScannerReport extends Report<ScalpScannerConfig> {
     // Fetch extra calendar days to account for weekends/holidays
     const start = new Date(end.getTime() - this.config.lookbackDays * 1.5 * 86_400_000);
 
-    const allBars = await this.#fetchAllBars(symbols, start, end);
+    const [allBars, names] = await Promise.all([
+      this.#fetchAllBars(symbols, start, end),
+      fetchUsEquityNames(this.#api),
+    ]);
     const results: ScanResult[] = [];
 
     for (const symbol of symbols) {
@@ -133,7 +137,7 @@ export class ScalpScannerReport extends Report<ScalpScannerConfig> {
       .filter(r => r.er >= this.config.erThreshold)
       .sort((a, b) => b.er - a.er);
 
-    return this.#formatResults(scalpFriendly, trending, results.length);
+    return this.#formatResults(scalpFriendly, trending, results.length, names);
   }
 
   async #fetchAllBars(symbols: string[], start: Date, end: Date): Promise<Map<string, Bar[]>> {
@@ -198,51 +202,45 @@ export class ScalpScannerReport extends Report<ScalpScannerConfig> {
     return [...dayMap.values()];
   }
 
-  #formatResults(scalpFriendly: ScanResult[], trending: ScanResult[], total: number): string {
+  #formatResults(scalpFriendly: ScanResult[], trending: ScanResult[], total: number, names: Map<string, string>): string {
     const lines: string[] = [];
     const top = 20;
 
+    const scalpFriendlyTop = scalpFriendly.slice(0, top);
+    const trendingTop = trending.slice(0, top);
+
+    // Message 1: header + top scalp-friendly
     lines.push(`**Scalp Scanner: ${total} stocks analyzed**`);
     lines.push(`Lookback: ${this.config.lookbackDays} trading days | ER threshold: ${this.config.erThreshold}`);
     lines.push('');
-
-    // Scalp-friendly table
-    lines.push(`**Top ${Math.min(top, scalpFriendly.length)} Scalp-Friendly Stocks (lowest ER = most choppy)**`);
-    lines.push('```');
-    lines.push('Rank  Ticker     ER      ATR%    Offset    Net Chg    Price');
-    lines.push('----  ------     ----    ----    ------    -------    -----');
-
-    for (let i = 0; i < Math.min(top, scalpFriendly.length); i++) {
-      const r = scalpFriendly[i];
+    lines.push(`**Top ${scalpFriendlyTop.length} Scalp-Friendly Stocks (lowest ER = most choppy)**`);
+    for (let i = 0; i < scalpFriendlyTop.length; i++) {
+      const r = scalpFriendlyTop[i];
+      const netChange = (r.netChangePct >= 0 ? '+' : '') + r.netChangePct.toFixed(1);
       lines.push(
-        `${String(i + 1).padStart(4)}  ${r.symbol.padEnd(10)} ${r.er.toFixed(2).padStart(5)}   ${r.atrPct.toFixed(1).padStart(5)}%   ${r.suggestedOffset.padStart(6)}   ${(r.netChangePct >= 0 ? '+' : '') + r.netChangePct.toFixed(1).padStart(5)}%   $${r.priceEnd.toFixed(2)}`
+        `${i + 1}. ${formatSymbolWithName(r.symbol, names)} — ER: ${r.er.toFixed(2)}, ATR: ${r.atrPct.toFixed(1)}%, offset: ${r.suggestedOffset}, net: ${netChange}%, price: $${r.priceEnd.toFixed(2)}`
       );
     }
-    lines.push('```');
 
-    // Trending table
-    lines.push('');
-    lines.push(`**Top ${Math.min(top, trending.length)} Trending Stocks (highest ER = most directional)**`);
-    lines.push('```');
-    lines.push('Rank  Ticker     ER      ATR%    Net Chg    Price');
-    lines.push('----  ------     ----    ----    -------    -----');
-
-    for (let i = 0; i < Math.min(top, trending.length); i++) {
-      const r = trending[i];
+    // Message 2: top trending
+    lines.push(MESSAGE_BREAK);
+    lines.push(`**Top ${trendingTop.length} Trending Stocks (highest ER = most directional)**`);
+    for (let i = 0; i < trendingTop.length; i++) {
+      const r = trendingTop[i];
+      const netChange = (r.netChangePct >= 0 ? '+' : '') + r.netChangePct.toFixed(1);
       lines.push(
-        `${String(i + 1).padStart(4)}  ${r.symbol.padEnd(10)} ${r.er.toFixed(2).padStart(5)}   ${r.atrPct.toFixed(1).padStart(5)}%   ${(r.netChangePct >= 0 ? '+' : '') + r.netChangePct.toFixed(1).padStart(5)}%   $${r.priceEnd.toFixed(2)}`
+        `${i + 1}. ${formatSymbolWithName(r.symbol, names)} — ER: ${r.er.toFixed(2)}, ATR: ${r.atrPct.toFixed(1)}%, net: ${netChange}%, price: $${r.priceEnd.toFixed(2)}`
       );
     }
-    lines.push('```');
 
-    // Top picks summary
-    lines.push('');
+    // Message 3: top picks + summary + disclaimer
+    lines.push(MESSAGE_BREAK);
     const pickCount = 5;
     const picks = scalpFriendly.filter(r => r.atrPct >= 2.0).slice(0, pickCount);
     if (picks.length > 0) {
       lines.push(`**Top Picks for Scalping (low ER + ATR >= 2%):**`);
       for (const r of picks) {
-        lines.push(`- ${r.symbol} (ER: ${r.er.toFixed(2)}, ATR: ${r.atrPct.toFixed(1)}%, offset: ${r.suggestedOffset}, price: $${r.priceEnd.toFixed(2)})`);
+        lines.push(`- ${formatSymbolWithName(r.symbol, names)} (ER: ${r.er.toFixed(2)}, ATR: ${r.atrPct.toFixed(1)}%, offset: ${r.suggestedOffset}, price: $${r.priceEnd.toFixed(2)})`);
       }
     } else {
       lines.push(`No strong scalp candidates found (need low ER + ATR >= 2%).`);

--- a/packages/trading-strategies/src/report-sp500-momentum/SP500MomentumReport.ts
+++ b/packages/trading-strategies/src/report-sp500-momentum/SP500MomentumReport.ts
@@ -1,6 +1,7 @@
 import {z} from 'zod';
 import {AlpacaAPI} from '@typedtrader/exchange';
 import {Report} from '../report/Report.js';
+import {fetchUsEquityNames, formatSymbolWithName} from '../util/formatSymbolWithName.js';
 import {findFirstTradingDay, getDateString} from '../util/TimeUtil.js';
 import {SP500_TICKERS} from './sp500Tickers.js';
 
@@ -47,9 +48,10 @@ export class SP500MomentumReport extends Report<SP500MomentumConfig> {
     const toDate = getDateString(recentDate);
     const fromDate = getDateString(pastDate);
 
-    const [currentPrices, pastPrices] = await Promise.all([
+    const [currentPrices, pastPrices, names] = await Promise.all([
       this.#getClosingPrices(SP500_TICKERS, recentDate),
       this.#getClosingPrices(SP500_TICKERS, pastDate),
+      fetchUsEquityNames(this.#api),
     ]);
 
     const results: MomentumResult[] = [];
@@ -69,7 +71,7 @@ export class SP500MomentumReport extends Report<SP500MomentumConfig> {
 
     results.sort((a, b) => b.returnPct - a.returnPct);
 
-    return this.#formatResults(results, fromDate, toDate);
+    return this.#formatResults(results, fromDate, toDate, names);
   }
 
   async #getClosingPrices(symbols: string[], targetDate: Date): Promise<Map<string, number>> {
@@ -114,51 +116,38 @@ export class SP500MomentumReport extends Report<SP500MomentumConfig> {
     return result;
   }
 
-  #formatResults(results: MomentumResult[], fromDate: string, toDate: string): string {
+  #formatResults(results: MomentumResult[], fromDate: string, toDate: string, names: Map<string, string>): string {
     const top = 20;
     const lines: string[] = [];
 
     lines.push(`**S&P 500 Momentum: ${fromDate} → ${toDate}**`);
     lines.push('');
-    lines.push(`**Top ${top} Winners (12m return)**`);
-    lines.push('```');
-    lines.push('Rank  Ticker     12m Return    Price Now    Price 12m Ago');
-    lines.push('----  ------     ----------    ---------    -------------');
 
-    for (let i = 0; i < Math.min(top, results.length); i++) {
-      const r = results[i];
+    const winners = results.slice(0, top);
+    const losers = results.slice(-top).reverse();
+
+    lines.push(`**Top ${winners.length} Winners (12m return)**`);
+    for (let i = 0; i < winners.length; i++) {
+      const r = winners[i];
       lines.push(
-        `${String(i + 1).padStart(4)}  ${r.ticker.padEnd(10)} ${r.returnPct.toFixed(2).padStart(9)}%    $${r.priceNow.toFixed(2).padStart(8)}    $${r.price12MonthsAgo.toFixed(2).padStart(8)}`
+        `${i + 1}. ${formatSymbolWithName(r.ticker, names)} — ${r.returnPct.toFixed(2)}%, now $${r.priceNow.toFixed(2)}, 12m ago $${r.price12MonthsAgo.toFixed(2)}`
       );
     }
-    lines.push('```');
 
     lines.push('');
-    lines.push(`**Bottom ${top} Losers (12m return)**`);
-    lines.push('```');
-    lines.push('Rank  Ticker     12m Return    Price Now    Price 12m Ago');
-    lines.push('----  ------     ----------    ---------    -------------');
-
-    const bottom = results.slice(-top).reverse();
-    for (let i = 0; i < bottom.length; i++) {
-      const r = bottom[i];
+    lines.push(`**Bottom ${losers.length} Losers (12m return)**`);
+    for (let i = 0; i < losers.length; i++) {
+      const r = losers[i];
       lines.push(
-        `${String(i + 1).padStart(4)}  ${r.ticker.padEnd(10)} ${r.returnPct.toFixed(2).padStart(9)}%    $${r.priceNow.toFixed(2).padStart(8)}    $${r.price12MonthsAgo.toFixed(2).padStart(8)}`
+        `${i + 1}. ${formatSymbolWithName(r.ticker, names)} — ${r.returnPct.toFixed(2)}%, now $${r.priceNow.toFixed(2)}, 12m ago $${r.price12MonthsAgo.toFixed(2)}`
       );
     }
-    lines.push('```');
 
     lines.push('');
     lines.push(`Stocks ranked: ${results.length} / ${SP500_TICKERS.length}`);
 
-    // Recommendation
-    const winners = results.slice(0, top);
-    const losers = results.slice(-top).reverse();
     lines.push('');
-    lines.push('**Recommendation (based on 12-1 momentum, 3-month hold):**');
-    lines.push(`Buy: ${winners.map(r => r.ticker).join(', ')}`);
-    lines.push(`Avoid: ${losers.map(r => r.ticker).join(', ')}`);
-    lines.push('Hold for 3 months, then re-evaluate.');
+    lines.push('**Recommendation (based on 12-1 momentum, 3-month hold):** Hold the top winners for 3 months, then re-evaluate.');
 
     // Disclaimer
     lines.push('');

--- a/packages/trading-strategies/src/report-sp500-momentum/SP500MomentumReport.ts
+++ b/packages/trading-strategies/src/report-sp500-momentum/SP500MomentumReport.ts
@@ -1,6 +1,6 @@
 import {z} from 'zod';
 import {AlpacaAPI} from '@typedtrader/exchange';
-import {Report} from '../report/Report.js';
+import {MESSAGE_BREAK, Report} from '../report/Report.js';
 import {fetchUsEquityNames, formatSymbolWithName} from '../util/formatSymbolWithName.js';
 import {findFirstTradingDay, getDateString} from '../util/TimeUtil.js';
 import {SP500_TICKERS} from './sp500Tickers.js';
@@ -126,22 +126,36 @@ export class SP500MomentumReport extends Report<SP500MomentumConfig> {
     const winners = results.slice(0, top);
     const losers = results.slice(-top).reverse();
 
-    lines.push(`**Top ${winners.length} Winners (12m return)**`);
-    for (let i = 0; i < winners.length; i++) {
-      const r = winners[i];
-      lines.push(
-        `${i + 1}. ${formatSymbolWithName(r.ticker, names)} — ${r.returnPct.toFixed(2)}%, now $${r.priceNow.toFixed(2)}, 12m ago $${r.price12MonthsAgo.toFixed(2)}`
-      );
-    }
+    const tableNameMax = 22;
+    const stockColWidth = Math.max(
+      'Stock'.length,
+      ...winners.map(r => formatSymbolWithName(r.ticker, names, tableNameMax).length),
+      ...losers.map(r => formatSymbolWithName(r.ticker, names, tableNameMax).length)
+    );
 
-    lines.push('');
-    lines.push(`**Bottom ${losers.length} Losers (12m return)**`);
-    for (let i = 0; i < losers.length; i++) {
-      const r = losers[i];
-      lines.push(
-        `${i + 1}. ${formatSymbolWithName(r.ticker, names)} — ${r.returnPct.toFixed(2)}%, now $${r.priceNow.toFixed(2)}, 12m ago $${r.price12MonthsAgo.toFixed(2)}`
-      );
+    const renderRow = (index: number, r: MomentumResult): string => {
+      const stock = formatSymbolWithName(r.ticker, names, tableNameMax).padEnd(stockColWidth);
+      return `${String(index).padStart(4)}  ${stock}  ${(r.returnPct.toFixed(2) + '%').padStart(9)}  ${('$' + r.priceNow.toFixed(2)).padStart(9)}  ${('$' + r.price12MonthsAgo.toFixed(2)).padStart(9)}`;
+    };
+
+    lines.push(`**Top ${winners.length} Winners (12m return)**`);
+    lines.push('```');
+    lines.push(`Rank  ${'Stock'.padEnd(stockColWidth)}  12m Ret    Now        12m Ago`);
+    lines.push(`----  ${'-'.repeat(stockColWidth)}  ---------  ---------  ---------`);
+    for (let i = 0; i < winners.length; i++) {
+      lines.push(renderRow(i + 1, winners[i]));
     }
+    lines.push('```');
+
+    lines.push(MESSAGE_BREAK);
+    lines.push(`**Bottom ${losers.length} Losers (12m return)**`);
+    lines.push('```');
+    lines.push(`Rank  ${'Stock'.padEnd(stockColWidth)}  12m Ret    Now        12m Ago`);
+    lines.push(`----  ${'-'.repeat(stockColWidth)}  ---------  ---------  ---------`);
+    for (let i = 0; i < losers.length; i++) {
+      lines.push(renderRow(i + 1, losers[i]));
+    }
+    lines.push('```');
 
     lines.push('');
     lines.push(`Stocks ranked: ${results.length} / ${SP500_TICKERS.length}`);

--- a/packages/trading-strategies/src/report/Report.ts
+++ b/packages/trading-strategies/src/report/Report.ts
@@ -1,3 +1,13 @@
+/**
+ * Sentinel string that reports can insert between sections to force the
+ * messaging layer to deliver them as separate messages. Uses the ASCII form-feed
+ * character (U+000C) because it never appears in natural report text.
+ *
+ * Messaging platforms that don't care about message boundaries can safely
+ * treat it as a paragraph separator or strip it.
+ */
+export const MESSAGE_BREAK = '\f';
+
 export abstract class Report<T extends Record<string, unknown> = Record<string, unknown>> {
   static NAME: string;
 
@@ -10,6 +20,9 @@ export abstract class Report<T extends Record<string, unknown> = Record<string, 
   /**
    * Execute the report and return a formatted string result
    * suitable for sending as a chat message.
+   *
+   * To deliver a report as multiple messages, separate sections with
+   * {@link MESSAGE_BREAK}.
    */
   abstract run(): Promise<string>;
 }

--- a/packages/trading-strategies/src/util/formatSymbolWithName.ts
+++ b/packages/trading-strategies/src/util/formatSymbolWithName.ts
@@ -1,18 +1,22 @@
 import {AlpacaAPI, AssetClass} from '@typedtrader/exchange';
 
-const MAX_NAME_LENGTH = 30;
+const DEFAULT_MAX_NAME_LENGTH = 30;
 
 /**
  * Format a ticker symbol as `Name (SYMBOL)` using the given asset name map.
  * Falls back to the bare symbol if no name is known. Long names are truncated
  * with an ellipsis so tables remain readable.
  */
-export function formatSymbolWithName(symbol: string, names: Map<string, string>): string {
+export function formatSymbolWithName(
+  symbol: string,
+  names: Map<string, string>,
+  maxNameLength: number = DEFAULT_MAX_NAME_LENGTH
+): string {
   const name = names.get(symbol);
   if (!name) {
     return symbol;
   }
-  const truncated = name.length > MAX_NAME_LENGTH ? name.slice(0, MAX_NAME_LENGTH - 1) + '…' : name;
+  const truncated = name.length > maxNameLength ? name.slice(0, maxNameLength - 1) + '…' : name;
   return `${truncated} (${symbol})`;
 }
 

--- a/packages/trading-strategies/src/util/formatSymbolWithName.ts
+++ b/packages/trading-strategies/src/util/formatSymbolWithName.ts
@@ -1,0 +1,34 @@
+import {AlpacaAPI, AssetClass} from '@typedtrader/exchange';
+
+const MAX_NAME_LENGTH = 30;
+
+/**
+ * Format a ticker symbol as `Name (SYMBOL)` using the given asset name map.
+ * Falls back to the bare symbol if no name is known. Long names are truncated
+ * with an ellipsis so tables remain readable.
+ */
+export function formatSymbolWithName(symbol: string, names: Map<string, string>): string {
+  const name = names.get(symbol);
+  if (!name) {
+    return symbol;
+  }
+  const truncated = name.length > MAX_NAME_LENGTH ? name.slice(0, MAX_NAME_LENGTH - 1) + '…' : name;
+  return `${truncated} (${symbol})`;
+}
+
+/**
+ * Fetch all tradable US equities from Alpaca and build a `symbol → name` map.
+ * Returns an empty map on failure so reports still render with bare tickers.
+ */
+export async function fetchUsEquityNames(api: AlpacaAPI): Promise<Map<string, string>> {
+  try {
+    const assets = await api.getAssets({asset_class: AssetClass.US_EQUITY});
+    const map = new Map<string, string>();
+    for (const asset of assets) {
+      map.set(asset.symbol, asset.name);
+    }
+    return map;
+  } catch {
+    return new Map();
+  }
+}


### PR DESCRIPTION
## Summary

- **Company names in report output** — ScalpScanner and SP500 Momentum now display `Name (SYMBOL)` (e.g. *Apple Inc. (AAPL)*) by fetching Alpaca's `/v2/assets` once per run and joining it with the analysis results.
- **Cleaner, table-free rendering** — replaced the fixed-width column tables with numbered lists so long company names no longer break the layout. Reports are also shorter and render well on mobile.
- **Multi-message Telegram delivery** — introduced a `MESSAGE_BREAK` sentinel (`\f`, ASCII form-feed) in `trading-strategies` that reports can emit to force section splits. ScalpScanner uses it to deliver three separate messages: top scalp-friendly, top trending, and top picks/summary/disclaimer. A size-based chunker still runs per section as a safety net (Telegram caps messages at 4096 chars).
- **HTML parse mode** — Telegram messages are now sent with `parse_mode: 'HTML'` via a tiny `markdownToTelegramHtml()` helper that converts `**bold**` → `<b>bold</b>` and escapes `<`, `>`, `&`. Previously we used `MarkdownV2`, which silently fell back to plain text because the reports' `**` syntax and unescaped punctuation never parsed cleanly.
- **Migrate telegraf → grammY** — `telegraf@4.16.3` has had no release since February 2024. grammY is actively maintained (latest release April 3 2026, with a March 1 release that tracked Bot API 9.5 the day it dropped). The port rewrites `TelegramPlatform` to grammY's API (`Bot`, `bot.callbackQuery`, `bot.api`, `bot.init()` + non-blocking `bot.start()`) and replaces `Markup`-based keyboards with plain `{reply_markup: {inline_keyboard: ...}}` objects. Dependency footprint dropped by 33 packages.