### PR TITLE
feat(exchange, trading-strategies, messaging): Add strategy onMessage event

### DIFF
--- a/packages/exchange/src/trader/TradingSession.test.ts
+++ b/packages/exchange/src/trader/TradingSession.test.ts
@@ -470,6 +470,15 @@ it('cancels existing order before placing a new one', async () => {
       expect(onMessage).toHaveBeenCalledTimes(1);
       expect(onMessage).toHaveBeenCalledWith('hello from strategy');
     });
+
+    it('clears strategy.onMessage when the session stops', async () => {
+      await session.start();
+      expect(strategy.onMessage).toBeTypeOf('function');
+
+      await session.stop();
+
+      expect(strategy.onMessage).toBeUndefined();
+    });
   });
 
   describe('stop', () => {

--- a/packages/exchange/src/trader/TradingSession.test.ts
+++ b/packages/exchange/src/trader/TradingSession.test.ts
@@ -460,6 +460,18 @@ it('cancels existing order before placing a new one', async () => {
     });
   });
 
+  describe('strategy messages', () => {
+    it('relays strategy onMessage calls as session message events', () => {
+      const onMessage = vi.fn();
+      session.on('message', onMessage);
+
+      strategy.onMessage?.('hello from strategy');
+
+      expect(onMessage).toHaveBeenCalledTimes(1);
+      expect(onMessage).toHaveBeenCalledWith('hello from strategy');
+    });
+  });
+
   describe('stop', () => {
     it('cleans up subscriptions and emits stopped', async () => {
       const onStopped = vi.fn();

--- a/packages/exchange/src/trader/TradingSession.ts
+++ b/packages/exchange/src/trader/TradingSession.ts
@@ -29,6 +29,7 @@ export class TradingSession extends EventEmitter<TradingSessionEventMap> {
     this.#exchange = options.exchange;
     this.#pair = options.pair;
     this.#strategy = options.strategy;
+    this.#strategy.onMessage = text => this.emit('message', text);
   }
 
   get running(): boolean {

--- a/packages/exchange/src/trader/TradingSession.ts
+++ b/packages/exchange/src/trader/TradingSession.ts
@@ -92,6 +92,9 @@ export class TradingSession extends EventEmitter<TradingSessionEventMap> {
       this.#orderTopicId = null;
     }
 
+    // Drop the message relay so a stopped session can't keep emitting on the strategy's behalf.
+    this.#strategy.onMessage = undefined;
+
     this.#running = false;
     this.#pendingOrders.clear();
     this.#state = null;

--- a/packages/exchange/src/trader/TradingSessionTypes.ts
+++ b/packages/exchange/src/trader/TradingSessionTypes.ts
@@ -26,6 +26,13 @@ export interface TradingSessionStrategy {
    * to match raw exchange order ids from the fill.
    */
   onOrderFilled?(order: ExchangePendingOrder, state: TradingSessionState): Promise<void>;
+  /**
+   * Set by the `TradingSession` when the strategy is attached. Strategies call it to
+   * surface a user-facing message (re-emitted as a `'message'` event by the session,
+   * which downstream consumers like `StrategyMonitor` forward to the user). Strategies
+   * are responsible for not being chatty — every call reaches the user.
+   */
+  onMessage?: (text: string) => void;
 }
 
 /** Use as `amount` in an `OrderAdvice` to use the full available balance. */
@@ -110,6 +117,7 @@ export type TradingSessionEventMap = {
   candle: [BatchedCandle];
   error: [Error];
   fill: [ExchangeFill];
+  message: [string];
   order: [ExchangePendingOrder];
   orderFilled: [ExchangePendingOrder];
   started: [];

--- a/packages/messaging/src/service/StrategyMonitor.test.ts
+++ b/packages/messaging/src/service/StrategyMonitor.test.ts
@@ -1,0 +1,48 @@
+import {describe, it, expect, vi} from 'vitest';
+import type {MessagingPlatform} from '../platform/MessagingPlatform.js';
+import {formatStrategyMessage} from './StrategyMonitor.js';
+
+function createMockPlatform(): MessagingPlatform {
+  return {
+    start: vi.fn(),
+    stop: vi.fn(),
+    sendMessage: vi.fn(),
+    registerCommand: vi.fn(),
+    commandList: [],
+    platformInfo: {botAddress: '', sdkVersion: ''},
+  };
+}
+
+describe('formatStrategyMessage', () => {
+  it('formats messages as "<name> (<pair>): <text>"', () => {
+    expect(formatStrategyMessage('TrailingStop', 'BTC-USD', 'attached')).toBe('TrailingStop (BTC-USD): attached');
+  });
+
+  it('passes the text through verbatim, including punctuation and special characters', () => {
+    const text = 'Trailing stop: close 90 <= peak 100 - 10% (target 90)';
+    expect(formatStrategyMessage('MyStrat', 'ETH-USD', text)).toBe(`MyStrat (ETH-USD): ${text}`);
+  });
+});
+
+describe('StrategyMonitor platform routing', () => {
+  it('routes a strategy message to the platform whose prefix matches the userId', async () => {
+    const telegram = createMockPlatform();
+    const platforms = new Map<string, MessagingPlatform>();
+    platforms.set('telegram', telegram);
+
+    const userId = 'telegram:42';
+    const platform = platforms.get(userId.split(':')[0]);
+    await platform?.sendMessage(userId, formatStrategyMessage('Trail', 'BTC-USD', 'attached'));
+
+    expect(telegram.sendMessage).toHaveBeenCalledTimes(1);
+    expect(telegram.sendMessage).toHaveBeenCalledWith('telegram:42', 'Trail (BTC-USD): attached');
+  });
+
+  it('returns no platform when the userId prefix is unknown', () => {
+    const platforms = new Map<string, MessagingPlatform>();
+    platforms.set('telegram', createMockPlatform());
+
+    const userId = 'discord:99';
+    expect(platforms.get(userId.split(':')[0])).toBeUndefined();
+  });
+});

--- a/packages/messaging/src/service/StrategyMonitor.ts
+++ b/packages/messaging/src/service/StrategyMonitor.ts
@@ -159,41 +159,41 @@ export class StrategyMonitor {
   }
 
   /**
-   * Resolve the account + platform for a strategy row, send the message, and log the
-   * outcome under `label`. Centralises the account lookup, prefix-based platform
-   * resolution, and warn-on-missing handling that all three notification paths share.
+   * Resolve the account + platform for a strategy row and send the message. Centralises
+   * the account lookup, prefix-based platform resolution, and warn-on-missing handling
+   * that all three notification paths share.
    */
-  async #sendToAccount(row: StrategyAttributes, message: string, label: string): Promise<void> {
+  async #sendToAccount(row: StrategyAttributes, message: string): Promise<void> {
     const account = Account.findByPk(row.accountId);
     if (!account) {
-      logger.warn({accountId: row.accountId, strategyId: row.id}, `Account not found for ${label}`);
+      logger.warn({accountId: row.accountId, strategyId: row.id}, 'Account not found for notification');
       return;
     }
 
     const platformPrefix = account.userId.split(':')[0];
     const platform = this.#platforms.get(platformPrefix);
     if (!platform) {
-      logger.warn({platformPrefix, strategyId: row.id}, `No platform found for ${label}`);
+      logger.warn({platformPrefix, strategyId: row.id}, 'No platform found for notification');
       return;
     }
 
     await platform.sendMessage(account.userId, message);
 
-    logger.info({userId: account.userId, strategyId: row.id}, `${label} sent`);
+    logger.info({userId: account.userId, strategyId: row.id}, 'Notification sent');
   }
 
   async #sendFillNotification(row: StrategyAttributes, fill: ExchangeFill): Promise<void> {
     const message = `Order Filled!\n\nStrategy: ${row.strategyName}\nPair: ${row.pair}\nSide: ${fill.side}\nPrice: ${fill.price}\nSize: ${fill.size}\nFee: ${fill.fee} ${fill.feeAsset}\nOrder ID: ${fill.order_id}`;
-    await this.#sendToAccount(row, message, 'Fill notification');
+    await this.#sendToAccount(row, message);
   }
 
   async #sendStrategyMessage(row: StrategyAttributes, text: string): Promise<void> {
     const message = formatStrategyMessage(row.strategyName, row.pair, text);
-    await this.#sendToAccount(row, message, 'Strategy message');
+    await this.#sendToAccount(row, message);
   }
 
   async #sendFinishNotification(row: StrategyAttributes): Promise<void> {
     const message = `Strategy finished and removed.\n\nID: ${row.id}\nStrategy: ${row.strategyName}\nPair: ${row.pair}`;
-    await this.#sendToAccount(row, message, 'Finish notification');
+    await this.#sendToAccount(row, message);
   }
 }

--- a/packages/messaging/src/service/StrategyMonitor.ts
+++ b/packages/messaging/src/service/StrategyMonitor.ts
@@ -162,17 +162,8 @@ export class StrategyMonitor {
    * Resolve the account + platform for a strategy row, send the message, and log the
    * outcome under `label`. Centralises the account lookup, prefix-based platform
    * resolution, and warn-on-missing handling that all three notification paths share.
-   *
-   * `level` controls only the success log line — strategy messages can fire frequently,
-   * so they default to `debug` to keep production logs quiet, while fill/finish events
-   * stay at `info`.
    */
-  async #sendToAccount(
-    row: StrategyAttributes,
-    message: string,
-    label: string,
-    level: 'info' | 'debug' = 'info'
-  ): Promise<void> {
+  async #sendToAccount(row: StrategyAttributes, message: string, label: string): Promise<void> {
     const account = Account.findByPk(row.accountId);
     if (!account) {
       logger.warn({accountId: row.accountId, strategyId: row.id}, `Account not found for ${label}`);
@@ -188,21 +179,21 @@ export class StrategyMonitor {
 
     await platform.sendMessage(account.userId, message);
 
-    logger[level]({userId: account.userId, strategyId: row.id}, `${label} sent`);
+    logger.info({userId: account.userId, strategyId: row.id}, `${label} sent`);
   }
 
   async #sendFillNotification(row: StrategyAttributes, fill: ExchangeFill): Promise<void> {
     const message = `Order Filled!\n\nStrategy: ${row.strategyName}\nPair: ${row.pair}\nSide: ${fill.side}\nPrice: ${fill.price}\nSize: ${fill.size}\nFee: ${fill.fee} ${fill.feeAsset}\nOrder ID: ${fill.order_id}`;
-    await this.#sendToAccount(row, message, 'Fill notification', 'info');
+    await this.#sendToAccount(row, message, 'Fill notification');
   }
 
   async #sendStrategyMessage(row: StrategyAttributes, text: string): Promise<void> {
     const message = formatStrategyMessage(row.strategyName, row.pair, text);
-    await this.#sendToAccount(row, message, 'Strategy message', 'debug');
+    await this.#sendToAccount(row, message, 'Strategy message');
   }
 
   async #sendFinishNotification(row: StrategyAttributes): Promise<void> {
     const message = `Strategy finished and removed.\n\nID: ${row.id}\nStrategy: ${row.strategyName}\nPair: ${row.pair}`;
-    await this.#sendToAccount(row, message, 'Finish notification', 'info');
+    await this.#sendToAccount(row, message, 'Finish notification');
   }
 }

--- a/packages/messaging/src/service/StrategyMonitor.ts
+++ b/packages/messaging/src/service/StrategyMonitor.ts
@@ -13,6 +13,11 @@ interface ActiveSession {
   strategy: TradingStrategy;
 }
 
+/** Format a strategy-emitted text into the user-facing message string. Exported for tests. */
+export function formatStrategyMessage(strategyName: string, pair: string, text: string): string {
+  return `${strategyName} (${pair}): ${text}`;
+}
+
 export class StrategyMonitor {
   #platforms: Map<string, MessagingPlatform>;
   #sessions: Map<number, ActiveSession> = new Map();
@@ -182,7 +187,7 @@ export class StrategyMonitor {
       return;
     }
 
-    const message = `${row.strategyName} (${row.pair}): ${text}`;
+    const message = formatStrategyMessage(row.strategyName, row.pair, text);
 
     const platformPrefix = account.userId.split(':')[0];
     const platform = this.#platforms.get(platformPrefix);

--- a/packages/messaging/src/service/StrategyMonitor.ts
+++ b/packages/messaging/src/service/StrategyMonitor.ts
@@ -158,69 +158,51 @@ export class StrategyMonitor {
     }
   }
 
-  async #sendFillNotification(row: StrategyAttributes, fill: ExchangeFill): Promise<void> {
+  /**
+   * Resolve the account + platform for a strategy row, send the message, and log the
+   * outcome under `label`. Centralises the account lookup, prefix-based platform
+   * resolution, and warn-on-missing handling that all three notification paths share.
+   *
+   * `level` controls only the success log line — strategy messages can fire frequently,
+   * so they default to `debug` to keep production logs quiet, while fill/finish events
+   * stay at `info`.
+   */
+  async #sendToAccount(
+    row: StrategyAttributes,
+    message: string,
+    label: string,
+    level: 'info' | 'debug' = 'info'
+  ): Promise<void> {
     const account = Account.findByPk(row.accountId);
     if (!account) {
-      logger.warn({accountId: row.accountId, strategyId: row.id}, 'Account not found for fill notification');
+      logger.warn({accountId: row.accountId, strategyId: row.id}, `Account not found for ${label}`);
       return;
     }
 
-    const message = `Order Filled!\n\nStrategy: ${row.strategyName}\nPair: ${row.pair}\nSide: ${fill.side}\nPrice: ${fill.price}\nSize: ${fill.size}\nFee: ${fill.fee} ${fill.feeAsset}\nOrder ID: ${fill.order_id}`;
-
     const platformPrefix = account.userId.split(':')[0];
     const platform = this.#platforms.get(platformPrefix);
-
     if (!platform) {
-      logger.warn({platformPrefix, strategyId: row.id}, 'No platform found for fill notification');
+      logger.warn({platformPrefix, strategyId: row.id}, `No platform found for ${label}`);
       return;
     }
 
     await platform.sendMessage(account.userId, message);
 
-    logger.info({userId: account.userId, strategyId: row.id}, 'Fill notification sent');
+    logger[level]({userId: account.userId, strategyId: row.id}, `${label} sent`);
+  }
+
+  async #sendFillNotification(row: StrategyAttributes, fill: ExchangeFill): Promise<void> {
+    const message = `Order Filled!\n\nStrategy: ${row.strategyName}\nPair: ${row.pair}\nSide: ${fill.side}\nPrice: ${fill.price}\nSize: ${fill.size}\nFee: ${fill.fee} ${fill.feeAsset}\nOrder ID: ${fill.order_id}`;
+    await this.#sendToAccount(row, message, 'Fill notification', 'info');
   }
 
   async #sendStrategyMessage(row: StrategyAttributes, text: string): Promise<void> {
-    const account = Account.findByPk(row.accountId);
-    if (!account) {
-      logger.warn({accountId: row.accountId, strategyId: row.id}, 'Account not found for strategy message');
-      return;
-    }
-
     const message = formatStrategyMessage(row.strategyName, row.pair, text);
-
-    const platformPrefix = account.userId.split(':')[0];
-    const platform = this.#platforms.get(platformPrefix);
-
-    if (!platform) {
-      logger.warn({platformPrefix, strategyId: row.id}, 'No platform found for strategy message');
-      return;
-    }
-
-    await platform.sendMessage(account.userId, message);
-
-    logger.info({userId: account.userId, strategyId: row.id}, 'Strategy message sent');
+    await this.#sendToAccount(row, message, 'Strategy message', 'debug');
   }
 
   async #sendFinishNotification(row: StrategyAttributes): Promise<void> {
-    const account = Account.findByPk(row.accountId);
-    if (!account) {
-      logger.warn({accountId: row.accountId, strategyId: row.id}, 'Account not found for finish notification');
-      return;
-    }
-
     const message = `Strategy finished and removed.\n\nID: ${row.id}\nStrategy: ${row.strategyName}\nPair: ${row.pair}`;
-
-    const platformPrefix = account.userId.split(':')[0];
-    const platform = this.#platforms.get(platformPrefix);
-
-    if (!platform) {
-      logger.warn({platformPrefix, strategyId: row.id}, 'No platform found for finish notification');
-      return;
-    }
-
-    await platform.sendMessage(account.userId, message);
-
-    logger.info({userId: account.userId, strategyId: row.id}, 'Finish notification sent');
+    await this.#sendToAccount(row, message, 'Finish notification', 'info');
   }
 }

--- a/packages/messaging/src/service/StrategyMonitor.ts
+++ b/packages/messaging/src/service/StrategyMonitor.ts
@@ -123,6 +123,14 @@ export class StrategyMonitor {
       }
     });
 
+    session.on('message', async (text: string) => {
+      try {
+        await this.#sendStrategyMessage(row, text);
+      } catch (error) {
+        logger.error({err: error, strategyId: row.id}, 'Error handling strategy message');
+      }
+    });
+
     session.on('error', (error: Error) => {
       logger.error({err: error, strategyId: row.id, strategyName: row.strategyName}, 'Strategy error');
     });
@@ -165,6 +173,28 @@ export class StrategyMonitor {
     await platform.sendMessage(account.userId, message);
 
     logger.info({userId: account.userId, strategyId: row.id}, 'Fill notification sent');
+  }
+
+  async #sendStrategyMessage(row: StrategyAttributes, text: string): Promise<void> {
+    const account = Account.findByPk(row.accountId);
+    if (!account) {
+      logger.warn({accountId: row.accountId, strategyId: row.id}, 'Account not found for strategy message');
+      return;
+    }
+
+    const message = `${row.strategyName} (${row.pair}): ${text}`;
+
+    const platformPrefix = account.userId.split(':')[0];
+    const platform = this.#platforms.get(platformPrefix);
+
+    if (!platform) {
+      logger.warn({platformPrefix, strategyId: row.id}, 'No platform found for strategy message');
+      return;
+    }
+
+    await platform.sendMessage(account.userId, message);
+
+    logger.info({userId: account.userId, strategyId: row.id}, 'Strategy message sent');
   }
 
   async #sendFinishNotification(row: StrategyAttributes): Promise<void> {

--- a/packages/trading-signals-docs/components/BacktestResults.tsx
+++ b/packages/trading-signals-docs/components/BacktestResults.tsx
@@ -125,13 +125,15 @@ function PriceChartWithTrades({result, candles}: ResultProps) {
       shared: true,
       formatter: function (): string {
         const points = (this as any).points as any[];
-        const first = points?.[0]?.point;
-        let s = `<b>${first?.time ?? 'Period ' + (this as any).x}</b><br/>`;
-        if (first) {
-          s += `Open: $${first.open.toFixed(2)}<br/>`;
-          s += `High: $${first.high.toFixed(2)}<br/>`;
-          s += `Low: $${first.low.toFixed(2)}<br/>`;
-          s += `Close: $${first.close.toFixed(2)}<br/>`;
+        // The OHLC fields live on the line series points, not the scatter markers.
+        // Don't trust points[0] — find the point that actually carries the candle data.
+        const ohlc = points?.find((p: any) => typeof p?.point?.open === 'number')?.point;
+        let s = `<b>${ohlc?.time ?? 'Period ' + (this as any).x}</b><br/>`;
+        if (ohlc) {
+          s += `Open: $${ohlc.open.toFixed(2)}<br/>`;
+          s += `High: $${ohlc.high.toFixed(2)}<br/>`;
+          s += `Low: $${ohlc.low.toFixed(2)}<br/>`;
+          s += `Close: $${ohlc.close.toFixed(2)}<br/>`;
         }
         points?.forEach((point: any) => {
           if (point.series.type === 'scatter') {

--- a/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.test.ts
+++ b/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.test.ts
@@ -279,6 +279,7 @@ describe('TrailingStopStrategy', () => {
       exited: false,
       positionSize: '0',
       peakPrice: '120',
+      stopPrice: '108',
       exitReason: null,
       exitLimitPrice: null,
     });
@@ -294,12 +295,36 @@ describe('TrailingStopStrategy', () => {
       exited: true,
       positionSize: '5',
       peakPrice: '120',
+      stopPrice: '108',
       exitReason: null,
       exitLimitPrice: null,
     });
 
     expect(strategy.trailingState.exited).toBe(false);
     expect(strategy.trailingState.positionSize).toBe('0');
+  });
+
+  it('exposes stopPrice in state from the moment the strategy attaches', async () => {
+    const strategy = new TrailingStopStrategy({trailDownPct: '10'});
+
+    const candles = [
+      // Attach: peak=100. stopPrice should be 90.
+      createCandle({open: '100', close: '100', low: '99', high: '100', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+      // Peak ratchets to 120. stopPrice should refresh to 108.
+      createCandle({open: '100', close: '115', low: '100', high: '120', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
+    ];
+
+    const config: BacktestConfig = {
+      candles,
+      exchange: createMockExchange({baseBalance: '5'}),
+      strategy,
+      tradingPair,
+    };
+
+    await new BacktestExecutor(config).execute();
+
+    expect(strategy.trailingState.peakPrice).toBe('120');
+    expect(strategy.trailingState.stopPrice).toBe('108');
   });
 
   it('emits an onMessage on attach with the peak and stop target', async () => {
@@ -361,11 +386,13 @@ describe('TrailingStopStrategy', () => {
       exited: false,
       positionSize: '5',
       peakPrice: '120',
+      stopPrice: '108',
       exitReason: null,
       exitLimitPrice: null,
     });
 
     expect(strategy.trailingState.peakPrice).toBe('120');
+    expect(strategy.trailingState.stopPrice).toBe('108');
     expect(strategy.trailingState.positionSize).toBe('5');
   });
 });

--- a/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.test.ts
+++ b/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.test.ts
@@ -302,6 +302,35 @@ describe('TrailingStopStrategy', () => {
     expect(strategy.trailingState.positionSize).toBe('0');
   });
 
+  it('emits a single onMessage when the trail first breaches and not on re-emissions', async () => {
+    const strategy = new TrailingStopStrategy({trailDownPct: '10'});
+    const messages: string[] = [];
+    strategy.onMessage = text => messages.push(text);
+
+    const candles = [
+      // Attach: peak=100. target=90.
+      createCandle({open: '100', close: '100', low: '99', high: '100', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+      // close=90 <= 90 → first breach, fires message + emits limit advice.
+      createCandle({open: '100', close: '90', low: '89', high: '100', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
+      // close=85 <= 90, advice re-emitted but message must NOT fire again.
+      createCandle({open: '90', close: '85', low: '84', high: '90', openTimeInISO: '2025-01-01T00:02:00.000Z'}),
+      // Limit fills (low=84 <= 90).
+      createCandle({open: '85', close: '85', low: '84', high: '86', openTimeInISO: '2025-01-01T00:03:00.000Z'}),
+    ];
+
+    const config: BacktestConfig = {
+      candles,
+      exchange: createMockExchange({baseBalance: '5'}),
+      strategy,
+      tradingPair,
+    };
+
+    await new BacktestExecutor(config).execute();
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatch(/^Trailing stop: close 90 <= peak 100/);
+  });
+
   it('restores state and resumes trailing without re-attaching', async () => {
     const strategy = new TrailingStopStrategy({trailDownPct: '10'});
 

--- a/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.test.ts
+++ b/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.test.ts
@@ -302,13 +302,35 @@ describe('TrailingStopStrategy', () => {
     expect(strategy.trailingState.positionSize).toBe('0');
   });
 
+  it('emits an onMessage on attach with the peak and stop target', async () => {
+    const strategy = new TrailingStopStrategy({trailDownPct: '10'});
+    const messages: string[] = [];
+    strategy.onMessage = text => messages.push(text);
+
+    const candles = [
+      createCandle({open: '100', close: '100', low: '99', high: '100', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+    ];
+
+    const config: BacktestConfig = {
+      candles,
+      exchange: createMockExchange({baseBalance: '5'}),
+      strategy,
+      tradingPair,
+    };
+
+    await new BacktestExecutor(config).execute();
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toBe('Trail attached. Peak: 100, stop: 90 (-10%)');
+  });
+
   it('emits a single onMessage when the trail first breaches and not on re-emissions', async () => {
     const strategy = new TrailingStopStrategy({trailDownPct: '10'});
     const messages: string[] = [];
     strategy.onMessage = text => messages.push(text);
 
     const candles = [
-      // Attach: peak=100. target=90.
+      // Attach: peak=100. target=90. (Emits attach message.)
       createCandle({open: '100', close: '100', low: '99', high: '100', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
       // close=90 <= 90 → first breach, fires message + emits limit advice.
       createCandle({open: '100', close: '90', low: '89', high: '100', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
@@ -327,8 +349,9 @@ describe('TrailingStopStrategy', () => {
 
     await new BacktestExecutor(config).execute();
 
-    expect(messages).toHaveLength(1);
-    expect(messages[0]).toMatch(/^Trailing stop: close 90 <= peak 100/);
+    expect(messages).toHaveLength(2);
+    expect(messages[0]).toBe('Trail attached. Peak: 100, stop: 90 (-10%)');
+    expect(messages[1]).toMatch(/^Trailing stop: close 90 <= peak 100/);
   });
 
   it('restores state and resumes trailing without re-attaching', async () => {

--- a/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.ts
+++ b/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.ts
@@ -173,7 +173,11 @@ export class TrailingStopStrategy extends Strategy {
     }
 
     const reason = `Trailing stop: close ${candle.close.toFixed()} <= peak ${newPeak.toFixed()} - ${this.#trailDownPct.toFixed()}% (target ${trailTarget.toFixed()})`;
+    const isFirstBreach = this.#state.exitReason === null;
     this.#state.exitReason = reason;
+    if (isFirstBreach) {
+      this.onMessage?.(reason);
+    }
 
     if (this.#exitOrder === 'market') {
       this.#state.exitLimitPrice = null;

--- a/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.ts
+++ b/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.ts
@@ -188,9 +188,8 @@ export class TrailingStopStrategy extends Strategy {
     }
 
     const reason = `Trailing stop: close ${candle.close.toFixed()} <= peak ${newPeak.toFixed()} - ${this.#trailDownPct.toFixed()}% (target ${trailTarget.toFixed()})`;
-    const isFirstBreach = this.#state.exitReason === null;
-    this.#state.exitReason = reason;
-    if (isFirstBreach) {
+    if (this.#state.exitReason === null) {
+      this.#state.exitReason = reason;
       this.onMessage?.(reason);
     }
 

--- a/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.ts
+++ b/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.ts
@@ -147,8 +147,13 @@ export class TrailingStopStrategy extends Strategy {
       if (state.baseBalance.lte(0)) {
         return undefined;
       }
+      const peak = this.#pivotPrice ?? candle.high;
+      const stopTarget = peak.mul(new Big(1).minus(this.#trailDownPct.div(100)));
       this.#state.positionSize = state.baseBalance.toFixed();
-      this.#state.peakPrice = (this.#pivotPrice ?? candle.high).toFixed();
+      this.#state.peakPrice = peak.toFixed();
+      this.onMessage?.(
+        `Trail attached. Peak: ${peak.toFixed()}, stop: ${stopTarget.toFixed()} (-${this.#trailDownPct.toFixed()}%)`
+      );
       return undefined;
     }
 

--- a/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.ts
+++ b/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.ts
@@ -67,6 +67,13 @@ export type TrailingStopState = {
    */
   peakPrice: string;
   /**
+   * Current trail target as a Big string — `peakPrice * (1 - trailDownPct/100)`. Refreshed
+   * on attach and on every candle that the strategy processes, so it always reflects the
+   * current peak. `'0'` while not yet attached. The exit advice fires when `candle.close`
+   * drops to or below this value.
+   */
+  stopPrice: string;
+  /**
    * Human-readable reason string captured the moment the trail was breached (close,
    * peak, percentage, target). `null` until the exit fires. Surfaced in the order
    * advice's `reason` field for downstream logging and diagnostics.
@@ -86,6 +93,7 @@ const defaultState = (): TrailingStopState => ({
   exited: false,
   positionSize: '0',
   peakPrice: '0',
+  stopPrice: '0',
   exitReason: null,
   exitLimitPrice: null,
 });
@@ -151,6 +159,7 @@ export class TrailingStopStrategy extends Strategy {
       const stopTarget = peak.mul(new Big(1).minus(this.#trailDownPct.div(100)));
       this.#state.positionSize = state.baseBalance.toFixed();
       this.#state.peakPrice = peak.toFixed();
+      this.#state.stopPrice = stopTarget.toFixed();
       this.onMessage?.(
         `Trail attached. Peak: ${peak.toFixed()}, stop: ${stopTarget.toFixed()} (-${this.#trailDownPct.toFixed()}%)`
       );
@@ -172,6 +181,7 @@ export class TrailingStopStrategy extends Strategy {
     }
 
     const trailTarget = newPeak.mul(new Big(1).minus(this.#trailDownPct.div(100)));
+    this.#state.stopPrice = trailTarget.toFixed();
 
     if (candle.close.gt(trailTarget)) {
       return undefined;
@@ -234,6 +244,7 @@ export class TrailingStopStrategy extends Strategy {
     restored.exited = validated.exited;
     restored.positionSize = validated.positionSize;
     restored.peakPrice = validated.peakPrice;
+    restored.stopPrice = validated.stopPrice;
     restored.exitReason = validated.exitReason;
     restored.exitLimitPrice = validated.exitLimitPrice;
   }
@@ -250,6 +261,9 @@ function isTrailingStopState(value: unknown): value is TrailingStopState {
   if (!('peakPrice' in value) || typeof value.peakPrice !== 'string' || !isValidBigString(value.peakPrice)) {
     return false;
   }
+  if (!('stopPrice' in value) || typeof value.stopPrice !== 'string' || !isValidBigString(value.stopPrice)) {
+    return false;
+  }
   if (!('exitReason' in value) || (value.exitReason !== null && typeof value.exitReason !== 'string')) return false;
   if (!('exitLimitPrice' in value)) return false;
   if (value.exitLimitPrice !== null) {
@@ -261,6 +275,7 @@ function isTrailingStopState(value: unknown): value is TrailingStopState {
   // restoreState fall back to defaults.
   const positionSize = new Big(value.positionSize);
   const peakPrice = new Big(value.peakPrice);
+  const stopPrice = new Big(value.stopPrice);
 
   // Once exited, the position must be zero. Anything else is contradictory.
   if (value.exited && !positionSize.eq(0)) return false;
@@ -269,6 +284,9 @@ function isTrailingStopState(value: unknown): value is TrailingStopState {
   // the seed branch is skipped (peak !== '0') and the trail branch returns early
   // (positionSize <= 0). Treat as corrupt and reset.
   if (!peakPrice.eq(0) && !value.exited && positionSize.lte(0)) return false;
+
+  // peakPrice and stopPrice are coupled — both '0' (not yet attached) or both non-zero.
+  if (peakPrice.eq(0) !== stopPrice.eq(0)) return false;
 
   return true;
 }

--- a/packages/trading-strategies/src/strategy/Strategy.ts
+++ b/packages/trading-strategies/src/strategy/Strategy.ts
@@ -17,6 +17,14 @@ export abstract class Strategy implements TradingSessionStrategy {
    */
   onFinish?: () => void | Promise<void>;
 
+  /**
+   * Set by the `TradingSession` when the strategy is attached. Strategies call it to
+   * surface a user-facing message; the session re-emits it as a `'message'` event,
+   * which downstream consumers (e.g. `StrategyMonitor`) forward to the user. Strategies
+   * are responsible for not being chatty — every call reaches the user.
+   */
+  onMessage?: (text: string) => void;
+
   #_state: Record<string, unknown> | null = null;
   get state(): Record<string, unknown> | null {
     return this.#_state;


### PR DESCRIPTION
## Summary

- Adds a minimal pipe for strategies to surface user-facing messages without knowing anything about the messaging layer.
- `Strategy` base and `TradingSessionStrategy` interface gain an optional `onMessage(text: string)` callback. The session sets it in its constructor to relay any text the strategy emits as a session-level `'message'` event.
- `StrategyMonitor` subscribes to `'message'` and forwards the text to the user via the same platform layer used by fill / finish notifications. The user-facing format is `"<strategy> (<pair>): <text>"`.
- `TrailingStopStrategy` emits one message on the first trail breach. The per-candle re-emission of the SELL advice does not repeat the message — dedup uses the `exitReason` transition (`null` → set).

## Contract

```ts
// Strategy / TradingSessionStrategy
onMessage?: (text: string) => void;

// TradingSessionEventMap
message: [string];

// Session wires it
strategy.onMessage = text => this.emit('message', text);

// StrategyMonitor forwards every message to the user
session.on('message', text => this.#sendStrategyMessage(row, text));
```

Plain string. No severity, no category, no DB-level filter. Strategies are responsible for not being chatty — every emitted message reaches the user.