### PR TITLE
feat(trading-strategies): tag strategies with market types

### DIFF
--- a/packages/trading-strategies/src/strategy-buy-below-sell-above/BuyBelowSellAboveStrategy.ts
+++ b/packages/trading-strategies/src/strategy-buy-below-sell-above/BuyBelowSellAboveStrategy.ts
@@ -2,6 +2,7 @@ import {z} from 'zod';
 import {AllAvailableAmount, ExchangeOrderSide, ExchangeOrderType} from '@typedtrader/exchange';
 import type {OneMinuteBatchedCandle, OrderAdvice, TradingSessionState} from '@typedtrader/exchange';
 import Big from 'big.js';
+import {MarketType} from '../strategy/MarketType.js';
 import {ProtectedStrategy, ProtectedStrategySchema} from '../strategy-protected/ProtectedStrategy.js';
 import {positiveNumberString} from '../util/validators.js';
 
@@ -14,6 +15,7 @@ export type BuyBelowSellAboveConfig = z.input<typeof BuyBelowSellAboveSchema>;
 
 export class BuyBelowSellAboveStrategy extends ProtectedStrategy {
   static override NAME = '@typedtrader/strategy-buy-below-sell-above';
+  static override marketTypes: readonly MarketType[] = [MarketType.RANGING];
 
   constructor(config: BuyBelowSellAboveConfig = {}) {
     super({config});

--- a/packages/trading-strategies/src/strategy-buy-once/BuyOnceStrategy.ts
+++ b/packages/trading-strategies/src/strategy-buy-once/BuyOnceStrategy.ts
@@ -2,6 +2,7 @@ import {z} from 'zod';
 import {AllAvailableAmount, ExchangeOrderSide, ExchangeOrderType} from '@typedtrader/exchange';
 import type {OneMinuteBatchedCandle, OrderAdvice, TradingSessionState} from '@typedtrader/exchange';
 import Big from 'big.js';
+import {MarketType} from '../strategy/MarketType.js';
 import {ProtectedStrategy, ProtectedStrategySchema} from '../strategy-protected/ProtectedStrategy.js';
 import {BuyAmountSchema, positiveNumberString} from '../util/validators.js';
 
@@ -23,6 +24,7 @@ type BuyOnceState = {
  */
 export class BuyOnceStrategy extends ProtectedStrategy {
   static override NAME = '@typedtrader/strategy-buy-once';
+  static override marketTypes: readonly MarketType[] = [MarketType.BULLISH];
 
   constructor(config: BuyOnceConfig = {}) {
     super({config, state: {bought: false}});

--- a/packages/trading-strategies/src/strategy-coin-flip/CoinFlipStrategy.ts
+++ b/packages/trading-strategies/src/strategy-coin-flip/CoinFlipStrategy.ts
@@ -1,6 +1,7 @@
 import {z} from 'zod';
 import {AllAvailableAmount, ExchangeOrderSide, ExchangeOrderType} from '@typedtrader/exchange';
 import type {OneMinuteBatchedCandle, OrderAdvice, TradingSessionState} from '@typedtrader/exchange';
+import {MarketType} from '../strategy/MarketType.js';
 import {ProtectedStrategy, ProtectedStrategySchema} from '../strategy-protected/ProtectedStrategy.js';
 
 export const CoinFlipSchema = ProtectedStrategySchema.extend({});
@@ -9,6 +10,7 @@ export type CoinFlipConfig = z.input<typeof CoinFlipSchema>;
 
 export class CoinFlipStrategy extends ProtectedStrategy {
   static override NAME = '@typedtrader/strategy-coin-flip';
+  static override marketTypes: readonly MarketType[] = [MarketType.BENCHMARK];
 
   constructor(config: CoinFlipConfig = {}) {
     super({config});

--- a/packages/trading-strategies/src/strategy-mean-reversion/MeanReversionStrategy.ts
+++ b/packages/trading-strategies/src/strategy-mean-reversion/MeanReversionStrategy.ts
@@ -2,6 +2,7 @@ import {z} from 'zod';
 import {AllAvailableAmount, CandleBatcher, ExchangeOrderSide, ExchangeOrderType} from '@typedtrader/exchange';
 import type {ExchangeCandle, OneMinuteBatchedCandle, OrderAdvice, TradingSessionState} from '@typedtrader/exchange';
 import {BollingerBands} from 'trading-signals';
+import {MarketType} from '../strategy/MarketType.js';
 import {ProtectedStrategy, ProtectedStrategySchema} from '../strategy-protected/ProtectedStrategy.js';
 
 const ONE_HOUR_IN_MS = 3_600_000;
@@ -22,6 +23,7 @@ export type CandleFetcher = () => Promise<ExchangeCandle[]>;
 
 export class MeanReversionStrategy extends ProtectedStrategy {
   static override NAME = '@typedtrader/strategy-mean-reversion';
+  static override marketTypes: readonly MarketType[] = [MarketType.RANGING];
 
   readonly #bbands = new BollingerBands(PERIOD, DEVIATION_MULTIPLIER);
   readonly #batcher = new CandleBatcher(ONE_HOUR_IN_MS);

--- a/packages/trading-strategies/src/strategy-multi-indicator-confluence/MultiIndicatorConfluenceStrategy.ts
+++ b/packages/trading-strategies/src/strategy-multi-indicator-confluence/MultiIndicatorConfluenceStrategy.ts
@@ -2,6 +2,7 @@ import {z} from 'zod';
 import {AllAvailableAmount, ExchangeOrderSide, ExchangeOrderType} from '@typedtrader/exchange';
 import type {OneMinuteBatchedCandle, OrderAdvice, TradingSessionState} from '@typedtrader/exchange';
 import {BollingerBands, EMA, MACD, RSI} from 'trading-signals';
+import {MarketType} from '../strategy/MarketType.js';
 import {ProtectedStrategy, ProtectedStrategySchema} from '../strategy-protected/ProtectedStrategy.js';
 
 export const MultiIndicatorConfluenceSchema = ProtectedStrategySchema.extend({
@@ -43,6 +44,7 @@ export type MultiIndicatorConfluenceConfig = z.input<typeof MultiIndicatorConflu
 
 export class MultiIndicatorConfluenceStrategy extends ProtectedStrategy {
   static override NAME = '@typedtrader/strategy-multi-indicator-confluence';
+  static override marketTypes: readonly MarketType[] = [MarketType.BULLISH, MarketType.BEARISH];
 
   readonly #emaShort: EMA;
   readonly #emaLong: EMA;

--- a/packages/trading-strategies/src/strategy-noop/NoopStrategy.ts
+++ b/packages/trading-strategies/src/strategy-noop/NoopStrategy.ts
@@ -1,5 +1,6 @@
 import {z} from 'zod';
 import type {OneMinuteBatchedCandle, OrderAdvice, TradingSessionState} from '@typedtrader/exchange';
+import {MarketType} from '../strategy/MarketType.js';
 import {Strategy} from '../strategy/Strategy.js';
 
 export const NoopSchema = z.object({}).strict();
@@ -13,6 +14,7 @@ export type NoopConfig = z.input<typeof NoopSchema>;
  */
 export class NoopStrategy extends Strategy {
   static override NAME = '@typedtrader/strategy-noop';
+  static override marketTypes: readonly MarketType[] = [MarketType.BENCHMARK];
 
   constructor(_config: NoopConfig = {}) {
     super();

--- a/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.ts
+++ b/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.ts
@@ -2,6 +2,7 @@ import Big from 'big.js';
 import {z} from 'zod';
 import {AllAvailableAmount, ExchangeOrderSide, ExchangeOrderType} from '@typedtrader/exchange';
 import type {ExchangeFill, ExchangePendingOrder, LimitOrderAdvice, OneMinuteBatchedCandle, OrderAdvice, TradingSessionState} from '@typedtrader/exchange';
+import {MarketType} from '../strategy/MarketType.js';
 import {Strategy} from '../strategy/Strategy.js';
 import {positiveNumberString} from '../util/validators.js';
 
@@ -149,6 +150,7 @@ type ProtectedContainerState = {[PROTECTED_STATE_KEY]: ProtectedStrategyState};
  */
 export class ProtectedStrategy extends Strategy {
   static override NAME = '@typedtrader/strategy-protected';
+  static override marketTypes: readonly MarketType[] = [MarketType.UTILITY];
   readonly #stopLoss: GuardMode;
   readonly #takeProfit: GuardMode;
   readonly #stopLossOrder: GuardOrderType;

--- a/packages/trading-strategies/src/strategy-scalp/ScalpStrategy.ts
+++ b/packages/trading-strategies/src/strategy-scalp/ScalpStrategy.ts
@@ -3,6 +3,7 @@ import Big from 'big.js';
 import {AllAvailableAmount, CandleBatcher, ExchangeOrderSide, ExchangeOrderType} from '@typedtrader/exchange';
 import type {ExchangeFill, OneMinuteBatchedCandle, OrderAdvice, TradingSessionState} from '@typedtrader/exchange';
 import {EMA, ER} from 'trading-signals';
+import {MarketType} from '../strategy/MarketType.js';
 import {ProtectedStrategy, ProtectedStrategySchema} from '../strategy-protected/ProtectedStrategy.js';
 import {positiveNumberString} from '../util/validators.js';
 import {suggestScalpOffset} from './suggestScalpOffset.js';
@@ -27,6 +28,7 @@ type ScalpState = {
 
 export class ScalpStrategy extends ProtectedStrategy {
   static override NAME = '@typedtrader/strategy-scalp';
+  static override marketTypes: readonly MarketType[] = [MarketType.RANGING];
   static readonly ER_THRESHOLD = 0.4;
 
   readonly #ema: EMA;

--- a/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.ts
+++ b/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.ts
@@ -9,6 +9,7 @@ import type {
   OrderAdvice,
   TradingSessionState,
 } from '@typedtrader/exchange';
+import {MarketType} from '../strategy/MarketType.js';
 import {Strategy} from '../strategy/Strategy.js';
 import {positiveNumberString} from '../util/validators.js';
 
@@ -119,6 +120,7 @@ const defaultState = (): TrailingStopState => ({
  */
 export class TrailingStopStrategy extends Strategy {
   static override NAME = '@typedtrader/strategy-trailing-stop';
+  static override marketTypes: readonly MarketType[] = [MarketType.BULLISH];
 
   readonly #trailDownPct: Big;
   readonly #trailUpPct: Big | null;

--- a/packages/trading-strategies/src/strategy/MarketType.ts
+++ b/packages/trading-strategies/src/strategy/MarketType.ts
@@ -1,0 +1,18 @@
+/**
+ * Market regime a strategy is designed to operate in. A strategy may declare
+ * multiple values when it is genuinely effective in more than one regime
+ * (e.g. a confluence strategy that trades both up- and downtrends).
+ */
+export const MarketType = {
+  /** Up-trending market: higher highs and higher lows. */
+  BULLISH: 'bullish',
+  /** Down-trending market: lower highs and lower lows. */
+  BEARISH: 'bearish',
+  /** Sideways market: price oscillates between support and resistance. */
+  RANGING: 'ranging',
+  /** Reference strategy used to measure other strategies against (e.g. random or no-op baselines). */
+  BENCHMARK: 'benchmark',
+  /** Pipeline utility / base class — provides shared behavior, not a tradable view of the market. */
+  UTILITY: 'utility',
+} as const;
+export type MarketType = (typeof MarketType)[keyof typeof MarketType];

--- a/packages/trading-strategies/src/strategy/Strategy.ts
+++ b/packages/trading-strategies/src/strategy/Strategy.ts
@@ -1,7 +1,20 @@
-import type {OneMinuteBatchedCandle, OrderAdvice, TradingSessionState, TradingSessionStrategy} from '@typedtrader/exchange';
+import type {
+  OneMinuteBatchedCandle,
+  OrderAdvice,
+  TradingSessionState,
+  TradingSessionStrategy,
+} from '@typedtrader/exchange';
+import {MarketType} from './MarketType.js';
 
 export abstract class Strategy implements TradingSessionStrategy {
   static NAME: string;
+
+  /**
+   * Market regimes the strategy is designed to operate in. Subclasses should
+   * override this with the regime(s) that match their logic. An empty array
+   * means the strategy has not been categorized.
+   */
+  static marketTypes: readonly MarketType[] = [];
 
   latestAdvice: OrderAdvice | undefined = undefined;
   lastBatchedCandle: OneMinuteBatchedCandle | undefined = undefined;
@@ -99,5 +112,8 @@ export abstract class Strategy implements TradingSessionStrategy {
     });
   }
 
-  protected abstract processCandle(candle: OneMinuteBatchedCandle, state: TradingSessionState): Promise<OrderAdvice | void>;
+  protected abstract processCandle(
+    candle: OneMinuteBatchedCandle,
+    state: TradingSessionState
+  ): Promise<OrderAdvice | void>;
 }

--- a/packages/trading-strategies/src/strategy/Strategy.ts
+++ b/packages/trading-strategies/src/strategy/Strategy.ts
@@ -4,7 +4,7 @@ import type {
   TradingSessionState,
   TradingSessionStrategy,
 } from '@typedtrader/exchange';
-import {MarketType} from './MarketType.js';
+import type {MarketType} from './MarketType.js';
 
 export abstract class Strategy implements TradingSessionStrategy {
   static NAME: string;

--- a/packages/trading-strategies/src/strategy/index.ts
+++ b/packages/trading-strategies/src/strategy/index.ts
@@ -1,2 +1,3 @@
+export * from './MarketType.js';
 export * from './Strategy.js';
 export * from './StrategyRegistry.js';


### PR DESCRIPTION
## Summary

- Add `MarketType` enum — `BULLISH`, `BEARISH`, `RANGING`, `BENCHMARK`, `UTILITY` — modeled as a const-object + matching type alias, consistent with `ExchangeOrderSide` (the project enables `erasableSyntaxOnly`, which rules out `enum`).
- Add `static marketTypes: readonly MarketType[]` on the `Strategy` base class so each strategy declares which regime(s) it is designed for. The default is `[]` (uncategorized); filtering via `Strategy.marketTypes.includes(MarketType.BULLISH)` naturally excludes those.
- Tag every existing strategy:

| Strategy | Market types |
|---|---|
| `BuyOnceStrategy` (also exported as `BuyAndHoldStrategy`) | `[BULLISH]` |
| `BuyBelowSellAboveStrategy` | `[RANGING]` |
| `MeanReversionStrategy` | `[RANGING]` |
| `ScalpStrategy` | `[RANGING]` |
| `TrailingStopStrategy` | `[BULLISH]` |
| `MultiIndicatorConfluenceStrategy` | `[BULLISH, BEARISH]` |
| `ProtectedStrategy` | `[UTILITY]` |
| `CoinFlipStrategy` | `[BENCHMARK]` |
| `NoopStrategy` | `[BENCHMARK]` |

## Notes

- `marketTypes` is an array because some strategies are genuinely effective in multiple regimes (`MultiIndicatorConfluenceStrategy` trades both up- and downtrends).
- Multi-tag also leaves room for future strategies that bridge regimes without forcing an artificial single-bucket choice.
- No short-selling strategy exists yet — all directional strategies are currently long-biased.