### PR TITLE
fix(exchange, messaging): hard-exit on WS close + bound shutdown deadline

### DIFF
--- a/packages/exchange/src/exchange/alpaca/AlpacaWebSocket.ts
+++ b/packages/exchange/src/exchange/alpaca/AlpacaWebSocket.ts
@@ -82,16 +82,20 @@ class AlpacaWebSocket {
         this.#connections.set(connectionId, connection);
         this.#credentialToConnectionId.set(singletonKey, connectionId);
 
-        // Every close on this socket is currently a transport drop — no code path
-        // closes it intentionally. Terminate via SIGTERM so the application's
-        // centralized shutdown path can run cleanup and flush logs before exit,
-        // while still letting the orchestrator restart the worker. If an
-        // intentional close path is ever added, gate this listener with a flag.
+        // Every close on this socket is a transport drop — no code path closes it
+        // intentionally. Hard-exit so the orchestrator restarts the worker. We
+        // deliberately do NOT route this through the application's SIGTERM/shutdown
+        // handler: that path awaits cancelOpenOrders() over HTTP which can hang
+        // silently when the same network event that killed our WS also kills HTTP,
+        // leaving the worker stuck in shutdown forever. Observed in production:
+        // 2026-05-08 07:32:57 WS close → SIGTERM logged → process never exits,
+        // container "Up 3 days" with no further logs.
+        // If an intentional close path is ever added, gate this listener with a flag.
         stream.once('close', () => {
           console.error(
-            `Market-data WebSocket closed for "${connectionId}". Sending SIGTERM so the orchestrator restarts the worker after graceful shutdown.`
+            `Market-data WebSocket closed for "${connectionId}". Exiting so the orchestrator restarts the worker.`
           );
-          process.kill(process.pid, 'SIGTERM');
+          process.exit(1);
         });
 
         resolve(connection);

--- a/packages/messaging/src/startServer.ts
+++ b/packages/messaging/src/startServer.ts
@@ -243,8 +243,21 @@ export async function startServer() {
     logger.error({err: error}, 'Error starting report scheduler');
   });
 
-  // Graceful shutdown
+  // Graceful shutdown with a hard deadline. `strategyMonitor.stop()` awaits
+  // `session.stop({cancelOpenOrders})` which makes HTTP calls to the broker; if those
+  // hang (network failure, broker unreachable), the cleanup never completes and
+  // `process.exit(0)` in `finally` is never reached. Observed in production where a
+  // WS-close-triggered SIGTERM left the worker `Up 3 days` with no further logs.
+  // The deadline guarantees we exit within a bounded time regardless of what blocks.
+  const SHUTDOWN_DEADLINE_MS = 10_000;
   const shutdown = async () => {
+    const deadline = setTimeout(() => {
+      logger.error({deadlineMs: SHUTDOWN_DEADLINE_MS}, 'Shutdown deadline hit, force exiting');
+      logger.flush();
+      process.exit(1);
+    }, SHUTDOWN_DEADLINE_MS);
+    deadline.unref();
+
     try {
       monitors.watchMonitor.stop();
       await monitors.strategyMonitor.stop();
@@ -256,6 +269,7 @@ export async function startServer() {
     } catch (error) {
       logger.error({err: error}, 'Error during shutdown');
     } finally {
+      clearTimeout(deadline);
       logger.flush();
       process.exit(0);
     }


### PR DESCRIPTION
## Summary

Production observation today: the `INTC,USD` strategy went deaf again. Container reports `Up 3 days` but the log ends at `2026-05-08T07:32:57Z` with `Market-data WebSocket closed for "fb18a402-…". Sending SIGTERM…` and **nothing after**. No restart, no further logs. Worker stuck.

## Why

After PR #1071 merged, the close listener in `AlpacaWebSocket.ts` was tweaked from `process.exit(1)` to `process.kill(process.pid, 'SIGTERM')`. That routes recovery through the graceful-shutdown handler in `packages/messaging/src/startServer.ts`:

```ts
const shutdown = async () => {
  try {
    monitors.watchMonitor.stop();
    await monitors.strategyMonitor.stop();   // ← awaits session.stop({cancelOpenOrders: true})
    monitors.reportScheduler.stop();
    for (const platform of platforms.values()) await platform.stop();
  } catch (error) { … }
  finally {
    logger.flush();
    process.exit(0);    // ← never reached
  }
};
```

`strategyMonitor.stop()` → `session.stop({cancelOpenOrders: true})` → broker HTTP `cancelOpenOrders`. When the same network event that killed our WS also kills HTTP, the cancel call hangs silently — no timeout, no rejection. The `await` in `try` never returns, so `finally` never runs, so `process.exit(0)` never runs. Process lives forever in zombie state.

## Fix

**1. `AlpacaWebSocket.ts`** — revert to `process.exit(1)`. The whole point of "fail loud" is to bypass shutdown paths that can hang. Strategy state is persisted on every mutation, so nothing is lost beyond a few seconds of restart time.

**2. `startServer.ts`** — install a 10-second deadline timer at the top of `shutdown`. If cleanup hasn't completed by then, force-exit. This protects external SIGINT/SIGTERM from the same hang independently of the WS-close path.

```ts
const SHUTDOWN_DEADLINE_MS = 10_000;
const shutdown = async () => {
  const deadline = setTimeout(() => {
    logger.error({deadlineMs: SHUTDOWN_DEADLINE_MS}, 'Shutdown deadline hit, force exiting');
    logger.flush();
    process.exit(1);
  }, SHUTDOWN_DEADLINE_MS);
  deadline.unref();
  try { … } finally { clearTimeout(deadline); … }
};
```

## Operational note

Production worker is currently in the dead state described above. After this PR ships and you redeploy, recovery is automatic on the next disconnect. To recover **immediately** without waiting for the deploy, restart the worker manually:

```
ssh root@95.217.148.47 'dokku ps:restart trading-signals'
```

I can run that on your behalf if you want — say the word.