### PR TITLE
feat(trading-strategies, trading-signals-docs): add TrailingStopStrategy

### DIFF
--- a/packages/trading-signals-docs/pages/backtest.tsx
+++ b/packages/trading-signals-docs/pages/backtest.tsx
@@ -11,11 +11,13 @@ import {
   ScalpStrategy,
   MeanReversionStrategy,
   ProtectedStrategy,
+  TrailingStopStrategy,
   type BacktestResult,
   BuyOnceConfig,
   BuyBelowSellAboveConfig,
   type MultiIndicatorConfluenceConfig,
   type ScalpConfig,
+  type TrailingStopConfig,
 } from 'trading-strategies';
 import {DatasetSelector} from '../components/DatasetSelector';
 import {StrategyConfigurator} from '../components/StrategyConfigurator';
@@ -43,6 +45,8 @@ function createStrategy(strategyId: StrategyId, config: Record<string, unknown>)
       return new MeanReversionStrategy({config});
     case 'protection-only':
       return new ProtectedStrategy({config});
+    case 'trailing-stop':
+      return new TrailingStopStrategy(config as TrailingStopConfig);
   }
 }
 

--- a/packages/trading-signals-docs/utils/strategySchemas.ts
+++ b/packages/trading-signals-docs/utils/strategySchemas.ts
@@ -1,10 +1,10 @@
 import {z} from 'zod';
 import type {ExchangeCandle} from '@typedtrader/exchange';
-import {BuyOnceSchema, BuyBelowSellAboveSchema, CoinFlipSchema, MultiIndicatorConfluenceSchema, ScalpSchema, MeanReversionSchema, ProtectedStrategySchema, suggestScalpOffset} from 'trading-strategies';
+import {BuyOnceSchema, BuyBelowSellAboveSchema, CoinFlipSchema, MultiIndicatorConfluenceSchema, ScalpSchema, MeanReversionSchema, ProtectedStrategySchema, TrailingStopSchema, suggestScalpOffset} from 'trading-strategies';
 
-export {BuyOnceSchema, BuyBelowSellAboveSchema, CoinFlipSchema, MultiIndicatorConfluenceSchema, ScalpSchema, MeanReversionSchema, ProtectedStrategySchema};
+export {BuyOnceSchema, BuyBelowSellAboveSchema, CoinFlipSchema, MultiIndicatorConfluenceSchema, ScalpSchema, MeanReversionSchema, ProtectedStrategySchema, TrailingStopSchema};
 
-export type StrategyId = 'buy-and-hold' | 'buy-once' | 'buy-below-sell-above' | 'coin-flip' | 'multi-indicator-confluence' | 'scalp' | 'mean-reversion' | 'protection-only';
+export type StrategyId = 'buy-and-hold' | 'buy-once' | 'buy-below-sell-above' | 'coin-flip' | 'multi-indicator-confluence' | 'scalp' | 'mean-reversion' | 'protection-only' | 'trailing-stop';
 
 export interface StrategyDefinition {
   id: StrategyId;
@@ -135,5 +135,13 @@ export const strategyDefinitions: StrategyDefinition[] = [
         seedFromBalance: true,
       },
     }),
+  },
+  {
+    id: 'trailing-stop',
+    name: 'Trailing Stop',
+    description:
+      'Exit-only trailing stop. Attaches to an existing base balance, tracks the highest candle high since attach, and emits a sell-all advice when the close drops by trailDownPct from the peak. Set initialBase > 0 in the backtest setup so the strategy has a position to protect.',
+    schema: TrailingStopSchema,
+    getDefaultConfig: () => ({trailDownPct: '10', exitOrder: 'limit'}),
   },
 ];

--- a/packages/trading-strategies/README.md
+++ b/packages/trading-strategies/README.md
@@ -86,6 +86,12 @@ type Config = MultiIndicatorConfluenceConfig; // z.infer<typeof MultiIndicatorCo
 
 - **Asset identifiers** differ by market and licensing. A **ticker symbol** (e.g., `AAPL` for [Apple Inc.](https://en.wikipedia.org/wiki/Apple_Inc.)) is an exchange-specific code and not globally unique. An **ISIN** (`US0378331005`) is a 12-character global identifier under ISO 6166, while a **CUSIP** (`037833100`) is a 9-character code used mainly in the U.S. and Canada. Both ISIN and CUSIP databases are maintained by commercial organizations and require paid licenses for redistribution, which is why many open-source projects and free APIs rely on ticker symbols instead ([source](https://forum.alpaca.markets/t/is-there-a-list-for-all-etfs/9117/4)).
 
+- A **day trader** opens and closes every position within the same trading session and holds nothing overnight, which avoids gap risk and overnight margin costs but demands constant attention. Profits come from many small intraday moves, so the typical reference candles are 1-minute to 15-minute, and stops are tight because the horizon (minutes to hours) leaves no room for adverse moves to recover.
+
+- A **swing trader** holds positions for several days to a few weeks to capture a single directional "swing" within a broader trend. The horizon is long enough to ride out intraday noise but short enough that long-term fundamentals are secondary to chart patterns and momentum. Daily and 4-hour candles are the typical reference timeframes, and stops are wider than a day trader's to absorb overnight volatility.
+
+- A **position trader** holds for months to years and treats short-term price action as noise around a longer thesis driven by fundamentals (earnings, macro shifts, structural changes). Technical analysis serves mainly to time entries; once in, drawdowns of 20% or more are tolerated as part of normal holding behavior. Weekly and monthly candles are the relevant timeframes, and trade frequency is low enough that transaction costs barely matter.
+
 ## Strategies
 
 ### BuyOnce

--- a/packages/trading-strategies/src/index.ts
+++ b/packages/trading-strategies/src/index.ts
@@ -14,6 +14,12 @@ export {
 } from './strategy-mean-reversion/MeanReversionStrategy.js';
 export {NoopStrategy, NoopSchema, type NoopConfig} from './strategy-noop/NoopStrategy.js';
 export {
+  TrailingStopStrategy,
+  TrailingStopSchema,
+  type TrailingStopConfig,
+  type TrailingStopState,
+} from './strategy-trailing-stop/TrailingStopStrategy.js';
+export {
   ProtectedStrategy,
   ProtectedStrategySchema,
   type ProtectedStrategyConfig,

--- a/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.test.ts
+++ b/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.test.ts
@@ -1,0 +1,262 @@
+import Big from 'big.js';
+import {describe, expect, it} from 'vitest';
+import {AlpacaExchangeMock, ExchangeOrderSide, ExchangeOrderType, TradingPair} from '@typedtrader/exchange';
+import type {ExchangeCandle} from '@typedtrader/exchange';
+import {BacktestExecutor} from '../backtest/BacktestExecutor.js';
+import {TrailingStopStrategy} from './TrailingStopStrategy.js';
+import type {BacktestConfig} from '../backtest/BacktestConfig.js';
+
+function createCandle(overrides: Partial<ExchangeCandle> & {close: string; open: string}): ExchangeCandle {
+  const openNum = parseFloat(overrides.open);
+  const closeNum = parseFloat(overrides.close);
+
+  return {
+    base: 'BTC',
+    counter: 'USD',
+    high: overrides.high ?? String(Math.max(openNum, closeNum)),
+    low: overrides.low ?? String(Math.min(openNum, closeNum)),
+    open: overrides.open,
+    close: overrides.close,
+    openTimeInISO: overrides.openTimeInISO ?? '2025-01-01T00:00:00.000Z',
+    openTimeInMillis: overrides.openTimeInMillis ?? 1735689600000,
+    sizeInMillis: overrides.sizeInMillis ?? 60000,
+    volume: overrides.volume ?? '100',
+  };
+}
+
+function createMockExchange(options: {baseBalance?: string; counterBalance?: string} = {}) {
+  const balances = new Map([
+    ['BTC', {available: new Big(options.baseBalance ?? '5'), hold: new Big(0)}],
+    ['USD', {available: new Big(options.counterBalance ?? '0'), hold: new Big(0)}],
+  ]);
+  return new AlpacaExchangeMock({balances});
+}
+
+describe('TrailingStopStrategy', () => {
+  const tradingPair = new TradingPair('BTC', 'USD');
+
+  it('attaches on the first candle and exits with a limit sell at the trail target by default', async () => {
+    const strategy = new TrailingStopStrategy({trailDownPct: '10'});
+
+    // C1: attach at close=100. peak=100.
+    // C2: high=120 → peak ratchets to 120. close=118 > 108 → no exit.
+    // C3: high=120, close=107 → 107 <= 108 → exit fires (limit sell at 108).
+    // C4: limit sell fills (low=105 <= 108).
+    const candles = [
+      createCandle({open: '100', close: '100', low: '99', high: '101', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+      createCandle({open: '105', close: '118', low: '104', high: '120', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
+      createCandle({open: '118', close: '107', low: '106', high: '120', openTimeInISO: '2025-01-01T00:02:00.000Z'}),
+      createCandle({open: '107', close: '107', low: '105', high: '108', openTimeInISO: '2025-01-01T00:03:00.000Z'}),
+    ];
+
+    const config: BacktestConfig = {
+      candles,
+      exchange: createMockExchange({baseBalance: '5'}),
+      strategy,
+      tradingPair,
+    };
+
+    const result = await new BacktestExecutor(config).execute();
+
+    expect(result.trades).toHaveLength(1);
+    expect(result.trades[0].advice.side).toBe(ExchangeOrderSide.SELL);
+    expect(result.trades[0].advice.type).toBe(ExchangeOrderType.LIMIT);
+    expect(strategy.trailingState.exited).toBe(true);
+    expect(strategy.trailingState.exitLimitPrice).toBe('108');
+  });
+
+  it('does not exit while price stays above the trail target', async () => {
+    const strategy = new TrailingStopStrategy({trailDownPct: '5'});
+
+    // peak ratchets up; close never breaches peak * 0.95.
+    const candles = [
+      createCandle({open: '100', close: '100', low: '99', high: '101', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+      createCandle({open: '101', close: '105', low: '100', high: '106', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
+      createCandle({open: '105', close: '110', low: '104', high: '112', openTimeInISO: '2025-01-01T00:02:00.000Z'}),
+      createCandle({open: '110', close: '108', low: '107', high: '112', openTimeInISO: '2025-01-01T00:03:00.000Z'}),
+    ];
+
+    const config: BacktestConfig = {
+      candles,
+      exchange: createMockExchange({baseBalance: '5'}),
+      strategy,
+      tradingPair,
+    };
+
+    const result = await new BacktestExecutor(config).execute();
+
+    expect(result.trades).toHaveLength(0);
+    expect(strategy.trailingState.exited).toBe(false);
+    expect(new Big(strategy.trailingState.peakPrice).gte(new Big('110'))).toBe(true);
+  });
+
+  it('peak only ratchets upward — a lower high after a higher one does not lower the trail', async () => {
+    const strategy = new TrailingStopStrategy({trailDownPct: '10'});
+
+    const candles = [
+      createCandle({open: '100', close: '100', low: '99', high: '101', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+      createCandle({open: '105', close: '115', low: '104', high: '120', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
+      createCandle({open: '115', close: '110', low: '110', high: '116', openTimeInISO: '2025-01-01T00:02:00.000Z'}),
+      createCandle({open: '110', close: '107', low: '107', high: '111', openTimeInISO: '2025-01-01T00:03:00.000Z'}),
+      createCandle({open: '107', close: '107', low: '105', high: '108', openTimeInISO: '2025-01-01T00:04:00.000Z'}),
+    ];
+
+    const config: BacktestConfig = {
+      candles,
+      exchange: createMockExchange({baseBalance: '5'}),
+      strategy,
+      tradingPair,
+    };
+
+    const result = await new BacktestExecutor(config).execute();
+
+    expect(result.trades).toHaveLength(1);
+    expect(strategy.trailingState.peakPrice).toBe('120');
+    expect(strategy.trailingState.exited).toBe(true);
+  });
+
+  it('uses a market sell when exitOrder is "market"', async () => {
+    const strategy = new TrailingStopStrategy({trailDownPct: '10', exitOrder: 'market'});
+
+    const candles = [
+      createCandle({open: '100', close: '100', low: '99', high: '101', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+      createCandle({open: '105', close: '118', low: '104', high: '120', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
+      createCandle({open: '118', close: '107', low: '106', high: '120', openTimeInISO: '2025-01-01T00:02:00.000Z'}),
+      createCandle({open: '107', close: '107', low: '105', high: '108', openTimeInISO: '2025-01-01T00:03:00.000Z'}),
+    ];
+
+    const config: BacktestConfig = {
+      candles,
+      exchange: createMockExchange({baseBalance: '5'}),
+      strategy,
+      tradingPair,
+    };
+
+    const result = await new BacktestExecutor(config).execute();
+
+    expect(result.trades).toHaveLength(1);
+    expect(result.trades[0].advice.type).toBe(ExchangeOrderType.MARKET);
+    expect(strategy.trailingState.exitLimitPrice).toBeNull();
+  });
+
+  it('waits to attach until the base balance is non-zero', async () => {
+    const strategy = new TrailingStopStrategy({trailDownPct: '10'});
+
+    // Empty balance → no attach, no advice.
+    const candles = [
+      createCandle({open: '100', close: '100', low: '99', high: '101', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+      createCandle({open: '100', close: '100', low: '99', high: '101', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
+    ];
+
+    const config: BacktestConfig = {
+      candles,
+      exchange: createMockExchange({baseBalance: '0', counterBalance: '0'}),
+      strategy,
+      tradingPair,
+    };
+
+    const result = await new BacktestExecutor(config).execute();
+
+    expect(result.trades).toHaveLength(0);
+    expect(strategy.trailingState.peakPrice).toBe('0');
+  });
+
+  it('seeds the peak from the attach candle high, not from its close', async () => {
+    const strategy = new TrailingStopStrategy({trailDownPct: '10'});
+
+    const candles = [
+      // Attach: high=160 (intra-candle high), close=150. Peak=160 (from high). Target=144.
+      createCandle({open: '150', close: '150', low: '149', high: '160', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+      // close=143 <= 144 → exit fires. high=150 doesn't ratchet peak above 160.
+      createCandle({open: '150', close: '143', low: '140', high: '150', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
+      // Limit fills (low=140 <= 144).
+      createCandle({open: '143', close: '143', low: '140', high: '145', openTimeInISO: '2025-01-01T00:02:00.000Z'}),
+    ];
+
+    const config: BacktestConfig = {
+      candles,
+      exchange: createMockExchange({baseBalance: '5'}),
+      strategy,
+      tradingPair,
+    };
+
+    const result = await new BacktestExecutor(config).execute();
+
+    expect(result.trades).toHaveLength(1);
+    expect(strategy.trailingState.peakPrice).toBe('160');
+    expect(strategy.trailingState.exitLimitPrice).toBe('144');
+  });
+
+  it('seeds the peak from a configured pivotPrice instead of the attach candle high', async () => {
+    const strategy = new TrailingStopStrategy({trailDownPct: '10', pivotPrice: '200'});
+
+    const candles = [
+      // Attach candle high=160, but pivotPrice=200 wins. Peak=200, target=180.
+      createCandle({open: '150', close: '150', low: '149', high: '160', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+      // close=179 <= 180 → exit fires at limit 180. high=150 doesn't ratchet peak.
+      createCandle({open: '150', close: '179', low: '178', high: '150', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
+      // Limit fills (low=178 <= 180).
+      createCandle({open: '179', close: '179', low: '178', high: '181', openTimeInISO: '2025-01-01T00:02:00.000Z'}),
+    ];
+
+    const config: BacktestConfig = {
+      candles,
+      exchange: createMockExchange({baseBalance: '5'}),
+      strategy,
+      tradingPair,
+    };
+
+    const result = await new BacktestExecutor(config).execute();
+
+    expect(result.trades).toHaveLength(1);
+    expect(strategy.trailingState.peakPrice).toBe('200');
+    expect(strategy.trailingState.exitLimitPrice).toBe('180');
+  });
+
+  it('only ratchets the peak when a new high exceeds it by trailUpPct', async () => {
+    const strategy = new TrailingStopStrategy({trailDownPct: '10', trailUpPct: '5'});
+
+    const candles = [
+      // Attach. peak=100, ratchet threshold=105 (peak * 1.05).
+      createCandle({open: '100', close: '100', low: '99', high: '100', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+      // high=104 < 105 → does NOT ratchet. Peak stays at 100.
+      createCandle({open: '100', close: '102', low: '99', high: '104', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
+      // high=110 >= 105 → ratchets. Peak jumps to 110. New threshold=115.5.
+      createCandle({open: '102', close: '108', low: '101', high: '110', openTimeInISO: '2025-01-01T00:02:00.000Z'}),
+      // high=114 < 115.5 → does NOT ratchet. Peak stays at 110.
+      createCandle({open: '108', close: '112', low: '107', high: '114', openTimeInISO: '2025-01-01T00:03:00.000Z'}),
+      // close=98 <= 99 (110 * 0.9) → exit fires at limit 99.
+      createCandle({open: '112', close: '98', low: '97', high: '113', openTimeInISO: '2025-01-01T00:04:00.000Z'}),
+      // Limit fills (low=97 <= 99).
+      createCandle({open: '98', close: '98', low: '97', high: '100', openTimeInISO: '2025-01-01T00:05:00.000Z'}),
+    ];
+
+    const config: BacktestConfig = {
+      candles,
+      exchange: createMockExchange({baseBalance: '5'}),
+      strategy,
+      tradingPair,
+    };
+
+    const result = await new BacktestExecutor(config).execute();
+
+    expect(result.trades).toHaveLength(1);
+    expect(strategy.trailingState.peakPrice).toBe('110');
+    expect(strategy.trailingState.exitLimitPrice).toBe('99');
+  });
+
+  it('restores state and resumes trailing without re-attaching', async () => {
+    const strategy = new TrailingStopStrategy({trailDownPct: '10'});
+
+    strategy.restoreState({
+      exited: false,
+      positionSize: '5',
+      peakPrice: '120',
+      exitReason: null,
+      exitLimitPrice: null,
+    });
+
+    expect(strategy.trailingState.peakPrice).toBe('120');
+    expect(strategy.trailingState.positionSize).toBe('5');
+  });
+});

--- a/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.test.ts
+++ b/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.test.ts
@@ -270,6 +270,38 @@ describe('TrailingStopStrategy', () => {
     expect(strategy.trailingState.exitLimitPrice).toBe('90');
   });
 
+  it('rejects malformed restored state that would strand the strategy in a no-op', async () => {
+    const strategy = new TrailingStopStrategy({trailDownPct: '10'});
+
+    // peak set but no position and not exited → permanent no-op. Predicate rejects;
+    // the proxied state stays at defaults so the strategy can still attach.
+    strategy.restoreState({
+      exited: false,
+      positionSize: '0',
+      peakPrice: '120',
+      exitReason: null,
+      exitLimitPrice: null,
+    });
+
+    expect(strategy.trailingState.peakPrice).toBe('0');
+    expect(strategy.trailingState.positionSize).toBe('0');
+  });
+
+  it('rejects restored state where exited=true but positionSize is non-zero', async () => {
+    const strategy = new TrailingStopStrategy({trailDownPct: '10'});
+
+    strategy.restoreState({
+      exited: true,
+      positionSize: '5',
+      peakPrice: '120',
+      exitReason: null,
+      exitLimitPrice: null,
+    });
+
+    expect(strategy.trailingState.exited).toBe(false);
+    expect(strategy.trailingState.positionSize).toBe('0');
+  });
+
   it('restores state and resumes trailing without re-attaching', async () => {
     const strategy = new TrailingStopStrategy({trailDownPct: '10'});
 

--- a/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.test.ts
+++ b/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.test.ts
@@ -245,6 +245,31 @@ describe('TrailingStopStrategy', () => {
     expect(strategy.trailingState.exitLimitPrice).toBe('99');
   });
 
+  it('defaults trailDownPct to 10 when omitted', async () => {
+    const strategy = new TrailingStopStrategy({});
+
+    const candles = [
+      // Attach: peak=100. Default 10% trail → target=90.
+      createCandle({open: '100', close: '100', low: '99', high: '100', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+      // close=90 <= 90 → exit fires at limit 90.
+      createCandle({open: '100', close: '90', low: '89', high: '100', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
+      // Limit fills (low=89 <= 90).
+      createCandle({open: '90', close: '90', low: '89', high: '91', openTimeInISO: '2025-01-01T00:02:00.000Z'}),
+    ];
+
+    const config: BacktestConfig = {
+      candles,
+      exchange: createMockExchange({baseBalance: '5'}),
+      strategy,
+      tradingPair,
+    };
+
+    const result = await new BacktestExecutor(config).execute();
+
+    expect(result.trades).toHaveLength(1);
+    expect(strategy.trailingState.exitLimitPrice).toBe('90');
+  });
+
   it('restores state and resumes trailing without re-attaching', async () => {
     const strategy = new TrailingStopStrategy({trailDownPct: '10'});
 

--- a/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.ts
+++ b/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.ts
@@ -54,8 +54,8 @@ export type TrailingStopState = {
   exited: boolean;
   /**
    * Net base quantity currently held. Stored as a Big string. Starts at `'0'`, jumps to
-   * the seeded balance on attach, increases on external BUY fills, and decreases on SELL
-   * fills. When it reaches zero, `exited` flips to `true`.
+   * the seeded balance on attach, and decreases on SELL fills of the strategy's own
+   * exit orders. When it reaches zero, `exited` flips to `true`.
    */
   positionSize: string;
   /**
@@ -105,8 +105,9 @@ const defaultState = (): TrailingStopState => ({
  * Attach behavior: on each candle, if not yet attached and `state.baseBalance > 0`,
  * the strategy claims the full base balance as its position and seeds the peak from
  * the configured `pivotPrice` (when provided) or otherwise from the attach candle's
- * `high`. Subsequent external BUY fills add to the position via `onFill`, but the
- * peak is not re-anchored.
+ * `high`. The position is not modified again until the strategy's own SELL fills
+ * arrive — `TradingSession` only forwards fills for orders it placed itself, so any
+ * external buys made after attach do not reach `onFill` and are not tracked.
  */
 export class TrailingStopStrategy extends Strategy {
   static override NAME = '@typedtrader/strategy-trailing-stop';
@@ -198,15 +199,11 @@ export class TrailingStopStrategy extends Strategy {
   }
 
   async onFill(fill: ExchangeFill, _state: TradingSessionState): Promise<void> {
-    const fillSize = new Big(fill.size);
-    const currentSize = new Big(this.#state.positionSize);
-
-    if (fill.side === ExchangeOrderSide.BUY) {
-      this.#state.positionSize = currentSize.plus(fillSize).toFixed();
+    if (fill.side !== ExchangeOrderSide.SELL) {
       return;
     }
-
-    const newSize = currentSize.minus(fillSize);
+    const fillSize = new Big(fill.size);
+    const newSize = new Big(this.#state.positionSize).minus(fillSize);
     if (newSize.lte(0)) {
       this.#state.positionSize = '0';
       this.#state.exited = true;
@@ -251,6 +248,21 @@ function isTrailingStopState(value: unknown): value is TrailingStopState {
   if (value.exitLimitPrice !== null) {
     if (typeof value.exitLimitPrice !== 'string' || !isValidBigString(value.exitLimitPrice)) return false;
   }
+
+  // Cross-field invariants. Restoring a state that violates these would strand the
+  // strategy in a no-op or otherwise inconsistent runtime state, so reject and let
+  // restoreState fall back to defaults.
+  const positionSize = new Big(value.positionSize);
+  const peakPrice = new Big(value.peakPrice);
+
+  // Once exited, the position must be zero. Anything else is contradictory.
+  if (value.exited && !positionSize.eq(0)) return false;
+
+  // Attached (peak set) but not exited and no position left → permanent no-op:
+  // the seed branch is skipped (peak !== '0') and the trail branch returns early
+  // (positionSize <= 0). Treat as corrupt and reset.
+  if (!peakPrice.eq(0) && !value.exited && positionSize.lte(0)) return false;
+
   return true;
 }
 

--- a/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.ts
+++ b/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.ts
@@ -219,16 +219,14 @@ export class TrailingStopStrategy extends Strategy {
   }
 
   override restoreState(persisted: Record<string, unknown>): void {
-    super.restoreState(persisted);
-    if (!isTrailingStopState(persisted)) {
-      return;
-    }
+    const validated: TrailingStopState = isTrailingStopState(persisted) ? persisted : defaultState();
+    super.restoreState(validated);
     const restored = this.#state;
-    restored.exited = persisted.exited;
-    restored.positionSize = persisted.positionSize;
-    restored.peakPrice = persisted.peakPrice;
-    restored.exitReason = persisted.exitReason;
-    restored.exitLimitPrice = persisted.exitLimitPrice;
+    restored.exited = validated.exited;
+    restored.positionSize = validated.positionSize;
+    restored.peakPrice = validated.peakPrice;
+    restored.exitReason = validated.exitReason;
+    restored.exitLimitPrice = validated.exitLimitPrice;
   }
 }
 

--- a/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.ts
+++ b/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.ts
@@ -1,0 +1,264 @@
+import Big from 'big.js';
+import {z} from 'zod';
+import {AllAvailableAmount, ExchangeOrderSide, ExchangeOrderType} from '@typedtrader/exchange';
+import type {
+  ExchangeFill,
+  ExchangePendingOrder,
+  LimitOrderAdvice,
+  OneMinuteBatchedCandle,
+  OrderAdvice,
+  TradingSessionState,
+} from '@typedtrader/exchange';
+import {Strategy} from '../strategy/Strategy.js';
+import {positiveNumberString} from '../util/validators.js';
+
+export const TrailingStopSchema = z.object({
+  /**
+   * Exit threshold as a percentage of the running peak. "5" → exit when close drops to
+   * peak * 0.95. Always required.
+   */
+  trailDownPct: positiveNumberString,
+  /**
+   * Optional hysteresis on peak ratcheting. When set, a new candle high only updates
+   * the peak if it exceeds the previous peak by at least `trailUpPct` percent — i.e.
+   * `candle.high >= peakPrice * (1 + trailUpPct/100)`. When the threshold is crossed,
+   * the peak jumps to `candle.high` (the actual new high, not a ratcheted multiple).
+   * Useful in choppy markets to avoid letting every micro-tick reset the trail.
+   * When omitted, the peak ratchets on every candle high that exceeds the previous one.
+   */
+  trailUpPct: positiveNumberString.optional(),
+  /**
+   * Optional initial pivot price. When set, the peak seeds from this value on attach
+   * instead of the attach candle's `high`. From there the peak ratchets up normally on
+   * subsequent candle highs. Useful when you know the right anchor (e.g. cost basis or
+   * a recent swing high) and don't want the strategy to seed from whatever candle
+   * happens to be first.
+   */
+  pivotPrice: positiveNumberString.optional(),
+  /**
+   * Order type used to exit. `"limit"` (default) places the sell at the trail target —
+   * guaranteed price, but may not fill on a gap. `"market"` guarantees fill at the
+   * prevailing price.
+   */
+  exitOrder: z.enum(['limit', 'market']).default('limit'),
+});
+
+export type TrailingStopConfig = z.input<typeof TrailingStopSchema>;
+
+export type TrailingStopState = {
+  /**
+   * `true` once the trailing-stop sell has fully filled (position reduced to zero in
+   * `onFill`). Once set, `processCandle` short-circuits and emits no further advice;
+   * `onOrderFilled` invokes `onFinish` so the runtime can tear the session down.
+   */
+  exited: boolean;
+  /**
+   * Net base quantity currently held. Stored as a Big string. Starts at `'0'`, jumps to
+   * the seeded balance on attach, increases on external BUY fills, and decreases on SELL
+   * fills. When it reaches zero, `exited` flips to `true`.
+   */
+  positionSize: string;
+  /**
+   * Highest candle high observed since attach. Stored as a Big string. Seeded from the
+   * configured `pivotPrice` (when set) or otherwise from the attach candle's `high`,
+   * then ratchets upward only — falling prices never lower it, so the trail target is
+   * monotonic. `'0'` doubles as the "not yet attached" sentinel: while it is `'0'`, the
+   * next eligible candle (one with a non-zero base balance) will run the attach branch.
+   */
+  peakPrice: string;
+  /**
+   * Human-readable reason string captured the moment the trail was breached (close,
+   * peak, percentage, target). `null` until the exit fires. Surfaced in the order
+   * advice's `reason` field for downstream logging and diagnostics.
+   */
+  exitReason: string | null;
+  /**
+   * Limit price of the most recently emitted exit advice, as a Big string. `null` when
+   * `exitOrder` is `"market"` or before the trail is breached. Refreshed on every
+   * subsequent candle that re-emits the sell — so if the peak ratchets again before the
+   * order fills, the recorded price tracks the current peak's target rather than the
+   * original breach price.
+   */
+  exitLimitPrice: string | null;
+};
+
+const defaultState = (): TrailingStopState => ({
+  exited: false,
+  positionSize: '0',
+  peakPrice: '0',
+  exitReason: null,
+  exitLimitPrice: null,
+});
+
+/**
+ * Exit-only trailing stop. Attaches to an existing base balance — opened manually,
+ * by another strategy, or carried across a restart — and trails the highest candle
+ * high seen since attach. Emits a sell-all advice when the candle close drops to
+ * `peak * (1 - trailPct/100)`.
+ *
+ * The trail only ratchets upward — once the peak is set, falling prices never lower it,
+ * so the exit threshold is monotonic. The exit advice is re-emitted on every subsequent
+ * candle until `onFill` brings the position to zero, so a rejected or delayed sell is
+ * automatically retried. After the position is fully exited, `onFinish` is invoked so
+ * the runtime can tear down the session.
+ *
+ * Attach behavior: on each candle, if not yet attached and `state.baseBalance > 0`,
+ * the strategy claims the full base balance as its position and seeds the peak from
+ * the configured `pivotPrice` (when provided) or otherwise from the attach candle's
+ * `high`. Subsequent external BUY fills add to the position via `onFill`, but the
+ * peak is not re-anchored.
+ */
+export class TrailingStopStrategy extends Strategy {
+  static override NAME = '@typedtrader/strategy-trailing-stop';
+
+  readonly #trailDownPct: Big;
+  readonly #trailUpPct: Big | null;
+  readonly #pivotPrice: Big | null;
+  readonly #exitOrder: 'limit' | 'market';
+
+  constructor(config: TrailingStopConfig) {
+    super({config, state: defaultState()});
+    const parsed = TrailingStopSchema.parse(config);
+    this.#trailDownPct = new Big(parsed.trailDownPct);
+    this.#trailUpPct = parsed.trailUpPct ? new Big(parsed.trailUpPct) : null;
+    this.#pivotPrice = parsed.pivotPrice ? new Big(parsed.pivotPrice) : null;
+    this.#exitOrder = parsed.exitOrder;
+  }
+
+  get #state(): TrailingStopState {
+    return this.getProxiedState<TrailingStopState>();
+  }
+
+  /** Read-only snapshot of the current trailing-stop state. Useful for tests and diagnostics. */
+  get trailingState(): Readonly<TrailingStopState> {
+    return {...this.#state};
+  }
+
+  protected override async processCandle(
+    candle: OneMinuteBatchedCandle,
+    state: TradingSessionState
+  ): Promise<OrderAdvice | void> {
+    if (this.#state.exited) {
+      return undefined;
+    }
+
+    if (this.#state.peakPrice === '0') {
+      if (state.baseBalance.lte(0)) {
+        return undefined;
+      }
+      this.#state.positionSize = state.baseBalance.toFixed();
+      this.#state.peakPrice = (this.#pivotPrice ?? candle.high).toFixed();
+      return undefined;
+    }
+
+    const positionSize = new Big(this.#state.positionSize);
+    if (positionSize.lte(0)) {
+      return undefined;
+    }
+
+    const previousPeak = new Big(this.#state.peakPrice);
+    const ratchetThreshold = this.#trailUpPct
+      ? previousPeak.mul(new Big(1).plus(this.#trailUpPct.div(100)))
+      : previousPeak;
+    const newPeak = candle.high.gte(ratchetThreshold) && candle.high.gt(previousPeak) ? candle.high : previousPeak;
+    if (newPeak.gt(previousPeak)) {
+      this.#state.peakPrice = newPeak.toFixed();
+    }
+
+    const trailTarget = newPeak.mul(new Big(1).minus(this.#trailDownPct.div(100)));
+
+    if (candle.close.gt(trailTarget)) {
+      return undefined;
+    }
+
+    const reason = `Trailing stop: close ${candle.close.toFixed()} <= peak ${newPeak.toFixed()} - ${this.#trailDownPct.toFixed()}% (target ${trailTarget.toFixed()})`;
+    this.#state.exitReason = reason;
+
+    if (this.#exitOrder === 'market') {
+      this.#state.exitLimitPrice = null;
+      return {
+        side: ExchangeOrderSide.SELL,
+        type: ExchangeOrderType.MARKET,
+        amount: AllAvailableAmount,
+        amountIn: 'base',
+        reason,
+      };
+    }
+
+    this.#state.exitLimitPrice = trailTarget.toFixed();
+    const advice: LimitOrderAdvice = {
+      side: ExchangeOrderSide.SELL,
+      type: ExchangeOrderType.LIMIT,
+      amount: AllAvailableAmount,
+      amountIn: 'base',
+      price: trailTarget,
+      reason,
+    };
+    return advice;
+  }
+
+  async onFill(fill: ExchangeFill, _state: TradingSessionState): Promise<void> {
+    const fillSize = new Big(fill.size);
+    const currentSize = new Big(this.#state.positionSize);
+
+    if (fill.side === ExchangeOrderSide.BUY) {
+      this.#state.positionSize = currentSize.plus(fillSize).toFixed();
+      return;
+    }
+
+    const newSize = currentSize.minus(fillSize);
+    if (newSize.lte(0)) {
+      this.#state.positionSize = '0';
+      this.#state.exited = true;
+      return;
+    }
+    this.#state.positionSize = newSize.toFixed();
+  }
+
+  async onOrderFilled(order: ExchangePendingOrder, _state: TradingSessionState): Promise<void> {
+    if (this.#state.exited && order.side === ExchangeOrderSide.SELL) {
+      this.onFinish?.();
+    }
+  }
+
+  override restoreState(persisted: Record<string, unknown>): void {
+    super.restoreState(persisted);
+    if (!isTrailingStopState(persisted)) {
+      return;
+    }
+    const restored = this.#state;
+    restored.exited = persisted.exited;
+    restored.positionSize = persisted.positionSize;
+    restored.peakPrice = persisted.peakPrice;
+    restored.exitReason = persisted.exitReason;
+    restored.exitLimitPrice = persisted.exitLimitPrice;
+  }
+}
+
+function isTrailingStopState(value: unknown): value is TrailingStopState {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  if (!('exited' in value) || typeof value.exited !== 'boolean') return false;
+  if (!('positionSize' in value) || typeof value.positionSize !== 'string' || !isValidBigString(value.positionSize)) {
+    return false;
+  }
+  if (!('peakPrice' in value) || typeof value.peakPrice !== 'string' || !isValidBigString(value.peakPrice)) {
+    return false;
+  }
+  if (!('exitReason' in value) || (value.exitReason !== null && typeof value.exitReason !== 'string')) return false;
+  if (!('exitLimitPrice' in value)) return false;
+  if (value.exitLimitPrice !== null) {
+    if (typeof value.exitLimitPrice !== 'string' || !isValidBigString(value.exitLimitPrice)) return false;
+  }
+  return true;
+}
+
+function isValidBigString(value: string): boolean {
+  try {
+    new Big(value);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.ts
+++ b/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.ts
@@ -15,9 +15,9 @@ import {positiveNumberString} from '../util/validators.js';
 export const TrailingStopSchema = z.object({
   /**
    * Exit threshold as a percentage of the running peak. "5" → exit when close drops to
-   * peak * 0.95. Always required.
+   * peak * 0.95. Defaults to "10" (10%).
    */
-  trailDownPct: positiveNumberString,
+  trailDownPct: positiveNumberString.default('10'),
   /**
    * Optional hysteresis on peak ratcheting. When set, a new candle high only updates
    * the peak if it exceeds the previous peak by at least `trailUpPct` percent — i.e.

--- a/packages/trading-strategies/src/strategy/StrategyRegistry.ts
+++ b/packages/trading-strategies/src/strategy/StrategyRegistry.ts
@@ -10,6 +10,7 @@ import {MeanReversionStrategy, MeanReversionSchema} from '../strategy-mean-rever
 import {NoopStrategy, NoopSchema} from '../strategy-noop/NoopStrategy.js';
 import {ScalpStrategy, ScalpSchema} from '../strategy-scalp/ScalpStrategy.js';
 import {ProtectedStrategy, ProtectedStrategySchema} from '../strategy-protected/ProtectedStrategy.js';
+import {TrailingStopStrategy, TrailingStopSchema} from '../strategy-trailing-stop/TrailingStopStrategy.js';
 import type {Strategy} from './Strategy.js';
 
 interface StrategyEntry {
@@ -50,6 +51,10 @@ const registry: Record<string, StrategyEntry> = {
   [ProtectedStrategy.NAME]: {
     create: (config: unknown) => new ProtectedStrategy({config: ProtectedStrategySchema.parse(config ?? {})}),
     schema: ProtectedStrategySchema,
+  },
+  [TrailingStopStrategy.NAME]: {
+    create: (config: unknown) => new TrailingStopStrategy(TrailingStopSchema.parse(config ?? {})),
+    schema: TrailingStopSchema,
   },
 };
 


### PR DESCRIPTION
## Summary

- Adds `TrailingStopStrategy` — an exit-only trailing stop that extends `Strategy` directly. The strategy attaches to an existing base balance (manual position, another strategy, or post-restart) and never opens positions itself.
- Tracks the highest candle high seen since attach and emits a sell-all advice when `candle.close <= peak * (1 - trailDownPct/100)`. The advice re-emits on every candle until `onFill` brings the position to zero, then triggers `onFinish` for session teardown.
- Configuration:
  - `trailDownPct` — exit threshold below the running peak (defaults to `"10"`)
  - `trailUpPct` (optional) — hysteresis on peak ratcheting; the peak only updates when `candle.high >= peak * (1 + trailUpPct/100)`. Useful in choppy markets to avoid micro-ticks resetting the trail.
  - `pivotPrice` (optional) — explicit initial peak; overrides the default seed from the attach candle's `high`.
  - `exitOrder` — `"limit"` (default) places the sell at the trail target; `"market"` guarantees fill at the prevailing price.
- Registered in `StrategyRegistry` so `createStrategy()` and `StrategyMonitor` can instantiate it by name.
- State (`exited`, `positionSize`, `peakPrice`, `exitReason`, `exitLimitPrice`) round-trips through `restoreState` with a type-predicate guard that enforces cross-field invariants and falls back to `defaultState()` on a malformed blob. `peakPrice === '0'` doubles as the "not yet attached" sentinel.

## Docs site

- Surfaces `TrailingStopStrategy` in the interactive backtest page (`packages/trading-signals-docs/pages/backtest.tsx`) with default config `{trailDownPct: '10', exitOrder: 'limit'}`. The description nudges users to set `initialBase > 0` since the strategy is exit-only.

## README

- Adds glossary bullets to `packages/trading-strategies/README.md` defining **day trader**, **swing trader**, and **position trader** in the existing Domain Knowledge section.

## Notes

- The strategy is intentionally *not* anchored to cost basis — there is no break-even check or "wishful limit at break-even" fallback. A breach below the trail target always exits, regardless of P&L.
- If you attach mid-drawdown and don't supply `pivotPrice`, the peak seeds from the attach candle's `high`, which may be below the historical high. Use `pivotPrice` to set an explicit anchor when that matters.
- `TradingSession` only forwards fills for orders it placed, so external fills do not reach `onFill`. Position is set once at attach and only decreases via the strategy's own SELL fills.