### PR TITLE
feat(messaging): run scheduled reports immediately on creation

### DIFF
--- a/packages/messaging/src/platform/TelegramPlatform.ts
+++ b/packages/messaging/src/platform/TelegramPlatform.ts
@@ -593,7 +593,7 @@ export class TelegramPlatform implements MessagingPlatform {
       await replyWithMarkdown(ctx, result.message);
 
       if (result.report?.intervalMs && this.#reportScheduler) {
-        this.#reportScheduler.scheduleReport(result.report);
+        this.#reportScheduler.scheduleReport(result.report, {runImmediately: true});
       }
     });
   }

--- a/packages/messaging/src/service/ReportScheduler.ts
+++ b/packages/messaging/src/service/ReportScheduler.ts
@@ -34,7 +34,7 @@ export class ReportScheduler {
     this.#scheduled.clear();
   }
 
-  scheduleReport(row: ReportAttributes): void {
+  scheduleReport(row: ReportAttributes, options: {runImmediately?: boolean} = {}): void {
     if (!row.intervalMs) {
       return;
     }
@@ -53,6 +53,12 @@ export class ReportScheduler {
 
     this.#scheduled.set(row.id, {reportId: row.id, timer});
     console.log(`Scheduled report "${row.id}" (${row.reportName}) every ${ms(row.intervalMs, {long: true})}`);
+
+    if (options.runImmediately) {
+      this.#runAndNotify(row).catch(error => {
+        console.error(`Initial run of scheduled report ${row.id} (${row.reportName}) failed:`, error);
+      });
+    }
   }
 
   unscheduleReport(reportId: number): void {

--- a/packages/messaging/src/startServer.ts
+++ b/packages/messaging/src/startServer.ts
@@ -150,7 +150,7 @@ function registerCommands(platform: MessagingPlatform, monitors: Monitors): void
 
     if (result.report?.intervalMs) {
       try {
-        monitors.reportScheduler.scheduleReport(result.report);
+        monitors.reportScheduler.scheduleReport(result.report, {runImmediately: true});
       } catch (error) {
         console.error(`Error scheduling report: ${error}`);
       }


### PR DESCRIPTION
## Summary

- Scheduled reports created via `/reportAdd` now execute once immediately, then continue on the configured interval — previously users had to wait a full interval (up to a week) before seeing the first result.
- `ReportScheduler.scheduleReport` gains an opt-in `{runImmediately}` flag that fires `#runAndNotify` as a fire-and-forget background run; errors are logged without blocking the schedule registration.
- Both entry points opt in: the generic `/reportAdd` command handler in `startServer.ts` and the Telegram wizard in `TelegramPlatform.ts`.
- `ReportScheduler.start()` deliberately does **not** pass the flag, so restarting the server resumes persisted schedules without replaying every saved report.