### PR TITLE
fix(exchange): exit on market-data WebSocket close so orchestrator restarts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.bak
+# https://nextjs.org/docs/pages/guides/environment-variables#test-environment-variables
+.env*.local
 *.env
 *.tsbuildinfo
 *hot-update.js*

--- a/packages/exchange/src/exchange/alpaca/AlpacaWebSocket.ts
+++ b/packages/exchange/src/exchange/alpaca/AlpacaWebSocket.ts
@@ -9,6 +9,9 @@ const hasErrorCode = (error: unknown): error is {code: string | number} => {
 
 export interface AlpacaConnection {
   connectionId: string;
+}
+
+interface InternalConnection extends AlpacaConnection {
   stream: AlpacaStream;
 }
 
@@ -28,7 +31,7 @@ interface BarHandler {
  * connectionId across reconnects.
  */
 class AlpacaWebSocket {
-  #connections: Map<string, AlpacaConnection> = new Map();
+  #connections: Map<string, InternalConnection> = new Map();
   #symbols: Map<string, Set<string>> = new Map();
   #barHandlers: Map<string, BarHandler[]> = new Map();
   #connectionMeta: Map<string, {credentials: AlpacaStreamCredentials; source: string}> = new Map();
@@ -67,7 +70,7 @@ class AlpacaWebSocket {
     credentials: AlpacaStreamCredentials,
     source: string,
     reuseConnectionId?: string
-  ): Promise<AlpacaConnection> {
+  ): Promise<InternalConnection> {
     const singletonKey = `${credentials.apiKey}:${source}`;
 
     // Initial connect: reuse the existing connection if one already exists for these
@@ -85,13 +88,21 @@ class AlpacaWebSocket {
 
     const connectionId = reuseConnectionId ?? crypto.randomUUID();
 
-    return new Promise<AlpacaConnection>((resolve, reject) => {
+    return new Promise<InternalConnection>((resolve, reject) => {
       const stream = new AlpacaStream(credentials, source);
 
-      stream.on('error', (error: unknown) => {
+      const onPreAuthError = (error: unknown) => {
         console.error(`WebSocket streaming failed for ID "${connectionId}".`, error);
         reject(error);
-      });
+      };
+      const onPreAuthClose = () => {
+        // Server can drop the connection before sending an auth response. Without this,
+        // the surrounding `retry()` would hang forever.
+        reject(new Error(`WebSocket closed before authentication for ID "${connectionId}".`));
+      };
+
+      stream.on('error', onPreAuthError);
+      stream.on('close', onPreAuthClose);
 
       stream.on('subscription', (message: unknown) => {
         console.log(`WebSocket streaming is subscribed with ID "${connectionId}":`, JSON.stringify(message));
@@ -99,20 +110,26 @@ class AlpacaWebSocket {
 
       stream.on('authenticated', () => {
         console.log(`WebSocket streaming is authenticated with ID "${connectionId}".`);
+        stream.off('error', onPreAuthError);
+        stream.off('close', onPreAuthClose);
+
         const connection = {connectionId, stream};
         this.#connections.set(connectionId, connection);
         this.#credentialToConnectionId.set(singletonKey, connectionId);
         this.#connectionMeta.set(connectionId, {credentials, source});
 
-        // Replace the rejection-on-error handler with a logging-only handler. Errors
-        // after auth are message-level and shouldn't reject the (already-resolved)
-        // promise. If they're paired with a transport drop, the close listener below
-        // triggers reconnect.
-        stream.removeAllListeners('error');
+        // Post-auth: errors are message-level (e.g. server T:error) and shouldn't
+        // reject the already-resolved promise. Log them — and note that 405/409 codes
+        // returned for a re-subscribe are silently observed here, so the reconnect
+        // success log explicitly says "awaiting confirmation" rather than "done".
         stream.on('error', (error: unknown) => {
           console.error(`WebSocket streaming error after auth for ID "${connectionId}".`, error);
         });
         stream.once('close', () => {
+          // Skip if the caller has torn this connection down via disconnect().
+          if (!this.#connectionMeta.has(connectionId)) {
+            return;
+          }
           console.warn(`WebSocket closed for ID "${connectionId}", attempting to reconnect.`);
           void this.#reconnect(connectionId);
         });
@@ -125,7 +142,7 @@ class AlpacaWebSocket {
   async #reconnect(connectionId: string): Promise<void> {
     const meta = this.#connectionMeta.get(connectionId);
     if (!meta) {
-      console.warn(`No reconnect metadata for ID "${connectionId}", skipping reconnect.`);
+      // Caller called disconnect() in between the close event and this reconnect tick.
       return;
     }
     try {
@@ -145,15 +162,23 @@ class AlpacaWebSocket {
       if (symbols && symbols.size > 0) {
         connection.stream.subscribe('bars', Array.from(symbols));
       }
+      // Note: a 405 (symbol limit) or 409 (insufficient subscription) response to the
+      // resubscribe arrives as a post-auth `error` and is logged but doesn't fail this
+      // method. The "subscriptions resent" wording is deliberate — the actual confirmation
+      // appears as a separate `WebSocket streaming is subscribed` log line.
       console.log(
-        `WebSocket reconnected for ID "${connectionId}" with ${handlers.length} handler(s) and ${symbols?.size ?? 0} subscription(s).`
+        `WebSocket reconnected for ID "${connectionId}"; resent ${handlers.length} handler(s) and ${symbols?.size ?? 0} subscription(s) — awaiting confirmation.`
       );
     } catch (error) {
-      console.error(`WebSocket reconnect permanently failed for ID "${connectionId}".`, error);
+      console.error(
+        `WebSocket reconnect permanently failed for ID "${connectionId}", evicting connection.`,
+        error
+      );
+      this.#evict(connectionId);
     }
   }
 
-  #attachBarHandler(connection: AlpacaConnection, handler: BarHandler): void {
+  #attachBarHandler(connection: InternalConnection, handler: BarHandler): void {
     connection.stream.on('message', (message: StreamMessage) => {
       if (message.T === 'b' && message.S === handler.symbol) {
         handler.callback(message);
@@ -161,8 +186,36 @@ class AlpacaWebSocket {
     });
   }
 
+  /**
+   * Drop a connection from every internal map and close the underlying stream. After
+   * this the close listener that would otherwise trigger reconnect is a no-op (it
+   * checks `#connectionMeta` first), and a future `connect()` for the same credentials
+   * starts a fresh handshake instead of returning the dead entry.
+   */
+  #evict(connectionId: string): void {
+    const meta = this.#connectionMeta.get(connectionId);
+    if (meta) {
+      const singletonKey = `${meta.credentials.apiKey}:${meta.source}`;
+      this.#credentialToConnectionId.delete(singletonKey);
+    }
+    this.#connections.delete(connectionId);
+    this.#connectionMeta.delete(connectionId);
+    this.#symbols.delete(connectionId);
+    this.#barHandlers.delete(connectionId);
+  }
+
+  /** Tear a connection down for good. Stops the auto-reconnect loop and closes the stream. */
+  disconnect(connectionId: string): void {
+    const connection = this.#connections.get(connectionId);
+    // Evict first so the close listener installed in #establishConnection sees an empty
+    // meta entry and skips the reconnect path.
+    this.#evict(connectionId);
+    connection?.stream.close();
+  }
+
   async connect(credentials: AlpacaStreamCredentials, source: string): Promise<AlpacaConnection> {
-    return retry(() => this.#establishConnection(credentials, source), this.#retryConfig);
+    const connection = await retry(() => this.#establishConnection(credentials, source), this.#retryConfig);
+    return {connectionId: connection.connectionId};
   }
 
   /**

--- a/packages/exchange/src/exchange/alpaca/AlpacaWebSocket.ts
+++ b/packages/exchange/src/exchange/alpaca/AlpacaWebSocket.ts
@@ -83,7 +83,7 @@ class AlpacaWebSocket {
         this.#credentialToConnectionId.set(singletonKey, connectionId);
 
         // Every close on this socket is currently a transport drop — no code path
-        // closes it intentionally. Exit so Dokku restarts the worker and re-establishes
+        // closes it intentionally. Exit so the orchestrator restarts the worker and re-establishes
         // the stream from scratch. If an intentional close path is ever added, gate
         // this listener with a flag.
         stream.once('close', () => {

--- a/packages/exchange/src/exchange/alpaca/AlpacaWebSocket.ts
+++ b/packages/exchange/src/exchange/alpaca/AlpacaWebSocket.ts
@@ -88,6 +88,15 @@ class AlpacaWebSocket {
         // (Dokku) restarts it, which re-runs the full startup path: re-establish stream,
         // re-subscribe symbols, re-attach handlers. Strategies persist their state to
         // the encrypted DB on every mutation, so nothing is lost beyond a few seconds.
+        //
+        // Today no code path intentionally closes the market-data socket — strategy
+        // shutdown only unsubscribes individual symbols, and `AlpacaExchange.disconnect()`
+        // closes the trading socket but leaves this one open. So every `close` event we
+        // see here is a transport failure. If a future change adds an intentional close
+        // path (e.g. teardown when the last symbol unsubscribes, or a symmetric exchange
+        // shutdown that closes both sockets), gate this listener with an
+        // `#intentionalClose` flag the way `AlpacaTradingWebSocket.disconnect()` would —
+        // otherwise the worker will exit on a deliberate teardown.
         stream.once('close', () => {
           console.error(
             `Market-data WebSocket closed for "${connectionId}". Exiting so the orchestrator restarts the worker.`

--- a/packages/exchange/src/exchange/alpaca/AlpacaWebSocket.ts
+++ b/packages/exchange/src/exchange/alpaca/AlpacaWebSocket.ts
@@ -9,32 +9,17 @@ const hasErrorCode = (error: unknown): error is {code: string | number} => {
 
 export interface AlpacaConnection {
   connectionId: string;
-}
-
-interface InternalConnection extends AlpacaConnection {
   stream: AlpacaStream;
-}
-
-interface BarHandler {
-  symbol: string;
-  callback: (bar: MinuteBarMessage) => void;
 }
 
 /**
  * Alpaca only allows 1 WebSocket connection per API key. This class manages
  * WebSocket connections as singletons to avoid the following error:
  * {"T":"error","code":406,"msg":"connection limit exceeded"}
- *
- * If a previously authenticated stream drops (`close` event), the connection is
- * re-established under the same `connectionId` and all tracked subscriptions and
- * bar handlers are re-installed on the new stream. Callers keep using the same
- * connectionId across reconnects.
  */
 class AlpacaWebSocket {
-  #connections: Map<string, InternalConnection> = new Map();
+  #connections: Map<string, AlpacaConnection> = new Map();
   #symbols: Map<string, Set<string>> = new Map();
-  #barHandlers: Map<string, BarHandler[]> = new Map();
-  #connectionMeta: Map<string, {credentials: AlpacaStreamCredentials; source: string}> = new Map();
   #credentialToConnectionId: Map<string, string> = new Map();
 
   /**
@@ -66,43 +51,26 @@ class AlpacaWebSocket {
     timeout: 'INFINITELY',
   } as const;
 
-  async #establishConnection(
-    credentials: AlpacaStreamCredentials,
-    source: string,
-    reuseConnectionId?: string
-  ): Promise<InternalConnection> {
+  async #establishConnection(credentials: AlpacaStreamCredentials, source: string): Promise<AlpacaConnection> {
+    // Check if we already have a connection for these credentials + source
     const singletonKey = `${credentials.apiKey}:${source}`;
-
-    // Initial connect: reuse the existing connection if one already exists for these
-    // credentials. Reconnect path: skip the cache (the existing entry points at the
-    // dead stream we're replacing).
-    if (!reuseConnectionId) {
-      const existingConnectionId = this.#credentialToConnectionId.get(singletonKey);
-      if (existingConnectionId) {
-        const existing = this.#connections.get(existingConnectionId);
-        if (existing) {
-          return existing;
-        }
+    const existingConnectionId = this.#credentialToConnectionId.get(singletonKey);
+    if (existingConnectionId) {
+      const existing = this.#connections.get(existingConnectionId);
+      if (existing) {
+        return existing;
       }
     }
 
-    const connectionId = reuseConnectionId ?? crypto.randomUUID();
+    const connectionId = crypto.randomUUID();
 
-    return new Promise<InternalConnection>((resolve, reject) => {
+    return new Promise<AlpacaConnection>((resolve, reject) => {
       const stream = new AlpacaStream(credentials, source);
 
-      const onPreAuthError = (error: unknown) => {
+      stream.on('error', (error: unknown) => {
         console.error(`WebSocket streaming failed for ID "${connectionId}".`, error);
         reject(error);
-      };
-      const onPreAuthClose = () => {
-        // Server can drop the connection before sending an auth response. Without this,
-        // the surrounding `retry()` would hang forever.
-        reject(new Error(`WebSocket closed before authentication for ID "${connectionId}".`));
-      };
-
-      stream.on('error', onPreAuthError);
-      stream.on('close', onPreAuthClose);
+      });
 
       stream.on('subscription', (message: unknown) => {
         console.log(`WebSocket streaming is subscribed with ID "${connectionId}":`, JSON.stringify(message));
@@ -110,28 +78,21 @@ class AlpacaWebSocket {
 
       stream.on('authenticated', () => {
         console.log(`WebSocket streaming is authenticated with ID "${connectionId}".`);
-        stream.off('error', onPreAuthError);
-        stream.off('close', onPreAuthClose);
-
         const connection = {connectionId, stream};
         this.#connections.set(connectionId, connection);
         this.#credentialToConnectionId.set(singletonKey, connectionId);
-        this.#connectionMeta.set(connectionId, {credentials, source});
 
-        // Post-auth: errors are message-level (e.g. server T:error) and shouldn't
-        // reject the already-resolved promise. Log them — and note that 405/409 codes
-        // returned for a re-subscribe are silently observed here, so the reconnect
-        // success log explicitly says "awaiting confirmation" rather than "done".
-        stream.on('error', (error: unknown) => {
-          console.error(`WebSocket streaming error after auth for ID "${connectionId}".`, error);
-        });
+        // Fail loud on transport drop. Keeping the in-memory state consistent across an
+        // in-process reconnect is genuinely hard (singleton-per-credentials, per-symbol
+        // bar handlers, in-flight retries). Instead, exit the worker — the orchestrator
+        // (Dokku) restarts it, which re-runs the full startup path: re-establish stream,
+        // re-subscribe symbols, re-attach handlers. Strategies persist their state to
+        // the encrypted DB on every mutation, so nothing is lost beyond a few seconds.
         stream.once('close', () => {
-          // Skip if the caller has torn this connection down via disconnect().
-          if (!this.#connectionMeta.has(connectionId)) {
-            return;
-          }
-          console.warn(`WebSocket closed for ID "${connectionId}", attempting to reconnect.`);
-          void this.#reconnect(connectionId);
+          console.error(
+            `Market-data WebSocket closed for "${connectionId}". Exiting so the orchestrator restarts the worker.`
+          );
+          process.exit(1);
         });
 
         resolve(connection);
@@ -139,83 +100,8 @@ class AlpacaWebSocket {
     });
   }
 
-  async #reconnect(connectionId: string): Promise<void> {
-    const meta = this.#connectionMeta.get(connectionId);
-    if (!meta) {
-      // Caller called disconnect() in between the close event and this reconnect tick.
-      return;
-    }
-    try {
-      await retry(
-        () => this.#establishConnection(meta.credentials, meta.source, connectionId),
-        this.#retryConfig
-      );
-      const connection = this.#connections.get(connectionId);
-      if (!connection) {
-        return;
-      }
-      const handlers = this.#barHandlers.get(connectionId) ?? [];
-      for (const handler of handlers) {
-        this.#attachBarHandler(connection, handler);
-      }
-      const symbols = this.#symbols.get(connectionId);
-      if (symbols && symbols.size > 0) {
-        connection.stream.subscribe('bars', Array.from(symbols));
-      }
-      // Note: a 405 (symbol limit) or 409 (insufficient subscription) response to the
-      // resubscribe arrives as a post-auth `error` and is logged but doesn't fail this
-      // method. The "subscriptions resent" wording is deliberate — the actual confirmation
-      // appears as a separate `WebSocket streaming is subscribed` log line.
-      console.log(
-        `WebSocket reconnected for ID "${connectionId}"; resent ${handlers.length} handler(s) and ${symbols?.size ?? 0} subscription(s) — awaiting confirmation.`
-      );
-    } catch (error) {
-      console.error(
-        `WebSocket reconnect permanently failed for ID "${connectionId}", evicting connection.`,
-        error
-      );
-      this.#evict(connectionId);
-    }
-  }
-
-  #attachBarHandler(connection: InternalConnection, handler: BarHandler): void {
-    connection.stream.on('message', (message: StreamMessage) => {
-      if (message.T === 'b' && message.S === handler.symbol) {
-        handler.callback(message);
-      }
-    });
-  }
-
-  /**
-   * Drop a connection from every internal map and close the underlying stream. After
-   * this the close listener that would otherwise trigger reconnect is a no-op (it
-   * checks `#connectionMeta` first), and a future `connect()` for the same credentials
-   * starts a fresh handshake instead of returning the dead entry.
-   */
-  #evict(connectionId: string): void {
-    const meta = this.#connectionMeta.get(connectionId);
-    if (meta) {
-      const singletonKey = `${meta.credentials.apiKey}:${meta.source}`;
-      this.#credentialToConnectionId.delete(singletonKey);
-    }
-    this.#connections.delete(connectionId);
-    this.#connectionMeta.delete(connectionId);
-    this.#symbols.delete(connectionId);
-    this.#barHandlers.delete(connectionId);
-  }
-
-  /** Tear a connection down for good. Stops the auto-reconnect loop and closes the stream. */
-  disconnect(connectionId: string): void {
-    const connection = this.#connections.get(connectionId);
-    // Evict first so the close listener installed in #establishConnection sees an empty
-    // meta entry and skips the reconnect path.
-    this.#evict(connectionId);
-    connection?.stream.close();
-  }
-
   async connect(credentials: AlpacaStreamCredentials, source: string): Promise<AlpacaConnection> {
-    const connection = await retry(() => this.#establishConnection(credentials, source), this.#retryConfig);
-    return {connectionId: connection.connectionId};
+    return retry(() => this.#establishConnection(credentials, source), this.#retryConfig);
   }
 
   /**
@@ -237,15 +123,11 @@ class AlpacaWebSocket {
     }
     symbols.add(symbol);
 
-    // Track the callback so it can be re-attached on reconnect.
-    let handlers = this.#barHandlers.get(connectionId);
-    if (!handlers) {
-      handlers = [];
-      this.#barHandlers.set(connectionId, handlers);
-    }
-    const handler: BarHandler = {symbol, callback: cb};
-    handlers.push(handler);
-    this.#attachBarHandler(connection, handler);
+    connection.stream.on('message', (message: StreamMessage) => {
+      if (message.T === 'b' && message.S === symbol) {
+        cb(message);
+      }
+    });
 
     const allSymbols = Array.from(symbols);
     connection.stream.unsubscribe('bars', allSymbols);
@@ -260,14 +142,6 @@ class AlpacaWebSocket {
 
     const symbols = this.#symbols.get(connectionId);
     symbols?.delete(symbol);
-
-    const handlers = this.#barHandlers.get(connectionId);
-    if (handlers) {
-      const idx = handlers.findIndex(h => h.symbol === symbol);
-      if (idx !== -1) {
-        handlers.splice(idx, 1);
-      }
-    }
 
     connection.stream.unsubscribe('bars', [symbol]);
   }

--- a/packages/exchange/src/exchange/alpaca/AlpacaWebSocket.ts
+++ b/packages/exchange/src/exchange/alpaca/AlpacaWebSocket.ts
@@ -12,14 +12,26 @@ export interface AlpacaConnection {
   stream: AlpacaStream;
 }
 
+interface BarHandler {
+  symbol: string;
+  callback: (bar: MinuteBarMessage) => void;
+}
+
 /**
  * Alpaca only allows 1 WebSocket connection per API key. This class manages
  * WebSocket connections as singletons to avoid the following error:
  * {"T":"error","code":406,"msg":"connection limit exceeded"}
+ *
+ * If a previously authenticated stream drops (`close` event), the connection is
+ * re-established under the same `connectionId` and all tracked subscriptions and
+ * bar handlers are re-installed on the new stream. Callers keep using the same
+ * connectionId across reconnects.
  */
 class AlpacaWebSocket {
   #connections: Map<string, AlpacaConnection> = new Map();
   #symbols: Map<string, Set<string>> = new Map();
+  #barHandlers: Map<string, BarHandler[]> = new Map();
+  #connectionMeta: Map<string, {credentials: AlpacaStreamCredentials; source: string}> = new Map();
   #credentialToConnectionId: Map<string, string> = new Map();
 
   /**
@@ -51,18 +63,27 @@ class AlpacaWebSocket {
     timeout: 'INFINITELY',
   } as const;
 
-  async #establishConnection(credentials: AlpacaStreamCredentials, source: string): Promise<AlpacaConnection> {
-    // Check if we already have a connection for these credentials + source
+  async #establishConnection(
+    credentials: AlpacaStreamCredentials,
+    source: string,
+    reuseConnectionId?: string
+  ): Promise<AlpacaConnection> {
     const singletonKey = `${credentials.apiKey}:${source}`;
-    const existingConnectionId = this.#credentialToConnectionId.get(singletonKey);
-    if (existingConnectionId) {
-      const existing = this.#connections.get(existingConnectionId);
-      if (existing) {
-        return existing;
+
+    // Initial connect: reuse the existing connection if one already exists for these
+    // credentials. Reconnect path: skip the cache (the existing entry points at the
+    // dead stream we're replacing).
+    if (!reuseConnectionId) {
+      const existingConnectionId = this.#credentialToConnectionId.get(singletonKey);
+      if (existingConnectionId) {
+        const existing = this.#connections.get(existingConnectionId);
+        if (existing) {
+          return existing;
+        }
       }
     }
 
-    const connectionId = crypto.randomUUID();
+    const connectionId = reuseConnectionId ?? crypto.randomUUID();
 
     return new Promise<AlpacaConnection>((resolve, reject) => {
       const stream = new AlpacaStream(credentials, source);
@@ -81,8 +102,62 @@ class AlpacaWebSocket {
         const connection = {connectionId, stream};
         this.#connections.set(connectionId, connection);
         this.#credentialToConnectionId.set(singletonKey, connectionId);
+        this.#connectionMeta.set(connectionId, {credentials, source});
+
+        // Replace the rejection-on-error handler with a logging-only handler. Errors
+        // after auth are message-level and shouldn't reject the (already-resolved)
+        // promise. If they're paired with a transport drop, the close listener below
+        // triggers reconnect.
+        stream.removeAllListeners('error');
+        stream.on('error', (error: unknown) => {
+          console.error(`WebSocket streaming error after auth for ID "${connectionId}".`, error);
+        });
+        stream.once('close', () => {
+          console.warn(`WebSocket closed for ID "${connectionId}", attempting to reconnect.`);
+          void this.#reconnect(connectionId);
+        });
+
         resolve(connection);
       });
+    });
+  }
+
+  async #reconnect(connectionId: string): Promise<void> {
+    const meta = this.#connectionMeta.get(connectionId);
+    if (!meta) {
+      console.warn(`No reconnect metadata for ID "${connectionId}", skipping reconnect.`);
+      return;
+    }
+    try {
+      await retry(
+        () => this.#establishConnection(meta.credentials, meta.source, connectionId),
+        this.#retryConfig
+      );
+      const connection = this.#connections.get(connectionId);
+      if (!connection) {
+        return;
+      }
+      const handlers = this.#barHandlers.get(connectionId) ?? [];
+      for (const handler of handlers) {
+        this.#attachBarHandler(connection, handler);
+      }
+      const symbols = this.#symbols.get(connectionId);
+      if (symbols && symbols.size > 0) {
+        connection.stream.subscribe('bars', Array.from(symbols));
+      }
+      console.log(
+        `WebSocket reconnected for ID "${connectionId}" with ${handlers.length} handler(s) and ${symbols?.size ?? 0} subscription(s).`
+      );
+    } catch (error) {
+      console.error(`WebSocket reconnect permanently failed for ID "${connectionId}".`, error);
+    }
+  }
+
+  #attachBarHandler(connection: AlpacaConnection, handler: BarHandler): void {
+    connection.stream.on('message', (message: StreamMessage) => {
+      if (message.T === 'b' && message.S === handler.symbol) {
+        handler.callback(message);
+      }
     });
   }
 
@@ -109,11 +184,15 @@ class AlpacaWebSocket {
     }
     symbols.add(symbol);
 
-    connection.stream.on('message', (message: StreamMessage) => {
-      if (message.T === 'b' && message.S === symbol) {
-        cb(message);
-      }
-    });
+    // Track the callback so it can be re-attached on reconnect.
+    let handlers = this.#barHandlers.get(connectionId);
+    if (!handlers) {
+      handlers = [];
+      this.#barHandlers.set(connectionId, handlers);
+    }
+    const handler: BarHandler = {symbol, callback: cb};
+    handlers.push(handler);
+    this.#attachBarHandler(connection, handler);
 
     const allSymbols = Array.from(symbols);
     connection.stream.unsubscribe('bars', allSymbols);
@@ -128,6 +207,14 @@ class AlpacaWebSocket {
 
     const symbols = this.#symbols.get(connectionId);
     symbols?.delete(symbol);
+
+    const handlers = this.#barHandlers.get(connectionId);
+    if (handlers) {
+      const idx = handlers.findIndex(h => h.symbol === symbol);
+      if (idx !== -1) {
+        handlers.splice(idx, 1);
+      }
+    }
 
     connection.stream.unsubscribe('bars', [symbol]);
   }

--- a/packages/exchange/src/exchange/alpaca/AlpacaWebSocket.ts
+++ b/packages/exchange/src/exchange/alpaca/AlpacaWebSocket.ts
@@ -83,14 +83,15 @@ class AlpacaWebSocket {
         this.#credentialToConnectionId.set(singletonKey, connectionId);
 
         // Every close on this socket is currently a transport drop — no code path
-        // closes it intentionally. Exit so the orchestrator restarts the worker and re-establishes
-        // the stream from scratch. If an intentional close path is ever added, gate
-        // this listener with a flag.
+        // closes it intentionally. Terminate via SIGTERM so the application's
+        // centralized shutdown path can run cleanup and flush logs before exit,
+        // while still letting the orchestrator restart the worker. If an
+        // intentional close path is ever added, gate this listener with a flag.
         stream.once('close', () => {
           console.error(
-            `Market-data WebSocket closed for "${connectionId}". Exiting so the orchestrator restarts the worker.`
+            `Market-data WebSocket closed for "${connectionId}". Sending SIGTERM so the orchestrator restarts the worker after graceful shutdown.`
           );
-          process.exit(1);
+          process.kill(process.pid, 'SIGTERM');
         });
 
         resolve(connection);

--- a/packages/exchange/src/exchange/alpaca/AlpacaWebSocket.ts
+++ b/packages/exchange/src/exchange/alpaca/AlpacaWebSocket.ts
@@ -82,21 +82,10 @@ class AlpacaWebSocket {
         this.#connections.set(connectionId, connection);
         this.#credentialToConnectionId.set(singletonKey, connectionId);
 
-        // Fail loud on transport drop. Keeping the in-memory state consistent across an
-        // in-process reconnect is genuinely hard (singleton-per-credentials, per-symbol
-        // bar handlers, in-flight retries). Instead, exit the worker — the orchestrator
-        // (Dokku) restarts it, which re-runs the full startup path: re-establish stream,
-        // re-subscribe symbols, re-attach handlers. Strategies persist their state to
-        // the encrypted DB on every mutation, so nothing is lost beyond a few seconds.
-        //
-        // Today no code path intentionally closes the market-data socket — strategy
-        // shutdown only unsubscribes individual symbols, and `AlpacaExchange.disconnect()`
-        // closes the trading socket but leaves this one open. So every `close` event we
-        // see here is a transport failure. If a future change adds an intentional close
-        // path (e.g. teardown when the last symbol unsubscribes, or a symmetric exchange
-        // shutdown that closes both sockets), gate this listener with an
-        // `#intentionalClose` flag the way `AlpacaTradingWebSocket.disconnect()` would —
-        // otherwise the worker will exit on a deliberate teardown.
+        // Every close on this socket is currently a transport drop — no code path
+        // closes it intentionally. Exit so Dokku restarts the worker and re-establishes
+        // the stream from scratch. If an intentional close path is ever added, gate
+        // this listener with a flag.
         stream.once('close', () => {
           console.error(
             `Market-data WebSocket closed for "${connectionId}". Exiting so the orchestrator restarts the worker.`


### PR DESCRIPTION
## Summary

A market-data `WebSocket` that drops after authentication used to leave the singleton holding a dead stream. Subscribers stopped receiving candles silently. A trailing-stop strategy on `INTC,USD` lost ~9 hours of intraday candles on May 5 because of this — `peakPrice` never ratcheted past May 1's high.

After exploring an in-place reconnect (kept singleton, re-attached handlers, replayed subscribes), code review surfaced a steady stream of subtle races: in-flight retries vs. teardown, cached dead connection during reconnect, post-auth error suppression hiding 405/409s on resubscribe, etc. Each fix exposed another.

This PR takes the simpler path: **fail loud, let Dokku restart**. After the stream authenticates, listen for transport `close` and `process.exit(1)`. The orchestrator restarts the worker, the full startup path runs again (re-establish stream, re-subscribe symbols, re-attach handlers), strategies restore from persisted state.

## Implementation

A single `stream.once('close', ...)` listener installed inside the existing `'authenticated'` handler. No new state, no new types, no new APIs.

```ts
stream.once('close', () => {
  console.error(`Market-data WebSocket closed for "${connectionId}". Exiting so the orchestrator restarts the worker.`);
  process.exit(1);
});
```

Diff: +28 / -154 vs. the previous reconnect-in-place attempt.

## Operational note

Cost is ~5 seconds of downtime per disconnect. Acceptable until drops become frequent enough to justify a real reconnecting transport — at which point the right path is to push the reconnect into `AlpacaStream` itself (the layer that wraps the native `WebSocket`), not back into the singleton above it.

## Verification path

After this lands and the worker redeploys: a transport drop will produce a `Market-data WebSocket closed for "<id>"` log line followed by a Dokku restart, then the usual `WebSocket streaming is authenticated` log line for a fresh connection.