### PR TITLE
feat(messaging): Add /buyMarket, /sellMarket, /buyLimit, /sellLimit w…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15893,7 +15893,8 @@
         "moment-duration-format": "^2.3.2",
         "moment-timezone": "^0.6.1",
         "ms": "4.0.0-nightly.202508271359",
-        "trading-strategies": "0.3.5"
+        "trading-strategies": "0.3.5",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "drizzle-kit": "^0.31.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1235,6 +1235,18 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/@grammyjs/conversations": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@grammyjs/conversations/-/conversations-2.1.1.tgz",
+      "integrity": "sha512-hoxqwSkaXDeU7mzXulpk3A4Cmd6UZO3HU4aPoITX5ekSHK7ZcUEmMl7RhKKkqw3z6zVbbAShQreJoVV5/dDSLA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14.13.1"
+      },
+      "peerDependencies": {
+        "grammy": "^1.20.1"
+      }
+    },
     "node_modules/@grammyjs/types": {
       "version": "3.26.0",
       "resolved": "https://registry.npmjs.org/@grammyjs/types/-/types-3.26.0.tgz",
@@ -15869,6 +15881,7 @@
       "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
+        "@grammyjs/conversations": "^2.1.1",
         "@typedtrader/exchange": "0.2.5",
         "@types/moment-duration-format": "2.2.7",
         "@types/node": "^25.3.0",

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -12,6 +12,7 @@
     "moment": "^2.30.1",
     "moment-duration-format": "^2.3.2",
     "moment-timezone": "^0.6.1",
+    "@grammyjs/conversations": "^2.1.1",
     "grammy": "^1.42.0",
     "ms": "4.0.0-nightly.202508271359",
     "trading-strategies": "0.3.5"

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -15,7 +15,8 @@
     "@grammyjs/conversations": "^2.1.1",
     "grammy": "^1.42.0",
     "ms": "4.0.0-nightly.202508271359",
-    "trading-strategies": "0.3.5"
+    "trading-strategies": "0.3.5",
+    "zod": "^4.3.6"
   },
   "description": "Trading bot via messaging service.",
   "devDependencies": {

--- a/packages/messaging/src/command/index.ts
+++ b/packages/messaging/src/command/index.ts
@@ -4,6 +4,7 @@ export {accountRemove} from './account/accountRemove.js';
 export {accountTime} from './account/accountTime.js';
 export {candle} from './candle.js';
 export {health} from './health.js';
+export {placeOrder} from './placeOrder.js';
 export {price} from './price.js';
 export {time} from './time.js';
 export {uptime} from './uptime.js';

--- a/packages/messaging/src/command/placeOrder.ts
+++ b/packages/messaging/src/command/placeOrder.ts
@@ -1,0 +1,57 @@
+import {ExchangeOrderSide, getExchangeClient, TradingPair} from '@typedtrader/exchange';
+import {getAccountOrError} from '../validation/getAccountOrError.js';
+
+export interface PlaceOrderParams {
+  userId: string;
+  accountId: number;
+  pair: TradingPair;
+  side: ExchangeOrderSide;
+  /** Quantity in base asset (e.g. "100" for 100 shares). */
+  quantity: string;
+  /** Limit price in counter asset. Omit for market orders. */
+  limitPrice?: string;
+}
+
+/**
+ * Places a market or limit order on the user's exchange account and returns a
+ * human-readable reply. Any error (unknown account, exchange rejection, etc.)
+ * is caught and folded into the returned string — the caller never sees an
+ * exception.
+ */
+export const placeOrder = async (params: PlaceOrderParams): Promise<string> => {
+  try {
+    const account = getAccountOrError(params.userId, params.accountId);
+
+    const client = getExchangeClient({
+      exchangeId: account.exchange,
+      apiKey: account.apiKey,
+      apiSecret: account.apiSecret,
+      isPaper: account.isPaper,
+    });
+
+    const sideLabel = params.side === ExchangeOrderSide.BUY ? 'BUY' : 'SELL';
+
+    if (params.limitPrice === undefined) {
+      const order = await client.placeMarketOrder(params.pair, {
+        side: params.side,
+        size: params.quantity,
+        sizeInCounter: false,
+      });
+
+      return `Placed MARKET ${sideLabel} (${order.id}) for ${params.quantity} ${params.pair.base} on "${account.name}"`;
+    }
+
+    const order = await client.placeLimitOrder(params.pair, {
+      side: params.side,
+      size: params.quantity,
+      price: params.limitPrice,
+    });
+
+    return `Placed LIMIT ${sideLabel} (${order.id}) for ${params.quantity} ${params.pair.base} @ ${params.limitPrice} ${params.pair.counter} on "${account.name}"`;
+  } catch (error) {
+    if (error instanceof Error) {
+      return `Error placing order: ${error.message}`;
+    }
+    return 'Error placing order';
+  }
+};

--- a/packages/messaging/src/platform/TelegramPlatform.test.ts
+++ b/packages/messaging/src/platform/TelegramPlatform.test.ts
@@ -7,6 +7,7 @@ const mockStart = vi.fn().mockReturnValue(new Promise(() => {}));
 const mockStop = vi.fn();
 const mockCommand = vi.fn();
 const mockCallbackQuery = vi.fn();
+const mockUse = vi.fn();
 const botInfo = {username: 'testbot'};
 
 vi.mock('trading-strategies', () => ({
@@ -18,11 +19,17 @@ vi.mock('../command/report/reportAdd.js', () => ({
   reportAdd: vi.fn(),
 }));
 
+vi.mock('@grammyjs/conversations', () => ({
+  conversations: vi.fn(() => 'conversations-middleware'),
+  createConversation: vi.fn(() => 'create-conversation-middleware'),
+}));
+
 vi.mock('grammy', () => {
   function Bot() {
     return {
       command: mockCommand,
       callbackQuery: mockCallbackQuery,
+      use: mockUse,
       init: mockInit,
       start: mockStart,
       stop: mockStop,

--- a/packages/messaging/src/platform/TelegramPlatform.test.ts
+++ b/packages/messaging/src/platform/TelegramPlatform.test.ts
@@ -60,7 +60,8 @@ describe('TelegramPlatform', () => {
       platform.registerCommand('help', handler);
       platform.registerCommand('price', handler);
 
-      expect(platform.commandList).toEqual(['/help', '/price']);
+      expect(platform.commandList).toContain('/help');
+      expect(platform.commandList).toContain('/price');
     });
 
     it('includes reportadd when registered', () => {
@@ -71,10 +72,14 @@ describe('TelegramPlatform', () => {
       expect(platform.commandList).toContain('/reportadd');
     });
 
-    it('returns empty array when no commands are registered', () => {
+    it('includes the self-registered trade commands even before registerCommand is called', () => {
       const platform = new TelegramPlatform('bot-token');
 
-      expect(platform.commandList).toEqual([]);
+      // Trade commands register themselves in the TelegramPlatform constructor
+      // because their wizards depend on grammy + the conversations plugin.
+      expect(platform.commandList).toEqual(
+        expect.arrayContaining(['/buymarket', '/sellmarket', '/buylimit', '/selllimit'])
+      );
     });
   });
 
@@ -164,6 +169,19 @@ describe('TelegramPlatform', () => {
   });
 
   describe('auth middleware', () => {
+    // `bot.command(name, handler)` is called both by the constructor (for
+    // self-registered trade commands) and by each `registerCommand` call, so
+    // `mockCommand.mock.calls[0]` is no longer the command under test.
+    // Look up the callback by matching the first argument instead.
+    const findRegisteredCallback = (commandName: string) => {
+      const call = mockCommand.mock.calls.find(([names]) => {
+        if (Array.isArray(names)) return names.includes(commandName);
+        return names === commandName;
+      });
+      if (!call) throw new Error(`bot.command was never called with "${commandName}"`);
+      return call[1];
+    };
+
     it('blocks unauthorized senders when ownerIds is set', async () => {
       const platform = new TelegramPlatform('bot-token', '111,222');
 
@@ -171,8 +189,7 @@ describe('TelegramPlatform', () => {
 
       platform.registerCommand('help', handler);
 
-      // Retrieve the grammY command callback registered during registerCommand
-      const registeredCallback = mockCommand.mock.calls[0][1];
+      const registeredCallback = findRegisteredCallback('help');
 
       const ctxUnauthorized = {
         from: {id: 999},
@@ -192,7 +209,7 @@ describe('TelegramPlatform', () => {
 
       platform.registerCommand('help', handler);
 
-      const registeredCallback = mockCommand.mock.calls[0][1];
+      const registeredCallback = findRegisteredCallback('help');
 
       const ctxAuthorized = {
         from: {id: 111},
@@ -212,7 +229,7 @@ describe('TelegramPlatform', () => {
 
       platform.registerCommand('help', handler);
 
-      const registeredCallback = mockCommand.mock.calls[0][1];
+      const registeredCallback = findRegisteredCallback('help');
 
       const ctxAnySender = {
         from: {id: 999},
@@ -232,7 +249,7 @@ describe('TelegramPlatform', () => {
 
       platform.registerCommand('help', handler);
 
-      const registeredCallback = mockCommand.mock.calls[0][1];
+      const registeredCallback = findRegisteredCallback('help');
 
       const ctxNoFrom = {
         from: undefined,

--- a/packages/messaging/src/platform/TelegramPlatform.ts
+++ b/packages/messaging/src/platform/TelegramPlatform.ts
@@ -17,6 +17,14 @@ const INTERVAL_CALLBACK_PREFIX = 'reportinterval:';
 const TRADE_ACCOUNT_PREFIX = 't:a|';
 const TRADE_CONFIRM_PREFIX = 't:c|';
 
+/** Escapes regex metacharacters so a string constant can be safely embedded in a dynamic RegExp. */
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+const TRADE_ACCOUNT_CALLBACK_PATTERN = new RegExp(`^${escapeRegex(TRADE_ACCOUNT_PREFIX)}(.+)$`);
+const TRADE_CONFIRM_CALLBACK_PATTERN = new RegExp(`^${escapeRegex(TRADE_CONFIRM_PREFIX)}(.+)$`);
+
 const TRADE_COMMAND_NAMES = ['buyMarket', 'sellMarket', 'buyLimit', 'sellLimit'] as const;
 type TradeCommandName = (typeof TRADE_COMMAND_NAMES)[number];
 
@@ -417,7 +425,7 @@ export class TelegramPlatform implements MessagingPlatform {
 
   #registerTradeCallbacks(): void {
     // Step 1: User selected an account → show confirmation
-    this.#bot.callbackQuery(new RegExp(`^${TRADE_ACCOUNT_PREFIX.replace('|', '\\|')}(.+)$`), async ctx => {
+    this.#bot.callbackQuery(TRADE_ACCOUNT_CALLBACK_PATTERN, async ctx => {
       await ctx.answerCallbackQuery();
 
       const senderId = ctx.from?.id?.toString();
@@ -435,7 +443,7 @@ export class TelegramPlatform implements MessagingPlatform {
     });
 
     // Step 2: User confirmed (Yes) or cancelled (No) → execute or abort
-    this.#bot.callbackQuery(new RegExp(`^${TRADE_CONFIRM_PREFIX.replace('|', '\\|')}(.+)$`), async ctx => {
+    this.#bot.callbackQuery(TRADE_CONFIRM_CALLBACK_PATTERN, async ctx => {
       await ctx.answerCallbackQuery();
 
       const senderId = ctx.from?.id?.toString();

--- a/packages/messaging/src/platform/TelegramPlatform.ts
+++ b/packages/messaging/src/platform/TelegramPlatform.ts
@@ -1,8 +1,10 @@
 import {Bot} from 'grammy';
 import type {Context} from 'grammy';
+import {ExchangeOrderSide, TradingPair, getExchangeClient} from '@typedtrader/exchange';
 import {getAvailableReportNames, reportRequiresAccount} from 'trading-strategies';
 import type {CommandHandler, MessageContext, MessagingPlatform, PlatformInfo} from './MessagingPlatform.js';
 import {markdownToTelegramHtml, splitForTelegram} from './telegramMarkdown.js';
+import {placeOrder} from '../command/placeOrder.js';
 import {reportAdd} from '../command/report/reportAdd.js';
 import {Account} from '../database/models/Account.js';
 import type {ReportScheduler} from '../service/ReportScheduler.js';
@@ -12,6 +14,91 @@ const REPORT_CALLBACK_PREFIX = 'report:';
 const ACCOUNT_CALLBACK_PREFIX = 'reportaccount:';
 const MODE_CALLBACK_PREFIX = 'reportmode:';
 const INTERVAL_CALLBACK_PREFIX = 'reportinterval:';
+const TRADE_ACCOUNT_PREFIX = 't:a|';
+const TRADE_CONFIRM_PREFIX = 't:c|';
+
+const TRADE_COMMAND_NAMES = ['buyMarket', 'sellMarket', 'buyLimit', 'sellLimit'] as const;
+type TradeCommandName = (typeof TRADE_COMMAND_NAMES)[number];
+
+function isTradeCommandName(name: string): name is TradeCommandName {
+  return (TRADE_COMMAND_NAMES as readonly string[]).includes(name);
+}
+
+const TRADE_CODE_TO_COMMAND: Record<string, TradeCommandName> = {
+  bm: 'buyMarket',
+  sm: 'sellMarket',
+  bl: 'buyLimit',
+  sl: 'sellLimit',
+};
+
+const TRADE_COMMAND_TO_CODE: Record<TradeCommandName, string> = {
+  buyMarket: 'bm',
+  sellMarket: 'sm',
+  buyLimit: 'bl',
+  sellLimit: 'sl',
+};
+
+interface TradeCommandShape {
+  side: ExchangeOrderSide;
+  isLimit: boolean;
+}
+
+function tradeCommandShape(name: TradeCommandName): TradeCommandShape {
+  switch (name) {
+    case 'buyMarket':
+      return {side: ExchangeOrderSide.BUY, isLimit: false};
+    case 'sellMarket':
+      return {side: ExchangeOrderSide.SELL, isLimit: false};
+    case 'buyLimit':
+      return {side: ExchangeOrderSide.BUY, isLimit: true};
+    case 'sellLimit':
+      return {side: ExchangeOrderSide.SELL, isLimit: true};
+  }
+}
+
+function buildTradeActionLabel(
+  cmd: TradeCommandName,
+  pair: TradingPair,
+  quantity: string,
+  limitPrice: string | null
+): string {
+  const {side, isLimit} = tradeCommandShape(cmd);
+  const sideLabel = side === ExchangeOrderSide.BUY ? 'BUY' : 'SELL';
+  const kindLabel = isLimit ? 'LIMIT' : 'MARKET';
+  if (isLimit && limitPrice !== null) {
+    return `${kindLabel} ${sideLabel} ${quantity} ${pair.base} @ ${limitPrice} ${pair.counter}`;
+  }
+  return `${kindLabel} ${sideLabel} ${quantity} ${pair.base}`;
+}
+
+interface TradeFields {
+  cmd: TradeCommandName;
+  pairStr: string;
+  quantity: string;
+  /** `'-'` for market orders, a positive-number string for limit orders. */
+  priceField: string;
+  accountId: number;
+}
+
+function encodeTradeFields(prefix: string, fields: TradeFields, decision?: 'y' | 'n'): string {
+  const code = TRADE_COMMAND_TO_CODE[fields.cmd];
+  const base = `${prefix}${code}|${fields.pairStr}|${fields.quantity}|${fields.priceField}|${fields.accountId}`;
+  return decision ? `${base}|${decision}` : base;
+}
+
+function decodeTradeFields(payload: string): (TradeFields & {decision?: 'y' | 'n'}) | null {
+  const parts = payload.split('|');
+  if (parts.length < 5 || parts.length > 6) {
+    return null;
+  }
+  const [code, pairStr, quantity, priceField, accountIdStr, decision] = parts;
+  const cmd = TRADE_CODE_TO_COMMAND[code];
+  if (!cmd) return null;
+  const accountId = Number.parseInt(accountIdStr, 10);
+  if (!Number.isFinite(accountId)) return null;
+  if (decision !== undefined && decision !== 'y' && decision !== 'n') return null;
+  return {cmd, pairStr, quantity, priceField, accountId, decision};
+}
 
 interface InlineButton {
   text: string;
@@ -38,6 +125,7 @@ export class TelegramPlatform implements MessagingPlatform {
   #commands: Map<string, CommandHandler> = new Map();
   #platformInfo: PlatformInfo = {botAddress: '', sdkVersion: ''};
   #reportScheduler?: ReportScheduler;
+  #tradeCallbacksRegistered = false;
 
   constructor(botToken: string, ownerIds?: string) {
     this.#bot = new Bot(botToken);
@@ -57,6 +145,19 @@ export class TelegramPlatform implements MessagingPlatform {
     // reportadd is handled via inline keyboard buttons
     if (names.includes('reportadd')) {
       this.#registerReportAddCommand();
+      return;
+    }
+
+    // Trade commands have their own wizard (account picker → confirmation → execute)
+    const tradeNames = names.filter(isTradeCommandName);
+    if (tradeNames.length > 0) {
+      for (const tradeName of tradeNames) {
+        this.#registerTradeCommand(tradeName);
+      }
+      if (!this.#tradeCallbacksRegistered) {
+        this.#tradeCallbacksRegistered = true;
+        this.#registerTradeCallbacks();
+      }
       return;
     }
 
@@ -235,6 +336,211 @@ export class TelegramPlatform implements MessagingPlatform {
         this.#reportScheduler.scheduleReport(result.report);
       }
     });
+  }
+
+  #registerTradeCommand(name: TradeCommandName): void {
+    const {isLimit} = tradeCommandShape(name);
+
+    this.#bot.command(name, async ctx => {
+      const senderId = ctx.from?.id?.toString();
+      if (!senderId) {
+        await ctx.reply('Unable to determine sender');
+        return;
+      }
+
+      if (this.#ownerIds.length > 0 && !this.#ownerIds.includes(senderId)) {
+        return;
+      }
+
+      const text = ctx.message?.text ?? '';
+      const firstSpace = text.indexOf(' ');
+      const content = firstSpace === -1 ? '' : text.slice(firstSpace + 1).trim();
+      const parts = content.length > 0 ? content.split(/\s+/) : [];
+      const expected = isLimit ? 3 : 2;
+
+      if (parts.length !== expected) {
+        const usage = isLimit
+          ? `Usage: /${name} <PAIR> <QTY> <PRICE>\nExample: /${name} AAPL,USD 100 150`
+          : `Usage: /${name} <PAIR> <QTY>\nExample: /${name} AAPL,USD 100`;
+        await ctx.reply(`Invalid format.\n${usage}`);
+        return;
+      }
+
+      const [pairStr, quantity, priceInput] = parts;
+
+      let pair: TradingPair;
+      try {
+        pair = TradingPair.fromString(pairStr, ',');
+      } catch {
+        await ctx.reply(`Invalid pair "${pairStr}". Use format: BASE,COUNTER (e.g. AAPL,USD)`);
+        return;
+      }
+
+      if (!/^\d+(\.\d+)?$/.test(quantity) || Number.parseFloat(quantity) <= 0) {
+        await ctx.reply(`Invalid quantity "${quantity}". Must be a positive number.`);
+        return;
+      }
+
+      if (isLimit) {
+        if (!/^\d+(\.\d+)?$/.test(priceInput) || Number.parseFloat(priceInput) <= 0) {
+          await ctx.reply(`Invalid price "${priceInput}". Must be a positive number.`);
+          return;
+        }
+      }
+
+      const priceField = isLimit ? priceInput : '-';
+      const userId = `${PLATFORM_PREFIX}${senderId}`;
+      const accounts = Account.findByUserId(userId);
+
+      if (accounts.length === 0) {
+        await ctx.reply('No exchange account found. Use /accountadd to add one first.');
+        return;
+      }
+
+      const actionLabel = buildTradeActionLabel(name, pair, quantity, isLimit ? priceInput : null);
+      const rows: InlineButton[][] = accounts.map(acc => [
+        {
+          text: `${acc.name} (${acc.exchange}${acc.isPaper ? ' paper' : ''})`,
+          callback_data: encodeTradeFields(TRADE_ACCOUNT_PREFIX, {
+            cmd: name,
+            pairStr,
+            quantity,
+            priceField,
+            accountId: acc.id,
+          }),
+        },
+      ]);
+
+      await ctx.reply(`${actionLabel}\nSelect an account:`, inlineKeyboard(rows));
+    });
+  }
+
+  #registerTradeCallbacks(): void {
+    // Step 1: User selected an account → show confirmation
+    this.#bot.callbackQuery(new RegExp(`^${TRADE_ACCOUNT_PREFIX.replace('|', '\\|')}(.+)$`), async ctx => {
+      await ctx.answerCallbackQuery();
+
+      const senderId = ctx.from?.id?.toString();
+      if (!senderId) return;
+
+      const fields = decodeTradeFields(ctx.match[1]);
+      if (!fields) {
+        await ctx.editMessageText('Invalid trade session. Please run the command again.');
+        return;
+      }
+
+      const userId = `${PLATFORM_PREFIX}${senderId}`;
+      const {text, keyboard} = await this.#buildTradeConfirmation(userId, fields);
+      await ctx.editMessageText(text, keyboard);
+    });
+
+    // Step 2: User confirmed (Yes) or cancelled (No) → execute or abort
+    this.#bot.callbackQuery(new RegExp(`^${TRADE_CONFIRM_PREFIX.replace('|', '\\|')}(.+)$`), async ctx => {
+      await ctx.answerCallbackQuery();
+
+      const senderId = ctx.from?.id?.toString();
+      if (!senderId) return;
+
+      const fields = decodeTradeFields(ctx.match[1]);
+      if (!fields || fields.decision === undefined) {
+        await ctx.editMessageText('Invalid trade session. Please run the command again.');
+        return;
+      }
+
+      if (fields.decision === 'n') {
+        await ctx.editMessageText('Cancelled.');
+        return;
+      }
+
+      const userId = `${PLATFORM_PREFIX}${senderId}`;
+      let pair: TradingPair;
+      try {
+        pair = TradingPair.fromString(fields.pairStr, ',');
+      } catch (error) {
+        await ctx.editMessageText(error instanceof Error ? error.message : 'Invalid pair.');
+        return;
+      }
+
+      const {side, isLimit} = tradeCommandShape(fields.cmd);
+      const limitPrice = isLimit && fields.priceField !== '-' ? fields.priceField : undefined;
+
+      await ctx.editMessageText('Placing order…');
+
+      const result = await placeOrder({
+        userId,
+        accountId: fields.accountId,
+        pair,
+        side,
+        quantity: fields.quantity,
+        limitPrice,
+      });
+
+      await ctx.editMessageText(result);
+    });
+  }
+
+  async #buildTradeConfirmation(
+    userId: string,
+    fields: TradeFields
+  ): Promise<{text: string; keyboard: ReturnType<typeof inlineKeyboard>}> {
+    const account = Account.findByUserIdAndId(userId, fields.accountId);
+    if (!account) {
+      return {
+        text: `Account "${fields.accountId}" not found. Run the command again.`,
+        keyboard: inlineKeyboard([]),
+      };
+    }
+
+    let pair: TradingPair;
+    try {
+      pair = TradingPair.fromString(fields.pairStr, ',');
+    } catch (error) {
+      return {
+        text: error instanceof Error ? error.message : 'Invalid pair.',
+        keyboard: inlineKeyboard([]),
+      };
+    }
+
+    const limitPriceLabel = fields.priceField === '-' ? null : fields.priceField;
+    const actionLabel = buildTradeActionLabel(fields.cmd, pair, fields.quantity, limitPriceLabel);
+
+    // Fetch current price as confirmation context. Failure is non-fatal —
+    // the user still sees the action and can confirm without the price hint.
+    let priceContext = '';
+    try {
+      const client = getExchangeClient({
+        exchangeId: account.exchange,
+        apiKey: account.apiKey,
+        apiSecret: account.apiSecret,
+        isPaper: account.isPaper,
+      });
+      const smallestInterval = client.getSmallestInterval();
+      const candle = await client.getLatestCandle(pair, smallestInterval);
+      const currentPrice = Number.parseFloat(candle.close);
+      const qty = Number.parseFloat(fields.quantity);
+      if (Number.isFinite(currentPrice) && Number.isFinite(qty)) {
+        const estimated = (currentPrice * qty).toFixed(2);
+        priceContext = `\nCurrent ~${candle.close} ${pair.counter} · Estimated ~${estimated} ${pair.counter}`;
+      }
+    } catch {
+      // Ignore — price context is best-effort.
+    }
+
+    const text = `${actionLabel}\nAccount: ${account.name}${priceContext}\n\nProceed?`;
+    const keyboard = inlineKeyboard([
+      [
+        {
+          text: '✓ Yes, place order',
+          callback_data: encodeTradeFields(TRADE_CONFIRM_PREFIX, fields, 'y'),
+        },
+        {
+          text: '✗ Cancel',
+          callback_data: encodeTradeFields(TRADE_CONFIRM_PREFIX, fields, 'n'),
+        },
+      ],
+    ]);
+
+    return {text, keyboard};
   }
 
   async start(): Promise<void> {

--- a/packages/messaging/src/platform/TelegramPlatform.ts
+++ b/packages/messaging/src/platform/TelegramPlatform.ts
@@ -6,6 +6,7 @@ import {
   conversations,
   createConversation,
 } from '@grammyjs/conversations';
+import {z} from 'zod';
 import {ExchangeOrderSide, TradingPair, getExchangeClient} from '@typedtrader/exchange';
 import {getAvailableReportNames, reportRequiresAccount} from 'trading-strategies';
 import type {CommandHandler, MessageContext, MessagingPlatform, PlatformInfo} from './MessagingPlatform.js';
@@ -65,6 +66,12 @@ function buildTradeActionLabel(
 type TradeContext = ConversationFlavor<Context>;
 type TradeConversation = Conversation<TradeContext, TradeContext>;
 
+/** A string that parses as a finite positive decimal number (e.g. "1", "1.5", "0.001"). */
+const positiveNumberString = z
+  .string()
+  .regex(/^\d+(\.\d+)?$/, 'Must be a positive number')
+  .refine(value => Number.parseFloat(value) > 0, 'Must be greater than 0');
+
 interface TradeArgs {
   cmd: TradeCommandName;
   pairStr: string;
@@ -107,13 +114,15 @@ async function parseTradeCommandInput(
     return null;
   }
 
-  if (!/^\d+(\.\d+)?$/.test(quantity) || Number.parseFloat(quantity) <= 0) {
+  const quantityCheck = positiveNumberString.safeParse(quantity);
+  if (!quantityCheck.success) {
     await ctx.reply(`Invalid quantity "${quantity}". Must be a positive number.`);
     return null;
   }
 
   if (isLimit) {
-    if (!/^\d+(\.\d+)?$/.test(priceInput) || Number.parseFloat(priceInput) <= 0) {
+    const priceCheck = positiveNumberString.safeParse(priceInput);
+    if (!priceCheck.success) {
       await ctx.reply(`Invalid price "${priceInput}". Must be a positive number.`);
       return null;
     }

--- a/packages/messaging/src/platform/TelegramPlatform.ts
+++ b/packages/messaging/src/platform/TelegramPlatform.ts
@@ -67,10 +67,10 @@ type TradeContext = ConversationFlavor<Context>;
 type TradeConversation = Conversation<TradeContext, TradeContext>;
 
 /** A string that parses as a finite positive decimal number (e.g. "1", "1.5", "0.001"). */
-const positiveNumberString = z
-  .string()
-  .regex(/^\d+(\.\d+)?$/, 'Must be a positive number')
-  .refine(value => Number.parseFloat(value) > 0, 'Must be greater than 0');
+const positiveNumberString = z.string().refine(value => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0;
+}, 'Must be a positive number');
 
 interface TradeArgs {
   cmd: TradeCommandName;

--- a/packages/messaging/src/platform/TelegramPlatform.ts
+++ b/packages/messaging/src/platform/TelegramPlatform.ts
@@ -17,14 +17,6 @@ const INTERVAL_CALLBACK_PREFIX = 'reportinterval:';
 const TRADE_ACCOUNT_PREFIX = 't:a|';
 const TRADE_CONFIRM_PREFIX = 't:c|';
 
-/** Escapes regex metacharacters so a string constant can be safely embedded in a dynamic RegExp. */
-function escapeRegex(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-const TRADE_ACCOUNT_CALLBACK_PATTERN = new RegExp(`^${escapeRegex(TRADE_ACCOUNT_PREFIX)}(.+)$`);
-const TRADE_CONFIRM_CALLBACK_PATTERN = new RegExp(`^${escapeRegex(TRADE_CONFIRM_PREFIX)}(.+)$`);
-
 const TRADE_COMMAND_NAMES = ['buyMarket', 'sellMarket', 'buyLimit', 'sellLimit'] as const;
 type TradeCommandName = (typeof TRADE_COMMAND_NAMES)[number];
 
@@ -424,67 +416,85 @@ export class TelegramPlatform implements MessagingPlatform {
   }
 
   #registerTradeCallbacks(): void {
-    // Step 1: User selected an account → show confirmation
-    this.#bot.callbackQuery(TRADE_ACCOUNT_CALLBACK_PATTERN, async ctx => {
-      await ctx.answerCallbackQuery();
+    // A single catch-all callback_query:data handler that dispatches by prefix.
+    // Using plain `.startsWith` avoids building a RegExp from the constants,
+    // which would require escaping the `|` delimiter (CodeQL caught the partial
+    // escape in an earlier iteration). The filter only fires when data is
+    // present, and non-trade prefixes are ignored so other handlers are
+    // unaffected.
+    this.#bot.on('callback_query:data', async ctx => {
+      const data = ctx.callbackQuery.data;
 
-      const senderId = ctx.from?.id?.toString();
-      if (!senderId) return;
-
-      const fields = decodeTradeFields(ctx.match[1]);
-      if (!fields) {
-        await ctx.editMessageText('Invalid trade session. Please run the command again.');
+      if (data.startsWith(TRADE_ACCOUNT_PREFIX)) {
+        await this.#handleTradeAccountSelected(ctx, data.slice(TRADE_ACCOUNT_PREFIX.length));
         return;
       }
 
-      const userId = `${PLATFORM_PREFIX}${senderId}`;
-      const {text, keyboard} = await this.#buildTradeConfirmation(userId, fields);
-      await ctx.editMessageText(text, keyboard);
+      if (data.startsWith(TRADE_CONFIRM_PREFIX)) {
+        await this.#handleTradeConfirmation(ctx, data.slice(TRADE_CONFIRM_PREFIX.length));
+        return;
+      }
+    });
+  }
+
+  async #handleTradeAccountSelected(ctx: Context, payload: string): Promise<void> {
+    await ctx.answerCallbackQuery();
+
+    const senderId = ctx.from?.id?.toString();
+    if (!senderId) return;
+
+    const fields = decodeTradeFields(payload);
+    if (!fields) {
+      await ctx.editMessageText('Invalid trade session. Please run the command again.');
+      return;
+    }
+
+    const userId = `${PLATFORM_PREFIX}${senderId}`;
+    const {text, keyboard} = await this.#buildTradeConfirmation(userId, fields);
+    await ctx.editMessageText(text, keyboard);
+  }
+
+  async #handleTradeConfirmation(ctx: Context, payload: string): Promise<void> {
+    await ctx.answerCallbackQuery();
+
+    const senderId = ctx.from?.id?.toString();
+    if (!senderId) return;
+
+    const fields = decodeTradeFields(payload);
+    if (!fields || fields.decision === undefined) {
+      await ctx.editMessageText('Invalid trade session. Please run the command again.');
+      return;
+    }
+
+    if (fields.decision === 'n') {
+      await ctx.editMessageText('Cancelled.');
+      return;
+    }
+
+    const userId = `${PLATFORM_PREFIX}${senderId}`;
+    let pair: TradingPair;
+    try {
+      pair = TradingPair.fromString(fields.pairStr, ',');
+    } catch (error) {
+      await ctx.editMessageText(error instanceof Error ? error.message : 'Invalid pair.');
+      return;
+    }
+
+    const {side, isLimit} = tradeCommandShape(fields.cmd);
+    const limitPrice = isLimit && fields.priceField !== '-' ? fields.priceField : undefined;
+
+    await ctx.editMessageText('Placing order…');
+
+    const result = await placeOrder({
+      userId,
+      accountId: fields.accountId,
+      pair,
+      side,
+      quantity: fields.quantity,
+      limitPrice,
     });
 
-    // Step 2: User confirmed (Yes) or cancelled (No) → execute or abort
-    this.#bot.callbackQuery(TRADE_CONFIRM_CALLBACK_PATTERN, async ctx => {
-      await ctx.answerCallbackQuery();
-
-      const senderId = ctx.from?.id?.toString();
-      if (!senderId) return;
-
-      const fields = decodeTradeFields(ctx.match[1]);
-      if (!fields || fields.decision === undefined) {
-        await ctx.editMessageText('Invalid trade session. Please run the command again.');
-        return;
-      }
-
-      if (fields.decision === 'n') {
-        await ctx.editMessageText('Cancelled.');
-        return;
-      }
-
-      const userId = `${PLATFORM_PREFIX}${senderId}`;
-      let pair: TradingPair;
-      try {
-        pair = TradingPair.fromString(fields.pairStr, ',');
-      } catch (error) {
-        await ctx.editMessageText(error instanceof Error ? error.message : 'Invalid pair.');
-        return;
-      }
-
-      const {side, isLimit} = tradeCommandShape(fields.cmd);
-      const limitPrice = isLimit && fields.priceField !== '-' ? fields.priceField : undefined;
-
-      await ctx.editMessageText('Placing order…');
-
-      const result = await placeOrder({
-        userId,
-        accountId: fields.accountId,
-        pair,
-        side,
-        quantity: fields.quantity,
-        limitPrice,
-      });
-
-      await ctx.editMessageText(result);
-    });
+    await ctx.editMessageText(result);
   }
 
   async #buildTradeConfirmation(

--- a/packages/messaging/src/platform/TelegramPlatform.ts
+++ b/packages/messaging/src/platform/TelegramPlatform.ts
@@ -192,17 +192,20 @@ async function tradeWizard(
   const confirmation = await conversation.external(() =>
     buildTradeConfirmation(userId, args, pair, accountId)
   );
+  );
+  await accountSelection.answerCallbackQuery();
   await accountSelection.editMessageText(confirmation.text, confirmation.keyboard);
 
   // Step 3: wait for Yes / No
   const decision = await conversation.waitForCallbackQuery(['trade:cnf:y', 'trade:cnf:n']);
-  await decision.answerCallbackQuery();
   if (decision.match === 'trade:cnf:n') {
+    await decision.answerCallbackQuery();
     await decision.editMessageText('Cancelled.');
     return;
   }
 
   // Step 4: execute
+  await decision.answerCallbackQuery();
   await decision.editMessageText('Placing order…');
   const result = await conversation.external(() =>
     placeOrder({

--- a/packages/messaging/src/platform/TelegramPlatform.ts
+++ b/packages/messaging/src/platform/TelegramPlatform.ts
@@ -152,8 +152,16 @@ async function tradeWizard(
 
   // Account lookup touches the database — wrap it in `external` so the
   // conversations engine records the value in the replay log instead of
-  // re-executing the query on every resume.
-  const accounts = await conversation.external(() => Account.findByUserId(userId));
+  // re-executing the query on every resume. Only return the fields needed
+  // for the picker so sensitive credentials are not persisted in replay state.
+  const accounts = await conversation.external(async () =>
+    (await Account.findByUserId(userId)).map(acc => ({
+      id: acc.id,
+      name: acc.name,
+      exchange: acc.exchange,
+      isPaper: acc.isPaper,
+    }))
+  );
 
   if (accounts.length === 0) {
     await ctx.reply('No exchange account found. Use /accountadd to add one first.');

--- a/packages/messaging/src/platform/TelegramPlatform.ts
+++ b/packages/messaging/src/platform/TelegramPlatform.ts
@@ -196,6 +196,7 @@ async function tradeWizard(
 
   // Step 3: wait for Yes / No
   const decision = await conversation.waitForCallbackQuery(['trade:cnf:y', 'trade:cnf:n']);
+  await decision.answerCallbackQuery();
   if (decision.match === 'trade:cnf:n') {
     await decision.editMessageText('Cancelled.');
     return;

--- a/packages/messaging/src/platform/TelegramPlatform.ts
+++ b/packages/messaging/src/platform/TelegramPlatform.ts
@@ -66,20 +66,7 @@ function buildTradeActionLabel(
 type TradeContext = ConversationFlavor<Context>;
 type TradeConversation = Conversation<TradeContext, TradeContext>;
 
-/**
- * A string that parses as a finite positive decimal number (e.g. "1", "1.5",
- * "0.001"). Only digits and an optional decimal point are allowed — scientific
- * notation (`1e5`), hex / octal / binary literals (`0x10`, `0o17`, `0b10`),
- * whitespace, and signs are all rejected before `Number()` would silently
- * coerce them.
- */
-const positiveNumberString = z.string().refine(value => {
-  for (const char of value) {
-    if (char !== '.' && (char < '0' || char > '9')) return false;
-  }
-  const parsed = Number(value);
-  return Number.isFinite(parsed) && parsed > 0;
-}, 'Must be a positive number');
+const positiveNumber = z.coerce.number().positive().finite();
 
 interface TradeArgs {
   cmd: TradeCommandName;
@@ -123,21 +110,26 @@ async function parseTradeCommandInput(
     return null;
   }
 
-  const quantityCheck = positiveNumberString.safeParse(quantity);
+  const quantityCheck = positiveNumber.safeParse(quantity);
   if (!quantityCheck.success) {
     await ctx.reply(`Invalid quantity "${quantity}". Must be a positive number.`);
     return null;
   }
 
   if (isLimit) {
-    const priceCheck = positiveNumberString.safeParse(priceInput);
+    const priceCheck = positiveNumber.safeParse(priceInput);
     if (!priceCheck.success) {
       await ctx.reply(`Invalid price "${priceInput}". Must be a positive number.`);
       return null;
     }
   }
 
-  return {cmd, pairStr, quantity, limitPrice: isLimit ? priceInput : undefined};
+  return {
+    cmd,
+    pairStr,
+    quantity: String(quantityCheck.data),
+    limitPrice: isLimit ? String(positiveNumber.parse(priceInput)) : undefined,
+  };
 }
 
 /**

--- a/packages/messaging/src/platform/TelegramPlatform.ts
+++ b/packages/messaging/src/platform/TelegramPlatform.ts
@@ -1,5 +1,11 @@
 import {Bot} from 'grammy';
 import type {Context} from 'grammy';
+import {
+  type Conversation,
+  type ConversationFlavor,
+  conversations,
+  createConversation,
+} from '@grammyjs/conversations';
 import {ExchangeOrderSide, TradingPair, getExchangeClient} from '@typedtrader/exchange';
 import {getAvailableReportNames, reportRequiresAccount} from 'trading-strategies';
 import type {CommandHandler, MessageContext, MessagingPlatform, PlatformInfo} from './MessagingPlatform.js';
@@ -14,29 +20,14 @@ const REPORT_CALLBACK_PREFIX = 'report:';
 const ACCOUNT_CALLBACK_PREFIX = 'reportaccount:';
 const MODE_CALLBACK_PREFIX = 'reportmode:';
 const INTERVAL_CALLBACK_PREFIX = 'reportinterval:';
-const TRADE_ACCOUNT_PREFIX = 't:a|';
-const TRADE_CONFIRM_PREFIX = 't:c|';
 
+const TRADE_CONVERSATION_ID = 'trade';
 const TRADE_COMMAND_NAMES = ['buyMarket', 'sellMarket', 'buyLimit', 'sellLimit'] as const;
 type TradeCommandName = (typeof TRADE_COMMAND_NAMES)[number];
 
 function isTradeCommandName(name: string): name is TradeCommandName {
   return (TRADE_COMMAND_NAMES as readonly string[]).includes(name);
 }
-
-const TRADE_CODE_TO_COMMAND: Record<string, TradeCommandName> = {
-  bm: 'buyMarket',
-  sm: 'sellMarket',
-  bl: 'buyLimit',
-  sl: 'sellLimit',
-};
-
-const TRADE_COMMAND_TO_CODE: Record<TradeCommandName, string> = {
-  buyMarket: 'bm',
-  sellMarket: 'sm',
-  buyLimit: 'bl',
-  sellLimit: 'sl',
-};
 
 interface TradeCommandShape {
   side: ExchangeOrderSide;
@@ -71,33 +62,189 @@ function buildTradeActionLabel(
   return `${kindLabel} ${sideLabel} ${quantity} ${pair.base}`;
 }
 
-interface TradeFields {
+type TradeContext = ConversationFlavor<Context>;
+type TradeConversation = Conversation<TradeContext, TradeContext>;
+
+interface TradeArgs {
   cmd: TradeCommandName;
   pairStr: string;
   quantity: string;
-  /** `'-'` for market orders, a positive-number string for limit orders. */
-  priceField: string;
-  accountId: number;
+  /** Undefined for market orders, positive-number string for limit orders. */
+  limitPrice?: string;
 }
 
-function encodeTradeFields(prefix: string, fields: TradeFields, decision?: 'y' | 'n'): string {
-  const code = TRADE_COMMAND_TO_CODE[fields.cmd];
-  const base = `${prefix}${code}|${fields.pairStr}|${fields.quantity}|${fields.priceField}|${fields.accountId}`;
-  return decision ? `${base}|${decision}` : base;
-}
+/**
+ * Parses the raw text following a /buyMarket / /sellMarket / /buyLimit / /sellLimit
+ * command into validated args. Returns `null` and replies with the usage error if
+ * anything is off — the caller can just return early.
+ */
+async function parseTradeCommandInput(
+  ctx: Context,
+  cmd: TradeCommandName
+): Promise<TradeArgs | null> {
+  const {isLimit} = tradeCommandShape(cmd);
 
-function decodeTradeFields(payload: string): (TradeFields & {decision?: 'y' | 'n'}) | null {
-  const parts = payload.split('|');
-  if (parts.length < 5 || parts.length > 6) {
+  const text = ctx.message?.text ?? '';
+  const firstSpace = text.indexOf(' ');
+  const content = firstSpace === -1 ? '' : text.slice(firstSpace + 1).trim();
+  const parts = content.length > 0 ? content.split(/\s+/) : [];
+  const expected = isLimit ? 3 : 2;
+
+  if (parts.length !== expected) {
+    const usage = isLimit
+      ? `Usage: /${cmd} <PAIR> <QTY> <PRICE>\nExample: /${cmd} AAPL,USD 100 150`
+      : `Usage: /${cmd} <PAIR> <QTY>\nExample: /${cmd} AAPL,USD 100`;
+    await ctx.reply(`Invalid format.\n${usage}`);
     return null;
   }
-  const [code, pairStr, quantity, priceField, accountIdStr, decision] = parts;
-  const cmd = TRADE_CODE_TO_COMMAND[code];
-  if (!cmd) return null;
-  const accountId = Number.parseInt(accountIdStr, 10);
-  if (!Number.isFinite(accountId)) return null;
-  if (decision !== undefined && decision !== 'y' && decision !== 'n') return null;
-  return {cmd, pairStr, quantity, priceField, accountId, decision};
+
+  const [pairStr, quantity, priceInput] = parts;
+
+  try {
+    TradingPair.fromString(pairStr, ',');
+  } catch {
+    await ctx.reply(`Invalid pair "${pairStr}". Use format: BASE,COUNTER (e.g. AAPL,USD)`);
+    return null;
+  }
+
+  if (!/^\d+(\.\d+)?$/.test(quantity) || Number.parseFloat(quantity) <= 0) {
+    await ctx.reply(`Invalid quantity "${quantity}". Must be a positive number.`);
+    return null;
+  }
+
+  if (isLimit) {
+    if (!/^\d+(\.\d+)?$/.test(priceInput) || Number.parseFloat(priceInput) <= 0) {
+      await ctx.reply(`Invalid price "${priceInput}". Must be a positive number.`);
+      return null;
+    }
+  }
+
+  return {cmd, pairStr, quantity, limitPrice: isLimit ? priceInput : undefined};
+}
+
+/**
+ * The full trade wizard, expressed as a linear async function. Each `await`
+ * detaches and resumes when the user clicks the next button — the plugin
+ * handles state and routing for us. No `callback_data` encoding, no manual
+ * dispatcher, no step-state machine.
+ */
+async function tradeWizard(
+  conversation: TradeConversation,
+  ctx: TradeContext,
+  args: TradeArgs
+): Promise<void> {
+  const senderId = ctx.from?.id?.toString();
+  if (!senderId) {
+    await ctx.reply('Unable to determine sender');
+    return;
+  }
+  const userId = `${PLATFORM_PREFIX}${senderId}`;
+
+  // Account lookup touches the database — wrap it in `external` so the
+  // conversations engine records the value in the replay log instead of
+  // re-executing the query on every resume.
+  const accounts = await conversation.external(() => Account.findByUserId(userId));
+
+  if (accounts.length === 0) {
+    await ctx.reply('No exchange account found. Use /accountadd to add one first.');
+    return;
+  }
+
+  const pair = TradingPair.fromString(args.pairStr, ',');
+  const actionLabel = buildTradeActionLabel(args.cmd, pair, args.quantity, args.limitPrice ?? null);
+
+  // Step 1: account picker
+  const accountButtons: InlineButton[][] = accounts.map(acc => [
+    {
+      text: `${acc.name} (${acc.exchange}${acc.isPaper ? ' paper' : ''})`,
+      callback_data: `trade:acc:${acc.id}`,
+    },
+  ]);
+  await ctx.reply(`${actionLabel}\nSelect an account:`, inlineKeyboard(accountButtons));
+
+  const accountSelection = await conversation.waitForCallbackQuery(
+    accounts.map(acc => `trade:acc:${acc.id}`)
+  );
+  // `match` is `string | RegExpMatchArray` in the type system, but since we
+  // only pass literal strings as triggers it's always a string at runtime.
+  const selectedData = typeof accountSelection.match === 'string' ? accountSelection.match : '';
+  const accountId = Number.parseInt(selectedData.split(':')[2] ?? '', 10);
+
+  // Step 2: fetch price context + show confirmation
+  const confirmation = await conversation.external(() =>
+    buildTradeConfirmation(userId, args, pair, accountId)
+  );
+  await accountSelection.editMessageText(confirmation.text, confirmation.keyboard);
+
+  // Step 3: wait for Yes / No
+  const decision = await conversation.waitForCallbackQuery(['trade:cnf:y', 'trade:cnf:n']);
+  if (decision.match === 'trade:cnf:n') {
+    await decision.editMessageText('Cancelled.');
+    return;
+  }
+
+  // Step 4: execute
+  await decision.editMessageText('Placing order…');
+  const result = await conversation.external(() =>
+    placeOrder({
+      userId,
+      accountId,
+      pair,
+      side: tradeCommandShape(args.cmd).side,
+      quantity: args.quantity,
+      limitPrice: args.limitPrice,
+    })
+  );
+  await decision.editMessageText(result);
+}
+
+async function buildTradeConfirmation(
+  userId: string,
+  args: TradeArgs,
+  pair: TradingPair,
+  accountId: number
+): Promise<{text: string; keyboard: ReturnType<typeof inlineKeyboard>}> {
+  const account = Account.findByUserIdAndId(userId, accountId);
+  if (!account) {
+    return {
+      text: `Account "${accountId}" not found. Run the command again.`,
+      keyboard: inlineKeyboard([]),
+    };
+  }
+
+  const actionLabel = buildTradeActionLabel(args.cmd, pair, args.quantity, args.limitPrice ?? null);
+
+  // Fetch current price as confirmation context. Failure is non-fatal —
+  // the user still sees the action and can confirm without the price hint.
+  let priceContext = '';
+  try {
+    const client = getExchangeClient({
+      exchangeId: account.exchange,
+      apiKey: account.apiKey,
+      apiSecret: account.apiSecret,
+      isPaper: account.isPaper,
+    });
+    const smallestInterval = client.getSmallestInterval();
+    const candle = await client.getLatestCandle(pair, smallestInterval);
+    const currentPrice = Number.parseFloat(candle.close);
+    const qty = Number.parseFloat(args.quantity);
+    if (Number.isFinite(currentPrice) && Number.isFinite(qty)) {
+      const estimated = (currentPrice * qty).toFixed(2);
+      priceContext = `\nCurrent ~${candle.close} ${pair.counter} · Estimated ~${estimated} ${pair.counter}`;
+    }
+  } catch {
+    // Ignore — price context is best-effort.
+  }
+
+  const text = `${actionLabel}\nAccount: ${account.name}${priceContext}\n\nProceed?`;
+  const keyboard = inlineKeyboard([
+    [
+      {text: '✓ Yes, place order', callback_data: 'trade:cnf:y'},
+      {text: '✗ Cancel', callback_data: 'trade:cnf:n'},
+    ],
+  ]);
+
+  return {text, keyboard};
 }
 
 interface InlineButton {
@@ -120,16 +267,23 @@ async function replyWithMarkdown(ctx: Context, text: string): Promise<void> {
 }
 
 export class TelegramPlatform implements MessagingPlatform {
-  #bot: Bot;
+  #bot: Bot<TradeContext>;
   #ownerIds: string[];
   #commands: Map<string, CommandHandler> = new Map();
   #platformInfo: PlatformInfo = {botAddress: '', sdkVersion: ''};
   #reportScheduler?: ReportScheduler;
-  #tradeCallbacksRegistered = false;
 
   constructor(botToken: string, ownerIds?: string) {
-    this.#bot = new Bot(botToken);
+    this.#bot = new Bot<TradeContext>(botToken);
     this.#ownerIds = ownerIds ? ownerIds.split(',').map(id => id.trim()) : [];
+
+    // Install @grammyjs/conversations plugin BEFORE any command handlers are
+    // registered. The `conversations()` middleware must run for every update
+    // so it can resume active sessions on subsequent callback_query updates,
+    // and `createConversation(...)` has to be visible to the command handler
+    // that calls `ctx.conversation.enter(...)`.
+    this.#bot.use(conversations());
+    this.#bot.use(createConversation(tradeWizard, TRADE_CONVERSATION_ID));
   }
 
   setReportScheduler(scheduler: ReportScheduler): void {
@@ -148,15 +302,12 @@ export class TelegramPlatform implements MessagingPlatform {
       return;
     }
 
-    // Trade commands have their own wizard (account picker → confirmation → execute)
+    // Trade commands enter the shared `tradeWizard` conversation registered
+    // in the constructor. Each command just parses its args and hands off.
     const tradeNames = names.filter(isTradeCommandName);
     if (tradeNames.length > 0) {
       for (const tradeName of tradeNames) {
         this.#registerTradeCommand(tradeName);
-      }
-      if (!this.#tradeCallbacksRegistered) {
-        this.#tradeCallbacksRegistered = true;
-        this.#registerTradeCallbacks();
       }
       return;
     }
@@ -339,8 +490,6 @@ export class TelegramPlatform implements MessagingPlatform {
   }
 
   #registerTradeCommand(name: TradeCommandName): void {
-    const {isLimit} = tradeCommandShape(name);
-
     this.#bot.command(name, async ctx => {
       const senderId = ctx.from?.id?.toString();
       if (!senderId) {
@@ -352,213 +501,11 @@ export class TelegramPlatform implements MessagingPlatform {
         return;
       }
 
-      const text = ctx.message?.text ?? '';
-      const firstSpace = text.indexOf(' ');
-      const content = firstSpace === -1 ? '' : text.slice(firstSpace + 1).trim();
-      const parts = content.length > 0 ? content.split(/\s+/) : [];
-      const expected = isLimit ? 3 : 2;
+      const args = await parseTradeCommandInput(ctx, name);
+      if (!args) return; // parseTradeCommandInput already replied with the usage error
 
-      if (parts.length !== expected) {
-        const usage = isLimit
-          ? `Usage: /${name} <PAIR> <QTY> <PRICE>\nExample: /${name} AAPL,USD 100 150`
-          : `Usage: /${name} <PAIR> <QTY>\nExample: /${name} AAPL,USD 100`;
-        await ctx.reply(`Invalid format.\n${usage}`);
-        return;
-      }
-
-      const [pairStr, quantity, priceInput] = parts;
-
-      let pair: TradingPair;
-      try {
-        pair = TradingPair.fromString(pairStr, ',');
-      } catch {
-        await ctx.reply(`Invalid pair "${pairStr}". Use format: BASE,COUNTER (e.g. AAPL,USD)`);
-        return;
-      }
-
-      if (!/^\d+(\.\d+)?$/.test(quantity) || Number.parseFloat(quantity) <= 0) {
-        await ctx.reply(`Invalid quantity "${quantity}". Must be a positive number.`);
-        return;
-      }
-
-      if (isLimit) {
-        if (!/^\d+(\.\d+)?$/.test(priceInput) || Number.parseFloat(priceInput) <= 0) {
-          await ctx.reply(`Invalid price "${priceInput}". Must be a positive number.`);
-          return;
-        }
-      }
-
-      const priceField = isLimit ? priceInput : '-';
-      const userId = `${PLATFORM_PREFIX}${senderId}`;
-      const accounts = Account.findByUserId(userId);
-
-      if (accounts.length === 0) {
-        await ctx.reply('No exchange account found. Use /accountadd to add one first.');
-        return;
-      }
-
-      const actionLabel = buildTradeActionLabel(name, pair, quantity, isLimit ? priceInput : null);
-      const rows: InlineButton[][] = accounts.map(acc => [
-        {
-          text: `${acc.name} (${acc.exchange}${acc.isPaper ? ' paper' : ''})`,
-          callback_data: encodeTradeFields(TRADE_ACCOUNT_PREFIX, {
-            cmd: name,
-            pairStr,
-            quantity,
-            priceField,
-            accountId: acc.id,
-          }),
-        },
-      ]);
-
-      await ctx.reply(`${actionLabel}\nSelect an account:`, inlineKeyboard(rows));
+      await ctx.conversation.enter(TRADE_CONVERSATION_ID, args);
     });
-  }
-
-  #registerTradeCallbacks(): void {
-    // A single catch-all callback_query:data handler that dispatches by prefix.
-    // Using plain `.startsWith` avoids building a RegExp from the constants,
-    // which would require escaping the `|` delimiter (CodeQL caught the partial
-    // escape in an earlier iteration). The filter only fires when data is
-    // present, and non-trade prefixes are ignored so other handlers are
-    // unaffected.
-    this.#bot.on('callback_query:data', async ctx => {
-      const data = ctx.callbackQuery.data;
-
-      if (data.startsWith(TRADE_ACCOUNT_PREFIX)) {
-        await this.#handleTradeAccountSelected(ctx, data.slice(TRADE_ACCOUNT_PREFIX.length));
-        return;
-      }
-
-      if (data.startsWith(TRADE_CONFIRM_PREFIX)) {
-        await this.#handleTradeConfirmation(ctx, data.slice(TRADE_CONFIRM_PREFIX.length));
-        return;
-      }
-    });
-  }
-
-  async #handleTradeAccountSelected(ctx: Context, payload: string): Promise<void> {
-    await ctx.answerCallbackQuery();
-
-    const senderId = ctx.from?.id?.toString();
-    if (!senderId) return;
-
-    const fields = decodeTradeFields(payload);
-    if (!fields) {
-      await ctx.editMessageText('Invalid trade session. Please run the command again.');
-      return;
-    }
-
-    const userId = `${PLATFORM_PREFIX}${senderId}`;
-    const {text, keyboard} = await this.#buildTradeConfirmation(userId, fields);
-    await ctx.editMessageText(text, keyboard);
-  }
-
-  async #handleTradeConfirmation(ctx: Context, payload: string): Promise<void> {
-    await ctx.answerCallbackQuery();
-
-    const senderId = ctx.from?.id?.toString();
-    if (!senderId) return;
-
-    const fields = decodeTradeFields(payload);
-    if (!fields || fields.decision === undefined) {
-      await ctx.editMessageText('Invalid trade session. Please run the command again.');
-      return;
-    }
-
-    if (fields.decision === 'n') {
-      await ctx.editMessageText('Cancelled.');
-      return;
-    }
-
-    const userId = `${PLATFORM_PREFIX}${senderId}`;
-    let pair: TradingPair;
-    try {
-      pair = TradingPair.fromString(fields.pairStr, ',');
-    } catch (error) {
-      await ctx.editMessageText(error instanceof Error ? error.message : 'Invalid pair.');
-      return;
-    }
-
-    const {side, isLimit} = tradeCommandShape(fields.cmd);
-    const limitPrice = isLimit && fields.priceField !== '-' ? fields.priceField : undefined;
-
-    await ctx.editMessageText('Placing order…');
-
-    const result = await placeOrder({
-      userId,
-      accountId: fields.accountId,
-      pair,
-      side,
-      quantity: fields.quantity,
-      limitPrice,
-    });
-
-    await ctx.editMessageText(result);
-  }
-
-  async #buildTradeConfirmation(
-    userId: string,
-    fields: TradeFields
-  ): Promise<{text: string; keyboard: ReturnType<typeof inlineKeyboard>}> {
-    const account = Account.findByUserIdAndId(userId, fields.accountId);
-    if (!account) {
-      return {
-        text: `Account "${fields.accountId}" not found. Run the command again.`,
-        keyboard: inlineKeyboard([]),
-      };
-    }
-
-    let pair: TradingPair;
-    try {
-      pair = TradingPair.fromString(fields.pairStr, ',');
-    } catch (error) {
-      return {
-        text: error instanceof Error ? error.message : 'Invalid pair.',
-        keyboard: inlineKeyboard([]),
-      };
-    }
-
-    const limitPriceLabel = fields.priceField === '-' ? null : fields.priceField;
-    const actionLabel = buildTradeActionLabel(fields.cmd, pair, fields.quantity, limitPriceLabel);
-
-    // Fetch current price as confirmation context. Failure is non-fatal —
-    // the user still sees the action and can confirm without the price hint.
-    let priceContext = '';
-    try {
-      const client = getExchangeClient({
-        exchangeId: account.exchange,
-        apiKey: account.apiKey,
-        apiSecret: account.apiSecret,
-        isPaper: account.isPaper,
-      });
-      const smallestInterval = client.getSmallestInterval();
-      const candle = await client.getLatestCandle(pair, smallestInterval);
-      const currentPrice = Number.parseFloat(candle.close);
-      const qty = Number.parseFloat(fields.quantity);
-      if (Number.isFinite(currentPrice) && Number.isFinite(qty)) {
-        const estimated = (currentPrice * qty).toFixed(2);
-        priceContext = `\nCurrent ~${candle.close} ${pair.counter} · Estimated ~${estimated} ${pair.counter}`;
-      }
-    } catch {
-      // Ignore — price context is best-effort.
-    }
-
-    const text = `${actionLabel}\nAccount: ${account.name}${priceContext}\n\nProceed?`;
-    const keyboard = inlineKeyboard([
-      [
-        {
-          text: '✓ Yes, place order',
-          callback_data: encodeTradeFields(TRADE_CONFIRM_PREFIX, fields, 'y'),
-        },
-        {
-          text: '✗ Cancel',
-          callback_data: encodeTradeFields(TRADE_CONFIRM_PREFIX, fields, 'n'),
-        },
-      ],
-    ]);
-
-    return {text, keyboard};
   }
 
   async start(): Promise<void> {

--- a/packages/messaging/src/platform/TelegramPlatform.ts
+++ b/packages/messaging/src/platform/TelegramPlatform.ts
@@ -29,10 +29,6 @@ const TRADE_CONVERSATION_ID = 'trade';
 const TRADE_COMMAND_NAMES = ['buymarket', 'sellmarket', 'buylimit', 'selllimit'] as const;
 type TradeCommandName = (typeof TRADE_COMMAND_NAMES)[number];
 
-function isTradeCommandName(name: string): name is TradeCommandName {
-  return (TRADE_COMMAND_NAMES as readonly string[]).includes(name);
-}
-
 interface TradeCommandShape {
   side: ExchangeOrderSide;
   isLimit: boolean;
@@ -157,8 +153,8 @@ async function tradeWizard(
   // conversations engine records the value in the replay log instead of
   // re-executing the query on every resume. Only return the fields needed
   // for the picker so sensitive credentials are not persisted in replay state.
-  const accounts = await conversation.external(async () =>
-    (await Account.findByUserId(userId)).map(acc => ({
+  const accounts = await conversation.external(() =>
+    Account.findByUserId(userId).map(acc => ({
       id: acc.id,
       name: acc.name,
       exchange: acc.exchange,
@@ -303,6 +299,13 @@ export class TelegramPlatform implements MessagingPlatform {
     // that calls `ctx.conversation.enter(...)`.
     this.#bot.use(conversations());
     this.#bot.use(createConversation(tradeWizard, TRADE_CONVERSATION_ID));
+
+    // Trade commands are Telegram-specific: they need inline keyboards and
+    // the conversations plugin, so they register themselves directly here
+    // instead of going through the cross-platform `registerCommand` interface.
+    for (const name of TRADE_COMMAND_NAMES) {
+      this.#registerTradeCommand(name);
+    }
   }
 
   setReportScheduler(scheduler: ReportScheduler): void {
@@ -318,16 +321,6 @@ export class TelegramPlatform implements MessagingPlatform {
     // reportadd is handled via inline keyboard buttons
     if (names.includes('reportadd')) {
       this.#registerReportAddCommand();
-      return;
-    }
-
-    // Trade commands enter the shared `tradeWizard` conversation registered
-    // in the constructor. Each command just parses its args and hands off.
-    const tradeNames = names.filter(isTradeCommandName);
-    if (tradeNames.length > 0) {
-      for (const tradeName of tradeNames) {
-        this.#registerTradeCommand(tradeName);
-      }
       return;
     }
 
@@ -509,6 +502,12 @@ export class TelegramPlatform implements MessagingPlatform {
   }
 
   #registerTradeCommand(name: TradeCommandName): void {
+    // Record the command name so it appears in `/help`. The handler stored
+    // here is never invoked directly — the real wizard runs via the
+    // `bot.command(...)` handler installed below — but `commandList` reads
+    // from `#commands`.
+    this.#commands.set(name, async () => {});
+
     this.#bot.command(name, async ctx => {
       const senderId = ctx.from?.id?.toString();
       if (!senderId) {

--- a/packages/messaging/src/platform/TelegramPlatform.ts
+++ b/packages/messaging/src/platform/TelegramPlatform.ts
@@ -226,12 +226,7 @@ async function buildTradeConfirmation(
     });
     const smallestInterval = client.getSmallestInterval();
     const candle = await client.getLatestCandle(pair, smallestInterval);
-    const currentPrice = Number.parseFloat(candle.close);
-    const qty = Number.parseFloat(args.quantity);
-    if (Number.isFinite(currentPrice) && Number.isFinite(qty)) {
-      const estimated = (currentPrice * qty).toFixed(2);
-      priceContext = `\nCurrent ~${candle.close} ${pair.counter} · Estimated ~${estimated} ${pair.counter}`;
-    }
+    priceContext = `\nCurrent ~${candle.close} ${pair.counter}`;
   } catch {
     // Ignore — price context is best-effort.
   }

--- a/packages/messaging/src/platform/TelegramPlatform.ts
+++ b/packages/messaging/src/platform/TelegramPlatform.ts
@@ -66,8 +66,17 @@ function buildTradeActionLabel(
 type TradeContext = ConversationFlavor<Context>;
 type TradeConversation = Conversation<TradeContext, TradeContext>;
 
-/** A string that parses as a finite positive decimal number (e.g. "1", "1.5", "0.001"). */
+/**
+ * A string that parses as a finite positive decimal number (e.g. "1", "1.5",
+ * "0.001"). Only digits and an optional decimal point are allowed — scientific
+ * notation (`1e5`), hex / octal / binary literals (`0x10`, `0o17`, `0b10`),
+ * whitespace, and signs are all rejected before `Number()` would silently
+ * coerce them.
+ */
 const positiveNumberString = z.string().refine(value => {
+  for (const char of value) {
+    if (char !== '.' && (char < '0' || char > '9')) return false;
+  }
   const parsed = Number(value);
   return Number.isFinite(parsed) && parsed > 0;
 }, 'Must be a positive number');

--- a/packages/messaging/src/platform/TelegramPlatform.ts
+++ b/packages/messaging/src/platform/TelegramPlatform.ts
@@ -23,7 +23,10 @@ const MODE_CALLBACK_PREFIX = 'reportmode:';
 const INTERVAL_CALLBACK_PREFIX = 'reportinterval:';
 
 const TRADE_CONVERSATION_ID = 'trade';
-const TRADE_COMMAND_NAMES = ['buyMarket', 'sellMarket', 'buyLimit', 'sellLimit'] as const;
+// Telegram requires command names to be lowercase [a-z0-9_] — uppercase
+// letters are silently ignored during command matching. Keep these names
+// in sync with the entries registered in startServer.ts.
+const TRADE_COMMAND_NAMES = ['buymarket', 'sellmarket', 'buylimit', 'selllimit'] as const;
 type TradeCommandName = (typeof TRADE_COMMAND_NAMES)[number];
 
 function isTradeCommandName(name: string): name is TradeCommandName {
@@ -37,13 +40,13 @@ interface TradeCommandShape {
 
 function tradeCommandShape(name: TradeCommandName): TradeCommandShape {
   switch (name) {
-    case 'buyMarket':
+    case 'buymarket':
       return {side: ExchangeOrderSide.BUY, isLimit: false};
-    case 'sellMarket':
+    case 'sellmarket':
       return {side: ExchangeOrderSide.SELL, isLimit: false};
-    case 'buyLimit':
+    case 'buylimit':
       return {side: ExchangeOrderSide.BUY, isLimit: true};
-    case 'sellLimit':
+    case 'selllimit':
       return {side: ExchangeOrderSide.SELL, isLimit: true};
   }
 }
@@ -77,7 +80,7 @@ interface TradeArgs {
 }
 
 /**
- * Parses the raw text following a /buyMarket / /sellMarket / /buyLimit / /sellLimit
+ * Parses the raw text following a /buymarket / /sellmarket / /buylimit / /selllimit
  * command into validated args. Returns `null` and replies with the usage error if
  * anything is off — the caller can just return early.
  */

--- a/packages/messaging/src/platform/TelegramPlatform.ts
+++ b/packages/messaging/src/platform/TelegramPlatform.ts
@@ -192,7 +192,6 @@ async function tradeWizard(
   const confirmation = await conversation.external(() =>
     buildTradeConfirmation(userId, args, pair, accountId)
   );
-  );
   await accountSelection.answerCallbackQuery();
   await accountSelection.editMessageText(confirmation.text, confirmation.keyboard);
 

--- a/packages/messaging/src/startServer.ts
+++ b/packages/messaging/src/startServer.ts
@@ -176,10 +176,10 @@ function registerCommands(platform: MessagingPlatform, monitors: Monitors): void
   const tradeFallback: CommandHandler = async ctx => {
     await ctx.reply('Trade commands are only supported on Telegram right now.');
   };
-  platform.registerCommand('buyMarket', tradeFallback);
-  platform.registerCommand('sellMarket', tradeFallback);
-  platform.registerCommand('buyLimit', tradeFallback);
-  platform.registerCommand('sellLimit', tradeFallback);
+  platform.registerCommand('buymarket', tradeFallback);
+  platform.registerCommand('sellmarket', tradeFallback);
+  platform.registerCommand('buylimit', tradeFallback);
+  platform.registerCommand('selllimit', tradeFallback);
 
   platform.registerCommand('myaddress', async ctx => {
     await ctx.reply(`Your address is: ${ctx.senderId.split(':').slice(1).join(':')}`);

--- a/packages/messaging/src/startServer.ts
+++ b/packages/messaging/src/startServer.ts
@@ -19,7 +19,7 @@ import {
   watchRemove,
 } from './command/index.js';
 import {initializeDatabase} from './database/initializeDatabase.js';
-import type {MessagingPlatform} from './platform/index.js';
+import type {CommandHandler, MessagingPlatform} from './platform/index.js';
 import {TelegramPlatform} from './platform/TelegramPlatform.js';
 import {WatchMonitor, StrategyMonitor, ReportScheduler} from './service/index.js';
 
@@ -169,6 +169,17 @@ function registerCommands(platform: MessagingPlatform, monitors: Monitors): void
       monitors.reportScheduler.unscheduleReport(result.reportId);
     }
   });
+
+  // Trade commands run as interactive wizards on Telegram (account picker +
+  // Yes/No confirmation). The fallback handler below only runs on platforms
+  // that don't install a wizard override — currently none do.
+  const tradeFallback: CommandHandler = async ctx => {
+    await ctx.reply('Trade commands are only supported on Telegram right now.');
+  };
+  platform.registerCommand('buyMarket', tradeFallback);
+  platform.registerCommand('sellMarket', tradeFallback);
+  platform.registerCommand('buyLimit', tradeFallback);
+  platform.registerCommand('sellLimit', tradeFallback);
 
   platform.registerCommand('myaddress', async ctx => {
     await ctx.reply(`Your address is: ${ctx.senderId.split(':').slice(1).join(':')}`);

--- a/packages/messaging/src/startServer.ts
+++ b/packages/messaging/src/startServer.ts
@@ -19,7 +19,7 @@ import {
   watchRemove,
 } from './command/index.js';
 import {initializeDatabase} from './database/initializeDatabase.js';
-import type {CommandHandler, MessagingPlatform} from './platform/index.js';
+import type {MessagingPlatform} from './platform/index.js';
 import {TelegramPlatform} from './platform/TelegramPlatform.js';
 import {WatchMonitor, StrategyMonitor, ReportScheduler} from './service/index.js';
 
@@ -169,17 +169,6 @@ function registerCommands(platform: MessagingPlatform, monitors: Monitors): void
       monitors.reportScheduler.unscheduleReport(result.reportId);
     }
   });
-
-  // Trade commands run as interactive wizards on Telegram (account picker +
-  // Yes/No confirmation). The fallback handler below only runs on platforms
-  // that don't install a wizard override — currently none do.
-  const tradeFallback: CommandHandler = async ctx => {
-    await ctx.reply('Trade commands are only supported on Telegram right now.');
-  };
-  platform.registerCommand('buymarket', tradeFallback);
-  platform.registerCommand('sellmarket', tradeFallback);
-  platform.registerCommand('buylimit', tradeFallback);
-  platform.registerCommand('selllimit', tradeFallback);
 
   platform.registerCommand('myaddress', async ctx => {
     await ctx.reply(`Your address is: ${ctx.senderId.split(':').slice(1).join(':')}`);


### PR DESCRIPTION
Four new Telegram commands for placing one-off orders through an interactive wizard. Every step is an inline-keyboard click — no free-text input, no new dependencies.

Commands:
- /buyMarket  <PAIR> <QTY>         e.g. AAPL,USD 100
- /sellMarket <PAIR> <QTY>         e.g. AAPL,USD 100
- /buyLimit   <PAIR> <QTY> <PRICE> e.g. AAPL,USD 100 150
- /sellLimit  <PAIR> <QTY> <PRICE> e.g. AAPL,USD 100 150

Flow (mirrors /reportadd):
1. Parse args, validate pair / quantity / price, reject on malformed input. Require an existing exchange account.
2. Always show an inline-keyboard account picker, even when the user has a single account — matches /reportadd UX.
3. On account click, show Yes/No confirmation with the action label and a best-effort current-price estimate pulled from client.getLatestCandle. Price fetch failures are non-fatal.
4. On Yes, call the new placeOrder() helper which resolves the account, builds the exchange client, and calls placeMarketOrder or placeLimitOrder. Errors are folded into the reply string. On No, "Cancelled".

Implementation notes:
- New placeOrder() lives in packages/messaging/src/command/placeOrder.ts as platform-agnostic business logic. Non-Telegram platforms get a fallback handler in startServer that replies "only supported on Telegram right now".
- State is encoded in callback_data with short prefixes (t:a|, t:c|) and a compact command code (bm/sm/bl/sl). Longest realistic payload stays well under Telegram's 64-byte limit.
- The wizard special case in TelegramPlatform.registerCommand mirrors the existing /reportadd special case. Callback handlers are registered once via a guarded flag.
- Quantity is always base asset. Limit price is always counter asset. Pair format matches every other command in the repo (AAPL,USD).

Scope limits (deliberate, follow-up territory):
- No counter-amount "spend $X" mode.
- No USD defaulting for pair.
- Telegram-only wizard. Other platforms get the fallback message.
- Owner-gating inherited from existing TelegramPlatform behavior.

<!--
Thanks for your contribution!

Please check the following to make sure your contribution follows our guideline when adding a new indicator.
-->

## Checklist for new indicators

- [ ] Indicator is documented and implemented by extending `IndicatorSeries`
- [ ] Tests for `getResult` are present
- [ ] Tests for error handling are present
- [ ] Indicator is exposed in `src/index.ts`
- [ ] Indicator is listed in `README.md`
