### PR TITLE
fix(exchange, messaging): kill-switch race + stock precision + fill order ID

### DIFF
--- a/packages/exchange/src/exchange/alpaca/AlpacaExchange.test.ts
+++ b/packages/exchange/src/exchange/alpaca/AlpacaExchange.test.ts
@@ -206,7 +206,7 @@ describe.sequential('AlpacaExchange', () => {
       const rules = await exchange.getTradingRules(pair);
 
       expect(rules.base_min_size).toBe('0');
-      expect(rules.base_increment).toBe('0.00000001');
+      expect(rules.base_increment).toBe('0.000000001');
       expect(rules.counter_increment).toBe('0.01');
     });
 

--- a/packages/exchange/src/exchange/alpaca/AlpacaExchange.ts
+++ b/packages/exchange/src/exchange/alpaca/AlpacaExchange.ts
@@ -438,8 +438,10 @@ export class AlpacaExchange extends Exchange {
           pair,
         };
       }
+      // Notional and quantity fields can take up to 9 decimal point values:
+      // @see https://docs.alpaca.markets/docs/fractional-trading#supported-order-types
       return {
-        base_increment: '0.00000001',
+        base_increment: '0.000000001',
         base_max_size: Number.MAX_SAFE_INTEGER.toString(),
         base_min_size: '0',
         counter_increment: '0.01',

--- a/packages/exchange/src/exchange/alpaca/AlpacaExchange.ts
+++ b/packages/exchange/src/exchange/alpaca/AlpacaExchange.ts
@@ -438,7 +438,7 @@ export class AlpacaExchange extends Exchange {
           pair,
         };
       }
-      // Notional and quantity fields can take up to 9 decimal point values:
+      // Notional and quantity fields can take up to 9 decimal places:
       // @see https://docs.alpaca.markets/docs/fractional-trading#supported-order-types
       return {
         base_increment: '0.000000001',

--- a/packages/exchange/src/trader/TradingSession.test.ts
+++ b/packages/exchange/src/trader/TradingSession.test.ts
@@ -284,7 +284,53 @@ describe.sequential('TradingSession', () => {
       });
     });
 
-    it('cancels existing order before placing a new one', async () => {
+    it('keeps a pending order tracked when it fills in the race window before being canceled', async () => {
+      const advice: OrderAdvice = {
+        side: ExchangeOrderSide.SELL,
+        type: ExchangeOrderType.LIMIT,
+        amount: '1',
+        amountIn: 'base',
+        price: new Big('250'),
+      };
+      strategy.onCandle.mockResolvedValue(advice);
+
+      await session.start();
+
+      exchange.emit('candle-topic-1', sampleCandle);
+      await vi.waitFor(() => expect(exchange.placeLimitOrder).toHaveBeenCalledTimes(1));
+
+      // Race window: the order filled on the exchange before our cancel reached it,
+      // so cancelOpenOrders has no IDs to return. The order must stay tracked so the
+      // late FILL websocket event still matches.
+      exchange.cancelOpenOrders.mockResolvedValueOnce([]);
+      exchange.placeLimitOrder.mockResolvedValueOnce({
+        id: 'order-1-replacement',
+        pair,
+        side: ExchangeOrderSide.SELL,
+        size: '10',
+        type: ExchangeOrderType.LIMIT,
+        price: '253.00',
+      } satisfies ExchangePendingLimitOrder);
+
+      const onFill = vi.fn();
+      const onOrderFilled = vi.fn();
+      session.on('fill', onFill);
+      session.on('orderFilled', onOrderFilled);
+
+      // Next candle: cancel-and-replace cycle runs, but order-1 stays in pendingOrders
+      exchange.emit('candle-topic-1', sampleCandle);
+      await vi.waitFor(() => expect(exchange.placeLimitOrder).toHaveBeenCalledTimes(2));
+
+      // The late FILL event for order-1 finally arrives and is processed
+      const lateFill: ExchangeFill = {...sampleFill, order_id: 'order-1', side: ExchangeOrderSide.SELL};
+      exchange.emit('order-topic-1', lateFill);
+
+      await vi.waitFor(() => expect(onOrderFilled).toHaveBeenCalledTimes(1));
+      expect(onFill).toHaveBeenCalledWith(lateFill);
+      expect(strategy.onFill).toHaveBeenCalledWith(lateFill, expect.anything());
+    });
+
+it('cancels existing order before placing a new one', async () => {
       const advice: OrderAdvice = {
         side: ExchangeOrderSide.BUY,
         type: ExchangeOrderType.MARKET,

--- a/packages/exchange/src/trader/TradingSession.ts
+++ b/packages/exchange/src/trader/TradingSession.ts
@@ -151,8 +151,13 @@ export class TradingSession extends EventEmitter<TradingSessionEventMap> {
 
   async #executeAdvice(advice: OrderAdvice): Promise<void> {
     if (this.#pendingOrders.size > 0) {
-      await this.#exchange.cancelOpenOrders(this.#pair);
-      this.#pendingOrders.clear();
+      // Only forget orders that were actually canceled. Any pending order missing
+      // from the canceled list filled before our cancel reached the exchange —
+      // keep it so the late FILL websocket event still matches and onFinish fires.
+      const canceledIds = await this.#exchange.cancelOpenOrders(this.#pair);
+      for (const orderId of canceledIds) {
+        this.#pendingOrders.delete(orderId);
+      }
     }
 
     const balances = await this.#exchange.getAvailableBalances(this.#pair);

--- a/packages/messaging/src/service/StrategyMonitor.ts
+++ b/packages/messaging/src/service/StrategyMonitor.ts
@@ -152,7 +152,7 @@ export class StrategyMonitor {
       return;
     }
 
-    const message = `Order Filled!\n\nStrategy: ${row.strategyName}\nPair: ${row.pair}\nSide: ${fill.side}\nPrice: ${fill.price}\nSize: ${fill.size}\nFee: ${fill.fee} ${fill.feeAsset}`;
+    const message = `Order Filled!\n\nStrategy: ${row.strategyName}\nPair: ${row.pair}\nSide: ${fill.side}\nPrice: ${fill.price}\nSize: ${fill.size}\nFee: ${fill.fee} ${fill.feeAsset}\nOrder ID: ${fill.order_id}`;
 
     const platformPrefix = account.userId.split(':')[0];
     const platform = this.#platforms.get(platformPrefix);


### PR DESCRIPTION
## Summary

Three related bugs surfaced today after `@typedtrader/strategy-buy-once` kill switches fired on `CLS,USD` and `SITM,USD`:

### 1. `fix(exchange)` — 9-decimal `base_increment` for Alpaca stocks
Alpaca accepts fractional stock orders up to **9 decimal places**, but our hardcoded default in `AlpacaExchange.getTradingRules` rounded to **8**. Every kill-switch SELL truncated the trailing 9th decimal, leaving sub-share dust:
- CLS: BUY `0.957680115` → SELL `0.95768011` → dust `0.000000005`
- SITM: BUY `0.705659032` → SELL `0.70565903` → dust `0.000000002`

Source: https://docs.alpaca.markets/docs/fractional-trading#supported-order-types

### 2. `fix(exchange)` — keep uncanceled pending orders so late FILL events match
The kill switch re-issues its SELL on every candle. `TradingSession#executeAdvice` cancels and replaces, but `cancelOpenOrders` returns no IDs when an order has already filled, and we were still calling `#pendingOrders.clear()`. The late websocket FILL event then arrived to an empty map and was dropped — `onOrderFilled` / `onFinish` never fired, the strategy stayed in the DB, and no "Strategy finished and removed" notification was sent.

Reproduced from CLS's order log today: the final SELL took 49s to fill, the next candle ran ~10s later, FILL arrived ~25s after that → dropped.

Now we only delete orders that were actually canceled; anything missing from the canceled list stays tracked so the late FILL still matches. Regression test added in `TradingSession.test.ts`.

Known minor caveat: an order canceled out-of-band (e.g. via Alpaca's UI) will leak in `#pendingOrders` until session stop, since we never see a cancellation event for it. Acceptable trade-off for the simpler logic.

### 3. `feat(messaging)` — include order ID in fill notifications
So the user can cross-check a fill against their exchange UI without digging through order history.

## Notes

- Existing CLS/SITM dust on Alpaca is not auto-resolved by this PR — that's leftover from prior runs.
- The CLS strategy row that got stuck in the DB needs a manual `/strategyRemove` since it's already past the point where the fix would help.