### PR TITLE
feat(messaging): add /strategyCopy command

### DIFF
--- a/packages/messaging/src/command/index.ts
+++ b/packages/messaging/src/command/index.ts
@@ -10,6 +10,7 @@ export {time} from './time.js';
 export {uptime} from './uptime.js';
 export {strategyAdd} from './strategy/strategyAdd.js';
 export {strategyConfig} from './strategy/strategyConfig.js';
+export {strategyCopy} from './strategy/strategyCopy.js';
 export {strategyList} from './strategy/strategyList.js';
 export {strategyRemove} from './strategy/strategyRemove.js';
 export {strategyState} from './strategy/strategyState.js';

--- a/packages/messaging/src/command/strategy/strategyCopy.ts
+++ b/packages/messaging/src/command/strategy/strategyCopy.ts
@@ -1,0 +1,65 @@
+import {TradingPair} from '@typedtrader/exchange';
+import {Strategy, type StrategyAttributes} from '../../database/models/Strategy.js';
+import {assertId} from '../../validation/assertId.js';
+import {getAccountOrError} from '../../validation/getAccountOrError.js';
+
+export interface StrategyCopyResult {
+  message: string;
+  strategy?: StrategyAttributes;
+}
+
+// Request Example: "/strategyCopy 5 2 BTC,USD"
+// Format: "<sourceStrategyId> <targetAccountId> <targetPair>"
+export const strategyCopy = async (request: string, userId: string): Promise<StrategyCopyResult> => {
+  const parts = request.trim().split(/\s+/).filter(Boolean);
+
+  if (parts.length !== 3) {
+    return {
+      message:
+        'Invalid format. Usage: /strategyCopy <sourceStrategyId> <targetAccountId> <targetPair>\nExample: /strategyCopy 5 2 BTC,USD',
+    };
+  }
+
+  const [sourceIdStr, targetAccountIdStr, pairStr] = parts;
+
+  let pair: TradingPair;
+  try {
+    pair = TradingPair.fromString(pairStr, ',');
+  } catch {
+    return {message: 'Invalid pair format. Use BASE,COUNTER (e.g., BTC,USD).'};
+  }
+
+  try {
+    const sourceId = assertId(sourceIdStr);
+    const source = Strategy.findByPk(sourceId);
+
+    if (!source) {
+      return {message: `Strategy with ID "${sourceId}" not found`};
+    }
+
+    // Security: verify the source strategy's account belongs to the user
+    // before exposing its config to a copy operation.
+    getAccountOrError(userId, source.accountId);
+
+    const targetAccountId = assertId(targetAccountIdStr);
+    const targetAccount = getAccountOrError(userId, targetAccountId);
+
+    const pairString = pair.asString(',');
+    const row = Strategy.create({
+      accountId: targetAccount.id,
+      strategyName: source.strategyName,
+      config: source.config,
+      pair: pairString,
+    });
+
+    return {
+      message: `Strategy copied (ID: ${row.id})\nSource: ${sourceId} (${source.strategyName} on ${source.pair})\nStrategy: ${source.strategyName}\nPair: ${pairString}\nAccount: ${targetAccount.name}`,
+      strategy: row,
+    };
+  } catch (error) {
+    if (error instanceof Error) {
+      return {message: `Error copying strategy: ${error.message}`};
+    }
+    return {message: 'Error copying strategy'};
+  }
+};

--- a/packages/messaging/src/command/strategy/strategyCopy.ts
+++ b/packages/messaging/src/command/strategy/strategyCopy.ts
@@ -1,4 +1,5 @@
 import {TradingPair} from '@typedtrader/exchange';
+import {createStrategy} from 'trading-strategies';
 import {Strategy, type StrategyAttributes} from '../../database/models/Strategy.js';
 import {assertId} from '../../validation/assertId.js';
 import {getAccountOrError} from '../../validation/getAccountOrError.js';
@@ -8,8 +9,10 @@ export interface StrategyCopyResult {
   strategy?: StrategyAttributes;
 }
 
-// Request Example: "/strategyCopy 5 2 BTC,USD"
-// Format: "<sourceStrategyId> <targetAccountId> <targetPair>"
+// Chat command example: "/strategyCopy 5 2 BTC,USD"
+// The MessagingPlatform strips the command name, so `request` only contains the args.
+// Args format: "<sourceStrategyId> <targetAccountId> <targetPair>"
+// Args example: "5 2 BTC,USD"
 export const strategyCopy = async (request: string, userId: string): Promise<StrategyCopyResult> => {
   const parts = request.trim().split(/\s+/).filter(Boolean);
 
@@ -43,6 +46,16 @@ export const strategyCopy = async (request: string, userId: string): Promise<Str
 
     const targetAccountId = assertId(targetAccountIdStr);
     const targetAccount = getAccountOrError(userId, targetAccountId);
+
+    // Validate the source strategy is still instantiable before persisting a copy
+    // that StrategyMonitor would otherwise fail to start.
+    let parsedConfig: unknown;
+    try {
+      parsedConfig = JSON.parse(source.config);
+    } catch {
+      return {message: `Source strategy ${sourceId} has invalid config JSON and cannot be copied.`};
+    }
+    createStrategy(source.strategyName, parsedConfig);
 
     const pairString = pair.asString(',');
     const row = Strategy.create({

--- a/packages/messaging/src/startServer.ts
+++ b/packages/messaging/src/startServer.ts
@@ -11,6 +11,7 @@ import {
   reportRemove,
   strategyAdd,
   strategyConfig,
+  strategyCopy,
   strategyList,
   strategyRemove,
   strategyState,
@@ -136,6 +137,19 @@ function registerCommands(platform: MessagingPlatform, monitors: Monitors): void
 
   platform.registerCommand('strategyConfig', async ctx => {
     await ctx.reply(await strategyConfig(ctx.content, ctx.senderId));
+  });
+
+  platform.registerCommand('strategyCopy', async ctx => {
+    const result = await strategyCopy(ctx.content, ctx.senderId);
+    await ctx.reply(result.message);
+
+    if (result.strategy) {
+      try {
+        await monitors.strategyMonitor.subscribeToStrategy(result.strategy);
+      } catch (error) {
+        logger.error({err: error}, 'Error starting copied strategy');
+      }
+    }
   });
 
   platform.registerCommand('strategyState', async ctx => {


### PR DESCRIPTION
## Summary
- Adds `/strategyCopy <sourceStrategyId> <targetAccountId> <targetPair>` to clone an existing strategy's `strategyName` and `config` onto a different account and trading pair, without carrying over runtime state.
- Verifies both the source strategy's account and the target account belong to the caller before exposing the source config to the copy.
- Subscribes the new strategy via `StrategyMonitor` so it starts running immediately, matching the `/strategyAdd` flow.