### PR TITLE
refactor(trading-signals, exchange, trading-signals-docs): adopt TypeScript 6 and enable erasableSyntaxOnly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ dist/
 lerna-debug.log
 node_modules/
 npm-debug.log*
+.claude/scheduled_tasks.lock

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This project uses [Lerna](https://lerna.js.org/) for managing the [monorepo](htt
 
 ## Relationships
 
-At the foundation, **trading-signals** provides technical indicators like SMA, EMA, RSI, and Bollinger Bands. The **trading-strategies** package builds on top of these indicators to form actionable trading advice. **@typedtrader/exchange** abstracts away broker differences behind a unified interface, so strategies can run against any supported exchange. Finally, **@typedtrader/messaging** ties it all together into a chatbot that lets you control your trading bot remotely through XMTP (encrypted) or Telegram.
+At the foundation, **trading-signals** provides technical indicators like SMA, EMA, RSI, and Bollinger Bands. The **trading-strategies** package builds on top of these indicators to form actionable trading advice. **@typedtrader/exchange** abstracts away broker differences behind a unified interface, so strategies can run against any supported exchange. Finally, **@typedtrader/messaging** ties it all together into a chatbot that lets you control your trading bot remotely through Telegram.
 
 ```mermaid
 graph TD

--- a/packages/exchange/src/exchange/Exchange.ts
+++ b/packages/exchange/src/exchange/Exchange.ts
@@ -3,10 +3,11 @@ import {EventEmitter} from 'node:events';
 import type {TradingPair} from './TradingPair.js';
 import {z} from 'zod';
 
-export enum ExchangeOrderSide {
-  BUY = 'BUY',
-  SELL = 'SELL',
-}
+export const ExchangeOrderSide = {
+  BUY: 'BUY',
+  SELL: 'SELL',
+} as const;
+export type ExchangeOrderSide = (typeof ExchangeOrderSide)[keyof typeof ExchangeOrderSide];
 
 interface ExchangeOrderBase {
   side: ExchangeOrderSide;
@@ -33,12 +34,13 @@ export const ExchangeCandleBaseSchema = z.object({
 
 export type ExchangeCandleBase = z.infer<typeof ExchangeCandleBaseSchema>;
 
-export enum ExchangeOrderType {
+export const ExchangeOrderType = {
   /** Maker */
-  LIMIT = 'LIMIT',
+  LIMIT: 'LIMIT',
   /** Taker */
-  MARKET = 'MARKET',
-}
+  MARKET: 'MARKET',
+} as const;
+export type ExchangeOrderType = (typeof ExchangeOrderType)[keyof typeof ExchangeOrderType];
 
 export const ExchangeCandleSchema = z
   .object({
@@ -81,15 +83,16 @@ export interface ExchangeCandleImportRequest {
  */
 export interface ExchangeFeeRate {
   /** The maker commission: When you put in a limit order on an exchange that doesn't fill immediately, it adds to the available orders for that stock. To attract more traders, the exchange may offer a lower fee when adding to the order book. */
-  [ExchangeOrderType.LIMIT]: Big;
+  LIMIT: Big;
   /** The taker commission: Market orders are usually filled immediately, but they reduce available liquidity on an order book, which isn't good for exchanges. To prevent this, exchanges usually have higher taker fees than maker fees. */
-  [ExchangeOrderType.MARKET]: Big;
+  MARKET: Big;
 }
 
-export enum ExchangeOrderPosition {
-  LONG = 'LONG',
-  SHORT = 'SHORT',
-}
+export const ExchangeOrderPosition = {
+  LONG: 'LONG',
+  SHORT: 'SHORT',
+} as const;
+export type ExchangeOrderPosition = (typeof ExchangeOrderPosition)[keyof typeof ExchangeOrderPosition];
 
 export interface ExchangeFill {
   /** Date in ISO 8601 format */
@@ -116,12 +119,12 @@ export interface ExchangePendingOrderBase {
 
 export interface ExchangePendingLimitOrder extends ExchangePendingOrderBase {
   price: string;
-  type: ExchangeOrderType.LIMIT;
+  type: 'LIMIT';
 }
 
 export interface ExchangePendingMarketOrder extends ExchangePendingOrderBase {
   /** Market orders don't have a price. */
-  type: ExchangeOrderType.MARKET;
+  type: 'MARKET';
 }
 
 /**
@@ -134,14 +137,14 @@ export interface ExchangePendingMarketOrder extends ExchangePendingOrderBase {
 export interface ExchangeMarketOrderOptions extends ExchangeOrderBase {
   sizeInCounter: boolean;
 
-  type: ExchangeOrderType.MARKET;
+  type: 'MARKET';
 }
 
 export interface ExchangeLimitOrderOptions extends ExchangeOrderBase {
   price: string;
 
   sizeInCounter: false;
-  type: ExchangeOrderType.LIMIT;
+  type: 'LIMIT';
 }
 
 export type ExchangeOrderOptions = ExchangeMarketOrderOptions | ExchangeLimitOrderOptions;
@@ -179,8 +182,11 @@ export interface ExchangeTradingRules {
 }
 
 export abstract class Exchange extends EventEmitter {
-  constructor(public loggerName: string) {
+  loggerName: string;
+
+  constructor(loggerName: string) {
     super();
+    this.loggerName = loggerName;
   }
 
   /**

--- a/packages/exchange/src/exchange/TradingPair.ts
+++ b/packages/exchange/src/exchange/TradingPair.ts
@@ -14,16 +14,19 @@ export type TradingPairJSON = {
  * Base: BTC, Counter: USDT
  */
 export class TradingPair implements TradingPairJSON {
+  readonly base: string;
+  readonly counter: string;
+
   /**
    * Constructs a trading pair.
    *
    * @param base - Symbol of the base asset (i.e. TSLA)
    * @param counter - Symbol of the counter asset (i.e. EUR)
    */
-  constructor(
-    public readonly base: string,
-    public readonly counter: string
-  ) {}
+  constructor(base: string, counter: string) {
+    this.base = base;
+    this.counter = counter;
+  }
 
   isEqual(other: TradingPair): boolean {
     return this.base === other.base && this.counter === other.counter;

--- a/packages/exchange/src/exchange/alpaca/api/schema/PositionSchema.ts
+++ b/packages/exchange/src/exchange/alpaca/api/schema/PositionSchema.ts
@@ -20,7 +20,7 @@ export const PositionSchema = z.looseObject({
   lastday_price: z.string(),
   market_value: z.string(),
   qty: z.string(),
-  side: z.enum(['long', 'short']),
+  side: z.enum([PositionSide.LONG, PositionSide.SHORT]),
   symbol: z.string(),
   unrealized_intraday_pl: z.string(),
   unrealized_intraday_plpc: z.string(),

--- a/packages/exchange/src/exchange/alpaca/api/schema/PositionSchema.ts
+++ b/packages/exchange/src/exchange/alpaca/api/schema/PositionSchema.ts
@@ -3,10 +3,11 @@ import {z} from 'zod';
 export type Position = z.infer<typeof PositionSchema>;
 
 /** Position side values returned by Alpaca API */
-export enum PositionSide {
-  LONG = 'long',
-  SHORT = 'short',
-}
+export const PositionSide = {
+  LONG: 'long',
+  SHORT: 'short',
+} as const;
+export type PositionSide = (typeof PositionSide)[keyof typeof PositionSide];
 
 /** @see https://docs.alpaca.markets/reference/getallopenpositions */
 export const PositionSchema = z.looseObject({
@@ -19,7 +20,7 @@ export const PositionSchema = z.looseObject({
   lastday_price: z.string(),
   market_value: z.string(),
   qty: z.string(),
-  side: z.nativeEnum(PositionSide),
+  side: z.enum(['long', 'short']),
   symbol: z.string(),
   unrealized_intraday_pl: z.string(),
   unrealized_intraday_plpc: z.string(),

--- a/packages/exchange/src/trader/TradingSession.test.ts
+++ b/packages/exchange/src/trader/TradingSession.test.ts
@@ -13,7 +13,7 @@ import {
   type ExchangePendingMarketOrder,
   type ExchangeTradingRules,
 } from '../exchange/Exchange.js';
-import {ALL_AVAILABLE_AMOUNT} from './TradingSessionTypes.js';
+import {AllAvailableAmount} from './TradingSessionTypes.js';
 import type {OrderAdvice, TradingSessionStrategy} from './TradingSessionTypes.js';
 
 const pair = new TradingPair('TSLA', 'USD');
@@ -198,7 +198,7 @@ describe.sequential('TradingSession', () => {
       const advice: OrderAdvice = {
         side: ExchangeOrderSide.BUY,
         type: ExchangeOrderType.MARKET,
-        amount: ALL_AVAILABLE_AMOUNT,
+        amount: AllAvailableAmount,
         amountIn: 'counter',
       };
       strategy.onCandle.mockResolvedValue(advice);
@@ -243,7 +243,7 @@ describe.sequential('TradingSession', () => {
       const advice: OrderAdvice = {
         side: ExchangeOrderSide.SELL,
         type: ExchangeOrderType.MARKET,
-        amount: ALL_AVAILABLE_AMOUNT,
+        amount: AllAvailableAmount,
         amountIn: 'base',
       };
       strategy.onCandle.mockResolvedValue(advice);
@@ -265,7 +265,7 @@ describe.sequential('TradingSession', () => {
       const advice: OrderAdvice = {
         side: ExchangeOrderSide.BUY,
         type: ExchangeOrderType.LIMIT,
-        amount: ALL_AVAILABLE_AMOUNT,
+        amount: AllAvailableAmount,
         amountIn: 'base',
         price: '250',
       };
@@ -382,7 +382,7 @@ describe.sequential('TradingSession', () => {
       const advice: OrderAdvice = {
         side: ExchangeOrderSide.SELL,
         type: ExchangeOrderType.MARKET,
-        amount: ALL_AVAILABLE_AMOUNT,
+        amount: AllAvailableAmount,
         amountIn: 'base',
       };
       strategy.onCandle.mockResolvedValue(advice);

--- a/packages/exchange/src/trader/TradingSession.ts
+++ b/packages/exchange/src/trader/TradingSession.ts
@@ -5,7 +5,7 @@ import type {BatchedCandle} from '../candle/BatchedCandle.js';
 import {ONE_MINUTE_IN_MS} from '../candle/BatchedCandle.js';
 import type {ExchangeCandle, ExchangeFill, ExchangePendingOrder} from '../exchange/Exchange.js';
 import {ExchangeOrderSide, ExchangeOrderType} from '../exchange/Exchange.js';
-import {ALL_AVAILABLE_AMOUNT} from './TradingSessionTypes.js';
+import {AllAvailableAmount} from './TradingSessionTypes.js';
 import type {
   OrderAdvice,
   TradingSessionEventMap,
@@ -199,7 +199,7 @@ export class TradingSession extends EventEmitter<TradingSessionEventMap> {
   #resolveOrderSize(advice: OrderAdvice): Big | null {
     const {tradingRules} = this.#state!;
 
-    if (advice.amount !== ALL_AVAILABLE_AMOUNT) {
+    if (advice.amount !== AllAvailableAmount) {
       const amount = new Big(advice.amount);
       if (advice.amountIn === 'counter') {
         return this.#applyPrecision(amount, tradingRules.counter_increment);

--- a/packages/exchange/src/trader/TradingSessionTypes.ts
+++ b/packages/exchange/src/trader/TradingSessionTypes.ts
@@ -22,8 +22,8 @@ export interface TradingSessionStrategy {
 }
 
 /** Use as `amount` in an `OrderAdvice` to use the full available balance. */
-export const ALL_AVAILABLE_AMOUNT = 'ALL_AVAILABLE_AMOUNT' as const;
-type AllAvailableAmount = typeof ALL_AVAILABLE_AMOUNT;
+export const AllAvailableAmount = 'ALL_AVAILABLE_AMOUNT' as const;
+type AllAvailableAmount = typeof AllAvailableAmount;
 
 type OrderAdviceBase = {
   reason?: string;

--- a/packages/exchange/src/trader/TradingSessionTypes.ts
+++ b/packages/exchange/src/trader/TradingSessionTypes.ts
@@ -9,7 +9,6 @@ import {
   type ExchangeLimitOrderOptions,
   type ExchangeMarketOrderOptions,
   ExchangeOrderSide,
-  ExchangeOrderType,
   type ExchangePendingLimitOrder,
   type ExchangePendingMarketOrder,
   type ExchangePendingOrder,
@@ -31,23 +30,23 @@ type OrderAdviceBase = {
 };
 
 type MarketBuyBaseAdvice = OrderAdviceBase & {
-  type: ExchangeOrderType.MARKET;
-  side: ExchangeOrderSide.BUY;
+  type: 'MARKET';
+  side: 'BUY';
   amountIn: 'base';
   /** Must be explicit — cannot derive base quantity from null without a price */
   amount: BigSource;
 };
 
 type MarketBuyCounterAdvice = OrderAdviceBase & {
-  type: ExchangeOrderType.MARKET;
-  side: ExchangeOrderSide.BUY;
+  type: 'MARKET';
+  side: 'BUY';
   amountIn: 'counter';
   amount: BigSource | AllAvailableAmount;
 };
 
 type MarketSellAdvice = OrderAdviceBase & {
-  type: ExchangeOrderType.MARKET;
-  side: ExchangeOrderSide.SELL;
+  type: 'MARKET';
+  side: 'SELL';
   amountIn: 'base' | 'counter';
   amount: BigSource | typeof ALL_AVAILABLE_AMOUNT;
 };
@@ -55,7 +54,7 @@ type MarketSellAdvice = OrderAdviceBase & {
 export type MarketOrderAdvice = MarketBuyBaseAdvice | MarketBuyCounterAdvice | MarketSellAdvice;
 
 export type LimitOrderAdvice = OrderAdviceBase & {
-  type: ExchangeOrderType.LIMIT;
+  type: 'LIMIT';
   side: ExchangeOrderSide;
   amountIn: 'base';
   amount: BigSource | AllAvailableAmount;

--- a/packages/exchange/src/trader/TradingSessionTypes.ts
+++ b/packages/exchange/src/trader/TradingSessionTypes.ts
@@ -48,7 +48,7 @@ type MarketSellAdvice = OrderAdviceBase & {
   type: 'MARKET';
   side: 'SELL';
   amountIn: 'base' | 'counter';
-  amount: BigSource | typeof ALL_AVAILABLE_AMOUNT;
+  amount: BigSource | AllAvailableAmount;
 };
 
 export type MarketOrderAdvice = MarketBuyBaseAdvice | MarketBuyCounterAdvice | MarketSellAdvice;

--- a/packages/trading-signals-docs/tsconfig.json
+++ b/packages/trading-signals-docs/tsconfig.json
@@ -1,12 +1,11 @@
 {
   "compilerOptions": {
     "allowJs": true,
-    "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "incremental": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": ["dom", "esnext"],
     "module": "esnext",
     "moduleResolution": "bundler",
     "noEmit": true,

--- a/packages/trading-signals/src/momentum/AC/AC.ts
+++ b/packages/trading-signals/src/momentum/AC/AC.ts
@@ -17,13 +17,15 @@ export class AC extends TrendIndicatorSeries<HighLow<number>> {
   public readonly ao: AO;
   public readonly momentum: MOM;
   public readonly signal: SMA;
+  public readonly shortAO: number;
+  public readonly longAO: number;
+  public readonly signalInterval: number;
 
-  constructor(
-    public readonly shortAO: number,
-    public readonly longAO: number,
-    public readonly signalInterval: number
-  ) {
+  constructor(shortAO: number, longAO: number, signalInterval: number) {
     super();
+    this.shortAO = shortAO;
+    this.longAO = longAO;
+    this.signalInterval = signalInterval;
     this.ao = new AO(shortAO, longAO);
     this.momentum = new MOM(1);
     this.signal = new SMA(signalInterval);

--- a/packages/trading-signals/src/momentum/AO/AO.ts
+++ b/packages/trading-signals/src/momentum/AO/AO.ts
@@ -23,13 +23,13 @@ import {TrendIndicatorSeries, TradingSignal} from '../../types/Indicator.js';
 export class AO extends TrendIndicatorSeries<HighLow<number>> {
   public readonly long: MovingAverage;
   public readonly short: MovingAverage;
+  public readonly shortInterval: number;
+  public readonly longInterval: number;
 
-  constructor(
-    public readonly shortInterval: number,
-    public readonly longInterval: number,
-    SmoothingIndicator: MovingAverageTypes = SMA
-  ) {
+  constructor(shortInterval: number, longInterval: number, SmoothingIndicator: MovingAverageTypes = SMA) {
     super();
+    this.shortInterval = shortInterval;
+    this.longInterval = longInterval;
     this.short = new SmoothingIndicator(shortInterval);
     this.long = new SmoothingIndicator(longInterval);
   }

--- a/packages/trading-signals/src/momentum/CCI/CCI.ts
+++ b/packages/trading-signals/src/momentum/CCI/CCI.ts
@@ -31,9 +31,11 @@ import {MAD} from '../../volatility/MAD/MAD.js';
 export class CCI extends TrendIndicatorSeries<HighLowClose<number>> {
   readonly #sma: SMA;
   readonly #typicalPrices: number[];
+  public readonly interval: number;
 
-  constructor(public readonly interval: number) {
+  constructor(interval: number) {
     super();
+    this.interval = interval;
     this.#sma = new SMA(this.interval);
     this.#typicalPrices = [];
   }

--- a/packages/trading-signals/src/momentum/CG/CG.ts
+++ b/packages/trading-signals/src/momentum/CG/CG.ts
@@ -26,11 +26,13 @@ export class CG extends TrendIndicatorSeries {
     return this.signal.isStable;
   }
 
-  constructor(
-    public readonly interval: number,
-    public readonly signalInterval: number
-  ) {
+  public readonly interval: number;
+  public readonly signalInterval: number;
+
+  constructor(interval: number, signalInterval: number) {
     super();
+    this.interval = interval;
+    this.signalInterval = signalInterval;
     this.signal = new SMA(signalInterval);
   }
 

--- a/packages/trading-signals/src/momentum/ER/ER.ts
+++ b/packages/trading-signals/src/momentum/ER/ER.ts
@@ -22,8 +22,11 @@ export class ER extends TrendIndicatorSeries<HighLowClose> {
   readonly #highs: number[] = [];
   readonly #lows: number[] = [];
 
-  constructor(public readonly interval: number) {
+  public readonly interval: number;
+
+  constructor(interval: number) {
     super();
+    this.interval = interval;
   }
 
   override getRequiredInputs() {

--- a/packages/trading-signals/src/momentum/MACD/MACD.ts
+++ b/packages/trading-signals/src/momentum/MACD/MACD.ts
@@ -22,12 +22,15 @@ export class MACD extends TechnicalIndicator<MACDResult, number> {
   public readonly prices: number[] = [];
   #previousResult?: MACDResult;
 
-  constructor(
-    public readonly short: EMA | DEMA,
-    public readonly long: EMA | DEMA,
-    public readonly signal: EMA | DEMA
-  ) {
+  public readonly short: EMA | DEMA;
+  public readonly long: EMA | DEMA;
+  public readonly signal: EMA | DEMA;
+
+  constructor(short: EMA | DEMA, long: EMA | DEMA, signal: EMA | DEMA) {
     super();
+    this.short = short;
+    this.long = long;
+    this.signal = signal;
   }
 
   override getRequiredInputs() {

--- a/packages/trading-signals/src/momentum/MOM/MOM.ts
+++ b/packages/trading-signals/src/momentum/MOM/MOM.ts
@@ -14,8 +14,11 @@ export class MOM extends TrendIndicatorSeries {
   readonly #history: number[];
   readonly #historyLength: number;
 
-  constructor(public readonly interval: number) {
+  public readonly interval: number;
+
+  constructor(interval: number) {
     super();
+    this.interval = interval;
     this.#historyLength = interval + 1;
     this.#history = [];
   }

--- a/packages/trading-signals/src/momentum/OBV/OBV.ts
+++ b/packages/trading-signals/src/momentum/OBV/OBV.ts
@@ -13,8 +13,11 @@ import {pushUpdate} from '../../util/pushUpdate.js';
 export class OBV extends TrendIndicatorSeries<OpenHighLowCloseVolume<number>> {
   public readonly candles: OpenHighLowCloseVolume<number>[] = [];
 
-  constructor(public readonly interval: number) {
+  public readonly interval: number;
+
+  constructor(interval: number) {
     super();
+    this.interval = interval;
   }
 
   override getRequiredInputs() {

--- a/packages/trading-signals/src/momentum/REI/REI.ts
+++ b/packages/trading-signals/src/momentum/REI/REI.ts
@@ -25,8 +25,11 @@ export class REI extends TrendIndicatorSeries<HighLowClose<number>> {
   readonly #lows: number[] = [];
   readonly #closes: number[] = [];
 
-  constructor(public readonly interval: number) {
+  public readonly interval: number;
+
+  constructor(interval: number) {
     super();
+    this.interval = interval;
   }
 
   protected calculateSignalState(result?: number | null | undefined) {

--- a/packages/trading-signals/src/momentum/ROC/ROC.ts
+++ b/packages/trading-signals/src/momentum/ROC/ROC.ts
@@ -13,8 +13,11 @@ import {pushUpdate} from '../../util/pushUpdate.js';
 export class ROC extends TrendIndicatorSeries {
   public readonly prices: number[] = [];
 
-  constructor(public readonly interval: number) {
+  public readonly interval: number;
+
+  constructor(interval: number) {
     super();
+    this.interval = interval;
   }
 
   override getRequiredInputs() {

--- a/packages/trading-signals/src/momentum/RSI/RSI.ts
+++ b/packages/trading-signals/src/momentum/RSI/RSI.ts
@@ -25,11 +25,11 @@ export class RSI extends TrendIndicatorSeries {
   readonly #avgLoss: MovingAverage;
   readonly #maxValue = 100;
 
-  constructor(
-    public readonly interval: number,
-    SmoothingIndicator: MovingAverageTypes = WSMA
-  ) {
+  public readonly interval: number;
+
+  constructor(interval: number, SmoothingIndicator: MovingAverageTypes = WSMA) {
     super();
+    this.interval = interval;
     this.#avgGain = new SmoothingIndicator(this.interval);
     this.#avgLoss = new SmoothingIndicator(this.interval);
   }

--- a/packages/trading-signals/src/momentum/STOCH/StochasticOscillator.ts
+++ b/packages/trading-signals/src/momentum/STOCH/StochasticOscillator.ts
@@ -39,12 +39,15 @@ export class StochasticOscillator extends TechnicalIndicator<StochasticResult, H
    * @param m The %k slowing period
    * @param p The %d period
    */
-  constructor(
-    public n: number,
-    public m: number,
-    public p: number
-  ) {
+  public n: number;
+  public m: number;
+  public p: number;
+
+  constructor(n: number, m: number, p: number) {
     super();
+    this.n = n;
+    this.m = m;
+    this.p = p;
     this.#periodM = new SMA(m);
     this.#periodP = new SMA(p);
   }

--- a/packages/trading-signals/src/momentum/STOCHRSI/StochasticRSI.ts
+++ b/packages/trading-signals/src/momentum/STOCHRSI/StochasticRSI.ts
@@ -29,10 +29,16 @@ export class StochasticRSI extends TrendIndicatorSeries {
   readonly #period: Period;
   readonly #rsi: RSI;
 
+  public readonly interval: number;
+  public readonly smoothing: {
+    readonly k: MovingAverage;
+    readonly d: MovingAverage;
+  };
+
   constructor(
-    public readonly interval: number,
+    interval: number,
     SmoothingRSI: MovingAverageTypes = WSMA,
-    public readonly smoothing: {
+    smoothing: {
       readonly k: MovingAverage;
       readonly d: MovingAverage;
     } = {
@@ -41,6 +47,8 @@ export class StochasticRSI extends TrendIndicatorSeries {
     }
   ) {
     super();
+    this.interval = interval;
+    this.smoothing = smoothing;
     this.#period = new Period(interval);
     this.#rsi = new RSI(interval, SmoothingRSI);
   }

--- a/packages/trading-signals/src/momentum/WILLR/WilliamsR.ts
+++ b/packages/trading-signals/src/momentum/WILLR/WilliamsR.ts
@@ -21,8 +21,11 @@ import {pushUpdate} from '../../util/pushUpdate.js';
 export class WilliamsR extends TrendIndicatorSeries<HighLowClose<number>> {
   public readonly candles: HighLowClose<number>[] = [];
 
-  constructor(public readonly interval: number) {
+  public readonly interval: number;
+
+  constructor(interval: number) {
     super();
+    this.interval = interval;
   }
 
   override getRequiredInputs() {

--- a/packages/trading-signals/src/trend/ADX/ADX.ts
+++ b/packages/trading-signals/src/trend/ADX/ADX.ts
@@ -40,11 +40,11 @@ export class ADX extends IndicatorSeries<HighLowClose<number>> {
   readonly #dx: DX;
   readonly #smoothed: MovingAverage;
 
-  constructor(
-    public readonly interval: number,
-    SmoothingIndicator: MovingAverageTypes = WSMA
-  ) {
+  public readonly interval: number;
+
+  constructor(interval: number, SmoothingIndicator: MovingAverageTypes = WSMA) {
     super();
+    this.interval = interval;
     this.#smoothed = new SmoothingIndicator(this.interval);
     this.#dx = new DX(interval, SmoothingIndicator);
   }

--- a/packages/trading-signals/src/trend/DEMA/DEMA.ts
+++ b/packages/trading-signals/src/trend/DEMA/DEMA.ts
@@ -13,8 +13,11 @@ export class DEMA extends IndicatorSeries {
   readonly #inner: EMA;
   readonly #outer: EMA;
 
-  constructor(public readonly interval: number) {
+  public readonly interval: number;
+
+  constructor(interval: number) {
     super();
+    this.interval = interval;
     this.#inner = new EMA(interval);
     this.#outer = new EMA(interval);
   }

--- a/packages/trading-signals/src/trend/DX/DX.ts
+++ b/packages/trading-signals/src/trend/DX/DX.ts
@@ -27,11 +27,11 @@ export class DX extends IndicatorSeries<HighLowClose<number>> {
   public mdi?: number;
   public pdi?: number;
 
-  constructor(
-    public readonly interval: number,
-    SmoothingIndicator: MovingAverageTypes = WSMA
-  ) {
+  public readonly interval: number;
+
+  constructor(interval: number, SmoothingIndicator: MovingAverageTypes = WSMA) {
     super();
+    this.interval = interval;
     this.#atr = new ATR(this.interval, SmoothingIndicator);
     this.#movesDown = new SmoothingIndicator(this.interval);
     this.#movesUp = new SmoothingIndicator(this.interval);

--- a/packages/trading-signals/src/trend/EMA/EMA.ts
+++ b/packages/trading-signals/src/trend/EMA/EMA.ts
@@ -12,9 +12,11 @@ import {NotEnoughDataError} from '../../error/index.js';
 export class EMA extends MovingAverage {
   #pricesCounter = 0;
   readonly #weightFactor: number;
+  override readonly interval: number;
 
-  constructor(public override readonly interval: number) {
+  constructor(interval: number) {
     super(interval);
+    this.interval = interval;
     this.#weightFactor = 2 / (this.interval + 1);
   }
 

--- a/packages/trading-signals/src/trend/LINREG/LinearRegression.ts
+++ b/packages/trading-signals/src/trend/LINREG/LinearRegression.ts
@@ -19,8 +19,11 @@ export type LinearRegressionResult = {
 export class LinearRegression extends TechnicalIndicator<LinearRegressionResult, number> {
   public readonly prices: number[] = [];
 
-  constructor(public readonly interval: number) {
+  public readonly interval: number;
+
+  constructor(interval: number) {
     super();
+    this.interval = interval;
   }
 
   override getRequiredInputs() {

--- a/packages/trading-signals/src/trend/MA/MovingAverage.ts
+++ b/packages/trading-signals/src/trend/MA/MovingAverage.ts
@@ -9,7 +9,10 @@ import {IndicatorSeries} from '../../types/Indicator.js';
  * @see https://www.investopedia.com/terms/m/movingaverage.asp
  */
 export abstract class MovingAverage extends IndicatorSeries {
-  constructor(public readonly interval: number) {
+  public readonly interval: number;
+
+  constructor(interval: number) {
     super();
+    this.interval = interval;
   }
 }

--- a/packages/trading-signals/src/trend/RMA/RMA.ts
+++ b/packages/trading-signals/src/trend/RMA/RMA.ts
@@ -13,9 +13,11 @@ import {NotEnoughDataError} from '../../error/index.js';
 export class RMA extends MovingAverage {
   #pricesCounter = 0;
   readonly #weightFactor: number;
+  override readonly interval: number;
 
-  constructor(public override readonly interval: number) {
+  constructor(interval: number) {
     super(interval);
+    this.interval = interval;
     this.#weightFactor = 1 / this.interval;
   }
 

--- a/packages/trading-signals/src/trend/WMA/WMA.ts
+++ b/packages/trading-signals/src/trend/WMA/WMA.ts
@@ -11,9 +11,11 @@ import {pushUpdate} from '../../util/pushUpdate.js';
  */
 export class WMA extends MovingAverage {
   public readonly prices: number[] = [];
+  override readonly interval: number;
 
-  constructor(public override readonly interval: number) {
+  constructor(interval: number) {
     super(interval);
+    this.interval = interval;
   }
 
   override getRequiredInputs() {

--- a/packages/trading-signals/src/trend/WSMA/WSMA.ts
+++ b/packages/trading-signals/src/trend/WSMA/WSMA.ts
@@ -20,8 +20,11 @@ export class WSMA extends IndicatorSeries {
   readonly #indicator: SMA;
   readonly #smoothingFactor: number;
 
-  constructor(public readonly interval: number) {
+  public readonly interval: number;
+
+  constructor(interval: number) {
     super();
+    this.interval = interval;
     this.#indicator = new SMA(interval);
     this.#smoothingFactor = 1 / this.interval;
   }

--- a/packages/trading-signals/src/types/Period.ts
+++ b/packages/trading-signals/src/types/Period.ts
@@ -21,8 +21,11 @@ export class Period extends TechnicalIndicator<PeriodResult, number> {
     return this.#lowest;
   }
 
-  constructor(public readonly interval: number) {
+  public readonly interval: number;
+
+  constructor(interval: number) {
     super();
+    this.interval = interval;
     this.values = [];
   }
 

--- a/packages/trading-signals/src/volatility/ABANDS/AccelerationBands.ts
+++ b/packages/trading-signals/src/volatility/ABANDS/AccelerationBands.ts
@@ -32,12 +32,13 @@ export class AccelerationBands extends TechnicalIndicator<BandsResult, HighLowCl
   #lastClose?: number;
   #previousClose?: number;
 
-  constructor(
-    public readonly interval: number,
-    public readonly width: number,
-    SmoothingIndicator: MovingAverageTypes = SMA
-  ) {
+  public readonly interval: number;
+  public readonly width: number;
+
+  constructor(interval: number, width: number, SmoothingIndicator: MovingAverageTypes = SMA) {
     super();
+    this.interval = interval;
+    this.width = width;
     this.#lowerBand = new SmoothingIndicator(interval);
     this.#middleBand = new SmoothingIndicator(interval);
     this.#upperBand = new SmoothingIndicator(interval);

--- a/packages/trading-signals/src/volatility/ATR/ATR.ts
+++ b/packages/trading-signals/src/volatility/ATR/ATR.ts
@@ -25,11 +25,11 @@ export class ATR extends IndicatorSeries<HighLowClose<number>> {
   readonly #tr: TR;
   readonly #smoothing: MovingAverage;
 
-  constructor(
-    public readonly interval: number,
-    SmoothingIndicator: MovingAverageTypes = WSMA
-  ) {
+  public readonly interval: number;
+
+  constructor(interval: number, SmoothingIndicator: MovingAverageTypes = WSMA) {
     super();
+    this.interval = interval;
     this.#tr = new TR();
     this.#smoothing = new SmoothingIndicator(interval);
   }

--- a/packages/trading-signals/src/volatility/BBANDS/BollingerBands.ts
+++ b/packages/trading-signals/src/volatility/BBANDS/BollingerBands.ts
@@ -19,11 +19,13 @@ export class BollingerBands extends TechnicalIndicator<BandsResult, number> {
   #lastPrice?: number;
   #previousPrice?: number;
 
-  constructor(
-    public readonly interval: number,
-    public readonly deviationMultiplier: number = 2
-  ) {
+  public readonly interval: number;
+  public readonly deviationMultiplier: number;
+
+  constructor(interval: number, deviationMultiplier: number = 2) {
     super();
+    this.interval = interval;
+    this.deviationMultiplier = deviationMultiplier;
   }
 
   override getRequiredInputs() {

--- a/packages/trading-signals/src/volatility/BBW/BollingerBandsWidth.ts
+++ b/packages/trading-signals/src/volatility/BBW/BollingerBandsWidth.ts
@@ -10,8 +10,11 @@ import {IndicatorSeries} from '../../types/Indicator.js';
  * @see https://www.tradingview.com/support/solutions/43000501972-bollinger-bands-width-bbw/
  */
 export class BollingerBandsWidth extends IndicatorSeries {
-  constructor(public readonly bollingerBands: BollingerBands) {
+  public readonly bollingerBands: BollingerBands;
+
+  constructor(bollingerBands: BollingerBands) {
     super();
+    this.bollingerBands = bollingerBands;
   }
 
   override getRequiredInputs() {

--- a/packages/trading-signals/src/volatility/IQR/IQR.ts
+++ b/packages/trading-signals/src/volatility/IQR/IQR.ts
@@ -13,8 +13,11 @@ import {getQuartile} from '../../util/getQuartile.js';
 export class IQR extends IndicatorSeries {
   readonly #values: number[] = [];
 
-  constructor(public readonly interval: number) {
+  public readonly interval: number;
+
+  constructor(interval: number) {
     super();
+    this.interval = interval;
   }
 
   override getRequiredInputs() {

--- a/packages/trading-signals/src/volatility/MAD/MAD.ts
+++ b/packages/trading-signals/src/volatility/MAD/MAD.ts
@@ -12,8 +12,11 @@ import {getAverage, pushUpdate} from '../../util/index.js';
 export class MAD extends IndicatorSeries {
   public readonly prices: number[] = [];
 
-  constructor(public readonly interval: number) {
+  public readonly interval: number;
+
+  constructor(interval: number) {
     super();
+    this.interval = interval;
   }
 
   override getRequiredInputs() {

--- a/packages/trading-signals/src/volume/CMF/CMF.ts
+++ b/packages/trading-signals/src/volume/CMF/CMF.ts
@@ -20,8 +20,11 @@ import {pushUpdate} from '../../util/pushUpdate.js';
 export class CMF extends TrendIndicatorSeries<HighLowCloseVolume> {
   readonly #candles: HighLowCloseVolume[] = [];
 
-  constructor(public readonly interval: number) {
+  public readonly interval: number;
+
+  constructor(interval: number) {
     super();
+    this.interval = interval;
   }
 
   override getRequiredInputs() {

--- a/packages/trading-signals/src/volume/EMV/EMV.ts
+++ b/packages/trading-signals/src/volume/EMV/EMV.ts
@@ -24,11 +24,11 @@ export class EMV extends TrendIndicatorSeries<HighLowCloseVolume> {
   readonly #sma: SMA;
   readonly #scale: number;
 
-  constructor(
-    public readonly interval: number,
-    scale: number = 100_000_000
-  ) {
+  public readonly interval: number;
+
+  constructor(interval: number, scale: number = 100_000_000) {
     super();
+    this.interval = interval;
     this.#sma = new SMA(interval);
     this.#scale = scale;
   }

--- a/packages/trading-signals/src/volume/VROC/VROC.ts
+++ b/packages/trading-signals/src/volume/VROC/VROC.ts
@@ -18,8 +18,11 @@ export class VROC extends TrendIndicatorSeries {
   readonly #volumes: number[] = [];
   readonly #historyLength: number;
 
-  constructor(public readonly interval: number) {
+  public readonly interval: number;
+
+  constructor(interval: number) {
     super();
+    this.interval = interval;
     this.#historyLength = interval + 1;
   }
 

--- a/packages/trading-signals/src/volume/VWMA/VWMA.ts
+++ b/packages/trading-signals/src/volume/VWMA/VWMA.ts
@@ -25,12 +25,11 @@ export class VWMA extends TrendIndicatorSeries<HighLowCloseVolume> {
   readonly #candles: HighLowCloseVolume[] = [];
   readonly #signalLine: MovingAverage;
 
-  constructor(
-    public readonly interval: number,
-    SignalIndicator: MovingAverageTypes = SMA,
-    signalInterval: number = interval
-  ) {
+  public readonly interval: number;
+
+  constructor(interval: number, SignalIndicator: MovingAverageTypes = SMA, signalInterval: number = interval) {
     super();
+    this.interval = interval;
     this.#signalLine = new SignalIndicator(signalInterval);
   }
 

--- a/packages/trading-strategies/src/backtest/BacktestExecutor.test.ts
+++ b/packages/trading-strategies/src/backtest/BacktestExecutor.test.ts
@@ -1,6 +1,6 @@
 import Big from 'big.js';
 import {describe, expect, it} from 'vitest';
-import {ALL_AVAILABLE_AMOUNT, AlpacaExchangeMock, ExchangeOrderSide, ExchangeOrderType} from '@typedtrader/exchange';
+import {AllAvailableAmount, AlpacaExchangeMock, ExchangeOrderSide, ExchangeOrderType} from '@typedtrader/exchange';
 import type {ExchangeCandle, ExchangeTradingRules, OrderAdvice, TradingSessionState} from '@typedtrader/exchange';
 import {TradingPair} from '@typedtrader/exchange';
 import {BacktestExecutor} from './BacktestExecutor.js';
@@ -179,7 +179,7 @@ describe('BacktestExecutor', () => {
           return {
             side: ExchangeOrderSide.BUY,
             type: ExchangeOrderType.MARKET,
-            amount: ALL_AVAILABLE_AMOUNT,
+            amount: AllAvailableAmount,
             amountIn: 'counter',
           };
         }
@@ -444,7 +444,7 @@ describe('BacktestExecutor', () => {
           return {
             side: ExchangeOrderSide.BUY,
             type: ExchangeOrderType.MARKET,
-            amount: ALL_AVAILABLE_AMOUNT,
+            amount: AllAvailableAmount,
             amountIn: 'counter',
           };
         }
@@ -565,7 +565,7 @@ describe('BacktestExecutor', () => {
           return {
             side: ExchangeOrderSide.BUY,
             type: ExchangeOrderType.MARKET,
-            amount: ALL_AVAILABLE_AMOUNT,
+            amount: AllAvailableAmount,
             amountIn: 'counter',
           };
         }
@@ -598,7 +598,7 @@ describe('BacktestExecutor', () => {
           return {
             side: ExchangeOrderSide.SELL,
             type: ExchangeOrderType.MARKET,
-            amount: ALL_AVAILABLE_AMOUNT,
+            amount: AllAvailableAmount,
             amountIn: 'base',
           };
         }
@@ -673,7 +673,7 @@ describe('BacktestExecutor', () => {
           return {
             side: ExchangeOrderSide.BUY,
             type: ExchangeOrderType.LIMIT,
-            amount: ALL_AVAILABLE_AMOUNT,
+            amount: AllAvailableAmount,
             amountIn: 'base',
             price: candle.close,
           };

--- a/packages/trading-strategies/src/backtest/BacktestExecutor.ts
+++ b/packages/trading-strategies/src/backtest/BacktestExecutor.ts
@@ -1,5 +1,5 @@
 import Big from 'big.js';
-import {ALL_AVAILABLE_AMOUNT, CandleBatcher, ExchangeOrderSide, ExchangeOrderType} from '@typedtrader/exchange';
+import {AllAvailableAmount, CandleBatcher, ExchangeOrderSide, ExchangeOrderType} from '@typedtrader/exchange';
 import type {ExchangeCandle, ExchangeFeeRate, ExchangeTradingRules, OrderAdvice, TradingSessionState} from '@typedtrader/exchange';
 import type {BacktestConfig} from './BacktestConfig.js';
 import type {BacktestPerformanceSummary, BacktestResult, BacktestTrade} from './BacktestResult.js';
@@ -103,7 +103,7 @@ export class BacktestExecutor {
       return {
         side: ExchangeOrderSide.BUY,
         type: ExchangeOrderType.MARKET,
-        amount: ALL_AVAILABLE_AMOUNT,
+        amount: AllAvailableAmount,
         amountIn: 'counter',
       };
     }
@@ -149,7 +149,7 @@ export class BacktestExecutor {
 
         let size: Big;
         if (advice.side === ExchangeOrderSide.BUY) {
-          if (advice.amount !== ALL_AVAILABLE_AMOUNT) {
+          if (advice.amount !== AllAvailableAmount) {
             size = new Big(advice.amount);
           } else {
             const feeRate = feeRates[ExchangeOrderType.LIMIT];
@@ -158,7 +158,7 @@ export class BacktestExecutor {
           }
         } else {
           // SELL
-          const amount = advice.amount !== ALL_AVAILABLE_AMOUNT ? new Big(advice.amount) : balances.base;
+          const amount = advice.amount !== AllAvailableAmount ? new Big(advice.amount) : balances.base;
           if (amount.lte(0) || balances.base.lte(0)) {
             return;
           }
@@ -181,7 +181,7 @@ export class BacktestExecutor {
 
         if (advice.side === ExchangeOrderSide.BUY) {
           if (advice.amountIn === 'counter') {
-            const spendAmount = advice.amount !== ALL_AVAILABLE_AMOUNT ? new Big(advice.amount) : balances.counter;
+            const spendAmount = advice.amount !== AllAvailableAmount ? new Big(advice.amount) : balances.counter;
             if (spendAmount.lte(0) || balances.counter.lte(0)) {
               return;
             }
@@ -221,7 +221,7 @@ export class BacktestExecutor {
           }
         } else {
           // SELL MARKET
-          const amount = advice.amount !== ALL_AVAILABLE_AMOUNT ? new Big(advice.amount) : balances.base;
+          const amount = advice.amount !== AllAvailableAmount ? new Big(advice.amount) : balances.base;
           if (amount.lte(0) || balances.base.lte(0)) {
             return;
           }

--- a/packages/trading-strategies/src/strategy-buy-below-sell-above/BuyBelowSellAboveStrategy.ts
+++ b/packages/trading-strategies/src/strategy-buy-below-sell-above/BuyBelowSellAboveStrategy.ts
@@ -1,5 +1,5 @@
 import {z} from 'zod';
-import {ALL_AVAILABLE_AMOUNT, ExchangeOrderSide, ExchangeOrderType} from '@typedtrader/exchange';
+import {AllAvailableAmount, ExchangeOrderSide, ExchangeOrderType} from '@typedtrader/exchange';
 import type {OneMinuteBatchedCandle, OrderAdvice, TradingSessionState} from '@typedtrader/exchange';
 import Big from 'big.js';
 import {ProtectedStrategy, ProtectedStrategySchema} from '../strategy-protected/ProtectedStrategy.js';
@@ -38,7 +38,7 @@ export class BuyBelowSellAboveStrategy extends ProtectedStrategy {
         return {
           side: ExchangeOrderSide.BUY,
           type: ExchangeOrderType.LIMIT,
-          amount: ALL_AVAILABLE_AMOUNT,
+          amount: AllAvailableAmount,
           amountIn: 'base',
           price: closePrice,
         };
@@ -52,7 +52,7 @@ export class BuyBelowSellAboveStrategy extends ProtectedStrategy {
         return {
           side: ExchangeOrderSide.SELL,
           type: ExchangeOrderType.LIMIT,
-          amount: ALL_AVAILABLE_AMOUNT,
+          amount: AllAvailableAmount,
           amountIn: 'base',
           price: closePrice,
         };

--- a/packages/trading-strategies/src/strategy-buy-once/BuyOnceStrategy.ts
+++ b/packages/trading-strategies/src/strategy-buy-once/BuyOnceStrategy.ts
@@ -1,5 +1,5 @@
 import {z} from 'zod';
-import {ALL_AVAILABLE_AMOUNT, ExchangeOrderSide, ExchangeOrderType} from '@typedtrader/exchange';
+import {AllAvailableAmount, ExchangeOrderSide, ExchangeOrderType} from '@typedtrader/exchange';
 import type {OneMinuteBatchedCandle, OrderAdvice, TradingSessionState} from '@typedtrader/exchange';
 import Big from 'big.js';
 import {ProtectedStrategy, ProtectedStrategySchema} from '../strategy-protected/ProtectedStrategy.js';
@@ -61,7 +61,7 @@ export class BuyOnceStrategy extends ProtectedStrategy {
       return {
         side: ExchangeOrderSide.BUY,
         type: ExchangeOrderType.MARKET,
-        amount: spend ?? ALL_AVAILABLE_AMOUNT,
+        amount: spend ?? AllAvailableAmount,
         amountIn: 'counter',
       };
     }
@@ -74,7 +74,7 @@ export class BuyOnceStrategy extends ProtectedStrategy {
 
     this.#state.bought = true;
 
-    let amount: string | typeof ALL_AVAILABLE_AMOUNT = ALL_AVAILABLE_AMOUNT;
+    let amount: string | typeof AllAvailableAmount = AllAvailableAmount;
     if (quantity) {
       amount = quantity;
     } else if (spend) {

--- a/packages/trading-strategies/src/strategy-coin-flip/CoinFlipStrategy.ts
+++ b/packages/trading-strategies/src/strategy-coin-flip/CoinFlipStrategy.ts
@@ -1,5 +1,5 @@
 import {z} from 'zod';
-import {ALL_AVAILABLE_AMOUNT, ExchangeOrderSide, ExchangeOrderType} from '@typedtrader/exchange';
+import {AllAvailableAmount, ExchangeOrderSide, ExchangeOrderType} from '@typedtrader/exchange';
 import type {OneMinuteBatchedCandle, OrderAdvice, TradingSessionState} from '@typedtrader/exchange';
 import {ProtectedStrategy, ProtectedStrategySchema} from '../strategy-protected/ProtectedStrategy.js';
 
@@ -23,14 +23,14 @@ export class CoinFlipStrategy extends ProtectedStrategy {
     const buyMarket: OrderAdvice = {
       side: ExchangeOrderSide.BUY,
       type: ExchangeOrderType.MARKET,
-      amount: ALL_AVAILABLE_AMOUNT,
+      amount: AllAvailableAmount,
       amountIn: 'counter',
     };
 
     const sellMarket: OrderAdvice = {
       side: ExchangeOrderSide.SELL,
       type: ExchangeOrderType.MARKET,
-      amount: ALL_AVAILABLE_AMOUNT,
+      amount: AllAvailableAmount,
       amountIn: 'base',
     };
 

--- a/packages/trading-strategies/src/strategy-mean-reversion/MeanReversionStrategy.ts
+++ b/packages/trading-strategies/src/strategy-mean-reversion/MeanReversionStrategy.ts
@@ -1,5 +1,5 @@
 import {z} from 'zod';
-import {ALL_AVAILABLE_AMOUNT, CandleBatcher, ExchangeOrderSide, ExchangeOrderType} from '@typedtrader/exchange';
+import {AllAvailableAmount, CandleBatcher, ExchangeOrderSide, ExchangeOrderType} from '@typedtrader/exchange';
 import type {ExchangeCandle, OneMinuteBatchedCandle, OrderAdvice, TradingSessionState} from '@typedtrader/exchange';
 import {BollingerBands} from 'trading-signals';
 import {ProtectedStrategy, ProtectedStrategySchema} from '../strategy-protected/ProtectedStrategy.js';
@@ -86,7 +86,7 @@ export class MeanReversionStrategy extends ProtectedStrategy {
         return {
           side: ExchangeOrderSide.SELL,
           type: ExchangeOrderType.MARKET,
-          amount: ALL_AVAILABLE_AMOUNT,
+          amount: AllAvailableAmount,
           amountIn: 'base',
           reason: `Price ${closePrice.toFixed(2)} broke above upper band ${upper.toFixed(2)}`,
         };
@@ -99,7 +99,7 @@ export class MeanReversionStrategy extends ProtectedStrategy {
         return {
           side: ExchangeOrderSide.BUY,
           type: ExchangeOrderType.MARKET,
-          amount: ALL_AVAILABLE_AMOUNT,
+          amount: AllAvailableAmount,
           amountIn: 'counter',
           reason: `Price ${closePrice.toFixed(2)} returned to middle band ${middle.toFixed(2)}`,
         };

--- a/packages/trading-strategies/src/strategy-multi-indicator-confluence/MultiIndicatorConfluenceStrategy.ts
+++ b/packages/trading-strategies/src/strategy-multi-indicator-confluence/MultiIndicatorConfluenceStrategy.ts
@@ -1,5 +1,5 @@
 import {z} from 'zod';
-import {ALL_AVAILABLE_AMOUNT, ExchangeOrderSide, ExchangeOrderType} from '@typedtrader/exchange';
+import {AllAvailableAmount, ExchangeOrderSide, ExchangeOrderType} from '@typedtrader/exchange';
 import type {OneMinuteBatchedCandle, OrderAdvice, TradingSessionState} from '@typedtrader/exchange';
 import {BollingerBands, EMA, MACD, RSI} from 'trading-signals';
 import {ProtectedStrategy, ProtectedStrategySchema} from '../strategy-protected/ProtectedStrategy.js';
@@ -141,7 +141,7 @@ export class MultiIndicatorConfluenceStrategy extends ProtectedStrategy {
       return {
         side: ExchangeOrderSide.BUY,
         type: ExchangeOrderType.MARKET,
-        amount: ALL_AVAILABLE_AMOUNT,
+        amount: AllAvailableAmount,
         amountIn: 'counter',
         reason,
       };
@@ -159,7 +159,7 @@ export class MultiIndicatorConfluenceStrategy extends ProtectedStrategy {
       return {
         side: ExchangeOrderSide.SELL,
         type: ExchangeOrderType.MARKET,
-        amount: ALL_AVAILABLE_AMOUNT,
+        amount: AllAvailableAmount,
         amountIn: 'base',
         reason,
       };

--- a/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.test.ts
+++ b/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.test.ts
@@ -3,7 +3,7 @@ import {ms} from 'ms';
 import {describe, expect, it, vi} from 'vitest';
 import {z} from 'zod';
 import {
-  ALL_AVAILABLE_AMOUNT,
+  AllAvailableAmount,
   CandleBatcher,
   ExchangeOrderPosition,
   ExchangeOrderSide,
@@ -118,7 +118,7 @@ class TestProtectedStrategy extends ProtectedStrategy {
       return {
         side: ExchangeOrderSide.BUY,
         type: ExchangeOrderType.MARKET,
-        amount: ALL_AVAILABLE_AMOUNT,
+        amount: AllAvailableAmount,
         amountIn: 'counter',
         reason: 'test buy',
       };
@@ -167,7 +167,7 @@ describe('ProtectedStrategy', () => {
       const advice = await strategy.onCandle(makeCandle(95), mockState);
 
       assertLimitSell(advice);
-      expect(advice.amount).toBe(ALL_AVAILABLE_AMOUNT);
+      expect(advice.amount).toBe(AllAvailableAmount);
       expect(advice.amountIn).toBe('base');
       expect(new Big(advice.price).toFixed(2)).toBe('95.00');
       expect(advice.reason).toContain('[KILL SWITCH]');
@@ -812,7 +812,7 @@ describe('ProtectedStrategy', () => {
 
       const advice = await strategy.onCandle(makeCandle(95), mockState);
       assertMarketSell(advice);
-      expect(advice.amount).toBe(ALL_AVAILABLE_AMOUNT);
+      expect(advice.amount).toBe(AllAvailableAmount);
       expect(advice.amountIn).toBe('base');
       expect(advice.reason).toContain('[KILL SWITCH]');
       expect(advice.reason).toContain('Stop-loss');

--- a/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.ts
+++ b/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.ts
@@ -1,6 +1,6 @@
 import Big from 'big.js';
 import {z} from 'zod';
-import {ALL_AVAILABLE_AMOUNT, ExchangeOrderSide, ExchangeOrderType} from '@typedtrader/exchange';
+import {AllAvailableAmount, ExchangeOrderSide, ExchangeOrderType} from '@typedtrader/exchange';
 import type {ExchangeFill, LimitOrderAdvice, OneMinuteBatchedCandle, OrderAdvice, TradingSessionState} from '@typedtrader/exchange';
 import {Strategy} from '../strategy/Strategy.js';
 import {positiveNumberString} from '../util/validators.js';
@@ -460,7 +460,7 @@ export class ProtectedStrategy extends Strategy {
       return {
         side: ExchangeOrderSide.SELL,
         type: ExchangeOrderType.MARKET,
-        amount: ALL_AVAILABLE_AMOUNT,
+        amount: AllAvailableAmount,
         amountIn: 'base',
         reason: `[KILL SWITCH] ${reason}`,
       };
@@ -471,7 +471,7 @@ export class ProtectedStrategy extends Strategy {
     const advice: LimitOrderAdvice = {
       side: ExchangeOrderSide.SELL,
       type: ExchangeOrderType.LIMIT,
-      amount: ALL_AVAILABLE_AMOUNT,
+      amount: AllAvailableAmount,
       amountIn: 'base',
       price: limitPrice,
       reason: `[KILL SWITCH] ${reason}`,

--- a/packages/trading-strategies/src/strategy-scalp/ScalpStrategy.ts
+++ b/packages/trading-strategies/src/strategy-scalp/ScalpStrategy.ts
@@ -1,6 +1,6 @@
 import {z} from 'zod';
 import Big from 'big.js';
-import {ALL_AVAILABLE_AMOUNT, CandleBatcher, ExchangeOrderSide, ExchangeOrderType} from '@typedtrader/exchange';
+import {AllAvailableAmount, CandleBatcher, ExchangeOrderSide, ExchangeOrderType} from '@typedtrader/exchange';
 import type {ExchangeFill, OneMinuteBatchedCandle, OrderAdvice, TradingSessionState} from '@typedtrader/exchange';
 import {EMA, ER} from 'trading-signals';
 import {ProtectedStrategy, ProtectedStrategySchema} from '../strategy-protected/ProtectedStrategy.js';
@@ -197,7 +197,7 @@ export class ScalpStrategy extends ProtectedStrategy {
     return {
       side: ExchangeOrderSide.BUY,
       type: ExchangeOrderType.MARKET,
-      amount: ALL_AVAILABLE_AMOUNT,
+      amount: AllAvailableAmount,
       amountIn: 'counter',
       reason: `Entry: price ${closePrice.toFixed(2)} above EMA(${this.#ema.interval}) ${emaValue.toFixed(2)}`,
     };
@@ -220,7 +220,7 @@ export class ScalpStrategy extends ProtectedStrategy {
       return {
         side: ExchangeOrderSide.SELL,
         type: ExchangeOrderType.LIMIT,
-        amount: ALL_AVAILABLE_AMOUNT,
+        amount: AllAvailableAmount,
         amountIn: 'base',
         price: sellPrice,
         reason: `Scalp sell: fill ${lastFillPrice.toFixed(2)} + offset ${offset.toFixed(2)}`,
@@ -233,7 +233,7 @@ export class ScalpStrategy extends ProtectedStrategy {
     return {
       side: ExchangeOrderSide.BUY,
       type: ExchangeOrderType.LIMIT,
-      amount: ALL_AVAILABLE_AMOUNT,
+      amount: AllAvailableAmount,
       amountIn: 'base',
       price: buyPrice,
       reason: `Scalp buy: fill ${lastFillPrice.toFixed(2)} - offset ${offset.toFixed(2)}`,

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -2,11 +2,11 @@
   "compilerOptions": {
     "declaration": true,
     "emitDecoratorMetadata": false,
+    "erasableSyntaxOnly": true,
     "experimentalDecorators": true,
     "forceConsistentCasingInFileNames": true,
     "lib": ["es2023"],
-    "module": "nodenext",
-    "moduleResolution": "nodenext",
+    "module": "node20",
     "newLine": "lf",
     "noEmitOnError": true,
     "noImplicitOverride": true,


### PR DESCRIPTION
## Summary

- Updates `tsconfig.lib.json` to `module: node20` (the fixed-version Node target, inferring its matching `moduleResolution` automatically) and enables `erasableSyntaxOnly` so the workspace stays compatible with Node's native TypeScript execution.
- Drops `dom.iterable` (folded into the base `dom` lib in TS 6) and the now-always-on `esModuleInterop` from the `trading-signals-docs` tsconfig.
- Converts every `enum` to an `as const` object plus a derived type, and every `constructor(public readonly …)` parameter property to an explicit field assigned in the constructor body.

## Public API

Preserved. Callers keep using `EnumName.MEMBER` for values and `EnumName` for annotations; class constructor signatures are unchanged. The single behavioural knock-on is in the Alpaca schema, where `z.nativeEnum(PositionSide)` becomes `z.enum(['long', 'short'])` — same validation surface.

All five workspaces type-check cleanly after the changes.