### PR TITLE
fix(messaging): use persisted config when running scheduled reports

### DIFF
--- a/packages/messaging/src/service/ReportScheduler.ts
+++ b/packages/messaging/src/service/ReportScheduler.ts
@@ -1,4 +1,4 @@
-import {createReport, resolveReportConfig} from 'trading-strategies';
+import {createReport} from 'trading-strategies';
 import type {MessagingPlatform} from '../platform/MessagingPlatform.js';
 import {Report, type ReportAttributes} from '../database/models/Report.js';
 import {logger} from '../logger.js';
@@ -78,7 +78,7 @@ export class ReportScheduler {
   }
 
   async #runAndNotify(row: ReportAttributes): Promise<void> {
-    const config = resolveReportConfig(row.reportName) ?? JSON.parse(row.config);
+    const config = JSON.parse(row.config);
     const report = createReport(row.reportName, config);
     const result = await report.run();
 


### PR DESCRIPTION
## Summary

`ReportScheduler.#runAndNotify` was calling `resolveReportConfig(row.reportName) ?? JSON.parse(row.config)`. For account-required reports (e.g. `@typedtrader/report-sp500-momentum`), `resolveReportConfig` returns `{}` — truthy — so the `??` fallback to `row.config` never ran. The apiKey/apiSecret merged in from the account at `/reportAdd` time were effectively discarded on every tick, causing the scheduled run to fail with a ZodError for missing credentials.

Fix: read `row.config` directly. `reportAdd` already resolves env + account config and persists it when scheduling, so the stored row is the single source of truth.