### PR TITLE
feat(exchange): add isEarningsDay util backed by Finnhub

### DIFF
--- a/packages/exchange/src/index.ts
+++ b/packages/exchange/src/index.ts
@@ -2,3 +2,4 @@ export * from './candle/index.js';
 export * from './exchange/index.js';
 export * from './exchange/alpaca/index.js';
 export * from './trader/index.js';
+export * from './util/index.js';

--- a/packages/exchange/src/util/index.ts
+++ b/packages/exchange/src/util/index.ts
@@ -1,0 +1,1 @@
+export * from './isEarningsDay.js';

--- a/packages/exchange/src/util/isEarningsDay.test.ts
+++ b/packages/exchange/src/util/isEarningsDay.test.ts
@@ -1,0 +1,118 @@
+import {describe, expect, it, vi, beforeEach} from 'vitest';
+
+const mockGet = vi.fn();
+
+vi.mock('axios', () => ({
+  default: {
+    create: vi.fn(() => ({get: mockGet})),
+  },
+}));
+
+// axios-retry runs at module-load time and wraps interceptors on the axios
+// instance. We bypass it because the mocked axios instance has no
+// interceptors — the real retry behavior is exercised by the production
+// client, not by these unit tests.
+vi.mock('axios-retry', () => ({
+  default: vi.fn(),
+}));
+
+const {isEarningsDay} = await import('./isEarningsDay.js');
+
+describe('isEarningsDay', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+  });
+
+  it('returns true when the calendar contains a matching entry for the given date and symbol', async () => {
+    mockGet.mockResolvedValueOnce({
+      data: {
+        earningsCalendar: [{date: '2026-05-01', hour: 'amc', quarter: 1, symbol: 'AAPL', year: 2026}],
+      },
+    });
+
+    const result = await isEarningsDay({
+      apiKey: 'test-key',
+      date: new Date('2026-05-01T14:30:00Z'),
+      symbol: 'AAPL',
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('returns false when the earnings calendar is empty', async () => {
+    mockGet.mockResolvedValueOnce({data: {earningsCalendar: []}});
+
+    const result = await isEarningsDay({
+      apiKey: 'test-key',
+      date: new Date('2026-05-01T14:30:00Z'),
+      symbol: 'AAPL',
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when the earnings calendar is null', async () => {
+    mockGet.mockResolvedValueOnce({data: {earningsCalendar: null}});
+
+    const result = await isEarningsDay({
+      apiKey: 'test-key',
+      date: new Date('2026-05-01T14:30:00Z'),
+      symbol: 'AAPL',
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when the calendar contains a different symbol on the same date', async () => {
+    mockGet.mockResolvedValueOnce({
+      data: {
+        earningsCalendar: [{date: '2026-05-01', hour: 'amc', quarter: 1, symbol: 'MSFT', year: 2026}],
+      },
+    });
+
+    const result = await isEarningsDay({
+      apiKey: 'test-key',
+      date: new Date('2026-05-01T14:30:00Z'),
+      symbol: 'AAPL',
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when the calendar contains the symbol but on a different date', async () => {
+    mockGet.mockResolvedValueOnce({
+      data: {
+        earningsCalendar: [{date: '2026-05-02', hour: 'amc', quarter: 1, symbol: 'AAPL', year: 2026}],
+      },
+    });
+
+    const result = await isEarningsDay({
+      apiKey: 'test-key',
+      date: new Date('2026-05-01T14:30:00Z'),
+      symbol: 'AAPL',
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('formats the request with a UTC YYYY-MM-DD range and the expected params', async () => {
+    mockGet.mockResolvedValueOnce({data: {earningsCalendar: []}});
+
+    await isEarningsDay({
+      apiKey: 'secret-key',
+      // Late-evening UTC rolls into the next calendar day in Asia but stays
+      // on 2026-05-01 in UTC. The implementation must anchor to UTC.
+      date: new Date('2026-05-01T23:45:00Z'),
+      symbol: 'AAPL',
+    });
+
+    expect(mockGet).toHaveBeenCalledWith('/calendar/earnings', {
+      params: {
+        from: '2026-05-01',
+        symbol: 'AAPL',
+        to: '2026-05-01',
+        token: 'secret-key',
+      },
+    });
+  });
+});

--- a/packages/exchange/src/util/isEarningsDay.ts
+++ b/packages/exchange/src/util/isEarningsDay.ts
@@ -1,0 +1,51 @@
+import axios from 'axios';
+import axiosRetry from 'axios-retry';
+import {z} from 'zod';
+
+const EarningsEntrySchema = z.looseObject({
+  date: z.string(),
+  hour: z.string(),
+  quarter: z.number(),
+  symbol: z.string(),
+  year: z.number(),
+});
+
+const EarningsCalendarResponseSchema = z.looseObject({
+  earningsCalendar: z.array(EarningsEntrySchema).nullable(),
+});
+
+export type EarningsEntry = z.infer<typeof EarningsEntrySchema>;
+
+function toIsoDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+const client = axios.create({
+  baseURL: 'https://finnhub.io/api/v1',
+});
+
+axiosRetry(client, {
+  retries: 3,
+  retryCondition: error => axiosRetry.isNetworkError(error) || error.response?.status === 429,
+  retryDelay: retryCount => retryCount * 1_000,
+});
+
+/**
+ * Checks whether a symbol is reporting quarterly earnings on the given UTC date.
+ *
+ * @see https://finnhub.io/docs/api/earnings-calendar
+ */
+export async function isEarningsDay(options: {apiKey: string; date: Date; symbol: string}): Promise<boolean> {
+  const isoDate = toIsoDate(options.date);
+  const response = await client.get('/calendar/earnings', {
+    params: {
+      from: isoDate,
+      symbol: options.symbol,
+      to: isoDate,
+      token: options.apiKey,
+    },
+  });
+  const parsed = EarningsCalendarResponseSchema.parse(response.data);
+  const entries = parsed.earningsCalendar ?? [];
+  return entries.some(entry => entry.symbol === options.symbol && entry.date === isoDate);
+}

--- a/packages/trading-signals-docs/pages/indicators/utilities.tsx
+++ b/packages/trading-signals-docs/pages/indicators/utilities.tsx
@@ -1,5 +1,4 @@
 import {getAverage, getMedian, getStandardDeviation, getMaximum, getMinimum} from 'trading-signals';
-import {CodeExample} from '../../components/CodeExample';
 import IndicatorDemo, {IndicatorExample} from '../../components/IndicatorDemo';
 
 export default function UtilityFunctions() {
@@ -166,38 +165,6 @@ console.log(getMinimum(values)); // 25`,
             </div>
           ))}
         </div>
-      </div>
-
-      <div className="bg-slate-800/50 border border-slate-700 rounded-lg p-6">
-        <h2 className="text-2xl font-semibold text-white mb-4">Exchange Utilities</h2>
-        <p className="text-slate-300 mb-4">
-          Helpers from <code className="text-slate-200">@typedtrader/exchange</code> that pull live data. Useful when a
-          strategy needs to react to real-world events outside the candle stream.
-        </p>
-        <div className="bg-slate-900/50 rounded p-4 mb-4">
-          <div className="flex items-baseline gap-3 mb-2 flex-wrap">
-            <code className="text-slate-200 font-mono font-semibold">isEarningsDay</code>
-            <span className="text-slate-500 text-xs">requires a Finnhub API key</span>
-          </div>
-          <p className="text-slate-400 text-sm">
-            Returns <code>true</code> when the given symbol is reporting quarterly earnings on the provided UTC date.
-            Handy for strategies that want to close or skip entries before earnings-driven gap risk.
-          </p>
-        </div>
-        <CodeExample
-          title="Usage"
-          code={`import { isEarningsDay } from '@typedtrader/exchange';
-
-const earnings = await isEarningsDay({
-  apiKey: process.env.FINNHUB_API_KEY!,
-  date: new Date(),
-  symbol: 'AAPL',
-});
-
-if (earnings) {
-  // step aside — avoid post-earnings gap risk
-}`}
-        />
       </div>
     </div>
   );

--- a/packages/trading-signals-docs/pages/indicators/utilities.tsx
+++ b/packages/trading-signals-docs/pages/indicators/utilities.tsx
@@ -1,4 +1,5 @@
 import {getAverage, getMedian, getStandardDeviation, getMaximum, getMinimum} from 'trading-signals';
+import {CodeExample} from '../../components/CodeExample';
 import IndicatorDemo, {IndicatorExample} from '../../components/IndicatorDemo';
 
 export default function UtilityFunctions() {
@@ -165,6 +166,38 @@ console.log(getMinimum(values)); // 25`,
             </div>
           ))}
         </div>
+      </div>
+
+      <div className="bg-slate-800/50 border border-slate-700 rounded-lg p-6">
+        <h2 className="text-2xl font-semibold text-white mb-4">Exchange Utilities</h2>
+        <p className="text-slate-300 mb-4">
+          Helpers from <code className="text-slate-200">@typedtrader/exchange</code> that pull live data. Useful when a
+          strategy needs to react to real-world events outside the candle stream.
+        </p>
+        <div className="bg-slate-900/50 rounded p-4 mb-4">
+          <div className="flex items-baseline gap-3 mb-2 flex-wrap">
+            <code className="text-slate-200 font-mono font-semibold">isEarningsDay</code>
+            <span className="text-slate-500 text-xs">requires a Finnhub API key</span>
+          </div>
+          <p className="text-slate-400 text-sm">
+            Returns <code>true</code> when the given symbol is reporting quarterly earnings on the provided UTC date.
+            Handy for strategies that want to close or skip entries before earnings-driven gap risk.
+          </p>
+        </div>
+        <CodeExample
+          title="Usage"
+          code={`import { isEarningsDay } from '@typedtrader/exchange';
+
+const earnings = await isEarningsDay({
+  apiKey: process.env.FINNHUB_API_KEY!,
+  date: new Date(),
+  symbol: 'AAPL',
+});
+
+if (earnings) {
+  // step aside — avoid post-earnings gap risk
+}`}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Adds `isEarningsDay({apiKey, date, symbol})` in `packages/exchange/src/util/isEarningsDay.ts`, which queries the Finnhub earnings calendar to determine whether a symbol is reporting on the given UTC date.
- Follows existing exchange conventions: axios + axios-retry (network errors & HTTP 429), zod `looseObject` schemas, exported type alias, `@see` JSDoc link to the API reference.
- Exported through a new `util/` barrel so it is reachable from `@typedtrader/exchange`.

## Motivation
Enables strategies to step aside before quarterly earnings — e.g. close a profitable position on the report date to avoid post-earnings gap risk.

## Notes
- Dates are converted to `YYYY-MM-DD` in UTC. Callers running in non-UTC sessions should anchor the `Date` to their exchange's trading day.
- The Finnhub `hour` field (`bmo`/`amc`) is intentionally not considered here — the util answers strictly "is the report dated today?". Pre-shifting the date one day for AMC reports can be layered on by the caller.