### PR TITLE
fix(trading-strategies): Share TELEGRAM_TABLE_NAME_MAX across reports

### DIFF
--- a/packages/trading-strategies/src/report-scalp-scanner/ScalpScannerReport.ts
+++ b/packages/trading-strategies/src/report-scalp-scanner/ScalpScannerReport.ts
@@ -6,7 +6,7 @@ import {MESSAGE_BREAK, Report} from '../report/Report.js';
 import {SP500_TICKERS} from '../report-sp500-momentum/sp500Tickers.js';
 import {ScalpStrategy} from '../strategy-scalp/ScalpStrategy.js';
 import {suggestScalpOffset} from '../strategy-scalp/suggestScalpOffset.js';
-import {fetchUsEquityNames, formatSymbolWithName} from '../util/formatSymbolWithName.js';
+import {fetchUsEquityNames, formatSymbolWithName, TELEGRAM_TABLE_NAME_MAX} from '../util/formatSymbolWithName.js';
 
 export const ScalpScannerSchema = z.object({
   /** Alpaca API key */
@@ -200,11 +200,10 @@ export class ScalpScannerReport extends Report<ScalpScannerConfig> {
     const scalpFriendlyTop = scalpFriendly.slice(0, top);
     const trendingTop = trending.slice(0, top);
 
-    const tableNameMax = 12;
     const stockColWidth = Math.max(
       'Stock'.length,
-      ...scalpFriendlyTop.map(r => formatSymbolWithName(r.symbol, names, tableNameMax).length),
-      ...trendingTop.map(r => formatSymbolWithName(r.symbol, names, tableNameMax).length)
+      ...scalpFriendlyTop.map(r => formatSymbolWithName(r.symbol, names, TELEGRAM_TABLE_NAME_MAX).length),
+      ...trendingTop.map(r => formatSymbolWithName(r.symbol, names, TELEGRAM_TABLE_NAME_MAX).length)
     );
 
     // Message 1: header + top scalp-friendly table
@@ -217,7 +216,7 @@ export class ScalpScannerReport extends Report<ScalpScannerConfig> {
     lines.push(`----  ${'-'.repeat(stockColWidth)}  -----  ------  -------`);
     for (let i = 0; i < scalpFriendlyTop.length; i++) {
       const r = scalpFriendlyTop[i];
-      const stock = formatSymbolWithName(r.symbol, names, tableNameMax).padEnd(stockColWidth);
+      const stock = formatSymbolWithName(r.symbol, names, TELEGRAM_TABLE_NAME_MAX).padEnd(stockColWidth);
       lines.push(
         `${String(i + 1).padStart(4)}  ${stock}  ${r.er.toFixed(2).padStart(5)}  ${(r.atrPct.toFixed(1) + '%').padStart(6)}  ${r.suggestedOffset.padStart(7)}`
       );
@@ -232,7 +231,7 @@ export class ScalpScannerReport extends Report<ScalpScannerConfig> {
     lines.push(`----  ${'-'.repeat(stockColWidth)}  -----  ------`);
     for (let i = 0; i < trendingTop.length; i++) {
       const r = trendingTop[i];
-      const stock = formatSymbolWithName(r.symbol, names, tableNameMax).padEnd(stockColWidth);
+      const stock = formatSymbolWithName(r.symbol, names, TELEGRAM_TABLE_NAME_MAX).padEnd(stockColWidth);
       lines.push(
         `${String(i + 1).padStart(4)}  ${stock}  ${r.er.toFixed(2).padStart(5)}  ${(r.atrPct.toFixed(1) + '%').padStart(6)}`
       );
@@ -246,7 +245,7 @@ export class ScalpScannerReport extends Report<ScalpScannerConfig> {
     if (picks.length > 0) {
       const pickColWidth = Math.max(
         'Stock'.length,
-        ...picks.map(r => formatSymbolWithName(r.symbol, names, tableNameMax).length)
+        ...picks.map(r => formatSymbolWithName(r.symbol, names, TELEGRAM_TABLE_NAME_MAX).length)
       );
       lines.push(`**Top Picks for Scalping (low ER + ATR >= 2%)**`);
       lines.push('```');
@@ -254,7 +253,7 @@ export class ScalpScannerReport extends Report<ScalpScannerConfig> {
       lines.push(`----  ${'-'.repeat(pickColWidth)}  -----  ------  -------`);
       for (let i = 0; i < picks.length; i++) {
         const r = picks[i];
-        const stock = formatSymbolWithName(r.symbol, names, tableNameMax).padEnd(pickColWidth);
+        const stock = formatSymbolWithName(r.symbol, names, TELEGRAM_TABLE_NAME_MAX).padEnd(pickColWidth);
         lines.push(
           `${String(i + 1).padStart(4)}  ${stock}  ${r.er.toFixed(2).padStart(5)}  ${(r.atrPct.toFixed(1) + '%').padStart(6)}  ${r.suggestedOffset.padStart(7)}`
         );

--- a/packages/trading-strategies/src/report-sp500-momentum/SP500MomentumReport.ts
+++ b/packages/trading-strategies/src/report-sp500-momentum/SP500MomentumReport.ts
@@ -1,7 +1,7 @@
 import {z} from 'zod';
 import {AlpacaAPI} from '@typedtrader/exchange';
 import {MESSAGE_BREAK, Report} from '../report/Report.js';
-import {fetchUsEquityNames, formatSymbolWithName} from '../util/formatSymbolWithName.js';
+import {fetchUsEquityNames, formatSymbolWithName, TELEGRAM_TABLE_NAME_MAX} from '../util/formatSymbolWithName.js';
 import {findFirstTradingDay, getDateString} from '../util/TimeUtil.js';
 import {SP500_TICKERS} from './sp500Tickers.js';
 
@@ -126,15 +126,14 @@ export class SP500MomentumReport extends Report<SP500MomentumConfig> {
     const winners = results.slice(0, top);
     const losers = results.slice(-top).reverse();
 
-    const tableNameMax = 22;
     const stockColWidth = Math.max(
       'Stock'.length,
-      ...winners.map(r => formatSymbolWithName(r.ticker, names, tableNameMax).length),
-      ...losers.map(r => formatSymbolWithName(r.ticker, names, tableNameMax).length)
+      ...winners.map(r => formatSymbolWithName(r.ticker, names, TELEGRAM_TABLE_NAME_MAX).length),
+      ...losers.map(r => formatSymbolWithName(r.ticker, names, TELEGRAM_TABLE_NAME_MAX).length)
     );
 
     const renderRow = (index: number, r: MomentumResult): string => {
-      const stock = formatSymbolWithName(r.ticker, names, tableNameMax).padEnd(stockColWidth);
+      const stock = formatSymbolWithName(r.ticker, names, TELEGRAM_TABLE_NAME_MAX).padEnd(stockColWidth);
       return `${String(index).padStart(4)}  ${stock}  ${(r.returnPct.toFixed(2) + '%').padStart(9)}  ${('$' + r.priceNow.toFixed(2)).padStart(9)}  ${('$' + r.price12MonthsAgo.toFixed(2)).padStart(9)}`;
     };
 

--- a/packages/trading-strategies/src/util/formatSymbolWithName.ts
+++ b/packages/trading-strategies/src/util/formatSymbolWithName.ts
@@ -3,6 +3,18 @@ import {AlpacaAPI, AssetClass} from '@typedtrader/exchange';
 const DEFAULT_MAX_NAME_LENGTH = 30;
 
 /**
+ * Max name length for symbol-with-name columns inside monospace tables sent
+ * over Telegram. Tuned so a row like `Apple Inc.… (AAPL)` plus a handful of
+ * data columns fits on one line on a typical mobile client (~55-60 chars
+ * before wrapping).
+ *
+ * Reports that render monospace tables should reuse this value via
+ * `formatSymbolWithName(symbol, names, TELEGRAM_TABLE_NAME_MAX)` so all
+ * tables stay visually consistent and fit in one line.
+ */
+export const TELEGRAM_TABLE_NAME_MAX = 12;
+
+/**
  * Format a ticker symbol as `Name (SYMBOL)` using the given asset name map.
  * Falls back to the bare symbol if no name is known. Long names are truncated
  * with an ellipsis so tables remain readable.


### PR DESCRIPTION
## Summary

The S&P 500 Momentum report was wrapping on mobile Telegram — rows were ~70 characters wide because of a local `tableNameMax = 22` combined with three 9-char price/return columns. The Scalp Scanner's rows fit cleanly at ~51 chars because it used a local `tableNameMax = 12`.

This PR extracts the cap into a single shared constant `TELEGRAM_TABLE_NAME_MAX = 12` exported from \`formatSymbolWithName.ts\`, so both reports render consistent one-line rows and any future tuning happens in one place.

## Changes

- **`util/formatSymbolWithName.ts`** — adds \`export const TELEGRAM_TABLE_NAME_MAX = 12\` with a docblock explaining the tuning target (one-line monospace on mobile Telegram, ~55-60 chars before wrapping).
- **`report-sp500-momentum/SP500MomentumReport.ts`** — drops the local \`tableNameMax = 22\` and imports the shared constant. Drops the row width from ~70 to ~60 chars.
- **`report-scalp-scanner/ScalpScannerReport.ts`** — drops its local \`tableNameMax = 12\` and imports the shared constant. Output is unchanged; this is just a dedup so both reports have one source of truth.

Long company names are still truncated with an ellipsis by the existing \`formatSymbolWithName\` helper — only the cap moved.