### PR TITLE
feat(trading-strategies, trading-signals-docs): ProtectedStrategy rollout + backtester protection modal

### DIFF
--- a/packages/trading-signals-docs/components/ProtectionModal.tsx
+++ b/packages/trading-signals-docs/components/ProtectionModal.tsx
@@ -1,0 +1,249 @@
+import {useState, useEffect} from 'react';
+
+type TriggerType = 'pct' | 'nominal' | 'price';
+type OrderType = 'limit' | 'market';
+
+interface GuardForm {
+  enabled: boolean;
+  triggerType: TriggerType;
+  value: string;
+  orderType: OrderType;
+}
+
+const emptyGuard = (): GuardForm => ({
+  enabled: false,
+  triggerType: 'pct',
+  value: '',
+  orderType: 'limit',
+});
+
+function toTriggerType(value: string): TriggerType {
+  return value === 'nominal' || value === 'price' ? value : 'pct';
+}
+
+function toOrderType(value: string): OrderType {
+  return value === 'market' ? 'market' : 'limit';
+}
+
+function parseGuard(
+  protectedConfig: Record<string, unknown> | undefined,
+  prefix: 'stopLoss' | 'takeProfit'
+): GuardForm {
+  if (!protectedConfig) {
+    return emptyGuard();
+  }
+  const pct = protectedConfig[`${prefix}Pct`];
+  const nominal = protectedConfig[`${prefix}Nominal`];
+  const price = protectedConfig[`${prefix}Price`];
+  const order = protectedConfig[`${prefix}Order`];
+  const orderType: OrderType = typeof order === 'string' ? toOrderType(order) : 'limit';
+
+  if (typeof pct === 'string') {
+    return {enabled: true, triggerType: 'pct', value: pct, orderType};
+  }
+  if (typeof nominal === 'string') {
+    return {enabled: true, triggerType: 'nominal', value: nominal, orderType};
+  }
+  if (typeof price === 'string') {
+    return {enabled: true, triggerType: 'price', value: price, orderType};
+  }
+  return emptyGuard();
+}
+
+function buildProtectedConfig(
+  stopLoss: GuardForm,
+  takeProfit: GuardForm
+): Record<string, unknown> | undefined {
+  const result: Record<string, unknown> = {};
+
+  if (stopLoss.enabled && stopLoss.value.trim()) {
+    const value = stopLoss.value.trim();
+    if (stopLoss.triggerType === 'pct') result.stopLossPct = value;
+    if (stopLoss.triggerType === 'nominal') result.stopLossNominal = value;
+    if (stopLoss.triggerType === 'price') result.stopLossPrice = value;
+    result.stopLossOrder = stopLoss.orderType;
+  }
+
+  if (takeProfit.enabled && takeProfit.value.trim()) {
+    const value = takeProfit.value.trim();
+    if (takeProfit.triggerType === 'pct') result.takeProfitPct = value;
+    if (takeProfit.triggerType === 'nominal') result.takeProfitNominal = value;
+    if (takeProfit.triggerType === 'price') result.takeProfitPrice = value;
+    result.takeProfitOrder = takeProfit.orderType;
+  }
+
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+interface ProtectionModalProps {
+  open: boolean;
+  initialProtected: Record<string, unknown> | undefined;
+  onSave: (protectedConfig: Record<string, unknown> | undefined) => void;
+  onClose: () => void;
+}
+
+export function ProtectionModal({open, initialProtected, onSave, onClose}: ProtectionModalProps) {
+  const [stopLoss, setStopLoss] = useState<GuardForm>(emptyGuard);
+  const [takeProfit, setTakeProfit] = useState<GuardForm>(emptyGuard);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    if (initialProtected) {
+      setStopLoss(parseGuard(initialProtected, 'stopLoss'));
+      setTakeProfit(parseGuard(initialProtected, 'takeProfit'));
+    } else {
+      // Fresh open with no existing protection: pre-enable stop-loss so the
+      // form is visible immediately. User just has to type a value and Save.
+      setStopLoss({enabled: true, triggerType: 'pct', value: '', orderType: 'limit'});
+      setTakeProfit(emptyGuard());
+    }
+  }, [open, initialProtected]);
+
+  if (!open) {
+    return null;
+  }
+
+  const builtConfig = buildProtectedConfig(stopLoss, takeProfit);
+  const hasIncompleteGuard =
+    (stopLoss.enabled && !stopLoss.value.trim()) || (takeProfit.enabled && !takeProfit.value.trim());
+  const canSave = builtConfig !== undefined;
+  const hint = hasIncompleteGuard
+    ? 'Enter a value for each enabled guard to save.'
+    : !stopLoss.enabled && !takeProfit.enabled
+      ? 'Enable stop-loss or take-profit to add protection.'
+      : null;
+
+  const handleSave = () => {
+    if (!canSave) {
+      return;
+    }
+    onSave(builtConfig);
+    onClose();
+  };
+
+  const handleRemove = () => {
+    onSave(undefined);
+    onClose();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4"
+      onClick={onClose}>
+      <div
+        className="bg-slate-800 border border-slate-700 rounded-lg p-6 w-full max-w-md shadow-xl"
+        onClick={e => e.stopPropagation()}>
+        <h3 className="text-lg font-semibold text-white mb-2">Protection settings</h3>
+        <p className="text-xs text-slate-400 mb-4">
+          Stop-loss and take-profit kill switches run on top of the selected strategy. Enable either or
+          both to have the backtester exit automatically when thresholds are reached. Once a guard fires,
+          the strategy is terminal for the session.
+        </p>
+
+        <GuardSection title="Stop-loss" suffix="loss" guard={stopLoss} onChange={setStopLoss} />
+        <div className="h-3" />
+        <GuardSection title="Take-profit" suffix="gain" guard={takeProfit} onChange={setTakeProfit} />
+
+        {hint && <p className="text-xs text-amber-400 mt-3">{hint}</p>}
+
+        <div className="flex gap-2 mt-6">
+          <button
+            onClick={handleRemove}
+            className="flex-1 py-2 px-3 bg-slate-700 hover:bg-slate-600 text-white rounded-md text-sm cursor-pointer transition-colors">
+            Remove
+          </button>
+          <button
+            onClick={onClose}
+            className="flex-1 py-2 px-3 bg-slate-700 hover:bg-slate-600 text-white rounded-md text-sm cursor-pointer transition-colors">
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={!canSave}
+            className={`flex-1 py-2 px-3 rounded-md text-sm transition-colors ${
+              canSave
+                ? 'bg-purple-600 hover:bg-purple-700 text-white cursor-pointer'
+                : 'bg-slate-700 text-slate-500 cursor-not-allowed'
+            }`}>
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface GuardSectionProps {
+  title: string;
+  suffix: 'loss' | 'gain';
+  guard: GuardForm;
+  onChange: (guard: GuardForm) => void;
+}
+
+function GuardSection({title, suffix, guard, onChange}: GuardSectionProps) {
+  const update = (patch: Partial<GuardForm>) => onChange({...guard, ...patch});
+
+  const valueLabel =
+    guard.triggerType === 'pct'
+      ? `Percent ${suffix === 'loss' ? 'drop' : 'gain'} from avg entry`
+      : guard.triggerType === 'nominal'
+        ? `Counter-currency ${suffix}`
+        : 'Absolute price target';
+
+  const valuePlaceholder =
+    guard.triggerType === 'pct' ? '5' : guard.triggerType === 'nominal' ? '10' : suffix === 'loss' ? '95' : '110';
+
+  return (
+    <div className="bg-slate-900/50 border border-slate-700 rounded-md p-3">
+      <label className="flex items-center gap-2 text-sm text-white cursor-pointer">
+        <input
+          type="checkbox"
+          checked={guard.enabled}
+          onChange={e => update({enabled: e.target.checked})}
+          className="accent-purple-500 w-4 h-4"
+        />
+        <span className="font-semibold">{title}</span>
+      </label>
+
+      {guard.enabled && (
+        <div className="mt-3 space-y-3">
+          <div>
+            <label className="block text-xs text-slate-400 mb-1">Trigger type</label>
+            <select
+              value={guard.triggerType}
+              onChange={e => update({triggerType: toTriggerType(e.target.value)})}
+              className="w-full px-2 py-1.5 bg-slate-900 border border-slate-600 rounded text-white text-sm focus:outline-none focus:border-purple-500">
+              <option value="pct">Percentage</option>
+              <option value="nominal">Nominal (counter currency)</option>
+              <option value="price">Absolute price</option>
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-xs text-slate-400 mb-1">{valueLabel}</label>
+            <input
+              type="text"
+              value={guard.value}
+              onChange={e => update({value: e.target.value})}
+              placeholder={valuePlaceholder}
+              className="w-full px-2 py-1.5 bg-slate-900 border border-slate-600 rounded text-white text-sm focus:outline-none focus:border-purple-500"
+            />
+          </div>
+
+          <div>
+            <label className="block text-xs text-slate-400 mb-1">Order type</label>
+            <select
+              value={guard.orderType}
+              onChange={e => update({orderType: toOrderType(e.target.value)})}
+              className="w-full px-2 py-1.5 bg-slate-900 border border-slate-600 rounded text-white text-sm focus:outline-none focus:border-purple-500">
+              <option value="limit">Limit (exact target, may not fill on gap)</option>
+              <option value="market">Market (guaranteed fill, slippage possible)</option>
+            </select>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/trading-signals-docs/pages/backtest.tsx
+++ b/packages/trading-signals-docs/pages/backtest.tsx
@@ -20,6 +20,7 @@ import {
 import {DatasetSelector} from '../components/DatasetSelector';
 import {StrategyConfigurator} from '../components/StrategyConfigurator';
 import {BacktestResults} from '../components/BacktestResults';
+import {ProtectionModal} from '../components/ProtectionModal';
 import {datasets} from '../utils/datasets';
 import type {CandleDataset} from '../utils/types';
 import {strategyDefinitions, type StrategyId} from '../utils/strategySchemas';
@@ -27,9 +28,9 @@ import {strategyDefinitions, type StrategyId} from '../utils/strategySchemas';
 function createStrategy(strategyId: StrategyId, config: Record<string, unknown>) {
   switch (strategyId) {
     case 'buy-and-hold':
-      return new BuyAndHoldStrategy();
+      return new BuyAndHoldStrategy(config);
     case 'coin-flip':
-      return new CoinFlipStrategy();
+      return new CoinFlipStrategy(config);
     case 'buy-once':
       return new BuyOnceStrategy(config as BuyOnceConfig);
     case 'buy-below-sell-above':
@@ -39,7 +40,7 @@ function createStrategy(strategyId: StrategyId, config: Record<string, unknown>)
     case 'scalp':
       return new ScalpStrategy(config as ScalpConfig);
     case 'mean-reversion':
-      return new MeanReversionStrategy();
+      return new MeanReversionStrategy({config});
   }
 }
 
@@ -79,6 +80,7 @@ export default function BacktestPage() {
   const [customDataset, setCustomDataset] = useState<CandleDataset | null>(null);
   const [initialBase, setInitialBase] = useState('0');
   const [initialCounter, setInitialCounter] = useState('10000');
+  const [protectionModalOpen, setProtectionModalOpen] = useState(false);
   const [toast, setToast] = useState<string | null>(null);
   const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -116,6 +118,37 @@ export default function BacktestPage() {
       setValidationError('Invalid JSON');
     }
   }, [configJson, selectedStrategy]);
+
+  const currentProtected: Record<string, unknown> | undefined = (() => {
+    try {
+      const parsed = JSON.parse(configJson);
+      if (parsed && typeof parsed === 'object' && parsed.protected && typeof parsed.protected === 'object') {
+        return parsed.protected;
+      }
+    } catch {
+      // invalid JSON — user is mid-edit, treat as no protection
+    }
+    return undefined;
+  })();
+
+  const handleProtectionSave = useCallback(
+    (nextProtected: Record<string, unknown> | undefined) => {
+      try {
+        const parsed = JSON.parse(configJson);
+        const base = parsed && typeof parsed === 'object' ? parsed : {};
+        const next = {...base};
+        if (nextProtected === undefined) {
+          delete next.protected;
+        } else {
+          next.protected = nextProtected;
+        }
+        setConfigJson(JSON.stringify(next, null, 2));
+      } catch {
+        showToast('Cannot update protection: config JSON is invalid');
+      }
+    },
+    [configJson, showToast]
+  );
 
   const copyConfig = useCallback(async () => {
     try {
@@ -235,6 +268,14 @@ export default function BacktestPage() {
           candles={candles}
         />
         <button
+          onClick={() => setProtectionModalOpen(true)}
+          className="w-full py-2.5 px-4 rounded-lg text-sm font-medium transition-colors bg-slate-700 hover:bg-slate-600 text-white cursor-pointer flex items-center justify-center gap-2">
+          <span>{currentProtected ? 'Edit Protection' : 'Add Protection'}</span>
+          {currentProtected && (
+            <span className="text-xs bg-purple-600/30 text-purple-200 px-2 py-0.5 rounded-full">active</span>
+          )}
+        </button>
+        <button
           onClick={copyConfig}
           disabled={!!validationError}
           className={`w-full py-2.5 px-4 rounded-lg text-sm font-medium transition-colors ${
@@ -260,6 +301,13 @@ export default function BacktestPage() {
           </div>
         )}
       </div>
+
+      <ProtectionModal
+        open={protectionModalOpen}
+        initialProtected={currentProtected}
+        onSave={handleProtectionSave}
+        onClose={() => setProtectionModalOpen(false)}
+      />
 
       {/* Toast notification */}
       {toast && (

--- a/packages/trading-strategies/src/index.ts
+++ b/packages/trading-strategies/src/index.ts
@@ -3,16 +3,20 @@ export * from './strategy/index.js';
 export {BuyAndHoldStrategy, BuyAndHoldSchema} from './strategy-buy-and-hold/BuyAndHoldStrategy.js';
 export {BuyOnceStrategy, BuyOnceSchema, type BuyOnceConfig} from './strategy-buy-once/BuyOnceStrategy.js';
 export {BuyBelowSellAboveStrategy, BuyBelowSellAboveSchema, type BuyBelowSellAboveConfig} from './strategy-buy-below-sell-above/BuyBelowSellAboveStrategy.js';
-export {CoinFlipStrategy, CoinFlipSchema} from './strategy-coin-flip/CoinFlipStrategy.js';
+export {CoinFlipStrategy, CoinFlipSchema, type CoinFlipConfig} from './strategy-coin-flip/CoinFlipStrategy.js';
 export {MultiIndicatorConfluenceStrategy, MultiIndicatorConfluenceSchema, type MultiIndicatorConfluenceConfig} from './strategy-multi-indicator-confluence/MultiIndicatorConfluenceStrategy.js';
 export {ScalpStrategy, ScalpSchema, type ScalpConfig} from './strategy-scalp/ScalpStrategy.js';
-export {MeanReversionStrategy, MeanReversionSchema} from './strategy-mean-reversion/MeanReversionStrategy.js';
 export {
-  GuardedStrategy,
-  GuardedStrategySchema,
-  type GuardedStrategyConfig,
-  type GuardedStrategyState,
-} from './strategy-guarded/GuardedStrategy.js';
+  MeanReversionStrategy,
+  MeanReversionSchema,
+  type MeanReversionConfig,
+} from './strategy-mean-reversion/MeanReversionStrategy.js';
+export {
+  ProtectedStrategy,
+  ProtectedStrategySchema,
+  type ProtectedStrategyConfig,
+  type ProtectedStrategyState,
+} from './strategy-protected/ProtectedStrategy.js';
 export {suggestScalpOffset} from './strategy-scalp/suggestScalpOffset.js';
 export * from './report/index.js';
 export {

--- a/packages/trading-strategies/src/strategy-buy-and-hold/BuyAndHoldStrategy.test.ts
+++ b/packages/trading-strategies/src/strategy-buy-and-hold/BuyAndHoldStrategy.test.ts
@@ -1,0 +1,185 @@
+import Big from 'big.js';
+import {describe, expect, it} from 'vitest';
+import {
+  CandleBatcher,
+  ExchangeOrderPosition,
+  ExchangeOrderSide,
+  ExchangeOrderType,
+  TradingPair,
+} from '@typedtrader/exchange';
+import type {
+  ExchangeCandle,
+  ExchangeFill,
+  LimitOrderAdvice,
+  MarketOrderAdvice,
+  OneMinuteBatchedCandle,
+  OrderAdvice,
+  TradingSessionState,
+} from '@typedtrader/exchange';
+import {BuyAndHoldStrategy} from './BuyAndHoldStrategy.js';
+
+function assertMarketBuy(advice: OrderAdvice | void): asserts advice is MarketOrderAdvice {
+  if (!advice || advice.type !== ExchangeOrderType.MARKET || advice.side !== ExchangeOrderSide.BUY) {
+    throw new Error(`Expected a MARKET BUY advice but received ${JSON.stringify(advice)}`);
+  }
+}
+
+function assertLimitSell(advice: OrderAdvice | void): asserts advice is LimitOrderAdvice {
+  if (!advice || advice.type !== ExchangeOrderType.LIMIT || advice.side !== ExchangeOrderSide.SELL) {
+    throw new Error(`Expected a LIMIT SELL advice but received ${JSON.stringify(advice)}`);
+  }
+}
+
+const pair = new TradingPair('AAPL', 'USD');
+
+const mockState: TradingSessionState = {
+  baseBalance: new Big(0),
+  counterBalance: new Big(1000),
+  tradingRules: {
+    base_increment: '0.01',
+    base_max_size: '10000',
+    base_min_size: '0.01',
+    counter_increment: '0.01',
+    counter_min_size: '1',
+    pair,
+  },
+  feeRates: {
+    [ExchangeOrderType.LIMIT]: new Big('0.001'),
+    [ExchangeOrderType.MARKET]: new Big('0.002'),
+  },
+};
+
+const ONE_MINUTE_IN_MS = 60_000;
+
+function makeCandle(close: number, index = 0): OneMinuteBatchedCandle {
+  const closeStr = String(close);
+  const exchangeCandle: ExchangeCandle = {
+    base: 'AAPL',
+    close: closeStr,
+    counter: 'USD',
+    high: String(close + 1),
+    low: String(close - 1),
+    open: closeStr,
+    openTimeInISO: new Date(1735689600000 + index * ONE_MINUTE_IN_MS).toISOString(),
+    openTimeInMillis: 1735689600000 + index * ONE_MINUTE_IN_MS,
+    sizeInMillis: ONE_MINUTE_IN_MS,
+    volume: '1000',
+  };
+  return CandleBatcher.createOneMinuteBatchedCandle([exchangeCandle]);
+}
+
+function makeFill(price: string, size: string, side: ExchangeOrderSide): ExchangeFill {
+  return {
+    created_at: '2025-01-01T00:00:00.000Z',
+    fee: '0',
+    feeAsset: 'USD',
+    order_id: 'order-1',
+    pair,
+    position: ExchangeOrderPosition.LONG,
+    price,
+    side,
+    size,
+  };
+}
+
+describe('BuyAndHoldStrategy', () => {
+  describe('unprotected', () => {
+    it('issues a market buy on the first candle and then stays silent', async () => {
+      const strategy = new BuyAndHoldStrategy();
+
+      const first = await strategy.onCandle(makeCandle(100), mockState);
+      assertMarketBuy(first);
+      expect(first.amountIn).toBe('counter');
+
+      const second = await strategy.onCandle(makeCandle(105, 1), mockState);
+      expect(second).toBeUndefined();
+
+      const third = await strategy.onCandle(makeCandle(50, 2), mockState);
+      expect(third).toBeUndefined();
+    });
+  });
+
+  describe('with stop-loss', () => {
+    it('buys first, then fires a kill-switch limit sell when the stop-loss threshold is hit', async () => {
+      const strategy = new BuyAndHoldStrategy({protected: {stopLossPct: '5'}});
+
+      const buy = await strategy.onCandle(makeCandle(100), mockState);
+      assertMarketBuy(buy);
+
+      // Simulate the exchange filling the market buy
+      await strategy.onFill(makeFill('100', '10', ExchangeOrderSide.BUY), mockState);
+
+      // Price drifts harmlessly — no guard fire
+      const hold = await strategy.onCandle(makeCandle(97, 1), mockState);
+      expect(hold).toBeUndefined();
+
+      // Price drops 5% — stop-loss fires
+      const exit = await strategy.onCandle(makeCandle(95, 2), mockState);
+      assertLimitSell(exit);
+      expect(new Big(exit.price).toFixed(2)).toBe('95.00');
+      expect(exit.reason).toContain('[KILL SWITCH]');
+      expect(exit.reason).toContain('Stop-loss');
+    });
+  });
+
+  describe('with take-profit', () => {
+    it('buys first, then fires a kill-switch limit sell when the take-profit threshold is hit', async () => {
+      const strategy = new BuyAndHoldStrategy({protected: {takeProfitPct: '10'}});
+
+      const buy = await strategy.onCandle(makeCandle(100), mockState);
+      assertMarketBuy(buy);
+      await strategy.onFill(makeFill('100', '10', ExchangeOrderSide.BUY), mockState);
+
+      const hold = await strategy.onCandle(makeCandle(105, 1), mockState);
+      expect(hold).toBeUndefined();
+
+      const exit = await strategy.onCandle(makeCandle(110, 2), mockState);
+      assertLimitSell(exit);
+      expect(new Big(exit.price).toFixed(2)).toBe('110.00');
+      expect(exit.reason).toContain('Take-profit');
+    });
+  });
+
+  describe('with both guards', () => {
+    it('does not re-enter after a stop-loss exit — buy-and-hold is a one-shot entry', async () => {
+      const strategy = new BuyAndHoldStrategy({protected: {stopLossPct: '5', takeProfitPct: '10'}});
+
+      await strategy.onCandle(makeCandle(100), mockState);
+      await strategy.onFill(makeFill('100', '10', ExchangeOrderSide.BUY), mockState);
+
+      // Fire stop-loss
+      const exit = await strategy.onCandle(makeCandle(95, 1), mockState);
+      assertLimitSell(exit);
+
+      // Sell fills — position closed
+      await strategy.onFill(makeFill('95', '10', ExchangeOrderSide.SELL), mockState);
+
+      // Even if the price recovers, nothing re-enters
+      const silent = await strategy.onCandle(makeCandle(120, 2), mockState);
+      expect(silent).toBeUndefined();
+    });
+  });
+
+  describe('state persistence', () => {
+    it('restores the bought flag and protected position through restoreState', async () => {
+      const original = new BuyAndHoldStrategy({protected: {stopLossPct: '5'}});
+      await original.onCandle(makeCandle(100), mockState);
+      await original.onFill(makeFill('100', '10', ExchangeOrderSide.BUY), mockState);
+
+      const snapshot = original.state;
+      expect(snapshot).not.toBeNull();
+
+      const restored = new BuyAndHoldStrategy({protected: {stopLossPct: '5'}});
+      restored.restoreState(snapshot!);
+
+      // Restored instance must not re-buy on the next candle
+      const shouldHold = await restored.onCandle(makeCandle(98, 1), mockState);
+      expect(shouldHold).toBeUndefined();
+
+      // And the guard must still fire at the original avg-entry-based threshold
+      const exit = await restored.onCandle(makeCandle(95, 2), mockState);
+      assertLimitSell(exit);
+      expect(new Big(exit.price).toFixed(2)).toBe('95.00');
+    });
+  });
+});

--- a/packages/trading-strategies/src/strategy-buy-and-hold/BuyAndHoldStrategy.ts
+++ b/packages/trading-strategies/src/strategy-buy-and-hold/BuyAndHoldStrategy.ts
@@ -1,30 +1,45 @@
 import {z} from 'zod';
 import {ExchangeOrderSide, ExchangeOrderType} from '@typedtrader/exchange';
 import type {OneMinuteBatchedCandle, OrderAdvice, TradingSessionState} from '@typedtrader/exchange';
-import {Strategy} from '../strategy/Strategy.js';
+import {ProtectedStrategy, ProtectedStrategySchema} from '../strategy-protected/ProtectedStrategy.js';
 
-export const BuyAndHoldSchema = z.object({});
+export const BuyAndHoldSchema = ProtectedStrategySchema.extend({});
+export type BuyAndHoldConfig = z.input<typeof BuyAndHoldSchema>;
 
 type BuyAndHoldState = {
   bought: boolean;
 };
 
 /**
- * Buys once at the first candle and holds for the entire period.
- * This is the simplest baseline strategy to compare other strategies against.
+ * Buys once at the first candle and holds for the entire period — the
+ * simplest baseline strategy to compare others against.
+ *
+ * Because it extends `ProtectedStrategy`, optional stop-loss / take-profit kill
+ * switches can be configured via the nested `protected` key. That turns the
+ * plain hold into a protected buy-and-hold: enter once at the first candle,
+ * then let the guards manage the exit. Once a guard fires, the strategy is
+ * terminal for the session — buy-and-hold only ever enters once.
  */
-export class BuyAndHoldStrategy extends Strategy {
+export class BuyAndHoldStrategy extends ProtectedStrategy {
   static override NAME = '@typedtrader/strategy-buy-and-hold';
 
-  constructor() {
-    super({state: {bought: false}});
+  constructor(config: BuyAndHoldConfig = {}) {
+    super({config, state: {bought: false}});
   }
 
   get #state(): BuyAndHoldState {
     return this.getProxiedState<BuyAndHoldState>();
   }
 
-  protected override async processCandle(_candle: OneMinuteBatchedCandle, _state: TradingSessionState): Promise<OrderAdvice | void> {
+  protected override async processCandle(
+    candle: OneMinuteBatchedCandle,
+    state: TradingSessionState
+  ): Promise<OrderAdvice | void> {
+    const guardAdvice = await super.processCandle(candle, state);
+    if (guardAdvice) {
+      return guardAdvice;
+    }
+
     if (this.#state.bought) {
       return undefined;
     }

--- a/packages/trading-strategies/src/strategy-buy-below-sell-above/BuyBelowSellAboveStrategy.ts
+++ b/packages/trading-strategies/src/strategy-buy-below-sell-above/BuyBelowSellAboveStrategy.ts
@@ -2,17 +2,17 @@ import {z} from 'zod';
 import {ExchangeOrderSide, ExchangeOrderType} from '@typedtrader/exchange';
 import type {OneMinuteBatchedCandle, OrderAdvice, TradingSessionState} from '@typedtrader/exchange';
 import Big from 'big.js';
-import {Strategy} from '../strategy/Strategy.js';
+import {ProtectedStrategy, ProtectedStrategySchema} from '../strategy-protected/ProtectedStrategy.js';
 import {positiveNumberString} from '../util/validators.js';
 
-export const BuyBelowSellAboveSchema = z.object({
+export const BuyBelowSellAboveSchema = ProtectedStrategySchema.extend({
   buyBelow: positiveNumberString.optional(),
   sellAbove: positiveNumberString.optional(),
 });
 
-export type BuyBelowSellAboveConfig = z.infer<typeof BuyBelowSellAboveSchema>;
+export type BuyBelowSellAboveConfig = z.input<typeof BuyBelowSellAboveSchema>;
 
-export class BuyBelowSellAboveStrategy extends Strategy {
+export class BuyBelowSellAboveStrategy extends ProtectedStrategy {
   static override NAME = '@typedtrader/strategy-buy-below-sell-above';
 
   constructor(config: BuyBelowSellAboveConfig = {}) {
@@ -23,7 +23,12 @@ export class BuyBelowSellAboveStrategy extends Strategy {
     return this.getProxiedConfig<BuyBelowSellAboveConfig>();
   }
 
-  protected override async processCandle(candle: OneMinuteBatchedCandle, _state: TradingSessionState): Promise<OrderAdvice | void> {
+  protected override async processCandle(candle: OneMinuteBatchedCandle, state: TradingSessionState): Promise<OrderAdvice | void> {
+    const guardAdvice = await super.processCandle(candle, state);
+    if (guardAdvice) {
+      return guardAdvice;
+    }
+
     const closePrice = candle.close;
 
     if (this.#config.buyBelow !== undefined) {

--- a/packages/trading-strategies/src/strategy-buy-once/BuyOnceStrategy.ts
+++ b/packages/trading-strategies/src/strategy-buy-once/BuyOnceStrategy.ts
@@ -2,15 +2,15 @@ import {z} from 'zod';
 import {ExchangeOrderSide, ExchangeOrderType} from '@typedtrader/exchange';
 import type {OneMinuteBatchedCandle, OrderAdvice, TradingSessionState} from '@typedtrader/exchange';
 import Big from 'big.js';
-import {Strategy} from '../strategy/Strategy.js';
+import {ProtectedStrategy, ProtectedStrategySchema} from '../strategy-protected/ProtectedStrategy.js';
 import {positiveNumberString} from '../util/validators.js';
 
-export const BuyOnceSchema = z.object({
+export const BuyOnceSchema = ProtectedStrategySchema.extend({
   /** The price at which to place the buy order. */
   buyAt: positiveNumberString,
 });
 
-export type BuyOnceConfig = z.infer<typeof BuyOnceSchema>;
+export type BuyOnceConfig = z.input<typeof BuyOnceSchema>;
 
 type BuyOnceState = {
   bought: boolean;
@@ -20,7 +20,7 @@ type BuyOnceState = {
  * Signals a single limit buy when the candle's close price drops to or below the predefined price.
  * After the buy is triggered, the strategy stays silent for all remaining candles.
  */
-export class BuyOnceStrategy extends Strategy {
+export class BuyOnceStrategy extends ProtectedStrategy {
   static override NAME = '@typedtrader/strategy-buy-once';
 
   constructor(config: BuyOnceConfig) {
@@ -35,7 +35,12 @@ export class BuyOnceStrategy extends Strategy {
     return this.getProxiedState<BuyOnceState>();
   }
 
-  protected override async processCandle(candle: OneMinuteBatchedCandle, _state: TradingSessionState): Promise<OrderAdvice | void> {
+  protected override async processCandle(candle: OneMinuteBatchedCandle, state: TradingSessionState): Promise<OrderAdvice | void> {
+    const guardAdvice = await super.processCandle(candle, state);
+    if (guardAdvice) {
+      return guardAdvice;
+    }
+
     if (this.#state.bought) {
       return undefined;
     }

--- a/packages/trading-strategies/src/strategy-coin-flip/CoinFlipStrategy.ts
+++ b/packages/trading-strategies/src/strategy-coin-flip/CoinFlipStrategy.ts
@@ -1,14 +1,25 @@
 import {z} from 'zod';
 import {ExchangeOrderSide, ExchangeOrderType} from '@typedtrader/exchange';
 import type {OneMinuteBatchedCandle, OrderAdvice, TradingSessionState} from '@typedtrader/exchange';
-import {Strategy} from '../strategy/Strategy.js';
+import {ProtectedStrategy, ProtectedStrategySchema} from '../strategy-protected/ProtectedStrategy.js';
 
-export const CoinFlipSchema = z.object({});
+export const CoinFlipSchema = ProtectedStrategySchema.extend({});
 
-export class CoinFlipStrategy extends Strategy {
+export type CoinFlipConfig = z.input<typeof CoinFlipSchema>;
+
+export class CoinFlipStrategy extends ProtectedStrategy {
   static override NAME = '@typedtrader/strategy-coin-flip';
 
-  protected override async processCandle(_candle: OneMinuteBatchedCandle, _state: TradingSessionState): Promise<OrderAdvice | void> {
+  constructor(config: CoinFlipConfig = {}) {
+    super({config});
+  }
+
+  protected override async processCandle(candle: OneMinuteBatchedCandle, state: TradingSessionState): Promise<OrderAdvice | void> {
+    const guardAdvice = await super.processCandle(candle, state);
+    if (guardAdvice) {
+      return guardAdvice;
+    }
+
     const buyMarket: OrderAdvice = {
       side: ExchangeOrderSide.BUY,
       type: ExchangeOrderType.MARKET,

--- a/packages/trading-strategies/src/strategy-mean-reversion/MeanReversionStrategy.ts
+++ b/packages/trading-strategies/src/strategy-mean-reversion/MeanReversionStrategy.ts
@@ -2,15 +2,15 @@ import {z} from 'zod';
 import {CandleBatcher, ExchangeOrderSide, ExchangeOrderType} from '@typedtrader/exchange';
 import type {ExchangeCandle, OneMinuteBatchedCandle, OrderAdvice, TradingSessionState} from '@typedtrader/exchange';
 import {BollingerBands} from 'trading-signals';
-import {Strategy} from '../strategy/Strategy.js';
+import {ProtectedStrategy, ProtectedStrategySchema} from '../strategy-protected/ProtectedStrategy.js';
 
 const ONE_HOUR_IN_MS = 3_600_000;
 const PERIOD = 20;
 const DEVIATION_MULTIPLIER = 2.5;
 
-export const MeanReversionSchema = z.object({});
+export const MeanReversionSchema = ProtectedStrategySchema.extend({});
 
-export type MeanReversionConfig = z.infer<typeof MeanReversionSchema>;
+export type MeanReversionConfig = z.input<typeof MeanReversionSchema>;
 
 type Phase = 'watching' | 'waitingForRebuy';
 
@@ -20,7 +20,7 @@ type MeanReversionState = {
 
 export type CandleFetcher = () => Promise<ExchangeCandle[]>;
 
-export class MeanReversionStrategy extends Strategy {
+export class MeanReversionStrategy extends ProtectedStrategy {
   static override NAME = '@typedtrader/strategy-mean-reversion';
 
   readonly #bbands = new BollingerBands(PERIOD, DEVIATION_MULTIPLIER);
@@ -28,9 +28,9 @@ export class MeanReversionStrategy extends Strategy {
   readonly #fetchCandles?: CandleFetcher;
   #warmedUp = false;
 
-  constructor(options?: {fetchCandles?: CandleFetcher}) {
+  constructor(options?: {fetchCandles?: CandleFetcher; config?: MeanReversionConfig}) {
     super({
-      config: {},
+      config: options?.config ?? {},
       state: {phase: 'watching'},
     });
     this.#fetchCandles = options?.fetchCandles;
@@ -55,7 +55,12 @@ export class MeanReversionStrategy extends Strategy {
     }
   }
 
-  protected override async processCandle(candle: OneMinuteBatchedCandle, _state: TradingSessionState): Promise<OrderAdvice | void> {
+  protected override async processCandle(candle: OneMinuteBatchedCandle, state: TradingSessionState): Promise<OrderAdvice | void> {
+    const guardAdvice = await super.processCandle(candle, state);
+    if (guardAdvice) {
+      return guardAdvice;
+    }
+
     if (!this.#warmedUp) {
       await this.#warmUp();
     }

--- a/packages/trading-strategies/src/strategy-multi-indicator-confluence/MultiIndicatorConfluenceStrategy.ts
+++ b/packages/trading-strategies/src/strategy-multi-indicator-confluence/MultiIndicatorConfluenceStrategy.ts
@@ -2,31 +2,30 @@ import {z} from 'zod';
 import {ExchangeOrderSide, ExchangeOrderType} from '@typedtrader/exchange';
 import type {OneMinuteBatchedCandle, OrderAdvice, TradingSessionState} from '@typedtrader/exchange';
 import {BollingerBands, EMA, MACD, RSI} from 'trading-signals';
-import {Strategy} from '../strategy/Strategy.js';
+import {ProtectedStrategy, ProtectedStrategySchema} from '../strategy-protected/ProtectedStrategy.js';
 
-export const MultiIndicatorConfluenceSchema = z
-  .object({
-    /** EMA short period for trend detection. */
-    emaShortPeriod: z.number().int().positive(),
-    /** EMA long period for trend detection. */
-    emaLongPeriod: z.number().int().positive(),
-    /** MACD short EMA period. */
-    macdShortPeriod: z.number().int().positive(),
-    /** MACD long EMA period. */
-    macdLongPeriod: z.number().int().positive(),
-    /** MACD signal EMA period. */
-    macdSignalPeriod: z.number().int().positive(),
-    /** Bollinger Bands period. */
-    bollingerPeriod: z.number().int().positive(),
-    /** Bollinger Bands standard deviation multiplier. */
-    bollingerDeviationMultiplier: z.number().positive(),
-    /** RSI period. */
-    rsiPeriod: z.number().int().positive(),
-    /** RSI overbought threshold (veto BUY above this). */
-    rsiOverbought: z.number().positive().max(100),
-    /** RSI oversold threshold (veto SELL below this). */
-    rsiOversold: z.number().positive().max(100),
-  })
+export const MultiIndicatorConfluenceSchema = ProtectedStrategySchema.extend({
+  /** EMA short period for trend detection. */
+  emaShortPeriod: z.number().int().positive(),
+  /** EMA long period for trend detection. */
+  emaLongPeriod: z.number().int().positive(),
+  /** MACD short EMA period. */
+  macdShortPeriod: z.number().int().positive(),
+  /** MACD long EMA period. */
+  macdLongPeriod: z.number().int().positive(),
+  /** MACD signal EMA period. */
+  macdSignalPeriod: z.number().int().positive(),
+  /** Bollinger Bands period. */
+  bollingerPeriod: z.number().int().positive(),
+  /** Bollinger Bands standard deviation multiplier. */
+  bollingerDeviationMultiplier: z.number().positive(),
+  /** RSI period. */
+  rsiPeriod: z.number().int().positive(),
+  /** RSI overbought threshold (veto BUY above this). */
+  rsiOverbought: z.number().positive().max(100),
+  /** RSI oversold threshold (veto SELL below this). */
+  rsiOversold: z.number().positive().max(100),
+})
   .refine(data => data.emaShortPeriod < data.emaLongPeriod, {
     message: 'emaShortPeriod must be less than emaLongPeriod',
     path: ['emaShortPeriod'],
@@ -40,9 +39,9 @@ export const MultiIndicatorConfluenceSchema = z
     path: ['rsiOversold'],
   });
 
-export type MultiIndicatorConfluenceConfig = z.infer<typeof MultiIndicatorConfluenceSchema>;
+export type MultiIndicatorConfluenceConfig = z.input<typeof MultiIndicatorConfluenceSchema>;
 
-export class MultiIndicatorConfluenceStrategy extends Strategy {
+export class MultiIndicatorConfluenceStrategy extends ProtectedStrategy {
   static override NAME = '@typedtrader/strategy-multi-indicator-confluence';
 
   readonly #emaShort: EMA;
@@ -96,7 +95,12 @@ export class MultiIndicatorConfluenceStrategy extends Strategy {
     return this.#candlesProcessed;
   }
 
-  protected override async processCandle(candle: OneMinuteBatchedCandle, _state: TradingSessionState): Promise<OrderAdvice | void> {
+  protected override async processCandle(candle: OneMinuteBatchedCandle, state: TradingSessionState): Promise<OrderAdvice | void> {
+    const guardAdvice = await super.processCandle(candle, state);
+    if (guardAdvice) {
+      return guardAdvice;
+    }
+
     const closePrice = candle.close.toNumber();
 
     this.#emaShort.add(closePrice);

--- a/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.test.ts
+++ b/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.test.ts
@@ -18,7 +18,7 @@ import type {
   OrderAdvice,
   TradingSessionState,
 } from '@typedtrader/exchange';
-import {GuardedStrategy, GuardedStrategySchema} from './GuardedStrategy.js';
+import {ProtectedStrategy, ProtectedStrategySchema} from './ProtectedStrategy.js';
 
 function assertLimitSell(advice: OrderAdvice | void): asserts advice is LimitOrderAdvice {
   if (!advice || advice.type !== ExchangeOrderType.LIMIT || advice.side !== ExchangeOrderSide.SELL) {
@@ -84,16 +84,16 @@ function makeFill(price: string, size: string, side: ExchangeOrderSide): Exchang
   };
 }
 
-const TestSchema = GuardedStrategySchema.extend({
+const TestSchema = ProtectedStrategySchema.extend({
   signalAdvice: z.boolean().optional(),
 });
 
 /**
- * Minimal GuardedStrategy subclass that records whether its own logic ran
+ * Minimal ProtectedStrategy subclass that records whether its own logic ran
  * and optionally returns a dummy BUY advice so we can assert that guards
  * take priority over subclass logic.
  */
-class TestGuardedStrategy extends GuardedStrategy {
+class TestProtectedStrategy extends ProtectedStrategy {
   ownLogicCallCount = 0;
 
   constructor(config: z.input<typeof TestSchema>) {
@@ -125,41 +125,41 @@ class TestGuardedStrategy extends GuardedStrategy {
   }
 }
 
-describe('GuardedStrategySchema', () => {
-  it('accepts valid thresholds inside the guarded sub-object', () => {
-    expect(() => GuardedStrategySchema.parse({guarded: {stopLossPct: '5', takeProfitPct: '10'}})).not.toThrow();
+describe('ProtectedStrategySchema', () => {
+  it('accepts valid thresholds inside the protected sub-object', () => {
+    expect(() => ProtectedStrategySchema.parse({protected: {stopLossPct: '5', takeProfitPct: '10'}})).not.toThrow();
   });
 
-  it('accepts empty config (no guarded key at all)', () => {
-    expect(() => GuardedStrategySchema.parse({})).not.toThrow();
+  it('accepts empty config (no protected key at all)', () => {
+    expect(() => ProtectedStrategySchema.parse({})).not.toThrow();
   });
 
-  it('accepts empty guarded object', () => {
-    expect(() => GuardedStrategySchema.parse({guarded: {}})).not.toThrow();
+  it('accepts empty protected object', () => {
+    expect(() => ProtectedStrategySchema.parse({protected: {}})).not.toThrow();
   });
 
   it('rejects non-positive thresholds', () => {
-    expect(() => GuardedStrategySchema.parse({guarded: {stopLossPct: '0'}})).toThrow();
-    expect(() => GuardedStrategySchema.parse({guarded: {stopLossPct: '-1'}})).toThrow();
-    expect(() => GuardedStrategySchema.parse({guarded: {takeProfitPct: '-0.5'}})).toThrow();
+    expect(() => ProtectedStrategySchema.parse({protected: {stopLossPct: '0'}})).toThrow();
+    expect(() => ProtectedStrategySchema.parse({protected: {stopLossPct: '-1'}})).toThrow();
+    expect(() => ProtectedStrategySchema.parse({protected: {takeProfitPct: '-0.5'}})).toThrow();
   });
 
   it('rejects non-numeric strings', () => {
-    expect(() => GuardedStrategySchema.parse({guarded: {stopLossPct: 'abc'}})).toThrow();
+    expect(() => ProtectedStrategySchema.parse({protected: {stopLossPct: 'abc'}})).toThrow();
   });
 
   it('applies default order types when omitted', () => {
-    const parsed = GuardedStrategySchema.parse({guarded: {stopLossPct: '5'}});
-    expect(parsed.guarded).toBeDefined();
-    expect(parsed.guarded?.stopLossOrder).toBe('limit');
-    expect(parsed.guarded?.takeProfitOrder).toBe('limit');
+    const parsed = ProtectedStrategySchema.parse({protected: {stopLossPct: '5'}});
+    expect(parsed.protected).toBeDefined();
+    expect(parsed.protected?.stopLossOrder).toBe('limit');
+    expect(parsed.protected?.takeProfitOrder).toBe('limit');
   });
 });
 
-describe('GuardedStrategy', () => {
+describe('ProtectedStrategy', () => {
   describe('stop-loss', () => {
     it('fires a LIMIT sell at the nominal target price when unrealized loss reaches the threshold', async () => {
-      const strategy = new TestGuardedStrategy({guarded: {stopLossPct: '5'}});
+      const strategy = new TestProtectedStrategy({protected: {stopLossPct: '5'}});
       await strategy.onFill(makeFill('100', '10', ExchangeOrderSide.BUY), mockState);
 
       // Price drops 5% — stop-loss should fire
@@ -171,11 +171,11 @@ describe('GuardedStrategy', () => {
       expect(new Big(advice.price).toFixed(2)).toBe('95.00');
       expect(advice.reason).toContain('[KILL SWITCH]');
       expect(advice.reason).toContain('Stop-loss');
-      expect(strategy.guardedState.killedLimitPrice).toBe('95');
+      expect(strategy.protectedState.killedLimitPrice).toBe('95');
     });
 
     it('places the limit at the nominal target even when the market has gapped below', async () => {
-      const strategy = new TestGuardedStrategy({guarded: {stopLossPct: '5'}});
+      const strategy = new TestProtectedStrategy({protected: {stopLossPct: '5'}});
       await strategy.onFill(makeFill('100', '10', ExchangeOrderSide.BUY), mockState);
 
       // Market gaps to 90 (-10%), far past the -5% threshold — limit still sits at 95
@@ -186,7 +186,7 @@ describe('GuardedStrategy', () => {
     });
 
     it('does not fire while within threshold', async () => {
-      const strategy = new TestGuardedStrategy({guarded: {stopLossPct: '5'}});
+      const strategy = new TestProtectedStrategy({protected: {stopLossPct: '5'}});
       await strategy.onFill(makeFill('100', '10', ExchangeOrderSide.BUY), mockState);
 
       // Price drops only 3% — guard should pass, subclass runs
@@ -199,7 +199,7 @@ describe('GuardedStrategy', () => {
     it('fires a LIMIT sell at the nominal USD loss target when stopLossNominal is reached', async () => {
       // 10 shares @ 100 = $1000 invested. stopLossNominal=10 → exit when unrealized loss
       // is $10, i.e. price of 99 (each share only needs to drop $1).
-      const strategy = new TestGuardedStrategy({guarded: {stopLossNominal: '10'}});
+      const strategy = new TestProtectedStrategy({protected: {stopLossNominal: '10'}});
       await strategy.onFill(makeFill('100', '10', ExchangeOrderSide.BUY), mockState);
 
       const notYet = await strategy.onCandle(makeCandle(99.5), mockState);
@@ -214,7 +214,7 @@ describe('GuardedStrategy', () => {
 
     it('fires a LIMIT sell at the exact configured price when stopLossPrice is reached', async () => {
       // stopLossPrice=92 → limit sell at exactly 92 as soon as price drops to 92 or below
-      const strategy = new TestGuardedStrategy({guarded: {stopLossPrice: '92'}});
+      const strategy = new TestProtectedStrategy({protected: {stopLossPrice: '92'}});
       await strategy.onFill(makeFill('100', '10', ExchangeOrderSide.BUY), mockState);
 
       const notYet = await strategy.onCandle(makeCandle(93), mockState);
@@ -229,7 +229,7 @@ describe('GuardedStrategy', () => {
 
     it('fires at the configured price regardless of avg entry', async () => {
       // Buy at 50 — far below the 92 stopLossPrice. Guard still arms and fires at 92.
-      const strategy = new TestGuardedStrategy({guarded: {stopLossPrice: '92'}});
+      const strategy = new TestProtectedStrategy({protected: {stopLossPrice: '92'}});
       await strategy.onFill(makeFill('50', '10', ExchangeOrderSide.BUY), mockState);
 
       // Price above the stop target — no fire even though we're above entry
@@ -244,7 +244,7 @@ describe('GuardedStrategy', () => {
 
   describe('take-profit', () => {
     it('fires a LIMIT sell at the nominal target price when unrealized gain reaches the threshold', async () => {
-      const strategy = new TestGuardedStrategy({guarded: {takeProfitPct: '10'}});
+      const strategy = new TestProtectedStrategy({protected: {takeProfitPct: '10'}});
       await strategy.onFill(makeFill('100', '10', ExchangeOrderSide.BUY), mockState);
 
       const advice = await strategy.onCandle(makeCandle(110), mockState);
@@ -253,13 +253,13 @@ describe('GuardedStrategy', () => {
       expect(new Big(advice.price).toFixed(2)).toBe('110.00');
       expect(advice.reason).toContain('[KILL SWITCH]');
       expect(advice.reason).toContain('Take-profit');
-      expect(strategy.guardedState.killedLimitPrice).toBe('110');
+      expect(strategy.protectedState.killedLimitPrice).toBe('110');
     });
 
     it('fires a LIMIT sell at the nominal USD target when takeProfitNominal is reached', async () => {
       // 10 shares @ 100 = $1000 invested. takeProfitNominal=10 → exit when portfolio hits $1010,
       // i.e. price of 101 (each share only needs to gain $1).
-      const strategy = new TestGuardedStrategy({guarded: {takeProfitNominal: '10'}});
+      const strategy = new TestProtectedStrategy({protected: {takeProfitNominal: '10'}});
       await strategy.onFill(makeFill('100', '10', ExchangeOrderSide.BUY), mockState);
 
       const notYet = await strategy.onCandle(makeCandle(100.5), mockState);
@@ -274,7 +274,7 @@ describe('GuardedStrategy', () => {
 
     it('fires a LIMIT sell at the exact configured price when takeProfitPrice is reached', async () => {
       // takeProfitPrice=108 → limit sell at exactly 108 as soon as price rises to 108 or above
-      const strategy = new TestGuardedStrategy({guarded: {takeProfitPrice: '108'}});
+      const strategy = new TestProtectedStrategy({protected: {takeProfitPrice: '108'}});
       await strategy.onFill(makeFill('100', '10', ExchangeOrderSide.BUY), mockState);
 
       const notYet = await strategy.onCandle(makeCandle(107), mockState);
@@ -288,7 +288,7 @@ describe('GuardedStrategy', () => {
     });
 
     it('does not fire while within threshold', async () => {
-      const strategy = new TestGuardedStrategy({guarded: {takeProfitPct: '10'}});
+      const strategy = new TestProtectedStrategy({protected: {takeProfitPct: '10'}});
       await strategy.onFill(makeFill('100', '10', ExchangeOrderSide.BUY), mockState);
 
       const advice = await strategy.onCandle(makeCandle(105), mockState);
@@ -300,7 +300,7 @@ describe('GuardedStrategy', () => {
 
   describe('no position', () => {
     it('skips guard checks when nothing has been bought', async () => {
-      const strategy = new TestGuardedStrategy({guarded: {stopLossPct: '1', takeProfitPct: '1'}, signalAdvice: true});
+      const strategy = new TestProtectedStrategy({protected: {stopLossPct: '1', takeProfitPct: '1'}, signalAdvice: true});
 
       const advice = await strategy.onCandle(makeCandle(100), mockState);
 
@@ -312,14 +312,14 @@ describe('GuardedStrategy', () => {
 
   describe('killed state', () => {
     it('keeps re-emitting the same limit-sell advice while the position has not yet been exited', async () => {
-      const strategy = new TestGuardedStrategy({guarded: {stopLossPct: '5'}, signalAdvice: true});
+      const strategy = new TestProtectedStrategy({protected: {stopLossPct: '5'}, signalAdvice: true});
       await strategy.onFill(makeFill('100', '10', ExchangeOrderSide.BUY), mockState);
 
       // Trigger stop-loss — position is still 10 because no sell fill has arrived yet
       const killAdvice = await strategy.onCandle(makeCandle(94), mockState);
       assertLimitSell(killAdvice);
       expect(new Big(killAdvice.price).toFixed(2)).toBe('95.00');
-      expect(strategy.guardedState.killed).toBe(true);
+      expect(strategy.protectedState.killed).toBe(true);
 
       // Simulate exchange rejecting/delaying the fill: next candle must retry with
       // the same nominal limit price, regardless of where the market is now.
@@ -333,15 +333,15 @@ describe('GuardedStrategy', () => {
     });
 
     it('goes silent once the position is fully exited via onFill', async () => {
-      const strategy = new TestGuardedStrategy({guarded: {stopLossPct: '5'}, signalAdvice: true});
+      const strategy = new TestProtectedStrategy({protected: {stopLossPct: '5'}, signalAdvice: true});
       await strategy.onFill(makeFill('100', '10', ExchangeOrderSide.BUY), mockState);
 
       await strategy.onCandle(makeCandle(94), mockState);
-      expect(strategy.guardedState.killed).toBe(true);
+      expect(strategy.protectedState.killed).toBe(true);
 
       // The sell advice finally fills — position goes to zero
       await strategy.onFill(makeFill('94', '10', ExchangeOrderSide.SELL), mockState);
-      expect(strategy.guardedState.totalPositionSize).toBe('0');
+      expect(strategy.protectedState.totalPositionSize).toBe('0');
 
       // Now subsequent candles return undefined — truly terminal
       const advice = await strategy.onCandle(makeCandle(120), mockState);
@@ -352,7 +352,7 @@ describe('GuardedStrategy', () => {
 
   describe('position tracking', () => {
     it('uses cost-basis averaging across multiple buys to compute the limit price', async () => {
-      const strategy = new TestGuardedStrategy({guarded: {stopLossPct: '5'}});
+      const strategy = new TestProtectedStrategy({protected: {stopLossPct: '5'}});
 
       // Buy 10 @ 100, then 10 @ 120 → avg = 110
       await strategy.onFill(makeFill('100', '10', ExchangeOrderSide.BUY), mockState);
@@ -369,7 +369,7 @@ describe('GuardedStrategy', () => {
     });
 
     it('uses the current average entry price after a partial sell', async () => {
-      const strategy = new TestGuardedStrategy({guarded: {stopLossPct: '5'}});
+      const strategy = new TestProtectedStrategy({protected: {stopLossPct: '5'}});
 
       // Buy 20 @ 100, then sell 10 (partial exit). Avg entry stays at 100.
       await strategy.onFill(makeFill('100', '20', ExchangeOrderSide.BUY), mockState);
@@ -382,13 +382,13 @@ describe('GuardedStrategy', () => {
     });
 
     it('resets position tracking to zero on a full exit', async () => {
-      const strategy = new TestGuardedStrategy({guarded: {stopLossPct: '5'}});
+      const strategy = new TestProtectedStrategy({protected: {stopLossPct: '5'}});
 
       await strategy.onFill(makeFill('100', '10', ExchangeOrderSide.BUY), mockState);
       await strategy.onFill(makeFill('110', '10', ExchangeOrderSide.SELL), mockState);
 
-      expect(strategy.guardedState.totalPositionSize).toBe('0');
-      expect(strategy.guardedState.totalCostBasis).toBe('0');
+      expect(strategy.protectedState.totalPositionSize).toBe('0');
+      expect(strategy.protectedState.totalCostBasis).toBe('0');
 
       // After a full exit, the guard should not fire on any price move — no position
       const advice = await strategy.onCandle(makeCandle(1), mockState);
@@ -398,7 +398,7 @@ describe('GuardedStrategy', () => {
 
   describe('no guards configured', () => {
     it('always passes through to the subclass', async () => {
-      const strategy = new TestGuardedStrategy({signalAdvice: true});
+      const strategy = new TestProtectedStrategy({signalAdvice: true});
       await strategy.onFill(makeFill('100', '10', ExchangeOrderSide.BUY), mockState);
 
       // Price crashes 99% — guard still does nothing because no thresholds set
@@ -412,44 +412,44 @@ describe('GuardedStrategy', () => {
 
   describe('mutual exclusion', () => {
     it('rejects setting both stopLossPct and stopLossNominal', () => {
-      expect(() => new TestGuardedStrategy({guarded: {stopLossPct: '5', stopLossNominal: '10'}})).toThrow(
+      expect(() => new TestProtectedStrategy({protected: {stopLossPct: '5', stopLossNominal: '10'}})).toThrow(
         /stopLossPct, stopLossNominal, and stopLossPrice are mutually exclusive/
       );
     });
 
     it('rejects setting both takeProfitPct and takeProfitNominal', () => {
-      expect(() => new TestGuardedStrategy({guarded: {takeProfitPct: '10', takeProfitNominal: '5'}})).toThrow(
+      expect(() => new TestProtectedStrategy({protected: {takeProfitPct: '10', takeProfitNominal: '5'}})).toThrow(
         /takeProfitPct, takeProfitNominal, and takeProfitPrice are mutually exclusive/
       );
     });
 
     it('rejects setting both stopLossPct and stopLossPrice', () => {
-      expect(() => new TestGuardedStrategy({guarded: {stopLossPct: '5', stopLossPrice: '95'}})).toThrow(
+      expect(() => new TestProtectedStrategy({protected: {stopLossPct: '5', stopLossPrice: '95'}})).toThrow(
         /stopLossPct, stopLossNominal, and stopLossPrice are mutually exclusive/
       );
     });
 
     it('rejects setting both stopLossNominal and stopLossPrice', () => {
-      expect(() => new TestGuardedStrategy({guarded: {stopLossNominal: '10', stopLossPrice: '95'}})).toThrow(
+      expect(() => new TestProtectedStrategy({protected: {stopLossNominal: '10', stopLossPrice: '95'}})).toThrow(
         /stopLossPct, stopLossNominal, and stopLossPrice are mutually exclusive/
       );
     });
 
     it('rejects setting both takeProfitPct and takeProfitPrice', () => {
-      expect(() => new TestGuardedStrategy({guarded: {takeProfitPct: '10', takeProfitPrice: '110'}})).toThrow(
+      expect(() => new TestProtectedStrategy({protected: {takeProfitPct: '10', takeProfitPrice: '110'}})).toThrow(
         /takeProfitPct, takeProfitNominal, and takeProfitPrice are mutually exclusive/
       );
     });
 
     it('rejects setting both takeProfitNominal and takeProfitPrice', () => {
-      expect(() => new TestGuardedStrategy({guarded: {takeProfitNominal: '10', takeProfitPrice: '110'}})).toThrow(
+      expect(() => new TestProtectedStrategy({protected: {takeProfitNominal: '10', takeProfitPrice: '110'}})).toThrow(
         /takeProfitPct, takeProfitNominal, and takeProfitPrice are mutually exclusive/
       );
     });
 
     it('rejects setting all three stop-loss variants', () => {
       expect(
-        () => new TestGuardedStrategy({guarded: {stopLossPct: '5', stopLossNominal: '10', stopLossPrice: '95'}})
+        () => new TestProtectedStrategy({protected: {stopLossPct: '5', stopLossNominal: '10', stopLossPrice: '95'}})
       ).toThrow(/stopLossPct, stopLossNominal, and stopLossPrice are mutually exclusive/);
     });
 
@@ -457,7 +457,7 @@ describe('GuardedStrategy', () => {
       // stopLossPct 5 + takeProfitNominal 10 on 10 @ 100
       //   → stop-loss target: 100 * 0.95 = 95
       //   → take-profit target: 100 + 10/10 = 101
-      const strategy = new TestGuardedStrategy({guarded: {stopLossPct: '5', takeProfitNominal: '10'}});
+      const strategy = new TestProtectedStrategy({protected: {stopLossPct: '5', takeProfitNominal: '10'}});
       await strategy.onFill(makeFill('100', '10', ExchangeOrderSide.BUY), mockState);
 
       // Hits take-profit first at 101
@@ -468,7 +468,7 @@ describe('GuardedStrategy', () => {
     });
 
     it('allows mixing nominal stop-loss with pct take-profit', async () => {
-      const strategy = new TestGuardedStrategy({guarded: {stopLossNominal: '10', takeProfitPct: '10'}});
+      const strategy = new TestProtectedStrategy({protected: {stopLossNominal: '10', takeProfitPct: '10'}});
       await strategy.onFill(makeFill('100', '10', ExchangeOrderSide.BUY), mockState);
 
       // -$10 at 10 shares → price 99
@@ -481,7 +481,7 @@ describe('GuardedStrategy', () => {
 
   describe('nominal across multiple buys', () => {
     it('uses the current cost-basis / positionSize when computing the nominal target', async () => {
-      const strategy = new TestGuardedStrategy({guarded: {takeProfitNominal: '20'}});
+      const strategy = new TestProtectedStrategy({protected: {takeProfitNominal: '20'}});
 
       // Buy 10 @ 100, then 10 @ 120 → positionSize 20, costBasis 2200, avgEntry 110
       await strategy.onFill(makeFill('100', '10', ExchangeOrderSide.BUY), mockState);
@@ -499,14 +499,14 @@ describe('GuardedStrategy', () => {
 
   describe('state persistence', () => {
     it('restores guard state through restoreState', async () => {
-      const strategy = new TestGuardedStrategy({guarded: {stopLossPct: '5'}});
+      const strategy = new TestProtectedStrategy({protected: {stopLossPct: '5'}});
       await strategy.onFill(makeFill('100', '10', ExchangeOrderSide.BUY), mockState);
 
       const snapshot = strategy.state;
       expect(snapshot).not.toBeNull();
 
       // New instance, restore state
-      const restored = new TestGuardedStrategy({guarded: {stopLossPct: '5'}});
+      const restored = new TestProtectedStrategy({protected: {stopLossPct: '5'}});
       restored.restoreState(snapshot!);
 
       // The restored strategy should know about the position and fire at -5%
@@ -516,17 +516,17 @@ describe('GuardedStrategy', () => {
     });
 
     it('restores the killedLimitPrice after a guard has already fired', async () => {
-      const strategy = new TestGuardedStrategy({guarded: {stopLossPct: '5'}});
+      const strategy = new TestProtectedStrategy({protected: {stopLossPct: '5'}});
       await strategy.onFill(makeFill('100', '10', ExchangeOrderSide.BUY), mockState);
       await strategy.onCandle(makeCandle(95), mockState); // fire the guard
-      expect(strategy.guardedState.killed).toBe(true);
+      expect(strategy.protectedState.killed).toBe(true);
 
       const snapshot = strategy.state;
 
-      const restored = new TestGuardedStrategy({guarded: {stopLossPct: '5'}});
+      const restored = new TestProtectedStrategy({protected: {stopLossPct: '5'}});
       restored.restoreState(snapshot!);
-      expect(restored.guardedState.killed).toBe(true);
-      expect(restored.guardedState.killedLimitPrice).toBe('95');
+      expect(restored.protectedState.killed).toBe(true);
+      expect(restored.protectedState.killedLimitPrice).toBe('95');
 
       // Retry on the restored instance should re-emit the same limit advice
       const advice = await restored.onCandle(makeCandle(50), mockState);
@@ -534,24 +534,24 @@ describe('GuardedStrategy', () => {
       expect(new Big(advice.price).toFixed(2)).toBe('95.00');
     });
 
-    it('applies default guard state when restoring legacy state without a guarded key', async () => {
-      const strategy = new TestGuardedStrategy({guarded: {stopLossPct: '5'}});
+    it('applies default guard state when restoring legacy state without a protected key', async () => {
+      const strategy = new TestProtectedStrategy({protected: {stopLossPct: '5'}});
 
-      // Simulate state persisted before guards existed — no `guarded` key
+      // Simulate state persisted before guards existed — no `protected` key
       strategy.restoreState({ownField: 42});
 
-      expect(strategy.guardedState.killed).toBe(false);
-      expect(strategy.guardedState.totalPositionSize).toBe('0');
-      expect(strategy.guardedState.totalCostBasis).toBe('0');
+      expect(strategy.protectedState.killed).toBe(false);
+      expect(strategy.protectedState.totalPositionSize).toBe('0');
+      expect(strategy.protectedState.totalCostBasis).toBe('0');
     });
 
     it('falls back to defaults when restored state has killed=true but no killedOrderType', async () => {
-      const strategy = new TestGuardedStrategy({guarded: {stopLossPct: '5'}});
+      const strategy = new TestProtectedStrategy({protected: {stopLossPct: '5'}});
 
       // Inconsistent persisted state: marked killed but missing the order type
       // needed for the retry path. Must not silently accept.
       strategy.restoreState({
-        guarded: {
+        protected: {
           killed: true,
           killedReason: 'stale',
           killedOrderType: null,
@@ -561,15 +561,15 @@ describe('GuardedStrategy', () => {
         },
       });
 
-      expect(strategy.guardedState.killed).toBe(false);
-      expect(strategy.guardedState.totalPositionSize).toBe('0');
+      expect(strategy.protectedState.killed).toBe(false);
+      expect(strategy.protectedState.totalPositionSize).toBe('0');
     });
 
     it('falls back to defaults when killedOrderType="limit" but killedLimitPrice is null', async () => {
-      const strategy = new TestGuardedStrategy({guarded: {stopLossPct: '5'}});
+      const strategy = new TestProtectedStrategy({protected: {stopLossPct: '5'}});
 
       strategy.restoreState({
-        guarded: {
+        protected: {
           killed: true,
           killedReason: 'stale',
           killedOrderType: 'limit',
@@ -579,14 +579,14 @@ describe('GuardedStrategy', () => {
         },
       });
 
-      expect(strategy.guardedState.killed).toBe(false);
+      expect(strategy.protectedState.killed).toBe(false);
     });
 
     it('accepts killed=true with killedOrderType="market" and no limit price', async () => {
-      const strategy = new TestGuardedStrategy({guarded: {stopLossPct: '5'}});
+      const strategy = new TestProtectedStrategy({protected: {stopLossPct: '5'}});
 
       strategy.restoreState({
-        guarded: {
+        protected: {
           killed: true,
           killedReason: 'Stop-loss fired',
           killedOrderType: 'market',
@@ -596,16 +596,16 @@ describe('GuardedStrategy', () => {
         },
       });
 
-      expect(strategy.guardedState.killed).toBe(true);
-      expect(strategy.guardedState.killedOrderType).toBe('market');
-      expect(strategy.guardedState.totalPositionSize).toBe('10');
+      expect(strategy.protectedState.killed).toBe(true);
+      expect(strategy.protectedState.killedOrderType).toBe('market');
+      expect(strategy.protectedState.totalPositionSize).toBe('10');
     });
 
     it('falls back to defaults when totalCostBasis is not a valid numeric string', async () => {
-      const strategy = new TestGuardedStrategy({guarded: {stopLossPct: '5'}});
+      const strategy = new TestProtectedStrategy({protected: {stopLossPct: '5'}});
 
       strategy.restoreState({
-        guarded: {
+        protected: {
           killed: false,
           killedReason: null,
           killedOrderType: null,
@@ -615,15 +615,15 @@ describe('GuardedStrategy', () => {
         },
       });
 
-      expect(strategy.guardedState.totalCostBasis).toBe('0');
-      expect(strategy.guardedState.totalPositionSize).toBe('0');
+      expect(strategy.protectedState.totalCostBasis).toBe('0');
+      expect(strategy.protectedState.totalPositionSize).toBe('0');
     });
 
     it('falls back to defaults when killedLimitPrice is not a valid numeric string', async () => {
-      const strategy = new TestGuardedStrategy({guarded: {stopLossPct: '5'}});
+      const strategy = new TestProtectedStrategy({protected: {stopLossPct: '5'}});
 
       strategy.restoreState({
-        guarded: {
+        protected: {
           killed: true,
           killedReason: null,
           killedOrderType: 'limit',
@@ -633,13 +633,13 @@ describe('GuardedStrategy', () => {
         },
       });
 
-      expect(strategy.guardedState.killed).toBe(false);
+      expect(strategy.protectedState.killed).toBe(false);
     });
   });
 
   describe('persistence (onSave)', () => {
     it('fires onSave when onFill accumulates a BUY', async () => {
-      const strategy = new TestGuardedStrategy({guarded: {stopLossPct: '5'}});
+      const strategy = new TestProtectedStrategy({protected: {stopLossPct: '5'}});
       const onSave = vi.fn();
       strategy.onSave = onSave;
 
@@ -649,7 +649,7 @@ describe('GuardedStrategy', () => {
     });
 
     it('fires onSave when onFill reduces the position on a SELL', async () => {
-      const strategy = new TestGuardedStrategy({guarded: {stopLossPct: '5'}});
+      const strategy = new TestProtectedStrategy({protected: {stopLossPct: '5'}});
       await strategy.onFill(makeFill('100', '10', ExchangeOrderSide.BUY), mockState);
 
       const onSave = vi.fn();
@@ -661,7 +661,7 @@ describe('GuardedStrategy', () => {
     });
 
     it('fires onSave when a guard fires during processCandle', async () => {
-      const strategy = new TestGuardedStrategy({guarded: {stopLossPct: '5'}});
+      const strategy = new TestProtectedStrategy({protected: {stopLossPct: '5'}});
       await strategy.onFill(makeFill('100', '10', ExchangeOrderSide.BUY), mockState);
 
       const onSave = vi.fn();
@@ -675,7 +675,7 @@ describe('GuardedStrategy', () => {
 
   describe('guard priority', () => {
     it('stop-loss takes priority — subclass logic does not run when fired', async () => {
-      const strategy = new TestGuardedStrategy({guarded: {stopLossPct: '5'}, signalAdvice: true});
+      const strategy = new TestProtectedStrategy({protected: {stopLossPct: '5'}, signalAdvice: true});
       await strategy.onFill(makeFill('100', '10', ExchangeOrderSide.BUY), mockState);
 
       const advice = await strategy.onCandle(makeCandle(90), mockState);
@@ -686,7 +686,7 @@ describe('GuardedStrategy', () => {
     });
 
     it('stop-loss fires before take-profit when both configured and loss is hit first', async () => {
-      const strategy = new TestGuardedStrategy({guarded: {stopLossPct: '5', takeProfitPct: '10'}});
+      const strategy = new TestProtectedStrategy({protected: {stopLossPct: '5', takeProfitPct: '10'}});
       await strategy.onFill(makeFill('100', '10', ExchangeOrderSide.BUY), mockState);
 
       const advice = await strategy.onCandle(makeCandle(94), mockState);
@@ -697,25 +697,25 @@ describe('GuardedStrategy', () => {
 
   describe('order type (stopLossOrder / takeProfitOrder)', () => {
     it('defaults stopLossOrder to "limit" when not configured', async () => {
-      const strategy = new TestGuardedStrategy({guarded: {stopLossPct: '5'}});
+      const strategy = new TestProtectedStrategy({protected: {stopLossPct: '5'}});
       await strategy.onFill(makeFill('100', '10', ExchangeOrderSide.BUY), mockState);
 
       const advice = await strategy.onCandle(makeCandle(95), mockState);
       assertLimitSell(advice);
-      expect(strategy.guardedState.killedOrderType).toBe('limit');
+      expect(strategy.protectedState.killedOrderType).toBe('limit');
     });
 
     it('defaults takeProfitOrder to "limit" when not configured', async () => {
-      const strategy = new TestGuardedStrategy({guarded: {takeProfitPct: '10'}});
+      const strategy = new TestProtectedStrategy({protected: {takeProfitPct: '10'}});
       await strategy.onFill(makeFill('100', '10', ExchangeOrderSide.BUY), mockState);
 
       const advice = await strategy.onCandle(makeCandle(110), mockState);
       assertLimitSell(advice);
-      expect(strategy.guardedState.killedOrderType).toBe('limit');
+      expect(strategy.protectedState.killedOrderType).toBe('limit');
     });
 
     it('fires a MARKET sell when stopLossOrder is "market"', async () => {
-      const strategy = new TestGuardedStrategy({guarded: {stopLossPct: '5', stopLossOrder: 'market'}});
+      const strategy = new TestProtectedStrategy({protected: {stopLossPct: '5', stopLossOrder: 'market'}});
       await strategy.onFill(makeFill('100', '10', ExchangeOrderSide.BUY), mockState);
 
       const advice = await strategy.onCandle(makeCandle(95), mockState);
@@ -725,26 +725,26 @@ describe('GuardedStrategy', () => {
       expect(advice.reason).toContain('[KILL SWITCH]');
       expect(advice.reason).toContain('Stop-loss');
       expect(advice.reason).toContain('(market)');
-      expect(strategy.guardedState.killedOrderType).toBe('market');
+      expect(strategy.protectedState.killedOrderType).toBe('market');
       // No limit price stored for market orders
-      expect(strategy.guardedState.killedLimitPrice).toBeNull();
+      expect(strategy.protectedState.killedLimitPrice).toBeNull();
     });
 
     it('fires a MARKET sell when takeProfitOrder is "market"', async () => {
-      const strategy = new TestGuardedStrategy({guarded: {takeProfitPct: '10', takeProfitOrder: 'market'}});
+      const strategy = new TestProtectedStrategy({protected: {takeProfitPct: '10', takeProfitOrder: 'market'}});
       await strategy.onFill(makeFill('100', '10', ExchangeOrderSide.BUY), mockState);
 
       const advice = await strategy.onCandle(makeCandle(110), mockState);
       assertMarketSell(advice);
       expect(advice.reason).toContain('Take-profit');
       expect(advice.reason).toContain('(market)');
-      expect(strategy.guardedState.killedOrderType).toBe('market');
-      expect(strategy.guardedState.killedLimitPrice).toBeNull();
+      expect(strategy.protectedState.killedOrderType).toBe('market');
+      expect(strategy.protectedState.killedLimitPrice).toBeNull();
     });
 
     it('can mix a market stop-loss with a limit take-profit', async () => {
-      const strategy = new TestGuardedStrategy({
-        guarded: {
+      const strategy = new TestProtectedStrategy({
+        protected: {
           stopLossPct: '5',
           stopLossOrder: 'market',
           takeProfitPct: '10',
@@ -758,8 +758,8 @@ describe('GuardedStrategy', () => {
     });
 
     it('can mix a limit stop-loss with a market take-profit', async () => {
-      const strategy = new TestGuardedStrategy({
-        guarded: {
+      const strategy = new TestProtectedStrategy({
+        protected: {
           stopLossPct: '5',
           takeProfitPct: '10',
           takeProfitOrder: 'market',
@@ -772,7 +772,7 @@ describe('GuardedStrategy', () => {
     });
 
     it('retries market advice on subsequent candles while the position is not exited', async () => {
-      const strategy = new TestGuardedStrategy({guarded: {stopLossPct: '5', stopLossOrder: 'market'}, signalAdvice: true});
+      const strategy = new TestProtectedStrategy({protected: {stopLossPct: '5', stopLossOrder: 'market'}, signalAdvice: true});
       await strategy.onFill(makeFill('100', '10', ExchangeOrderSide.BUY), mockState);
 
       // Fire
@@ -786,16 +786,16 @@ describe('GuardedStrategy', () => {
     });
 
     it('persists killedOrderType across restoreState', async () => {
-      const strategy = new TestGuardedStrategy({guarded: {stopLossPct: '5', stopLossOrder: 'market'}});
+      const strategy = new TestProtectedStrategy({protected: {stopLossPct: '5', stopLossOrder: 'market'}});
       await strategy.onFill(makeFill('100', '10', ExchangeOrderSide.BUY), mockState);
       await strategy.onCandle(makeCandle(95), mockState); // fire
 
       const snapshot = strategy.state;
 
-      const restored = new TestGuardedStrategy({guarded: {stopLossPct: '5', stopLossOrder: 'market'}});
+      const restored = new TestProtectedStrategy({protected: {stopLossPct: '5', stopLossOrder: 'market'}});
       restored.restoreState(snapshot!);
-      expect(restored.guardedState.killedOrderType).toBe('market');
-      expect(restored.guardedState.killedLimitPrice).toBeNull();
+      expect(restored.protectedState.killedOrderType).toBe('market');
+      expect(restored.protectedState.killedLimitPrice).toBeNull();
 
       // Retry on restored instance should still be MARKET, not LIMIT
       const advice = await restored.onCandle(makeCandle(50), mockState);

--- a/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.ts
+++ b/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.ts
@@ -6,10 +6,10 @@ import {Strategy} from '../strategy/Strategy.js';
 import {positiveNumberString} from '../util/validators.js';
 
 /**
- * All kill-switch settings live under a single nested `guarded` key so they can't
+ * All kill-switch settings live under a single nested `protected` key so they can't
  * collide with the subclass's own config fields.
  */
-export const GuardedConfigSchema = z.object({
+export const ProtectedConfigSchema = z.object({
   /**
    * Stop-loss as a percentage of avg entry. "5" = sell everything at avgEntry * 0.95.
    * Mutually exclusive with `stopLossNominal` and `stopLossPrice`. Omit all three to
@@ -60,13 +60,13 @@ export const GuardedConfigSchema = z.object({
   takeProfitOrder: z.enum(['limit', 'market']).default('limit'),
 });
 
-/** All of the kill-switch settings, nested under a single namespaced `guarded` key. */
-export const GuardedStrategySchema = z.object({
-  guarded: GuardedConfigSchema.optional(),
+/** All of the kill-switch settings, nested under a single namespaced `protected` key. */
+export const ProtectedStrategySchema = z.object({
+  protected: ProtectedConfigSchema.optional(),
 });
 
-export type GuardedConfig = z.infer<typeof GuardedConfigSchema>;
-export type GuardedStrategyConfig = z.infer<typeof GuardedStrategySchema>;
+export type ProtectedConfig = z.infer<typeof ProtectedConfigSchema>;
+export type ProtectedStrategyConfig = z.infer<typeof ProtectedStrategySchema>;
 
 type GuardOrderType = 'limit' | 'market';
 
@@ -76,7 +76,7 @@ type GuardMode =
   | {kind: 'price'; price: Big}
   | null;
 
-export type GuardedStrategyState = {
+export type ProtectedStrategyState = {
   killed: boolean;
   killedReason: string | null;
   /** Order type used when a guard fires. `null` until a guard fires. */
@@ -89,9 +89,9 @@ export type GuardedStrategyState = {
   totalPositionSize: string;
 };
 
-const GUARDED_STATE_KEY = 'guarded';
+const PROTECTED_STATE_KEY = 'protected';
 
-const defaultGuardedState = (): GuardedStrategyState => ({
+const defaultProtectedState = (): ProtectedStrategyState => ({
   killed: false,
   killedReason: null,
   killedOrderType: null,
@@ -100,7 +100,7 @@ const defaultGuardedState = (): GuardedStrategyState => ({
   totalPositionSize: '0',
 });
 
-type GuardedContainerState = {[GUARDED_STATE_KEY]: GuardedStrategyState};
+type ProtectedContainerState = {[PROTECTED_STATE_KEY]: ProtectedStrategyState};
 
 /**
  * A `Strategy` subclass that provides composable kill-switch behavior (stop-loss,
@@ -128,8 +128,8 @@ type GuardedContainerState = {[GUARDED_STATE_KEY]: GuardedStrategyState};
  *
  * Usage:
  *
- *     const schema = GuardedStrategySchema.extend({ mySetting: z.string() });
- *     class MyStrategy extends GuardedStrategy {
+ *     const schema = ProtectedStrategySchema.extend({ mySetting: z.string() });
+ *     class MyStrategy extends ProtectedStrategy {
  *       constructor(config: z.infer<typeof schema>) {
  *         super({ config, state: { mySubclassField: 0 } });
  *       }
@@ -140,7 +140,7 @@ type GuardedContainerState = {[GUARDED_STATE_KEY]: GuardedStrategyState};
  *       }
  *     }
  */
-export abstract class GuardedStrategy extends Strategy {
+export abstract class ProtectedStrategy extends Strategy {
   readonly #stopLoss: GuardMode;
   readonly #takeProfit: GuardMode;
   readonly #stopLossOrder: GuardOrderType;
@@ -151,75 +151,75 @@ export abstract class GuardedStrategy extends Strategy {
       config: options.config,
       state: {
         ...options.state,
-        [GUARDED_STATE_KEY]: defaultGuardedState(),
+        [PROTECTED_STATE_KEY]: defaultProtectedState(),
       },
     });
 
-    // Parse only the nested `guarded` sub-object — the subclass owns the rest of the config.
-    const guardedConfig = GuardedConfigSchema.parse(options.config[GUARDED_STATE_KEY] ?? {});
+    // Parse only the nested `protected` sub-object — the subclass owns the rest of the config.
+    const protectedConfig = ProtectedConfigSchema.parse(options.config[PROTECTED_STATE_KEY] ?? {});
 
     // Zod's `.refine()` would turn the schema into `ZodEffects`, which cannot
     // be `.extend()`-ed by subclasses. Mutual exclusion is validated here instead.
     const stopLossFields = [
-      guardedConfig.stopLossPct,
-      guardedConfig.stopLossNominal,
-      guardedConfig.stopLossPrice,
+      protectedConfig.stopLossPct,
+      protectedConfig.stopLossNominal,
+      protectedConfig.stopLossPrice,
     ].filter((value): value is string => value !== undefined);
     if (stopLossFields.length > 1) {
       throw new Error(
-        'GuardedStrategy: stopLossPct, stopLossNominal, and stopLossPrice are mutually exclusive — set at most one'
+        'ProtectedStrategy: stopLossPct, stopLossNominal, and stopLossPrice are mutually exclusive — set at most one'
       );
     }
 
     const takeProfitFields = [
-      guardedConfig.takeProfitPct,
-      guardedConfig.takeProfitNominal,
-      guardedConfig.takeProfitPrice,
+      protectedConfig.takeProfitPct,
+      protectedConfig.takeProfitNominal,
+      protectedConfig.takeProfitPrice,
     ].filter((value): value is string => value !== undefined);
     if (takeProfitFields.length > 1) {
       throw new Error(
-        'GuardedStrategy: takeProfitPct, takeProfitNominal, and takeProfitPrice are mutually exclusive — set at most one'
+        'ProtectedStrategy: takeProfitPct, takeProfitNominal, and takeProfitPrice are mutually exclusive — set at most one'
       );
     }
 
-    this.#stopLoss = guardedConfig.stopLossPct
-      ? {kind: 'pct', pct: new Big(guardedConfig.stopLossPct)}
-      : guardedConfig.stopLossNominal
-        ? {kind: 'nominal', nominal: new Big(guardedConfig.stopLossNominal)}
-        : guardedConfig.stopLossPrice
-          ? {kind: 'price', price: new Big(guardedConfig.stopLossPrice)}
+    this.#stopLoss = protectedConfig.stopLossPct
+      ? {kind: 'pct', pct: new Big(protectedConfig.stopLossPct)}
+      : protectedConfig.stopLossNominal
+        ? {kind: 'nominal', nominal: new Big(protectedConfig.stopLossNominal)}
+        : protectedConfig.stopLossPrice
+          ? {kind: 'price', price: new Big(protectedConfig.stopLossPrice)}
           : null;
 
-    this.#takeProfit = guardedConfig.takeProfitPct
-      ? {kind: 'pct', pct: new Big(guardedConfig.takeProfitPct)}
-      : guardedConfig.takeProfitNominal
-        ? {kind: 'nominal', nominal: new Big(guardedConfig.takeProfitNominal)}
-        : guardedConfig.takeProfitPrice
-          ? {kind: 'price', price: new Big(guardedConfig.takeProfitPrice)}
+    this.#takeProfit = protectedConfig.takeProfitPct
+      ? {kind: 'pct', pct: new Big(protectedConfig.takeProfitPct)}
+      : protectedConfig.takeProfitNominal
+        ? {kind: 'nominal', nominal: new Big(protectedConfig.takeProfitNominal)}
+        : protectedConfig.takeProfitPrice
+          ? {kind: 'price', price: new Big(protectedConfig.takeProfitPrice)}
           : null;
 
-    this.#stopLossOrder = guardedConfig.stopLossOrder;
-    this.#takeProfitOrder = guardedConfig.takeProfitOrder;
+    this.#stopLossOrder = protectedConfig.stopLossOrder;
+    this.#takeProfitOrder = protectedConfig.takeProfitOrder;
   }
 
-  get #guardedState(): GuardedStrategyState {
-    return this.getProxiedState<GuardedContainerState>()[GUARDED_STATE_KEY];
+  get #protectedState(): ProtectedStrategyState {
+    return this.getProxiedState<ProtectedContainerState>()[PROTECTED_STATE_KEY];
   }
 
   /**
-   * Reassigns the top-level `guarded` key on the proxied state with a merged
+   * Reassigns the top-level `protected` key on the proxied state with a merged
    * snapshot. The top-level write triggers the base `Strategy` Proxy's `set`
    * trap, which in turn fires `onSave` so `StrategyMonitor` persists to the DB.
    * Nested property mutations would silently bypass persistence.
    */
-  #setGuardedState(patch: Partial<GuardedStrategyState>): void {
-    const proxied = this.getProxiedState<GuardedContainerState>();
-    proxied[GUARDED_STATE_KEY] = {...proxied[GUARDED_STATE_KEY], ...patch};
+  #setProtectedState(patch: Partial<ProtectedStrategyState>): void {
+    const proxied = this.getProxiedState<ProtectedContainerState>();
+    proxied[PROTECTED_STATE_KEY] = {...proxied[PROTECTED_STATE_KEY], ...patch};
   }
 
-  /** Read-only snapshot of the current guarded state. Useful for tests and diagnostics. */
-  get guardedState(): Readonly<GuardedStrategyState> {
-    return {...this.#guardedState};
+  /** Read-only snapshot of the current protected state. Useful for tests and diagnostics. */
+  get protectedState(): Readonly<ProtectedStrategyState> {
+    return {...this.#protectedState};
   }
 
   /**
@@ -235,14 +235,14 @@ export abstract class GuardedStrategy extends Strategy {
   ): Promise<OrderAdvice | void> {
     this.lastBatchedCandle = candle;
 
-    const guardedState = this.#guardedState;
-    if (guardedState.killed) {
-      const positionSize = new Big(guardedState.totalPositionSize);
-      if (positionSize.gt(0) && guardedState.killedOrderType) {
-        const limitPrice = guardedState.killedLimitPrice ? new Big(guardedState.killedLimitPrice) : null;
+    const protectedState = this.#protectedState;
+    if (protectedState.killed) {
+      const positionSize = new Big(protectedState.totalPositionSize);
+      if (positionSize.gt(0) && protectedState.killedOrderType) {
+        const limitPrice = protectedState.killedLimitPrice ? new Big(protectedState.killedLimitPrice) : null;
         const advice = this.#killSwitchAdvice(
-          guardedState.killedReason ?? 'kill switch',
-          guardedState.killedOrderType,
+          protectedState.killedReason ?? 'kill switch',
+          protectedState.killedOrderType,
           limitPrice
         );
         this.latestAdvice = advice;
@@ -265,13 +265,13 @@ export abstract class GuardedStrategy extends Strategy {
       return;
     }
 
-    const guardedState = this.#guardedState;
-    const positionSize = new Big(guardedState.totalPositionSize);
+    const protectedState = this.#protectedState;
+    const positionSize = new Big(protectedState.totalPositionSize);
     if (positionSize.lte(0)) {
       return;
     }
 
-    const avgEntry = new Big(guardedState.totalCostBasis).div(positionSize);
+    const avgEntry = new Big(protectedState.totalCostBasis).div(positionSize);
     const currentPrice = candle.close;
 
     if (this.#stopLoss) {
@@ -279,7 +279,7 @@ export abstract class GuardedStrategy extends Strategy {
       if (currentPrice.lte(targetPrice)) {
         const orderType = this.#stopLossOrder;
         const reason = this.#stopLossReason(avgEntry, currentPrice, positionSize, targetPrice, orderType);
-        this.#setGuardedState({
+        this.#setProtectedState({
           killed: true,
           killedReason: reason,
           killedOrderType: orderType,
@@ -294,7 +294,7 @@ export abstract class GuardedStrategy extends Strategy {
       if (currentPrice.gte(targetPrice)) {
         const orderType = this.#takeProfitOrder;
         const reason = this.#takeProfitReason(avgEntry, currentPrice, positionSize, targetPrice, orderType);
-        this.#setGuardedState({
+        this.#setProtectedState({
           killed: true,
           killedReason: reason,
           killedOrderType: orderType,
@@ -384,14 +384,14 @@ export abstract class GuardedStrategy extends Strategy {
   }
 
   async onFill(fill: ExchangeFill, _state: TradingSessionState): Promise<void> {
-    const guardedState = this.#guardedState;
+    const protectedState = this.#protectedState;
     const fillPrice = new Big(fill.price);
     const fillSize = new Big(fill.size);
 
     if (fill.side === ExchangeOrderSide.BUY) {
-      const newCostBasis = new Big(guardedState.totalCostBasis).plus(fillPrice.mul(fillSize));
-      const newPositionSize = new Big(guardedState.totalPositionSize).plus(fillSize);
-      this.#setGuardedState({
+      const newCostBasis = new Big(protectedState.totalCostBasis).plus(fillPrice.mul(fillSize));
+      const newPositionSize = new Big(protectedState.totalPositionSize).plus(fillSize);
+      this.#setProtectedState({
         totalCostBasis: newCostBasis.toFixed(),
         totalPositionSize: newPositionSize.toFixed(),
       });
@@ -399,38 +399,40 @@ export abstract class GuardedStrategy extends Strategy {
     }
 
     // SELL: reduce position proportionally using the current average entry price.
-    const currentPositionSize = new Big(guardedState.totalPositionSize);
+    const currentPositionSize = new Big(protectedState.totalPositionSize);
     if (currentPositionSize.lte(0)) {
       return;
     }
 
-    const avgEntry = new Big(guardedState.totalCostBasis).div(currentPositionSize);
+    const avgEntry = new Big(protectedState.totalCostBasis).div(currentPositionSize);
     const newPositionSize = currentPositionSize.minus(fillSize);
 
     if (newPositionSize.lte(0)) {
-      this.#setGuardedState({totalCostBasis: '0', totalPositionSize: '0'});
+      this.#setProtectedState({totalCostBasis: '0', totalPositionSize: '0'});
       return;
     }
 
-    this.#setGuardedState({
+    this.#setProtectedState({
       totalCostBasis: avgEntry.mul(newPositionSize).toFixed(),
       totalPositionSize: newPositionSize.toFixed(),
     });
   }
 
   override restoreState(persisted: Record<string, unknown>): void {
-    const existing = persisted[GUARDED_STATE_KEY];
-    const restoredGuarded: GuardedStrategyState = isGuardedStrategyState(existing) ? existing : defaultGuardedState();
+    const existing = persisted[PROTECTED_STATE_KEY];
+    const restoredProtected: ProtectedStrategyState = isProtectedStrategyState(existing)
+      ? existing
+      : defaultProtectedState();
 
     super.restoreState({
       ...persisted,
-      [GUARDED_STATE_KEY]: restoredGuarded,
+      [PROTECTED_STATE_KEY]: restoredProtected,
     });
 
     // The base class only updates `#_state`; the proxied state still points at
-    // the original object from the constructor. Reassigning `guarded` through
+    // the original object from the constructor. Reassigning `protected` through
     // the proxy propagates restored values into the proxied state.
-    this.#setGuardedState(restoredGuarded);
+    this.#setProtectedState(restoredProtected);
   }
 
   #killSwitchAdvice(reason: string, orderType: GuardOrderType, limitPrice: Big | null): OrderAdvice {
@@ -444,7 +446,7 @@ export abstract class GuardedStrategy extends Strategy {
       };
     }
     if (!limitPrice) {
-      throw new Error('GuardedStrategy: limit order type requires a limit price');
+      throw new Error('ProtectedStrategy: limit order type requires a limit price');
     }
     const advice: LimitOrderAdvice = {
       side: ExchangeOrderSide.SELL,
@@ -459,7 +461,7 @@ export abstract class GuardedStrategy extends Strategy {
 }
 
 /**
- * Validates that a persisted object is a well-formed `GuardedStrategyState`.
+ * Validates that a persisted object is a well-formed `ProtectedStrategyState`.
  *
  * Beyond shape checks, this also enforces cross-field invariants that
  * `restoreState` relies on to produce a safe runtime state:
@@ -476,7 +478,7 @@ export abstract class GuardedStrategy extends Strategy {
  * Returning `false` from here causes `restoreState` to fall back to the
  * default state, re-arming the guards on the next candle.
  */
-function isGuardedStrategyState(value: unknown): value is GuardedStrategyState {
+function isProtectedStrategyState(value: unknown): value is ProtectedStrategyState {
   if (!value || typeof value !== 'object') {
     return false;
   }

--- a/packages/trading-strategies/src/strategy-protected/README.md
+++ b/packages/trading-strategies/src/strategy-protected/README.md
@@ -1,8 +1,8 @@
-# GuardedStrategy
+# ProtectedStrategy
 
-An abstract base class that adds composable **kill-switch** behaviour (stop-loss and take-profit) to any trading strategy. New strategies opt in by extending `GuardedStrategy` instead of `Strategy` and calling `super.processCandle()` at the top of their own `processCandle` — if a guard fires, the subclass returns immediately; otherwise it runs its own logic.
+An abstract base class that adds composable **kill-switch** behaviour (stop-loss and take-profit) to any trading strategy. New strategies opt in by extending `ProtectedStrategy` instead of `Strategy` and calling `super.processCandle()` at the top of their own `processCandle` — if a guard fires, the subclass returns immediately; otherwise it runs its own logic.
 
-`GuardedStrategy` does not decide what to trade. It only enforces exit conditions on positions built by a subclass.
+`ProtectedStrategy` does not decide what to trade. It only enforces exit conditions on positions built by a subclass.
 
 ## How it works
 
@@ -13,15 +13,15 @@ An abstract base class that adds composable **kill-switch** behaviour (stop-loss
 | **retrying** | Still tripped, position not yet fully exited. Keeps re-emitting the same advice on every candle until `onFill` clears it. |
 | **closed** | Position fully exited via `onFill`. `onCandle` returns `void` for the rest of the session. Truly terminal. |
 
-The kill switch is one-way: once tripped, the subclass never runs again. `GuardedStrategy` does not re-arm.
+The kill switch is one-way: once tripped, the subclass never runs again. `ProtectedStrategy` does not re-arm.
 
 ## Configuration
 
-All kill-switch settings live under a single nested `guarded` key on the strategy config so they can't collide with subclass-specific fields:
+All kill-switch settings live under a single nested `protected` key on the strategy config so they can't collide with subclass-specific fields:
 
 ```json
 {
-  "guarded": {
+  "protected": {
     "stopLossPct": "5",
     "stopLossOrder": "market",
     "takeProfitNominal": "10"
@@ -30,7 +30,7 @@ All kill-switch settings live under a single nested `guarded` key on the strateg
 }
 ```
 
-Stop-loss and take-profit are independent — you can configure both, either, or neither. Within each direction the three **trigger** variants are mutually exclusive (setting more than one throws at construction); the **order type** selects how the kill switch executes the exit. Omitting the `guarded` key entirely disables both guards.
+Stop-loss and take-profit are independent — you can configure both, either, or neither. Within each direction the three **trigger** variants are mutually exclusive (setting more than one throws at construction); the **order type** selects how the kill switch executes the exit. Omitting the `protected` key entirely disables both guards.
 
 ### Stop-loss trigger (pick at most one)
 
@@ -58,23 +58,23 @@ Stop-loss and take-profit are independent — you can configure both, either, or
 - **`"limit"`** (default) places a `LIMIT SELL` at the nominal target price. Guaranteed exit price, but may not fill if the market gaps past the target (especially for stop-loss). See the trade-off section below.
 - **`"market"`** places a `MARKET SELL` on the candle where the trigger fires. Guaranteed fill (near-immediate on live exchanges), but the exit price depends on wherever the market is at that moment — potentially worse than the target.
 
-Cross-direction mixing is allowed for both the trigger and the order type, e.g. `{ guarded: { stopLossPct: "5", stopLossOrder: "market", takeProfitNominal: "10" } }` uses a market stop-loss with a limit take-profit.
+Cross-direction mixing is allowed for both the trigger and the order type, e.g. `{ protected: { stopLossPct: "5", stopLossOrder: "market", takeProfitNominal: "10" } }` uses a market stop-loss with a limit take-profit.
 
 ## Usage
 
-Extend the base class and merge `GuardedStrategySchema` with your own config schema:
+Extend the base class and merge `ProtectedStrategySchema` with your own config schema:
 
 ```typescript
 import {z} from 'zod';
-import {GuardedStrategy, GuardedStrategySchema} from '@typedtrader/trading-strategies';
+import {ProtectedStrategy, ProtectedStrategySchema} from '@typedtrader/trading-strategies';
 
-const MyStrategySchema = GuardedStrategySchema.extend({
+const MyStrategySchema = ProtectedStrategySchema.extend({
   mySetting: z.string(),
 });
 
 type MyStrategyConfig = z.infer<typeof MyStrategySchema>;
 
-export class MyStrategy extends GuardedStrategy {
+export class MyStrategy extends ProtectedStrategy {
   static override NAME = '@typedtrader/strategy-my-strategy';
 
   constructor(config: MyStrategyConfig) {
@@ -140,9 +140,9 @@ When `stopLossOrder` / `takeProfitOrder` is `"limit"` (the default), the target 
 
 ## State persistence
 
-Kill-switch state is stored under a reserved `guarded` key inside the strategy's proxied state, alongside any subclass-specific fields — matching the `guarded` namespace used for config. Updates go through a private helper that reassigns `state.guarded` as a new object on every change, triggering the base `Strategy` Proxy's `set` trap, which fires `onSave`, which `StrategyMonitor` persists to the database.
+Kill-switch state is stored under a reserved `protected` key inside the strategy's proxied state, alongside any subclass-specific fields — matching the `protected` namespace used for config. Updates go through a private helper that reassigns `state.protected` as a new object on every change, triggering the base `Strategy` Proxy's `set` trap, which fires `onSave`, which `StrategyMonitor` persists to the database.
 
-Persisted guarded state:
+Persisted protected state:
 
 ```typescript
 {
@@ -155,4 +155,4 @@ Persisted guarded state:
 }
 ```
 
-`restoreState` is override-safe — if legacy state is restored without a `guarded` key, the kill-switch state is reset to defaults rather than crashing.
+`restoreState` is override-safe — if legacy state is restored without a `protected` key, the kill-switch state is reset to defaults rather than crashing.

--- a/packages/trading-strategies/src/strategy-scalp/ScalpStrategy.ts
+++ b/packages/trading-strategies/src/strategy-scalp/ScalpStrategy.ts
@@ -3,11 +3,11 @@ import Big from 'big.js';
 import {CandleBatcher, ExchangeOrderSide, ExchangeOrderType} from '@typedtrader/exchange';
 import type {ExchangeFill, OneMinuteBatchedCandle, OrderAdvice, TradingSessionState} from '@typedtrader/exchange';
 import {EMA, ER} from 'trading-signals';
-import {Strategy} from '../strategy/Strategy.js';
+import {ProtectedStrategy, ProtectedStrategySchema} from '../strategy-protected/ProtectedStrategy.js';
 import {positiveNumberString} from '../util/validators.js';
 import {suggestScalpOffset} from './suggestScalpOffset.js';
 
-export const ScalpSchema = z.object({
+export const ScalpSchema = ProtectedStrategySchema.extend({
   /** Nominal price offset for each leg of the scalp (e.g., "0.10" means sell at fill+0.10, re-buy at fill-0.10).
    *  When omitted, the offset is auto-computed from historical candles passed to `init()`. */
   offset: positiveNumberString.optional(),
@@ -25,7 +25,7 @@ type ScalpState = {
   lastFillSide: ExchangeOrderSide | null;
 };
 
-export class ScalpStrategy extends Strategy {
+export class ScalpStrategy extends ProtectedStrategy {
   static override NAME = '@typedtrader/strategy-scalp';
   static readonly ER_THRESHOLD = 0.4;
 
@@ -127,7 +127,8 @@ export class ScalpStrategy extends Strategy {
     return er.getResultOrThrow() < ScalpStrategy.ER_THRESHOLD;
   }
 
-  async onFill(fill: ExchangeFill, _state: TradingSessionState): Promise<void> {
+  override async onFill(fill: ExchangeFill, state: TradingSessionState): Promise<void> {
+    await super.onFill(fill, state);
     this.#state.lastFillPrice = fill.price;
     this.#state.lastFillSide = fill.side;
     this.#state.phase = 'pendingAdvice';
@@ -149,7 +150,12 @@ export class ScalpStrategy extends Strategy {
     }
   }
 
-  protected override async processCandle(candle: OneMinuteBatchedCandle, _state: TradingSessionState): Promise<OrderAdvice | void> {
+  protected override async processCandle(candle: OneMinuteBatchedCandle, state: TradingSessionState): Promise<OrderAdvice | void> {
+    const guardAdvice = await super.processCandle(candle, state);
+    if (guardAdvice) {
+      return guardAdvice;
+    }
+
     if (this.#state.phase === 'entry') {
       return this.#handleEntry(candle);
     }

--- a/packages/trading-strategies/src/strategy/StrategyRegistry.ts
+++ b/packages/trading-strategies/src/strategy/StrategyRegistry.ts
@@ -18,7 +18,7 @@ interface StrategyEntry {
 
 const registry: Record<string, StrategyEntry> = {
   [BuyAndHoldStrategy.NAME]: {
-    create: () => new BuyAndHoldStrategy(),
+    create: (config: unknown) => new BuyAndHoldStrategy(BuyAndHoldSchema.parse(config ?? {})),
     schema: BuyAndHoldSchema,
   },
   [BuyOnceStrategy.NAME]: {
@@ -30,7 +30,7 @@ const registry: Record<string, StrategyEntry> = {
     schema: BuyBelowSellAboveSchema,
   },
   [CoinFlipStrategy.NAME]: {
-    create: () => new CoinFlipStrategy(),
+    create: (config: unknown) => new CoinFlipStrategy(CoinFlipSchema.parse(config ?? {})),
     schema: CoinFlipSchema,
   },
   [MultiIndicatorConfluenceStrategy.NAME]: {
@@ -43,7 +43,7 @@ const registry: Record<string, StrategyEntry> = {
     schema: ScalpSchema,
   },
   [MeanReversionStrategy.NAME]: {
-    create: () => new MeanReversionStrategy(),
+    create: (config: unknown) => new MeanReversionStrategy({config: MeanReversionSchema.parse(config ?? {})}),
     schema: MeanReversionSchema,
   },
 };


### PR DESCRIPTION
## Summary

- Renames the kill-switch base class from `GuardedStrategy` to `ProtectedStrategy`. The directory, file, exported symbols, and the `guarded` config/state key all move to `protected`. Error messages and doc strings follow.
- Rolls the base class out to every concrete strategy: `BuyAndHold`, `BuyOnce`, `BuyBelowSellAbove`, `CoinFlip`, `MultiIndicatorConfluence`, `Scalp`, `MeanReversion`. Each now calls `super.processCandle` at the top of its own `processCandle` and returns early if a guard fires. `ScalpStrategy` additionally chains `super.onFill` so the base cost-basis tracking stays in sync with its own fill state machine. The `protected` key is fully optional, so every existing config keeps working unchanged.
- Plumbs configs through `StrategyRegistry` for `CoinFlip` and `MeanReversion` (previously constructed with no args), and through `backtest.tsx` for the same.
- Extends `MultiIndicatorConfluenceSchema` on top of `ProtectedStrategySchema` while keeping its `.refine()` chain for cross-field validation.

## Backtester UI

Adds an **Add Protection** / **Edit Protection** button to the docs backtester sidebar that opens a modal (`components/ProtectionModal.tsx`) with separate Stop-loss and Take-profit sections:

- Trigger type: Percentage / Nominal (counter currency) / Absolute price
- Value input with contextual label and placeholder
- Order type: Limit (exact target) or Market (guaranteed fill)

On first open (no existing protection) Stop-loss is pre-enabled so the form is visible immediately. The Save button is disabled when the form would produce a no-op, with an amber hint explaining why. On save, the modal merges a `protected` object into the current strategy config JSON; on Remove, it deletes the key. An `active` pill on the sidebar button signals when protection is currently set.

Exercised the feature in a browser against Buy & Hold, Coin Flip, Scalp, and Multi-Indicator Confluence on several datasets — the kill switch fires correctly and the backtest results reflect the reduced drawdown versus the unprotected baseline.