### PR TITLE
feat(messaging): add log rotation via pino-roll

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6684,6 +6684,16 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
     "node_modules/dateformat": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
@@ -12417,6 +12427,16 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/pino-roll": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pino-roll/-/pino-roll-4.0.0.tgz",
+      "integrity": "sha512-axI1aQaIxXdw1F4OFFli1EDxIrdYNGLowkw/ZoZogX8oCSLHUghzwVVXUS8U+xD/Savwa5IXpiXmsSGKFX/7Sg==",
+      "license": "MIT",
+      "dependencies": {
+        "date-fns": "^4.1.0",
+        "sonic-boom": "^4.0.1"
+      }
+    },
     "node_modules/pino-std-serializers": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
@@ -16025,6 +16045,7 @@
         "moment-timezone": "^0.6.1",
         "ms": "4.0.0-nightly.202508271359",
         "pino": "^10.3.1",
+        "pino-roll": "^4.0.0",
         "trading-strategies": "0.3.5",
         "zod": "^4.3.6"
       },

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -16,6 +16,7 @@
     "moment-timezone": "^0.6.1",
     "ms": "4.0.0-nightly.202508271359",
     "pino": "^10.3.1",
+    "pino-roll": "^4.0.0",
     "trading-strategies": "0.3.5",
     "zod": "^4.3.6"
   },

--- a/packages/messaging/src/logger.ts
+++ b/packages/messaging/src/logger.ts
@@ -17,7 +17,7 @@ if (logDirectory) {
     options: {
       file: path.join(logDirectory, 'typedtrader.log'),
       size: '10m',
-      limit: {count: 5},
+      limit: {count: 10},
       mkdir: true,
     },
     level: 'debug',

--- a/packages/messaging/src/logger.ts
+++ b/packages/messaging/src/logger.ts
@@ -13,9 +13,11 @@ const targets: pino.TransportTargetOptions[] = [
 
 if (logDirectory) {
   targets.push({
-    target: 'pino/file',
+    target: 'pino-roll',
     options: {
-      destination: path.join(logDirectory, 'typedtrader.log'),
+      file: path.join(logDirectory, 'typedtrader.log'),
+      size: '10m',
+      limit: {count: 5},
       mkdir: true,
     },
     level: 'debug',


### PR DESCRIPTION
## Summary

- Adds `pino-roll` for size-based log rotation on `typedtrader.log`
- Rotates at 10 MB, keeps at most 5 rotated files (~50 MB max disk usage)
- Prevents unbounded log growth on the Render persistent disk