### PR TITLE
feat(messaging): camelCase command names with case-insensitive matching

### DIFF
--- a/packages/messaging/README.md
+++ b/packages/messaging/README.md
@@ -20,6 +20,8 @@ Set `TELEGRAM_BOT_TOKEN` to enable. Message the bot from Telegram. Create a bot 
 
 ### Commands
 
+Command names are case-insensitive — `/reportAdd`, `/reportadd`, and `/REPORTADD` all work. The camelCase form is just for readability.
+
 | Command          | Description                                              |
 | ---------------- | -------------------------------------------------------- |
 | `/help`          | List all available commands                              |
@@ -28,7 +30,7 @@ Set `TELEGRAM_BOT_TOKEN` to enable. Message the bot from Telegram. Create a bot 
 | `/accountRemove` | Remove a trading account                                 |
 | `/accountTime`   | Show the current server time from an account's exchange  |
 | `/candle`        | Fetch OHLC candle data for a trading pair                |
-| `/myaddress`     | Show your address/ID on the current platform             |
+| `/myAddress`     | Show your address/ID on the current platform             |
 | `/price`         | Get the latest closing price for a trading pair          |
 | `/time`          | Display the current system time                          |
 | `/uptime`        | Show how long the bot has been running                   |
@@ -36,7 +38,7 @@ Set `TELEGRAM_BOT_TOKEN` to enable. Message the bot from Telegram. Create a bot 
 | `/watchAdd`      | Create a price alert that monitors a pair at an interval |
 | `/watchList`     | List all active price watches                            |
 | `/watchRemove`   | Remove an active price watch                             |
-| `/youraddress`   | Show the bot's address on the current platform           |
+| `/yourAddress`   | Show the bot's address on the current platform           |
 
 ## Motivation
 

--- a/packages/messaging/README.md
+++ b/packages/messaging/README.md
@@ -18,6 +18,8 @@ This package starts a chatbot based on environment variables. Control your tradi
 
 Set `TELEGRAM_BOT_TOKEN` to enable. Message the bot from Telegram. Create a bot token via [@BotFather](https://t.me/BotFather).
 
+You must also set `TELEGRAM_OWNER_IDS` to a comma-separated list of Telegram user IDs (e.g. `TELEGRAM_OWNER_IDS=111111,222222`). The bot is **fail-closed**: if no owner IDs are configured, it refuses to start instead of accepting messages from anyone. Look up your numeric user ID via [@userinfobot](https://t.me/userinfobot).
+
 ### Commands
 
 Command names are case-insensitive — `/reportAdd`, `/reportadd`, and `/REPORTADD` all work. The camelCase form is just for readability.

--- a/packages/messaging/src/command/report/reportAdd.ts
+++ b/packages/messaging/src/command/report/reportAdd.ts
@@ -3,35 +3,26 @@ import {createReport, getAvailableReportNames, reportRequiresAccount, resolveRep
 import {Account} from '../../database/models/Account.js';
 import {Report} from '../../database/models/Report.js';
 import type {ReportAttributes} from '../../database/models/Report.js';
-import {assertInterval} from '../../validation/assertInterval.js';
 
 export interface ReportAddResult {
   message: string;
   report?: ReportAttributes;
 }
 
-export const reportAdd = async (request: string, userId: string): Promise<ReportAddResult> => {
-  const everyFlagIndex = request.indexOf(' --every ');
-  let mainPart: string;
-  let intervalMs: number | null = null;
+export interface ReportAddOptions {
+  /** When set, the report is saved to the DB and scheduled instead of run once. */
+  intervalMs?: number;
+}
 
-  if (everyFlagIndex !== -1) {
-    mainPart = request.slice(0, everyFlagIndex).trim();
-    const intervalStr = request.slice(everyFlagIndex + ' --every '.length).trim();
-    if (!intervalStr) {
-      return {message: 'Missing interval after --every flag. Examples: 1m, 1h, 1d, 1w'};
-    }
-    try {
-      intervalMs = assertInterval(intervalStr);
-    } catch {
-      return {message: 'Invalid interval. Examples: 1m, 1h, 1d, 1w'};
-    }
-  } else {
-    mainPart = request.trim();
-  }
+export const reportAdd = async (
+  request: string,
+  userId: string,
+  options: ReportAddOptions = {}
+): Promise<ReportAddResult> => {
+  const {intervalMs} = options;
 
   // Parse "<reportName> [<accountId>]"
-  const parts = mainPart.split(/\s+/);
+  const parts = request.trim().split(/\s+/);
   const reportName = parts[0] ?? '';
   const accountIdStr = parts[1];
 
@@ -39,7 +30,7 @@ export const reportAdd = async (request: string, userId: string): Promise<Report
 
   if (!reportName) {
     return {
-      message: `Invalid format. Usage: /reportadd <reportName> [<accountId>] [--every <interval>]\nAvailable reports: ${available.join(', ') || 'none (check environment variables)'}`,
+      message: `Invalid format. Usage: /reportAdd <reportName> [<accountId>]\nAvailable reports: ${available.join(', ') || 'none (check environment variables)'}`,
     };
   }
 
@@ -52,7 +43,7 @@ export const reportAdd = async (request: string, userId: string): Promise<Report
   // If report requires an account, resolve credentials from the account database
   if (reportRequiresAccount(reportName)) {
     if (!accountIdStr) {
-      return {message: `Report "${reportName}" requires an exchange account.\nUsage: /reportadd ${reportName} <accountId> [--every <interval>]`};
+      return {message: `Report "${reportName}" requires an exchange account.\nUsage: /reportAdd ${reportName} <accountId>`};
     }
 
     const accountId = parseInt(accountIdStr, 10);
@@ -63,7 +54,7 @@ export const reportAdd = async (request: string, userId: string): Promise<Report
 
     const account = Account.findByUserIdAndId(userId, accountId);
     if (!account) {
-      return {message: `Account ${accountId} not found. Use /accountlist to see your accounts.`};
+      return {message: `Account ${accountId} not found. Use /accountList to see your accounts.`};
     }
 
     config.apiKey = account.apiKey;

--- a/packages/messaging/src/command/report/reportAdd.ts
+++ b/packages/messaging/src/command/report/reportAdd.ts
@@ -10,12 +10,6 @@ export interface ReportAddResult {
   report?: ReportAttributes;
 }
 
-// Format: "<reportName> [<accountId>] [--every <interval>]"
-// Without --every: runs the report immediately and returns the output
-// With --every: saves to DB and schedules recurring execution
-// Example: "/reportadd @typedtrader/report-sp500-momentum"
-// Example: "/reportadd @typedtrader/report-scalp-scanner 3"
-// Example: "/reportadd @typedtrader/report-scalp-scanner 3 --every 1d"
 export const reportAdd = async (request: string, userId: string): Promise<ReportAddResult> => {
   const everyFlagIndex = request.indexOf(' --every ');
   let mainPart: string;

--- a/packages/messaging/src/platform/TelegramPlatform.test.ts
+++ b/packages/messaging/src/platform/TelegramPlatform.test.ts
@@ -22,6 +22,15 @@ vi.mock('../command/report/reportAdd.js', () => ({
   reportAdd: vi.fn(),
 }));
 
+const mockFindByUserId = vi.fn().mockReturnValue([]);
+const mockFindByUserIdAndId = vi.fn().mockReturnValue(undefined);
+vi.mock('../database/models/Account.js', () => ({
+  Account: {
+    findByUserId: (...args: unknown[]) => mockFindByUserId(...args),
+    findByUserIdAndId: (...args: unknown[]) => mockFindByUserIdAndId(...args),
+  },
+}));
+
 vi.mock('@grammyjs/conversations', () => ({
   conversations: vi.fn(() => 'conversations-middleware'),
   createConversation: vi.fn(() => 'create-conversation-middleware'),
@@ -117,7 +126,10 @@ describe('TelegramPlatform', () => {
     });
 
     it('handles malformed schedule interval callback payloads without throwing', async () => {
-      const platform = new TelegramPlatform('bot-token');
+      const platform = new TelegramPlatform('bot-token', '123');
+
+      const {getAvailableReportNames} = await import('trading-strategies');
+      vi.mocked(getAvailableReportNames).mockReturnValue(['rsi']);
 
       platform.registerCommand('reportAdd', vi.fn());
 
@@ -135,6 +147,121 @@ describe('TelegramPlatform', () => {
         'Invalid interval "not-an-interval". Please select one of: 1m, 1h, 6h, 12h, 1d, 1w.'
       );
       expect(mockedReportAdd).not.toHaveBeenCalled();
+    });
+
+    describe('report wizard callback auth', () => {
+      const buildCtx = (senderId: number, match: string[]) => ({
+        answerCallbackQuery: vi.fn().mockResolvedValue(undefined),
+        editMessageText: vi.fn().mockResolvedValue(undefined),
+        from: {id: senderId},
+        match,
+      });
+
+      it('drops the report-pick callback when the sender is not an owner', async () => {
+        const platform = new TelegramPlatform('bot-token', '111');
+        platform.registerCommand('reportAdd', vi.fn());
+
+        const callback = findRegisteredCallbackQuery('report:');
+        const ctx = buildCtx(999, ['', 'rsi']);
+
+        await callback(ctx as never);
+
+        expect(ctx.editMessageText).not.toHaveBeenCalled();
+        expect(mockFindByUserId).not.toHaveBeenCalled();
+      });
+
+      it('drops the account-pick callback when the sender is not an owner', async () => {
+        const platform = new TelegramPlatform('bot-token', '111');
+        platform.registerCommand('reportAdd', vi.fn());
+
+        const callback = findRegisteredCallbackQuery('reportaccount:');
+        const ctx = buildCtx(999, ['', '42', 'rsi']);
+
+        await callback(ctx as never);
+
+        expect(ctx.editMessageText).not.toHaveBeenCalled();
+        expect(mockFindByUserIdAndId).not.toHaveBeenCalled();
+      });
+
+      it('drops the run-once callback when the sender is not an owner', async () => {
+        const platform = new TelegramPlatform('bot-token', '111');
+        platform.registerCommand('reportAdd', vi.fn());
+
+        const callback = findRegisteredCallbackQuery('reportmode:');
+        const ctx = buildCtx(999, ['', 'rsi']);
+
+        await callback(ctx as never);
+
+        expect(mockedReportAdd).not.toHaveBeenCalled();
+      });
+
+      it('rejects report names not in the whitelist', async () => {
+        const platform = new TelegramPlatform('bot-token', '111');
+        const {getAvailableReportNames} = await import('trading-strategies');
+        vi.mocked(getAvailableReportNames).mockReturnValue(['rsi']);
+
+        platform.registerCommand('reportAdd', vi.fn());
+
+        const callback = findRegisteredCallbackQuery('report:');
+        const ctx = buildCtx(111, ['', '../../etc/passwd']);
+
+        await callback(ctx as never);
+
+        expect(ctx.editMessageText).toHaveBeenCalledWith('Unknown report "../../etc/passwd".');
+        expect(mockFindByUserId).not.toHaveBeenCalled();
+      });
+
+      it('rejects account IDs that do not belong to the sender', async () => {
+        const platform = new TelegramPlatform('bot-token', '111');
+        const {getAvailableReportNames} = await import('trading-strategies');
+        vi.mocked(getAvailableReportNames).mockReturnValue(['rsi']);
+        // Sender 111 → no account 42 for them.
+        mockFindByUserIdAndId.mockReturnValue(undefined);
+
+        platform.registerCommand('reportAdd', vi.fn());
+
+        const callback = findRegisteredCallbackQuery('reportaccount:');
+        const ctx = buildCtx(111, ['', '42', 'rsi']);
+
+        await callback(ctx as never);
+
+        expect(mockFindByUserIdAndId).toHaveBeenCalledWith('telegram:111', 42);
+        expect(ctx.editMessageText).toHaveBeenCalledWith('Account not found.');
+      });
+
+      it('rejects run-once payloads that carry an unknown report name', async () => {
+        const platform = new TelegramPlatform('bot-token', '111');
+        const {getAvailableReportNames} = await import('trading-strategies');
+        vi.mocked(getAvailableReportNames).mockReturnValue(['rsi']);
+
+        platform.registerCommand('reportAdd', vi.fn());
+
+        const callback = findRegisteredCallbackQuery('reportmode:');
+        const ctx = buildCtx(111, ['', 'bogus-report']);
+
+        await callback(ctx as never);
+
+        expect(ctx.editMessageText).toHaveBeenCalledWith('Unknown report "bogus-report".');
+        expect(mockedReportAdd).not.toHaveBeenCalled();
+      });
+
+      it('rejects run-once payloads that carry an account not owned by the sender', async () => {
+        const platform = new TelegramPlatform('bot-token', '111');
+        const {getAvailableReportNames} = await import('trading-strategies');
+        vi.mocked(getAvailableReportNames).mockReturnValue(['rsi']);
+        mockFindByUserIdAndId.mockReturnValue(undefined);
+
+        platform.registerCommand('reportAdd', vi.fn());
+
+        const callback = findRegisteredCallbackQuery('reportmode:');
+        const ctx = buildCtx(111, ['', 'rsi 999']);
+
+        await callback(ctx as never);
+
+        expect(mockFindByUserIdAndId).toHaveBeenCalledWith('telegram:111', 999);
+        expect(ctx.editMessageText).toHaveBeenCalledWith('Account not found.');
+        expect(mockedReportAdd).not.toHaveBeenCalled();
+      });
     });
   });
 
@@ -254,7 +381,7 @@ describe('TelegramPlatform', () => {
       expect(handler).toHaveBeenCalledOnce();
     });
 
-    it('allows all senders when ownerIds is not set', async () => {
+    it('rejects every sender when ownerIds is not set (fail-closed)', async () => {
       const platform = new TelegramPlatform('bot-token');
 
       const handler = vi.fn().mockResolvedValue(undefined);
@@ -271,11 +398,12 @@ describe('TelegramPlatform', () => {
 
       await registeredCallback(ctxAnySender);
 
-      expect(handler).toHaveBeenCalledOnce();
+      expect(handler).not.toHaveBeenCalled();
+      expect(ctxAnySender.reply).not.toHaveBeenCalled();
     });
 
-    it('replies when sender ID cannot be determined', async () => {
-      const platform = new TelegramPlatform('bot-token');
+    it('silently drops updates with no sender', async () => {
+      const platform = new TelegramPlatform('bot-token', '111');
 
       const handler = vi.fn();
 
@@ -291,8 +419,8 @@ describe('TelegramPlatform', () => {
 
       await registeredCallback(ctxNoFrom);
 
-      expect(ctxNoFrom.reply).toHaveBeenCalledWith('Unable to determine sender');
       expect(handler).not.toHaveBeenCalled();
+      expect(ctxNoFrom.reply).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/messaging/src/platform/TelegramPlatform.test.ts
+++ b/packages/messaging/src/platform/TelegramPlatform.test.ts
@@ -1,5 +1,6 @@
 import {describe, it, expect, vi, beforeEach} from 'vitest';
-import {TelegramPlatform} from './TelegramPlatform.js';
+import type {Context} from 'grammy';
+import {TelegramPlatform, lowercaseCommandMiddleware} from './TelegramPlatform.js';
 
 const mockSendMessage = vi.fn();
 const mockInit = vi.fn();
@@ -64,12 +65,12 @@ describe('TelegramPlatform', () => {
       expect(platform.commandList).toContain('/price');
     });
 
-    it('includes reportadd when registered', () => {
+    it('includes reportAdd when registered', () => {
       const platform = new TelegramPlatform('bot-token');
 
-      platform.registerCommand('reportadd', vi.fn());
+      platform.registerCommand('reportAdd', vi.fn());
 
-      expect(platform.commandList).toContain('/reportadd');
+      expect(platform.commandList).toContain('/reportAdd');
     });
 
     it('includes the self-registered trade commands even before registerCommand is called', () => {
@@ -78,7 +79,7 @@ describe('TelegramPlatform', () => {
       // Trade commands register themselves in the TelegramPlatform constructor
       // because their wizards depend on grammy + the conversations plugin.
       expect(platform.commandList).toEqual(
-        expect.arrayContaining(['/buymarket', '/sellmarket', '/buylimit', '/selllimit'])
+        expect.arrayContaining(['/buyMarket', '/sellMarket', '/buyLimit', '/sellLimit'])
       );
     });
   });
@@ -95,12 +96,14 @@ describe('TelegramPlatform', () => {
       expect(mockCommand).toHaveBeenCalledWith(['help'], expect.any(Function));
     });
 
-    it('registers reportadd with inline keyboard buttons instead of regular command', () => {
+    it('registers reportAdd with inline keyboard buttons instead of regular command', () => {
       const platform = new TelegramPlatform('bot-token');
 
-      platform.registerCommand('reportadd', vi.fn());
+      platform.registerCommand('reportAdd', vi.fn());
 
-      // reportadd uses bot.command and bot.callbackQuery, not the generic handler path
+      // reportAdd uses bot.command and bot.callbackQuery, not the generic handler path.
+      // grammY only accepts lowercase command names, so the registration uses 'reportadd'
+      // while the display name stays camelCase.
       expect(mockCommand).toHaveBeenCalledWith('reportadd', expect.any(Function));
       expect(mockCallbackQuery).toHaveBeenCalledWith(expect.any(RegExp), expect.any(Function));
     });
@@ -261,6 +264,60 @@ describe('TelegramPlatform', () => {
 
       expect(ctxNoFrom.reply).toHaveBeenCalledWith('Unable to determine sender');
       expect(handler).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('lowercaseCommandMiddleware', () => {
+    function buildCtx(text: string): Context {
+      return {
+        message: {
+          text,
+          entities: [{type: 'bot_command', offset: 0, length: text.split(' ')[0].length}],
+        },
+      } as unknown as Context;
+    }
+
+    it('lowercases a mixed-case command', async () => {
+      const ctx = buildCtx('/ReportAdd');
+      await lowercaseCommandMiddleware(ctx, async () => {});
+      expect(ctx.message?.text).toBe('/reportadd');
+    });
+
+    it('lowercases an all-caps command', async () => {
+      const ctx = buildCtx('/REPORTADD');
+      await lowercaseCommandMiddleware(ctx, async () => {});
+      expect(ctx.message?.text).toBe('/reportadd');
+    });
+
+    it('lowercases a chaotic casing', async () => {
+      const ctx = buildCtx('/repOrTADd');
+      await lowercaseCommandMiddleware(ctx, async () => {});
+      expect(ctx.message?.text).toBe('/reportadd');
+    });
+
+    it('preserves the @botname suffix verbatim', async () => {
+      const ctx = buildCtx('/ReportAdd@MyBot');
+      await lowercaseCommandMiddleware(ctx, async () => {});
+      expect(ctx.message?.text).toBe('/reportadd@MyBot');
+    });
+
+    it('preserves arguments after the command', async () => {
+      const ctx = buildCtx('/BuyMarket AAPL,USD 100');
+      await lowercaseCommandMiddleware(ctx, async () => {});
+      expect(ctx.message?.text).toBe('/buymarket AAPL,USD 100');
+    });
+
+    it('is a no-op when no bot_command entity is present', async () => {
+      const ctx = {message: {text: 'hello world', entities: []}} as unknown as Context;
+      await lowercaseCommandMiddleware(ctx, async () => {});
+      expect(ctx.message?.text).toBe('hello world');
+    });
+
+    it('calls next exactly once', async () => {
+      const ctx = buildCtx('/help');
+      const next = vi.fn().mockResolvedValue(undefined);
+      await lowercaseCommandMiddleware(ctx, next);
+      expect(next).toHaveBeenCalledOnce();
     });
   });
 });

--- a/packages/messaging/src/platform/TelegramPlatform.test.ts
+++ b/packages/messaging/src/platform/TelegramPlatform.test.ts
@@ -1,6 +1,7 @@
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import type {Context} from 'grammy';
 import {TelegramPlatform, lowercaseCommandMiddleware} from './TelegramPlatform.js';
+import {reportAdd} from '../command/report/reportAdd.js';
 
 const mockSendMessage = vi.fn();
 const mockInit = vi.fn();
@@ -10,6 +11,7 @@ const mockCommand = vi.fn();
 const mockCallbackQuery = vi.fn();
 const mockUse = vi.fn();
 const botInfo = {username: 'testbot'};
+const mockedReportAdd = vi.mocked(reportAdd);
 
 vi.mock('trading-strategies', () => ({
   MESSAGE_BREAK: '\f',
@@ -85,6 +87,12 @@ describe('TelegramPlatform', () => {
   });
 
   describe('registerCommand', () => {
+    const findRegisteredCallbackQuery = (pattern: string) => {
+      const call = mockCallbackQuery.mock.calls.find(([regex]) => regex instanceof RegExp && regex.source.includes(pattern));
+      if (!call) throw new Error(`bot.callbackQuery was never called with pattern "${pattern}"`);
+      return call[1];
+    };
+
     it('stores the command handler and registers it with the bot', () => {
       const platform = new TelegramPlatform('bot-token');
 
@@ -106,6 +114,27 @@ describe('TelegramPlatform', () => {
       // while the display name stays camelCase.
       expect(mockCommand).toHaveBeenCalledWith('reportadd', expect.any(Function));
       expect(mockCallbackQuery).toHaveBeenCalledWith(expect.any(RegExp), expect.any(Function));
+    });
+
+    it('handles malformed schedule interval callback payloads without throwing', async () => {
+      const platform = new TelegramPlatform('bot-token');
+
+      platform.registerCommand('reportAdd', vi.fn());
+
+      const callback = findRegisteredCallbackQuery('reportinterval');
+      const ctx = {
+        answerCallbackQuery: vi.fn().mockResolvedValue(undefined),
+        editMessageText: vi.fn().mockResolvedValue(undefined),
+        from: {id: 123},
+        match: ['', 'not-an-interval', 'rsi'],
+      };
+
+      await callback(ctx as never);
+
+      expect(ctx.editMessageText).toHaveBeenCalledWith(
+        'Invalid interval "not-an-interval". Please select one of: 1m, 1h, 6h, 12h, 1d, 1w.'
+      );
+      expect(mockedReportAdd).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/messaging/src/platform/TelegramPlatform.test.ts
+++ b/packages/messaging/src/platform/TelegramPlatform.test.ts
@@ -305,7 +305,7 @@ describe('TelegramPlatform', () => {
 
   describe('start', () => {
     it('initializes the bot and populates platformInfo before starting polling', async () => {
-      const platform = new TelegramPlatform('bot-token');
+      const platform = new TelegramPlatform('bot-token', '111');
 
       const callOrder: string[] = [];
       mockInit.mockImplementation(async () => {
@@ -324,6 +324,14 @@ describe('TelegramPlatform', () => {
         botAddress: '@testbot',
         sdkVersion: 'grammY',
       });
+    });
+
+    it('throws when TELEGRAM_OWNER_IDS is not set (fail-closed)', async () => {
+      const platform = new TelegramPlatform('bot-token');
+
+      await expect(platform.start()).rejects.toThrow(/TELEGRAM_OWNER_IDS is not set/);
+      expect(mockInit).not.toHaveBeenCalled();
+      expect(mockStart).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/messaging/src/platform/TelegramPlatform.ts
+++ b/packages/messaging/src/platform/TelegramPlatform.ts
@@ -303,7 +303,10 @@ async function replyWithMarkdown(ctx: Context, text: string): Promise<void> {
   for (const chunk of splitForTelegram(text)) {
     try {
       await ctx.reply(markdownToTelegramHtml(chunk), {parse_mode: 'HTML'});
-    } catch {
+    } catch (error) {
+      // Log the escaper failure instead of silently swallowing it — a silent
+      // fallback would hide a real escaper bug (and any XSS it enables).
+      console.warn('Falling back to plaintext after markdown→HTML render failure:', error);
       await ctx.reply(chunk);
     }
   }
@@ -359,19 +362,8 @@ export class TelegramPlatform implements MessagingPlatform {
     }
 
     this.#bot.command(lowerNames, async ctx => {
-      const senderId = ctx.from?.id?.toString();
-
-      if (!senderId) {
-        await ctx.reply('Unable to determine sender');
-        return;
-      }
-
-      if (this.#ownerIds.length > 0 && !this.#ownerIds.includes(senderId)) {
-        console.warn(
-          `Ignoring Telegram message from "${senderId}" - only messages from owners [${this.#ownerIds.join(', ')}] are processed.`
-        );
-        return;
-      }
+      const userId = this.#authorizedUserId(ctx);
+      if (!userId) return;
 
       // Extract text after the /command
       const text = ctx.message?.text ?? '';
@@ -379,7 +371,7 @@ export class TelegramPlatform implements MessagingPlatform {
       const content = commandEnd === -1 ? '' : text.slice(commandEnd + 1);
 
       const messageCtx: MessageContext = {
-        senderId: `${PLATFORM_PREFIX}${senderId}`,
+        senderId: userId,
         platformId: 'telegram',
         content,
         reply: async (replyText: string) => {
@@ -391,18 +383,35 @@ export class TelegramPlatform implements MessagingPlatform {
     });
   }
 
+  /**
+   * Returns the platform-prefixed userId if the sender is authorized, or
+   * `null` otherwise. **Fail-closed**: an unset/empty `TELEGRAM_OWNER_IDS`
+   * list rejects every sender. Callers should return early on `null`.
+   *
+   * Every update-handling code path (commands, callback queries, conversation
+   * resumes) MUST go through this helper — it's the only gate between an
+   * inbound Telegram update and the bot's command machinery.
+   */
+  #authorizedUserId(ctx: Context): string | null {
+    const senderId = ctx.from?.id?.toString();
+    if (!senderId) return null;
+    if (this.#ownerIds.length === 0) {
+      console.warn('Ignoring Telegram update: TELEGRAM_OWNER_IDS is not set, so the bot rejects every message.');
+      return null;
+    }
+    if (!this.#ownerIds.includes(senderId)) {
+      console.warn(
+        `Ignoring Telegram update from "${senderId}" — only owners [${this.#ownerIds.join(', ')}] are authorized.`
+      );
+      return null;
+    }
+    return `${PLATFORM_PREFIX}${senderId}`;
+  }
+
   #registerReportAddCommand(): void {
     this.#bot.command('reportadd', async ctx => {
-      const senderId = ctx.from?.id?.toString();
-
-      if (!senderId) {
-        await ctx.reply('Unable to determine sender');
-        return;
-      }
-
-      if (this.#ownerIds.length > 0 && !this.#ownerIds.includes(senderId)) {
-        return;
-      }
+      const userId = this.#authorizedUserId(ctx);
+      if (!userId) return;
 
       const available = getAvailableReportNames();
       if (available.length === 0) {
@@ -421,12 +430,16 @@ export class TelegramPlatform implements MessagingPlatform {
     this.#bot.callbackQuery(new RegExp(`^${REPORT_CALLBACK_PREFIX}(.+)$`), async ctx => {
       await ctx.answerCallbackQuery();
 
+      const userId = this.#authorizedUserId(ctx);
+      if (!userId) return;
+
       const reportName = ctx.match[1];
-      const senderId = ctx.from?.id?.toString();
-      if (!senderId) return;
+      if (!this.#isKnownReport(reportName)) {
+        await ctx.editMessageText(`Unknown report "${reportName}".`);
+        return;
+      }
 
       if (reportRequiresAccount(reportName)) {
-        const userId = `${PLATFORM_PREFIX}${senderId}`;
         const userAccounts = Account.findByUserId(userId);
 
         if (userAccounts.length === 0) {
@@ -458,8 +471,24 @@ export class TelegramPlatform implements MessagingPlatform {
     this.#bot.callbackQuery(new RegExp(`^${ACCOUNT_CALLBACK_PREFIX}(\\d+):(.+)$`), async ctx => {
       await ctx.answerCallbackQuery();
 
-      const accountId = ctx.match[1];
+      const userId = this.#authorizedUserId(ctx);
+      if (!userId) return;
+
+      const accountIdStr = ctx.match[1];
       const reportName = ctx.match[2];
+
+      if (!this.#isKnownReport(reportName)) {
+        await ctx.editMessageText(`Unknown report "${reportName}".`);
+        return;
+      }
+
+      const accountId = Number.parseInt(accountIdStr, 10);
+      if (!Number.isFinite(accountId) || !Account.findByUserIdAndId(userId, accountId)) {
+        // Either the callback_data was crafted or the account belongs to
+        // someone else. Either way: refuse and leave no useful error detail.
+        await ctx.editMessageText('Account not found.');
+        return;
+      }
 
       // Carry accountId through by appending it to the reportName in the callback data
       const reportWithAccount = `${reportName} ${accountId}`;
@@ -477,13 +506,18 @@ export class TelegramPlatform implements MessagingPlatform {
     this.#bot.callbackQuery(new RegExp(`^${MODE_CALLBACK_PREFIX}once:(.+)$`), async ctx => {
       await ctx.answerCallbackQuery();
 
+      const userId = this.#authorizedUserId(ctx);
+      if (!userId) return;
+
       const reportInput = ctx.match[1];
-      const senderId = ctx.from?.id?.toString();
-      if (!senderId) return;
+      const validation = this.#validateReportInput(userId, reportInput);
+      if (!validation.ok) {
+        await ctx.editMessageText(validation.message);
+        return;
+      }
 
-      await ctx.editMessageText(`Running report: ${reportInput.split(' ')[0]}...`);
+      await ctx.editMessageText(`Running report: ${validation.reportName}...`);
 
-      const userId = `${PLATFORM_PREFIX}${senderId}`;
       const result = await reportAdd(reportInput, userId);
 
       await replyWithMarkdown(ctx, result.message);
@@ -493,11 +527,18 @@ export class TelegramPlatform implements MessagingPlatform {
     this.#bot.callbackQuery(new RegExp(`^${MODE_CALLBACK_PREFIX}schedule:(.+)$`), async ctx => {
       await ctx.answerCallbackQuery();
 
+      const userId = this.#authorizedUserId(ctx);
+      if (!userId) return;
+
       const reportInput = ctx.match[1];
-      const reportName = reportInput.split(' ')[0];
+      const validation = this.#validateReportInput(userId, reportInput);
+      if (!validation.ok) {
+        await ctx.editMessageText(validation.message);
+        return;
+      }
 
       await ctx.editMessageText(
-        `Report: ${reportName}\nSelect interval:`,
+        `Report: ${validation.reportName}\nSelect interval:`,
         inlineKeyboard([
           [
             {text: '1m', callback_data: `${INTERVAL_CALLBACK_PREFIX}1m:${reportInput}`},
@@ -517,12 +558,17 @@ export class TelegramPlatform implements MessagingPlatform {
     this.#bot.callbackQuery(new RegExp(`^${INTERVAL_CALLBACK_PREFIX}([^:]+):(.+)$`), async ctx => {
       await ctx.answerCallbackQuery();
 
+      const userId = this.#authorizedUserId(ctx);
+      if (!userId) return;
+
       const interval = ctx.match[1];
       const reportInput = ctx.match[2];
-      const senderId = ctx.from?.id?.toString();
-      if (!senderId) return;
+      const validation = this.#validateReportInput(userId, reportInput);
+      if (!validation.ok) {
+        await ctx.editMessageText(validation.message);
+        return;
+      }
 
-      const userId = `${PLATFORM_PREFIX}${senderId}`;
       let intervalMs: number;
       try {
         intervalMs = assertInterval(interval);
@@ -531,7 +577,7 @@ export class TelegramPlatform implements MessagingPlatform {
         return;
       }
 
-      await ctx.editMessageText(`Scheduling report: ${reportInput.split(' ')[0]} every ${interval}...`);
+      await ctx.editMessageText(`Scheduling report: ${validation.reportName} every ${interval}...`);
       const result = await reportAdd(reportInput, userId, {intervalMs});
 
       await replyWithMarkdown(ctx, result.message);
@@ -542,6 +588,40 @@ export class TelegramPlatform implements MessagingPlatform {
     });
   }
 
+  #isKnownReport(reportName: string): boolean {
+    return getAvailableReportNames().includes(reportName);
+  }
+
+  /**
+   * Parses a `reportInput` string (`"<reportName>"` or `"<reportName> <accountId>"`)
+   * extracted from a callback payload and verifies both the report name and, if
+   * present, that the account belongs to the sender. Defense-in-depth against a
+   * tampered callback_data that tries to run a report against someone else's
+   * account or a report the bot does not expose.
+   */
+  #validateReportInput(
+    userId: string,
+    reportInput: string
+  ): {ok: true; reportName: string; accountId?: number} | {ok: false; message: string} {
+    const parts = reportInput.split(/\s+/);
+    const reportName = parts[0] ?? '';
+    const accountIdStr = parts[1];
+
+    if (!this.#isKnownReport(reportName)) {
+      return {ok: false, message: `Unknown report "${reportName}".`};
+    }
+
+    if (accountIdStr !== undefined) {
+      const accountId = Number.parseInt(accountIdStr, 10);
+      if (!Number.isFinite(accountId) || !Account.findByUserIdAndId(userId, accountId)) {
+        return {ok: false, message: 'Account not found.'};
+      }
+      return {ok: true, reportName, accountId};
+    }
+
+    return {ok: true, reportName};
+  }
+
   #registerTradeCommand(name: TradeCommandName): void {
     // Record the camelCase name so it appears in `/help`. The handler stored
     // here is never invoked directly — the real wizard runs via the
@@ -550,15 +630,8 @@ export class TelegramPlatform implements MessagingPlatform {
     this.#commands.set(name, async () => {});
 
     this.#bot.command(name.toLowerCase(), async ctx => {
-      const senderId = ctx.from?.id?.toString();
-      if (!senderId) {
-        await ctx.reply('Unable to determine sender');
-        return;
-      }
-
-      if (this.#ownerIds.length > 0 && !this.#ownerIds.includes(senderId)) {
-        return;
-      }
+      const userId = this.#authorizedUserId(ctx);
+      if (!userId) return;
 
       const args = await parseTradeCommandInput(ctx, name);
       if (!args) return; // parseTradeCommandInput already replied with the usage error
@@ -571,7 +644,10 @@ export class TelegramPlatform implements MessagingPlatform {
     if (this.#ownerIds.length > 0) {
       console.log(`Only Telegram user IDs (${this.#ownerIds.join(', ')}) can message the bot.`);
     } else {
-      console.warn('Warning: TELEGRAM_OWNER_IDS is not set. Everyone can message the bot via Telegram.');
+      console.error(
+        'Error: TELEGRAM_OWNER_IDS is not set. The bot will reject every incoming message. ' +
+          'Set TELEGRAM_OWNER_IDS to a comma-separated list of Telegram user IDs.'
+      );
     }
 
     await this.#bot.init();
@@ -598,7 +674,8 @@ export class TelegramPlatform implements MessagingPlatform {
     for (const chunk of splitForTelegram(text)) {
       try {
         await this.#bot.api.sendMessage(chatId, markdownToTelegramHtml(chunk), {parse_mode: 'HTML'});
-      } catch {
+      } catch (error) {
+        console.warn('Falling back to plaintext after markdown→HTML render failure:', error);
         await this.#bot.api.sendMessage(chatId, chunk);
       }
     }

--- a/packages/messaging/src/platform/TelegramPlatform.ts
+++ b/packages/messaging/src/platform/TelegramPlatform.ts
@@ -522,10 +522,16 @@ export class TelegramPlatform implements MessagingPlatform {
       const senderId = ctx.from?.id?.toString();
       if (!senderId) return;
 
-      await ctx.editMessageText(`Scheduling report: ${reportInput.split(' ')[0]} every ${interval}...`);
-
       const userId = `${PLATFORM_PREFIX}${senderId}`;
-      const intervalMs = assertInterval(interval);
+      let intervalMs: number;
+      try {
+        intervalMs = assertInterval(interval);
+      } catch {
+        await ctx.editMessageText(`Invalid interval "${interval}". Please select one of: 1m, 1h, 6h, 12h, 1d, 1w.`);
+        return;
+      }
+
+      await ctx.editMessageText(`Scheduling report: ${reportInput.split(' ')[0]} every ${interval}...`);
       const result = await reportAdd(reportInput, userId, {intervalMs});
 
       await replyWithMarkdown(ctx, result.message);

--- a/packages/messaging/src/platform/TelegramPlatform.ts
+++ b/packages/messaging/src/platform/TelegramPlatform.ts
@@ -328,6 +328,15 @@ export class TelegramPlatform implements MessagingPlatform {
     // Must run before the command handlers installed below.
     this.#bot.use(lowercaseCommandMiddleware);
 
+    // Drop unauthorized updates before they reach the conversations plugin or
+    // any command / callback handler. This is the global gate — individual
+    // handlers still call `#authorizedUserId` to obtain the prefixed userId,
+    // but they can trust the middleware has already turned away non-owners.
+    this.#bot.use(async (ctx, next) => {
+      if (this.#authorizedUserId(ctx) === null) return;
+      await next();
+    });
+
     // Install @grammyjs/conversations plugin BEFORE any command handlers are
     // registered. The `conversations()` middleware must run for every update
     // so it can resume active sessions on subsequent callback_query updates,
@@ -384,21 +393,22 @@ export class TelegramPlatform implements MessagingPlatform {
   }
 
   /**
-   * Returns the platform-prefixed userId if the sender is authorized, or
-   * `null` otherwise. **Fail-closed**: an unset/empty `TELEGRAM_OWNER_IDS`
-   * list rejects every sender. Callers should return early on `null`.
+   * Returns the platform-prefixed userId for an authorized sender, or `null`
+   * otherwise. A global middleware installed in the constructor runs this on
+   * every inbound update and drops the update when it returns `null`, so by
+   * the time a command/callback handler fires the sender is guaranteed to be
+   * authorized. Handlers still call this helper to obtain the prefixed userId
+   * for downstream queries — the double-check is defense-in-depth against a
+   * future handler that bypasses the middleware.
    *
-   * Every update-handling code path (commands, callback queries, conversation
-   * resumes) MUST go through this helper — it's the only gate between an
-   * inbound Telegram update and the bot's command machinery.
+   * The empty-owner-list case cannot reach this helper at runtime: `start()`
+   * throws when `TELEGRAM_OWNER_IDS` is unset, so the bot refuses to boot
+   * instead of silently dropping every message.
    */
   #authorizedUserId(ctx: Context): string | null {
     const senderId = ctx.from?.id?.toString();
     if (!senderId) return null;
-    if (this.#ownerIds.length === 0) {
-      console.warn('Ignoring Telegram update: TELEGRAM_OWNER_IDS is not set, so the bot rejects every message.');
-      return null;
-    }
+    if (this.#ownerIds.length === 0) return null;
     if (!this.#ownerIds.includes(senderId)) {
       console.warn(
         `Ignoring Telegram update from "${senderId}" — only owners [${this.#ownerIds.join(', ')}] are authorized.`
@@ -641,14 +651,14 @@ export class TelegramPlatform implements MessagingPlatform {
   }
 
   async start(): Promise<void> {
-    if (this.#ownerIds.length > 0) {
-      console.log(`Only Telegram user IDs (${this.#ownerIds.join(', ')}) can message the bot.`);
-    } else {
-      console.error(
-        'Error: TELEGRAM_OWNER_IDS is not set. The bot will reject every incoming message. ' +
-          'Set TELEGRAM_OWNER_IDS to a comma-separated list of Telegram user IDs.'
+    if (this.#ownerIds.length === 0) {
+      throw new Error(
+        'TELEGRAM_OWNER_IDS is not set. Refusing to start the Telegram bot — without an ' +
+          'owner list the bot would accept messages from anyone. Set TELEGRAM_OWNER_IDS ' +
+          'to a comma-separated list of Telegram user IDs.'
       );
     }
+    console.log(`Only Telegram user IDs (${this.#ownerIds.join(', ')}) can message the bot.`);
 
     await this.#bot.init();
     this.#platformInfo = {

--- a/packages/messaging/src/platform/TelegramPlatform.ts
+++ b/packages/messaging/src/platform/TelegramPlatform.ts
@@ -23,10 +23,10 @@ const MODE_CALLBACK_PREFIX = 'reportmode:';
 const INTERVAL_CALLBACK_PREFIX = 'reportinterval:';
 
 const TRADE_CONVERSATION_ID = 'trade';
-// Telegram requires command names to be lowercase [a-z0-9_] — uppercase
-// letters are silently ignored during command matching. Keep these names
-// in sync with the entries registered in startServer.ts.
-const TRADE_COMMAND_NAMES = ['buymarket', 'sellmarket', 'buylimit', 'selllimit'] as const;
+// Display (camelCase) names shown in `/help` and usage errors. grammY
+// registration uses the lowercased form so command matching stays
+// case-insensitive via the middleware installed in the constructor.
+const TRADE_COMMAND_NAMES = ['buyMarket', 'sellMarket', 'buyLimit', 'sellLimit'] as const;
 type TradeCommandName = (typeof TRADE_COMMAND_NAMES)[number];
 
 interface TradeCommandShape {
@@ -36,13 +36,13 @@ interface TradeCommandShape {
 
 function tradeCommandShape(name: TradeCommandName): TradeCommandShape {
   switch (name) {
-    case 'buymarket':
+    case 'buyMarket':
       return {side: ExchangeOrderSide.BUY, isLimit: false};
-    case 'sellmarket':
+    case 'sellMarket':
       return {side: ExchangeOrderSide.SELL, isLimit: false};
-    case 'buylimit':
+    case 'buyLimit':
       return {side: ExchangeOrderSide.BUY, isLimit: true};
-    case 'selllimit':
+    case 'sellLimit':
       return {side: ExchangeOrderSide.SELL, isLimit: true};
   }
 }
@@ -163,7 +163,7 @@ async function tradeWizard(
   );
 
   if (accounts.length === 0) {
-    await ctx.reply('No exchange account found. Use /accountadd to add one first.');
+    await ctx.reply('No exchange account found. Use /accountAdd to add one first.');
     return;
   }
 
@@ -271,6 +271,33 @@ function inlineKeyboard(rows: InlineButton[][]) {
   return {reply_markup: {inline_keyboard: rows}};
 }
 
+/**
+ * Rewrites the bot_command entity at offset 0 to lowercase so grammY's
+ * case-sensitive command matching accepts any casing from the user. Only
+ * the command name is lowercased — the optional `@botname` suffix and any
+ * arguments after the command are left untouched.
+ *
+ * Exported for unit tests.
+ */
+export async function lowercaseCommandMiddleware(ctx: Context, next: () => Promise<void>): Promise<void> {
+  const message = ctx.message ?? ctx.channelPost;
+  const text = message?.text;
+  const entities = message?.entities;
+  if (text && entities) {
+    const entity = entities.find(e => e.type === 'bot_command' && e.offset === 0);
+    if (entity) {
+      const rawCommand = text.slice(0, entity.length);
+      const atIndex = rawCommand.indexOf('@');
+      const nameEnd = atIndex === -1 ? rawCommand.length : atIndex;
+      const normalized = rawCommand.slice(0, nameEnd).toLowerCase() + rawCommand.slice(nameEnd);
+      if (normalized !== rawCommand) {
+        (message as {text: string}).text = normalized + text.slice(entity.length);
+      }
+    }
+  }
+  await next();
+}
+
 async function replyWithMarkdown(ctx: Context, text: string): Promise<void> {
   for (const chunk of splitForTelegram(text)) {
     try {
@@ -291,6 +318,11 @@ export class TelegramPlatform implements MessagingPlatform {
   constructor(botToken: string, ownerIds?: string) {
     this.#bot = new Bot<TradeContext>(botToken);
     this.#ownerIds = ownerIds ? ownerIds.split(',').map(id => id.trim()) : [];
+
+    // Normalize incoming /Commands to lowercase so grammY's case-sensitive
+    // command matching accepts any casing (/reportAdd, /REPORTADD, /repOrTADd).
+    // Must run before the command handlers installed below.
+    this.#bot.use(lowercaseCommandMiddleware);
 
     // Install @grammyjs/conversations plugin BEFORE any command handlers are
     // registered. The `conversations()` middleware must run for every update
@@ -317,14 +349,15 @@ export class TelegramPlatform implements MessagingPlatform {
     for (const n of names) {
       this.#commands.set(n, handler);
     }
+    const lowerNames = names.map(n => n.toLowerCase());
 
     // reportadd is handled via inline keyboard buttons
-    if (names.includes('reportadd')) {
+    if (lowerNames.includes('reportadd')) {
       this.#registerReportAddCommand();
       return;
     }
 
-    this.#bot.command(names, async ctx => {
+    this.#bot.command(lowerNames, async ctx => {
       const senderId = ctx.from?.id?.toString();
 
       if (!senderId) {
@@ -396,7 +429,7 @@ export class TelegramPlatform implements MessagingPlatform {
         const userAccounts = Account.findByUserId(userId);
 
         if (userAccounts.length === 0) {
-          await ctx.editMessageText(`Report "${reportName}" requires an exchange account.\nUse /accountadd to add one first.`);
+          await ctx.editMessageText(`Report "${reportName}" requires an exchange account.\nUse /accountAdd to add one first.`);
           return;
         }
 
@@ -502,13 +535,13 @@ export class TelegramPlatform implements MessagingPlatform {
   }
 
   #registerTradeCommand(name: TradeCommandName): void {
-    // Record the command name so it appears in `/help`. The handler stored
+    // Record the camelCase name so it appears in `/help`. The handler stored
     // here is never invoked directly — the real wizard runs via the
     // `bot.command(...)` handler installed below — but `commandList` reads
     // from `#commands`.
     this.#commands.set(name, async () => {});
 
-    this.#bot.command(name, async ctx => {
+    this.#bot.command(name.toLowerCase(), async ctx => {
       const senderId = ctx.from?.id?.toString();
       if (!senderId) {
         await ctx.reply('Unable to determine sender');

--- a/packages/messaging/src/platform/TelegramPlatform.ts
+++ b/packages/messaging/src/platform/TelegramPlatform.ts
@@ -13,6 +13,7 @@ import type {CommandHandler, MessageContext, MessagingPlatform, PlatformInfo} fr
 import {markdownToTelegramHtml, splitForTelegram} from './telegramMarkdown.js';
 import {placeOrder} from '../command/placeOrder.js';
 import {reportAdd} from '../command/report/reportAdd.js';
+import {assertInterval} from '../validation/assertInterval.js';
 import {Account} from '../database/models/Account.js';
 import type {ReportScheduler} from '../service/ReportScheduler.js';
 
@@ -524,7 +525,8 @@ export class TelegramPlatform implements MessagingPlatform {
       await ctx.editMessageText(`Scheduling report: ${reportInput.split(' ')[0]} every ${interval}...`);
 
       const userId = `${PLATFORM_PREFIX}${senderId}`;
-      const result = await reportAdd(`${reportInput} --every ${interval}`, userId);
+      const intervalMs = assertInterval(interval);
+      const result = await reportAdd(reportInput, userId, {intervalMs});
 
       await replyWithMarkdown(ctx, result.message);
 

--- a/packages/messaging/src/startServer.ts
+++ b/packages/messaging/src/startServer.ts
@@ -36,7 +36,7 @@ function registerCommands(platform: MessagingPlatform, monitors: Monitors): void
     await ctx.reply(answer);
   });
 
-  platform.registerCommand('accountadd', async ctx => {
+  platform.registerCommand('accountAdd', async ctx => {
     const result = await accountAdd(ctx.content, ctx.senderId);
 
     if (result) {
@@ -44,11 +44,11 @@ function registerCommands(platform: MessagingPlatform, monitors: Monitors): void
     }
   });
 
-  platform.registerCommand('accountlist', async ctx => {
+  platform.registerCommand('accountList', async ctx => {
     await ctx.reply(await accountList(ctx.senderId));
   });
 
-  platform.registerCommand('accountremove', async ctx => {
+  platform.registerCommand('accountRemove', async ctx => {
     const result = await accountRemove(ctx.content, ctx.senderId);
 
     if (result) {
@@ -56,7 +56,7 @@ function registerCommands(platform: MessagingPlatform, monitors: Monitors): void
     }
   });
 
-  platform.registerCommand('accounttime', async ctx => {
+  platform.registerCommand('accountTime', async ctx => {
     const result = await accountTime(ctx.content, ctx.senderId);
 
     if (result) {
@@ -88,7 +88,7 @@ function registerCommands(platform: MessagingPlatform, monitors: Monitors): void
     await ctx.reply(await uptime());
   });
 
-  platform.registerCommand('watchadd', async ctx => {
+  platform.registerCommand('watchAdd', async ctx => {
     const result = await watchAdd(ctx.content, ctx.senderId);
     await ctx.reply(result.message);
 
@@ -101,11 +101,11 @@ function registerCommands(platform: MessagingPlatform, monitors: Monitors): void
     }
   });
 
-  platform.registerCommand('watchlist', async ctx => {
+  platform.registerCommand('watchList', async ctx => {
     await ctx.reply(await watchList(ctx.senderId));
   });
 
-  platform.registerCommand('watchremove', async ctx => {
+  platform.registerCommand('watchRemove', async ctx => {
     const result = await watchRemove(ctx.content, ctx.senderId);
     await ctx.reply(result.message);
 
@@ -114,7 +114,7 @@ function registerCommands(platform: MessagingPlatform, monitors: Monitors): void
     }
   });
 
-  platform.registerCommand('strategyadd', async ctx => {
+  platform.registerCommand('strategyAdd', async ctx => {
     const result = await strategyAdd(ctx.content, ctx.senderId);
     await ctx.reply(result.message);
 
@@ -127,11 +127,11 @@ function registerCommands(platform: MessagingPlatform, monitors: Monitors): void
     }
   });
 
-  platform.registerCommand('strategylist', async ctx => {
+  platform.registerCommand('strategyList', async ctx => {
     await ctx.reply(await strategyList(ctx.senderId));
   });
 
-  platform.registerCommand('strategyremove', async ctx => {
+  platform.registerCommand('strategyRemove', async ctx => {
     const result = await strategyRemove(ctx.content, ctx.senderId);
     await ctx.reply(result.message);
 
@@ -144,7 +144,7 @@ function registerCommands(platform: MessagingPlatform, monitors: Monitors): void
     }
   });
 
-  platform.registerCommand('reportadd', async ctx => {
+  platform.registerCommand('reportAdd', async ctx => {
     const result = await reportAdd(ctx.content, ctx.senderId);
     await ctx.reply(result.message);
 
@@ -157,11 +157,11 @@ function registerCommands(platform: MessagingPlatform, monitors: Monitors): void
     }
   });
 
-  platform.registerCommand('reportlist', async ctx => {
+  platform.registerCommand('reportList', async ctx => {
     await ctx.reply(await reportList(ctx.senderId));
   });
 
-  platform.registerCommand('reportremove', async ctx => {
+  platform.registerCommand('reportRemove', async ctx => {
     const result = await reportRemove(ctx.content, ctx.senderId);
     await ctx.reply(result.message);
 
@@ -170,11 +170,11 @@ function registerCommands(platform: MessagingPlatform, monitors: Monitors): void
     }
   });
 
-  platform.registerCommand('myaddress', async ctx => {
+  platform.registerCommand('myAddress', async ctx => {
     await ctx.reply(`Your address is: ${ctx.senderId.split(':').slice(1).join(':')}`);
   });
 
-  platform.registerCommand('youraddress', async ctx => {
+  platform.registerCommand('yourAddress', async ctx => {
     await ctx.reply(`My address is: ${platform.platformInfo.botAddress}`);
   });
 

--- a/packages/trading-signals-docs/pages/backtest.tsx
+++ b/packages/trading-signals-docs/pages/backtest.tsx
@@ -117,6 +117,17 @@ export default function BacktestPage() {
     }
   }, [configJson, selectedStrategy]);
 
+  const copyConfig = useCallback(async () => {
+    try {
+      // Compact to a single line so it drops cleanly onto a /strategyAdd line in the messenger.
+      const compact = JSON.stringify(JSON.parse(configJson));
+      await navigator.clipboard.writeText(compact);
+      showToast('Strategy config copied to clipboard');
+    } catch {
+      showToast('Failed to copy config');
+    }
+  }, [configJson, showToast]);
+
   const runBacktest = useCallback(async () => {
     setRunning(true);
     setError(null);
@@ -223,6 +234,16 @@ export default function BacktestPage() {
           validationError={validationError}
           candles={candles}
         />
+        <button
+          onClick={copyConfig}
+          disabled={!!validationError}
+          className={`w-full py-2.5 px-4 rounded-lg text-sm font-medium transition-colors ${
+            validationError
+              ? 'bg-slate-700 text-slate-500 cursor-not-allowed'
+              : 'bg-slate-700 hover:bg-slate-600 text-white cursor-pointer'
+          }`}>
+          Copy Config
+        </button>
         <button
           onClick={runBacktest}
           disabled={!!validationError || running}


### PR DESCRIPTION
## Summary

- Display messaging commands as camelCase in the README and `/help` list (e.g. `/reportAdd`, `/accountAdd`, `/myAddress`) instead of all-lowercase.
- Install a grammY middleware that lowercases the `bot_command` entity before command matching, so `/reportAdd`, `/REPORTADD`, and `/repOrTADd` all resolve to the same handler. The `@botname` suffix and any arguments are preserved verbatim.
- `registerCommand` now stores the camelCase display name in `#commands` (driving `/help`) while registering the lowercased form with grammY (which rejects non-lowercase command names).
- `TRADE_COMMAND_NAMES` flipped to `buyMarket` / `sellMarket` / `buyLimit` / `sellLimit`, with the corresponding `tradeCommandShape` switch updated.
- Added 7 unit tests for the new middleware covering mixed casing, all-caps, `@botname` preservation, arguments after the command, the no-bot-command no-op path, and `next()` invocation.