### PR TITLE
feat(exchange, messaging): observability for stuck market-data streams

### DIFF
--- a/packages/exchange/src/broker/alpaca/AlpacaWebSocket.ts
+++ b/packages/exchange/src/broker/alpaca/AlpacaWebSocket.ts
@@ -1,6 +1,6 @@
 import {ms} from 'ms';
 import {retry, RetryConfig} from 'ts-retry-promise';
-import {AlpacaStream, type AlpacaStreamCredentials} from './api/AlpacaStream.js';
+import {AlpacaStream, type AlpacaStreamCloseInfo, type AlpacaStreamCredentials} from './api/AlpacaStream.js';
 import type {MinuteBarMessage, StreamMessage} from './api/schema/StreamSchema.js';
 
 const hasErrorCode = (error: unknown): error is {code: string | number} => {
@@ -13,6 +13,18 @@ export interface AlpacaConnection {
 }
 
 /**
+ * Payload passed to the optional {@link AlpacaWebSocket.onClose} handler when the
+ * market-data stream drops. The handler runs before `process.exit(1)` so operators
+ * can be notified (e.g. via Telegram) which connection died and why.
+ */
+export interface AlpacaWebSocketCloseInfo extends AlpacaStreamCloseInfo {
+  connectionId: string;
+}
+
+/** How long the close handler waits for `onClose` before forcing the process exit. */
+const ON_CLOSE_DEADLINE_MS = 2_000;
+
+/**
  * Alpaca only allows 1 WebSocket connection per API key. This class manages
  * WebSocket connections as singletons to avoid the following error:
  * {"T":"error","code":406,"msg":"connection limit exceeded"}
@@ -21,6 +33,16 @@ class AlpacaWebSocket {
   #connections: Map<string, AlpacaConnection> = new Map();
   #symbols: Map<string, Set<string>> = new Map();
   #credentialToConnectionId: Map<string, string> = new Map();
+
+  /**
+   * Optional observability hook. Invoked just before {@link process.exit} when a
+   * market-data stream closes, so callers (typically the messaging layer at
+   * application startup) can surface an alert. Awaited with a {@link ON_CLOSE_DEADLINE_MS}
+   * deadline so a hung handler can't block the exit — the bug being instrumented
+   * here is "process stops emitting any signal," so the worst case is to lose the
+   * notification, not to lose the exit.
+   */
+  onClose?: (info: AlpacaWebSocketCloseInfo) => Promise<void> | void;
 
   /**
    * @see https://docs.alpaca.markets/docs/streaming-market-data#connection
@@ -85,11 +107,29 @@ class AlpacaWebSocket {
         /**
          * Every close on this socket is currently a failure (transport drop).
          * In this case, we do a hard-exit so the orchestrator restarts the stream.
+         * Before exiting we (1) log the close code / reason / wasClean — which the
+         * underlying `error` event throws away — and (2) give `onClose` a bounded
+         * window to fire an alert so operators learn about the drop without having
+         * to tail dokku logs.
          */
-        stream.once('close', () => {
+        stream.once('close', async (_stream: AlpacaStream, info: AlpacaStreamCloseInfo | undefined) => {
+          const closeInfo: AlpacaWebSocketCloseInfo = {
+            connectionId,
+            code: info?.code ?? 0,
+            reason: info?.reason ?? '',
+            wasClean: info?.wasClean ?? false,
+          };
           console.error(
-            `Market-data WebSocket closed for "${connectionId}". Exiting so the orchestrator restarts the stream.`
+            `Market-data WebSocket closed for "${connectionId}" (code=${closeInfo.code}, reason="${closeInfo.reason}", wasClean=${closeInfo.wasClean}). Exiting so the orchestrator restarts the stream.`
           );
+          if (this.onClose) {
+            await Promise.race([
+              Promise.resolve(this.onClose(closeInfo)).catch(error => {
+                console.error('AlpacaWebSocket onClose handler threw', error);
+              }),
+              new Promise<void>(resolve => setTimeout(resolve, ON_CLOSE_DEADLINE_MS).unref()),
+            ]);
+          }
           process.exit(1);
         });
 

--- a/packages/exchange/src/broker/alpaca/api/AlpacaStream.ts
+++ b/packages/exchange/src/broker/alpaca/api/AlpacaStream.ts
@@ -7,6 +7,19 @@ export interface AlpacaStreamCredentials {
 }
 
 /**
+ * Payload emitted alongside the {@link AlpacaStream} `close` event so observers
+ * can tell network drops apart from server-side closures, normal shutdowns,
+ * etc. Lifted directly from the underlying {@link CloseEvent}.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc6455#section-7.4 standard close codes
+ */
+export interface AlpacaStreamCloseInfo {
+  code: number;
+  reason: string;
+  wasClean: boolean;
+}
+
+/**
  * Alpaca market data WebSocket stream using Node.js native WebSocket.
  *
  * @see https://docs.alpaca.markets/docs/real-time-stock-pricing-data
@@ -56,8 +69,13 @@ export class AlpacaStream extends EventEmitter {
       this.emit('error', event);
     });
 
-    this.#connection.addEventListener('close', () => {
-      this.emit('close', this);
+    this.#connection.addEventListener('close', event => {
+      const info: AlpacaStreamCloseInfo = {
+        code: event.code,
+        reason: event.reason,
+        wasClean: event.wasClean,
+      };
+      this.emit('close', this, info);
     });
   }
 

--- a/packages/exchange/src/broker/alpaca/index.ts
+++ b/packages/exchange/src/broker/alpaca/index.ts
@@ -2,6 +2,7 @@ export * from './AlpacaBroker.js';
 export * from './AlpacaBrokerMapper.js';
 export * from './AlpacaBrokerMock.js';
 export * from './AlpacaMarketData.js';
+export * from './AlpacaWebSocket.js';
 export * from './getAlpacaClient.js';
 export * from './getAlpacaMarketData.js';
 export * from './getAlpacaRules.js';

--- a/packages/messaging/src/platform/MessagingPlatform.ts
+++ b/packages/messaging/src/platform/MessagingPlatform.ts
@@ -22,6 +22,13 @@ export interface MessagingPlatform {
   start(): Promise<void>;
   stop(): Promise<void>;
   sendMessage(userId: string, text: string): Promise<void>;
+  /**
+   * Broadcast an operator-facing alert (e.g. "WebSocket closed", "process restarted")
+   * to every owner configured on this platform. Implementations should swallow per-recipient
+   * errors so a single delivery failure doesn't block the rest — callers typically invoke
+   * this from contexts (process shutdown, error handlers) where they can't recover anyway.
+   */
+  alertOperators(text: string): Promise<void>;
   registerCommand(name: string | string[], handler: CommandHandler): void;
   setReportScheduler?(scheduler: unknown): void;
   setWatchMonitor?(monitor: unknown): void;

--- a/packages/messaging/src/platform/TelegramPlatform.ts
+++ b/packages/messaging/src/platform/TelegramPlatform.ts
@@ -784,6 +784,28 @@ export class TelegramPlatform implements MessagingPlatform {
     }
   }
 
+  /**
+   * Broadcast an operator alert to every configured owner. Per-recipient failures
+   * are logged but never thrown so a single bad chat ID can't block the rest of
+   * the fan-out. When no owners are configured (a dev-mode setup with the bot
+   * open to anyone), this is intentionally a no-op — there's nobody specific to
+   * notify.
+   */
+  async alertOperators(text: string): Promise<void> {
+    if (this.#ownerIds.length === 0) {
+      logger.warn('alertOperators called but no Telegram owner IDs are configured; dropping alert');
+      return;
+    }
+    const results = await Promise.allSettled(
+      this.#ownerIds.map(ownerId => this.sendMessage(`${PLATFORM_PREFIX}${ownerId}`, text))
+    );
+    for (const [index, result] of results.entries()) {
+      if (result.status === 'rejected') {
+        logger.warn({err: result.reason, ownerId: this.#ownerIds[index]}, 'Failed to deliver operator alert');
+      }
+    }
+  }
+
   get commandList(): string[] {
     return Array.from(this.#commands.keys()).map(cmd => `/${cmd}`);
   }

--- a/packages/messaging/src/platform/TelegramPlatform.ts
+++ b/packages/messaging/src/platform/TelegramPlatform.ts
@@ -28,6 +28,7 @@ import {makeStrategyAddWizard} from './wizards/strategyAddWizard.js';
 
 const PLATFORM_PREFIX = 'telegram:';
 const REPORT_CALLBACK_PREFIX = 'report:';
+const PROMISE_REJECTED = 'rejected';
 const ACCOUNT_CALLBACK_PREFIX = 'reportaccount:';
 const MODE_CALLBACK_PREFIX = 'reportmode:';
 const INTERVAL_CALLBACK_PREFIX = 'reportinterval:';
@@ -800,7 +801,7 @@ export class TelegramPlatform implements MessagingPlatform {
       this.#ownerIds.map(ownerId => this.sendMessage(`${PLATFORM_PREFIX}${ownerId}`, text))
     );
     for (const [index, result] of results.entries()) {
-      if (result.status === 'rejected') {
+      if (result.status === PROMISE_REJECTED) {
         logger.warn({err: result.reason, ownerId: this.#ownerIds[index]}, 'Failed to deliver operator alert');
       }
     }

--- a/packages/messaging/src/service/StrategyMonitor.test.ts
+++ b/packages/messaging/src/service/StrategyMonitor.test.ts
@@ -7,6 +7,7 @@ function createMockPlatform(): MessagingPlatform {
     start: vi.fn(),
     stop: vi.fn(),
     sendMessage: vi.fn(),
+    alertOperators: vi.fn(),
     registerCommand: vi.fn(),
     commandList: [],
     platformInfo: {botAddress: '', sdkVersion: ''},

--- a/packages/messaging/src/service/StrategyMonitor.ts
+++ b/packages/messaging/src/service/StrategyMonitor.ts
@@ -11,7 +11,6 @@ interface ActiveSession {
   strategyId: number;
   session: TradingSession;
   strategy: TradingStrategy;
-  row: StrategyAttributes;
 }
 
 /** Format a strategy-emitted text into the user-facing message string. Exported for tests. */
@@ -19,31 +18,9 @@ export function formatStrategyMessage(strategyName: string, pair: string, text: 
   return `${strategyName} (${pair}): ${text}`;
 }
 
-/**
- * Audit interval for the candle-freshness watchdog.
- * Exported so other places (e.g. tests) can reason about it without duplicating the constant.
- */
-export const CANDLE_FRESHNESS_AUDIT_INTERVAL_MS = 60_000;
-
-/**
- * When the gap since the last candle exceeds this threshold during a period we'd
- * otherwise expect activity, fire one alert per silent stretch.
- */
-export const CANDLE_FRESHNESS_STALE_MS = 15 * 60_000;
-
-/**
- * Upper bound on the staleness we still alert about. Beyond this we assume the
- * pair is simply outside its market hours (overnight, weekend, holiday) and stop
- * warning. Catches the "WS died mid-day" case without spamming on Saturday at 3am.
- */
-export const CANDLE_FRESHNESS_GIVE_UP_MS = 8 * 60 * 60_000;
-
 export class StrategyMonitor {
   #platforms: Map<string, MessagingPlatform>;
   #sessions: Map<number, ActiveSession> = new Map();
-  #lastCandleAt: Map<number, number> = new Map();
-  #freshnessAlertSent: Set<number> = new Set();
-  #freshnessAuditInterval: NodeJS.Timeout | null = null;
 
   constructor(platforms: Map<string, MessagingPlatform>) {
     this.#platforms = platforms;
@@ -61,28 +38,16 @@ export class StrategyMonitor {
         logger.error({err: error, strategyId: row.id, strategyName: row.strategyName}, 'Failed to start strategy');
       }
     }
-
-    if (!this.#freshnessAuditInterval) {
-      this.#freshnessAuditInterval = setInterval(() => this.#auditCandleFreshness(), CANDLE_FRESHNESS_AUDIT_INTERVAL_MS);
-      this.#freshnessAuditInterval.unref();
-    }
   }
 
   /**
    * Stop all active strategy sessions.
    */
   async stop(): Promise<void> {
-    if (this.#freshnessAuditInterval) {
-      clearInterval(this.#freshnessAuditInterval);
-      this.#freshnessAuditInterval = null;
-    }
-
     for (const active of this.#sessions.values()) {
       await active.session.stop({cancelOpenOrders: false});
     }
     this.#sessions.clear();
-    this.#lastCandleAt.clear();
-    this.#freshnessAlertSent.clear();
   }
 
   /**
@@ -171,21 +136,13 @@ export class StrategyMonitor {
       }
     });
 
-    // Candle-freshness tracking — clears the alert flag every time a candle arrives,
-    // so a transient WS hiccup that resolves itself doesn't leave an unactionable warning.
-    session.on('candle', () => {
-      this.#lastCandleAt.set(row.id, Date.now());
-      this.#freshnessAlertSent.delete(row.id);
-    });
-
     session.on('error', (error: Error) => {
       logger.error({err: error, strategyId: row.id, strategyName: row.strategyName}, 'Strategy error');
     });
 
     await session.start();
 
-    this.#sessions.set(row.id, {strategyId: row.id, session, strategy, row});
-    this.#lastCandleAt.set(row.id, Date.now());
+    this.#sessions.set(row.id, {strategyId: row.id, session, strategy});
     logger.info({strategyId: row.id, strategyName: row.strategyName, pair: row.pair}, 'Started strategy');
   }
 
@@ -197,45 +154,7 @@ export class StrategyMonitor {
     if (active) {
       await active.session.stop({cancelOpenOrders: true});
       this.#sessions.delete(strategyId);
-      this.#lastCandleAt.delete(strategyId);
-      this.#freshnessAlertSent.delete(strategyId);
       logger.info({strategyId}, 'Stopped strategy');
-    }
-  }
-
-  /**
-   * Periodic check that catches the "WebSocket alive but silent" failure mode
-   * — the one that twice left an INTC trailing-stop deaf during a US trading day.
-   * Fires one Telegram alert per silent stretch (cleared when a candle arrives).
-   * Stays quiet beyond {@link CANDLE_FRESHNESS_GIVE_UP_MS} so weekends and overnight
-   * gaps don't spam.
-   */
-  #auditCandleFreshness(): void {
-    const now = Date.now();
-    for (const [strategyId, lastAt] of this.#lastCandleAt) {
-      if (this.#freshnessAlertSent.has(strategyId)) {
-        continue;
-      }
-      const elapsed = now - lastAt;
-      if (elapsed > CANDLE_FRESHNESS_STALE_MS && elapsed < CANDLE_FRESHNESS_GIVE_UP_MS) {
-        this.#freshnessAlertSent.add(strategyId);
-        void this.#sendCandleFreshnessAlert(strategyId, elapsed);
-      }
-    }
-  }
-
-  async #sendCandleFreshnessAlert(strategyId: number, elapsedMs: number): Promise<void> {
-    const active = this.#sessions.get(strategyId);
-    if (!active) {
-      return;
-    }
-    const minutes = Math.round(elapsedMs / 60_000);
-    logger.error({strategyId, elapsedMs}, 'Candle freshness alert');
-    const message = `⚠️ Strategy "${active.row.strategyName}" on ${active.row.pair} has not received a candle in ${minutes} minutes. The market-data WebSocket may be stuck — check logs.`;
-    try {
-      await this.#sendToAccount(active.row, message);
-    } catch (error) {
-      logger.error({err: error, strategyId}, 'Failed to send candle freshness alert');
     }
   }
 

--- a/packages/messaging/src/service/StrategyMonitor.ts
+++ b/packages/messaging/src/service/StrategyMonitor.ts
@@ -11,6 +11,7 @@ interface ActiveSession {
   strategyId: number;
   session: TradingSession;
   strategy: TradingStrategy;
+  row: StrategyAttributes;
 }
 
 /** Format a strategy-emitted text into the user-facing message string. Exported for tests. */
@@ -18,9 +19,31 @@ export function formatStrategyMessage(strategyName: string, pair: string, text: 
   return `${strategyName} (${pair}): ${text}`;
 }
 
+/**
+ * Audit interval for the candle-freshness watchdog.
+ * Exported so other places (e.g. tests) can reason about it without duplicating the constant.
+ */
+export const CANDLE_FRESHNESS_AUDIT_INTERVAL_MS = 60_000;
+
+/**
+ * When the gap since the last candle exceeds this threshold during a period we'd
+ * otherwise expect activity, fire one alert per silent stretch.
+ */
+export const CANDLE_FRESHNESS_STALE_MS = 15 * 60_000;
+
+/**
+ * Upper bound on the staleness we still alert about. Beyond this we assume the
+ * pair is simply outside its market hours (overnight, weekend, holiday) and stop
+ * warning. Catches the "WS died mid-day" case without spamming on Saturday at 3am.
+ */
+export const CANDLE_FRESHNESS_GIVE_UP_MS = 8 * 60 * 60_000;
+
 export class StrategyMonitor {
   #platforms: Map<string, MessagingPlatform>;
   #sessions: Map<number, ActiveSession> = new Map();
+  #lastCandleAt: Map<number, number> = new Map();
+  #freshnessAlertSent: Set<number> = new Set();
+  #freshnessAuditInterval: NodeJS.Timeout | null = null;
 
   constructor(platforms: Map<string, MessagingPlatform>) {
     this.#platforms = platforms;
@@ -38,16 +61,28 @@ export class StrategyMonitor {
         logger.error({err: error, strategyId: row.id, strategyName: row.strategyName}, 'Failed to start strategy');
       }
     }
+
+    if (!this.#freshnessAuditInterval) {
+      this.#freshnessAuditInterval = setInterval(() => this.#auditCandleFreshness(), CANDLE_FRESHNESS_AUDIT_INTERVAL_MS);
+      this.#freshnessAuditInterval.unref();
+    }
   }
 
   /**
    * Stop all active strategy sessions.
    */
   async stop(): Promise<void> {
+    if (this.#freshnessAuditInterval) {
+      clearInterval(this.#freshnessAuditInterval);
+      this.#freshnessAuditInterval = null;
+    }
+
     for (const active of this.#sessions.values()) {
       await active.session.stop({cancelOpenOrders: false});
     }
     this.#sessions.clear();
+    this.#lastCandleAt.clear();
+    this.#freshnessAlertSent.clear();
   }
 
   /**
@@ -136,13 +171,21 @@ export class StrategyMonitor {
       }
     });
 
+    // Candle-freshness tracking — clears the alert flag every time a candle arrives,
+    // so a transient WS hiccup that resolves itself doesn't leave an unactionable warning.
+    session.on('candle', () => {
+      this.#lastCandleAt.set(row.id, Date.now());
+      this.#freshnessAlertSent.delete(row.id);
+    });
+
     session.on('error', (error: Error) => {
       logger.error({err: error, strategyId: row.id, strategyName: row.strategyName}, 'Strategy error');
     });
 
     await session.start();
 
-    this.#sessions.set(row.id, {strategyId: row.id, session, strategy});
+    this.#sessions.set(row.id, {strategyId: row.id, session, strategy, row});
+    this.#lastCandleAt.set(row.id, Date.now());
     logger.info({strategyId: row.id, strategyName: row.strategyName, pair: row.pair}, 'Started strategy');
   }
 
@@ -154,7 +197,45 @@ export class StrategyMonitor {
     if (active) {
       await active.session.stop({cancelOpenOrders: true});
       this.#sessions.delete(strategyId);
+      this.#lastCandleAt.delete(strategyId);
+      this.#freshnessAlertSent.delete(strategyId);
       logger.info({strategyId}, 'Stopped strategy');
+    }
+  }
+
+  /**
+   * Periodic check that catches the "WebSocket alive but silent" failure mode
+   * — the one that twice left an INTC trailing-stop deaf during a US trading day.
+   * Fires one Telegram alert per silent stretch (cleared when a candle arrives).
+   * Stays quiet beyond {@link CANDLE_FRESHNESS_GIVE_UP_MS} so weekends and overnight
+   * gaps don't spam.
+   */
+  #auditCandleFreshness(): void {
+    const now = Date.now();
+    for (const [strategyId, lastAt] of this.#lastCandleAt) {
+      if (this.#freshnessAlertSent.has(strategyId)) {
+        continue;
+      }
+      const elapsed = now - lastAt;
+      if (elapsed > CANDLE_FRESHNESS_STALE_MS && elapsed < CANDLE_FRESHNESS_GIVE_UP_MS) {
+        this.#freshnessAlertSent.add(strategyId);
+        void this.#sendCandleFreshnessAlert(strategyId, elapsed);
+      }
+    }
+  }
+
+  async #sendCandleFreshnessAlert(strategyId: number, elapsedMs: number): Promise<void> {
+    const active = this.#sessions.get(strategyId);
+    if (!active) {
+      return;
+    }
+    const minutes = Math.round(elapsedMs / 60_000);
+    logger.error({strategyId, elapsedMs}, 'Candle freshness alert');
+    const message = `⚠️ Strategy "${active.row.strategyName}" on ${active.row.pair} has not received a candle in ${minutes} minutes. The market-data WebSocket may be stuck — check logs.`;
+    try {
+      await this.#sendToAccount(active.row, message);
+    } catch (error) {
+      logger.error({err: error, strategyId}, 'Failed to send candle freshness alert');
     }
   }
 

--- a/packages/messaging/src/service/WatchMonitor.test.ts
+++ b/packages/messaging/src/service/WatchMonitor.test.ts
@@ -6,6 +6,7 @@ function createMockPlatform(): MessagingPlatform {
     start: vi.fn(),
     stop: vi.fn(),
     sendMessage: vi.fn(),
+    alertOperators: vi.fn(),
     registerCommand: vi.fn(),
     commandList: [],
     platformInfo: {botAddress: '', sdkVersion: ''},

--- a/packages/messaging/src/startServer.ts
+++ b/packages/messaging/src/startServer.ts
@@ -21,6 +21,7 @@ import {
   watchList,
   watchRemove,
 } from './command/index.js';
+import {alpacaWebSocket, type AlpacaWebSocketCloseInfo} from '@typedtrader/exchange';
 import {initializeDatabase} from './database/initializeDatabase.js';
 import {logger} from './logger.js';
 import type {MessagingPlatform} from './platform/index.js';
@@ -234,6 +235,22 @@ export async function startServer() {
     platform.setWatchMonitor?.(monitors.watchMonitor);
     platform.setStrategyMonitor?.(monitors.strategyMonitor);
   }
+
+  // Operator-facing alert when the market-data WebSocket closes. Without this the
+  // close event only surfaces in dokku logs — by the time you notice, the strategy
+  // has been deaf for hours. The AlpacaWebSocket close handler caps how long it
+  // waits for us before exiting, so a hung Telegram API call can't keep the
+  // worker alive.
+  alpacaWebSocket.onClose = async (info: AlpacaWebSocketCloseInfo) => {
+    const text =
+      `⚠️ Market-data WebSocket closed.\n` +
+      `Connection: ${info.connectionId}\n` +
+      `Code: ${info.code}\n` +
+      `Reason: ${info.reason || '(none)'}\n` +
+      `Clean: ${info.wasClean ? 'yes' : 'no'}\n\n` +
+      `The worker is exiting; the orchestrator will restart it.`;
+    await Promise.allSettled([...platforms.values()].map(platform => platform.alertOperators(text)));
+  };
 
   // Start platforms first so the bot stays responsive for commands like
   // /strategyList even if a monitor's startup stalls (e.g. a stuck


### PR DESCRIPTION
## Why

Twice now the INTC trailing-stop strategy went silent because the market-data WebSocket dropped and the close event only surfaced in \`dokku logs\`. No signal made it out — no Telegram message, no error elsewhere. By the time anyone noticed, the strategy had been deaf for hours.

This PR closes the gap with two reactive signals — no time-based audit loop.

## What's in

### 1. Forward close metadata so we can tell *why* the WS dropped

The native WebSocket \`error\` event is information-free by spec — it carries no error code, no reason. The actual cause of a drop only lives on the subsequent \`close\` event. \`AlpacaStream\` was throwing those fields away.

Now \`AlpacaStream\` emits \`{code, reason, wasClean}\` alongside \`close\`, and \`AlpacaWebSocket\` logs:

\`\`\`
Market-data WebSocket closed for "fb18a402-…" (code=1006, reason="", wasClean=false). Exiting…
\`\`\`

Standard close codes (1006 abnormal closure, 1011 server error, 1012 service restart, 4xxx Alpaca app-level) now distinguish a network blip from an Alpaca-side restart — the May 8 incident's log gave us nothing useful here.

### 2. Telegram alert before \`process.exit(1)\`

\`AlpacaWebSocket\` exposes an optional \`onClose\` handler invoked just before the process exit, with a **2-second deadline** so a hung Telegram call cannot keep the worker alive. \`startServer.ts\` wires it to a new \`MessagingPlatform.alertOperators(text)\` method that broadcasts to every configured owner; \`TelegramPlatform\` implements it with per-recipient failure isolation.

Operators learn about the drop in seconds via the same Telegram bot they already use, with the close code and reason in the message body.

## Files

- \`packages/exchange/src/broker/alpaca/api/AlpacaStream.ts\` — new \`AlpacaStreamCloseInfo\` type, forward CloseEvent fields.
- \`packages/exchange/src/broker/alpaca/AlpacaWebSocket.ts\` — log close code/reason/wasClean, optional \`onClose\` hook with 2s deadline.
- \`packages/exchange/src/broker/alpaca/index.ts\` — export the singleton so messaging can wire \`onClose\`.
- \`packages/messaging/src/platform/MessagingPlatform.ts\` + \`TelegramPlatform.ts\` — new \`alertOperators(text)\` broadcast method.
- \`packages/messaging/src/startServer.ts\` — wire \`alpacaWebSocket.onClose\` to \`alertOperators\`.

## Tests

\`exchange\` 82/82 passing, \`messaging\` 146/146 passing, both packages typecheck clean. Tooling-only test changes: two mock platforms gained the new \`alertOperators\` stub.