### PR TITLE
feat(trading-strategies): emit onMessage on TrailingStopStrategy peak ratchet

### DIFF
--- a/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.test.ts
+++ b/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.test.ts
@@ -349,6 +349,38 @@ describe('TrailingStopStrategy', () => {
     expect(messages[0]).toBe('Trail attached. Peak: 100, stop: 90 (-10%)');
   });
 
+  it('emits an onMessage on every peak ratchet with the new peak and stop target', async () => {
+    const strategy = new TrailingStopStrategy({trailDownPct: '10'});
+    const messages: string[] = [];
+    strategy.onMessage = text => messages.push(text);
+
+    const candles = [
+      // Attach: peak=100. attach message.
+      createCandle({open: '100', close: '100', low: '99', high: '100', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+      // high=120 → ratchet. peak=120, stop=108.
+      createCandle({open: '100', close: '115', low: '100', high: '120', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
+      // high=120 (no new peak). No ratchet message.
+      createCandle({open: '115', close: '118', low: '115', high: '120', openTimeInISO: '2025-01-01T00:02:00.000Z'}),
+      // high=130 → ratchet. peak=130, stop=117.
+      createCandle({open: '120', close: '125', low: '119', high: '130', openTimeInISO: '2025-01-01T00:03:00.000Z'}),
+    ];
+
+    const config: BacktestConfig = {
+      candles,
+      exchange: createMockExchange({baseBalance: '5'}),
+      strategy,
+      tradingPair,
+    };
+
+    await new BacktestExecutor(config).execute();
+
+    expect(messages).toEqual([
+      'Trail attached. Peak: 100, stop: 90 (-10%)',
+      'Peak moved to 120 (stop: 108)',
+      'Peak moved to 130 (stop: 117)',
+    ]);
+  });
+
   it('emits a single onMessage when the trail first breaches and not on re-emissions', async () => {
     const strategy = new TrailingStopStrategy({trailDownPct: '10'});
     const messages: string[] = [];

--- a/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.ts
+++ b/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.ts
@@ -187,8 +187,6 @@ export class TrailingStopStrategy extends Strategy {
     this.#state.stopPrice = trailTarget.toFixed();
 
     if (peakRatcheted) {
-      // Fires on every new peak. Without `trailUpPct` this can be chatty in trending
-      // markets — set `trailUpPct` to throttle ratchets to discrete steps.
       this.onMessage?.(`Peak moved to ${newPeak.toFixed()} (stop: ${trailTarget.toFixed()})`);
     }
 

--- a/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.ts
+++ b/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.ts
@@ -178,12 +178,19 @@ export class TrailingStopStrategy extends Strategy {
       ? previousPeak.mul(new Big(1).plus(this.#trailUpPct.div(100)))
       : previousPeak;
     const newPeak = candle.high.gte(ratchetThreshold) && candle.high.gt(previousPeak) ? candle.high : previousPeak;
-    if (newPeak.gt(previousPeak)) {
+    const peakRatcheted = newPeak.gt(previousPeak);
+    if (peakRatcheted) {
       this.#state.peakPrice = newPeak.toFixed();
     }
 
     const trailTarget = newPeak.mul(new Big(1).minus(this.#trailDownPct.div(100)));
     this.#state.stopPrice = trailTarget.toFixed();
+
+    if (peakRatcheted) {
+      // Fires on every new peak. Without `trailUpPct` this can be chatty in trending
+      // markets — set `trailUpPct` to throttle ratchets to discrete steps.
+      this.onMessage?.(`Peak moved to ${newPeak.toFixed()} (stop: ${trailTarget.toFixed()})`);
+    }
 
     if (candle.close.gt(trailTarget)) {
       return undefined;


### PR DESCRIPTION
## Summary

`TrailingStopStrategy` was silent between attach and breach — the peak could move without the user knowing. After PR #1071 fixed the WebSocket reconnect, INTC's peak correctly ratcheted to a new high on the first candle but no notification reached Telegram, because the strategy never told anyone.

This PR closes that gap. Every new peak emits `Peak moved to <peak> (stop: <stop>)` via the `onMessage` channel introduced in PR #1063, which the messaging layer forwards to the user.

## Implementation

A single new `if (peakRatcheted)` branch in `processCandle`, fired only when `newPeak.gt(previousPeak)` (i.e. the existing ratchet condition). No new state, no schema change.

## Throttling

Without `trailUpPct` set, this fires on every candle that prints a new high — potentially noisy in trending markets. Setting `trailUpPct: "1"` (for example) requires a 1% move above the current peak before ratcheting, which both reduces message volume and dampens trail-stop oscillations.