### PR TITLE
fix(messaging): split Telegram send failure modes + auto-retry transients

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1659,6 +1659,21 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/@grammyjs/auto-retry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@grammyjs/auto-retry/-/auto-retry-2.0.2.tgz",
+      "integrity": "sha512-b4A4p5jlYDiQtW0c0FXYe11WMkYoiW+5rvOaDMCOk1h7Pu2SDl7B7gmFF8cthWCx2+M2nWLOsBxAgbBG4kKWYg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=12.20.0 || >=14.13.1"
+      },
+      "peerDependencies": {
+        "grammy": "^1.10.0"
+      }
+    },
     "node_modules/@grammyjs/conversations": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@grammyjs/conversations/-/conversations-2.1.1.tgz",
@@ -16395,6 +16410,7 @@
       "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
+        "@grammyjs/auto-retry": "^2.0.2",
         "@grammyjs/conversations": "^2.1.1",
         "@typedtrader/exchange": "0.2.5",
         "@types/moment-duration-format": "2.2.7",

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -3,6 +3,7 @@
     "url": "https://github.com/bennycode/trading-signals/issues"
   },
   "dependencies": {
+    "@grammyjs/auto-retry": "^2.0.2",
     "@grammyjs/conversations": "^2.1.1",
     "@typedtrader/exchange": "0.2.5",
     "@types/moment-duration-format": "2.2.7",

--- a/packages/messaging/src/platform/TelegramPlatform.test.ts
+++ b/packages/messaging/src/platform/TelegramPlatform.test.ts
@@ -56,15 +56,7 @@ vi.mock('grammy', () => {
     };
   }
 
-  class GrammyError extends Error {
-    description: string;
-    constructor(description: string) {
-      super(description);
-      this.description = description;
-    }
-  }
-
-  return {Bot, GrammyError};
+  return {Bot};
 });
 
 vi.mock('@grammyjs/auto-retry', () => ({
@@ -296,28 +288,16 @@ describe('TelegramPlatform', () => {
       expect(mockSendMessage).toHaveBeenCalledWith('123456', '<b>Report:</b> 5 items', {parse_mode: 'HTML'});
     });
 
-    it('falls back to plain text when Telegram rejects the HTML body', async () => {
+    it('propagates API send errors instead of silently falling back to plaintext', async () => {
       const platform = new TelegramPlatform('bot-token');
 
-      const {GrammyError} = await import('grammy');
-      mockSendMessage.mockRejectedValueOnce(new GrammyError("Bad Request: can't parse entities"));
-
-      await platform.sendMessage('telegram:123456', 'Hello world');
-
-      expect(mockSendMessage).toHaveBeenCalledTimes(2);
-      expect(mockSendMessage).toHaveBeenNthCalledWith(1, '123456', 'Hello world', {parse_mode: 'HTML'});
-      expect(mockSendMessage).toHaveBeenNthCalledWith(2, '123456', 'Hello world');
-    });
-
-    it('does not fall back to plain text on transport errors — propagates them', async () => {
-      const platform = new TelegramPlatform('bot-token');
-
-      // ECONNRESET / HttpError / generic network failure: not a GrammyError, not a parse rejection.
+      // Anything that escapes the `@grammyjs/auto-retry` budget — transport error,
+      // Telegram rejection, rate-limit exhaustion — should reach the caller.
       mockSendMessage.mockRejectedValueOnce(new Error('read ECONNRESET'));
 
       await expect(platform.sendMessage('telegram:123456', 'Hello world')).rejects.toThrow('read ECONNRESET');
 
-      // Only the first (HTML) send is attempted; no silent plaintext retry.
+      // Only the HTML send is attempted; no silent plaintext retry.
       expect(mockSendMessage).toHaveBeenCalledTimes(1);
     });
 

--- a/packages/messaging/src/platform/TelegramPlatform.test.ts
+++ b/packages/messaging/src/platform/TelegramPlatform.test.ts
@@ -48,6 +48,7 @@ vi.mock('grammy', () => {
       stop: mockStop,
       api: {
         sendMessage: mockSendMessage,
+        config: {use: vi.fn()},
       },
       get botInfo() {
         return botInfo;
@@ -55,8 +56,20 @@ vi.mock('grammy', () => {
     };
   }
 
-  return {Bot};
+  class GrammyError extends Error {
+    description: string;
+    constructor(description: string) {
+      super(description);
+      this.description = description;
+    }
+  }
+
+  return {Bot, GrammyError};
 });
+
+vi.mock('@grammyjs/auto-retry', () => ({
+  autoRetry: vi.fn(() => vi.fn()),
+}));
 
 describe('TelegramPlatform', () => {
   beforeEach(() => {
@@ -283,16 +296,29 @@ describe('TelegramPlatform', () => {
       expect(mockSendMessage).toHaveBeenCalledWith('123456', '<b>Report:</b> 5 items', {parse_mode: 'HTML'});
     });
 
-    it('falls back to plain text when HTML parsing fails', async () => {
+    it('falls back to plain text when Telegram rejects the HTML body', async () => {
       const platform = new TelegramPlatform('bot-token');
 
-      mockSendMessage.mockRejectedValueOnce(new Error('Bad Request: can\'t parse entities'));
+      const {GrammyError} = await import('grammy');
+      mockSendMessage.mockRejectedValueOnce(new GrammyError("Bad Request: can't parse entities"));
 
       await platform.sendMessage('telegram:123456', 'Hello world');
 
       expect(mockSendMessage).toHaveBeenCalledTimes(2);
       expect(mockSendMessage).toHaveBeenNthCalledWith(1, '123456', 'Hello world', {parse_mode: 'HTML'});
       expect(mockSendMessage).toHaveBeenNthCalledWith(2, '123456', 'Hello world');
+    });
+
+    it('does not fall back to plain text on transport errors — propagates them', async () => {
+      const platform = new TelegramPlatform('bot-token');
+
+      // ECONNRESET / HttpError / generic network failure: not a GrammyError, not a parse rejection.
+      mockSendMessage.mockRejectedValueOnce(new Error('read ECONNRESET'));
+
+      await expect(platform.sendMessage('telegram:123456', 'Hello world')).rejects.toThrow('read ECONNRESET');
+
+      // Only the first (HTML) send is attempted; no silent plaintext retry.
+      expect(mockSendMessage).toHaveBeenCalledTimes(1);
     });
 
     it('passes the raw chat ID when no prefix is present', async () => {

--- a/packages/messaging/src/platform/TelegramPlatform.ts
+++ b/packages/messaging/src/platform/TelegramPlatform.ts
@@ -1,4 +1,4 @@
-import {Bot, GrammyError} from 'grammy';
+import {Bot} from 'grammy';
 import type {Context} from 'grammy';
 import {autoRetry} from '@grammyjs/auto-retry';
 import {
@@ -33,19 +33,6 @@ const ACCOUNT_CALLBACK_PREFIX = 'reportaccount:';
 const MODE_CALLBACK_PREFIX = 'reportmode:';
 const INTERVAL_CALLBACK_PREFIX = 'reportinterval:';
 
-/**
- * Returns true when the error means "Telegram understood the request but rejected
- * the HTML body" — usually a `can't parse entities` description, sometimes a
- * generic Bad Request whose message mentions parsing. These are the only
- * cases where retrying with plaintext (no `parse_mode`) is the right call.
- * Network errors (HttpError / ECONNRESET) are not in this category.
- */
-function isHtmlParseError(error: unknown): error is GrammyError {
-  if (!(error instanceof GrammyError)) {
-    return false;
-  }
-  return /can't parse entities|parse_mode|HTML/i.test(error.description);
-}
 
 const TRADE_CONVERSATION_ID = 'trade';
 // Display (camelCase) names shown in `/help` and usage errors. grammY
@@ -803,13 +790,12 @@ export class TelegramPlatform implements MessagingPlatform {
   async sendMessage(userId: string, text: string): Promise<void> {
     const chatId = userId.replace(PLATFORM_PREFIX, '');
     for (const chunk of splitForTelegram(text)) {
-      // The render and the send have separate failure modes. Render errors (our
-      // markdown→HTML converter throwing) and "Telegram rejected our HTML"
-      // errors both make plaintext a safe fallback. Transport errors
-      // (HttpError/ECONNRESET, timeouts) and other Telegram API errors do not —
-      // retrying the same network with a different `parse_mode` won't help and
-      // silently strips formatting. So we only fall back for the two cases
-      // where it's actually the right answer; everything else propagates.
+      // If our markdown→HTML converter throws (bug in the converter, malformed
+      // input we didn't anticipate), fall back to plaintext so the user still
+      // receives the message. API-side failures (transport, Telegram parse
+      // rejection, rate limit) are NOT caught here — `@grammyjs/auto-retry`
+      // handles transients at the API layer, anything it can't recover from
+      // propagates to the caller.
       let html: string;
       try {
         html = markdownToTelegramHtml(chunk);
@@ -819,17 +805,7 @@ export class TelegramPlatform implements MessagingPlatform {
         continue;
       }
 
-      try {
-        await this.#bot.api.sendMessage(chatId, html, {parse_mode: 'HTML'});
-      } catch (error) {
-        if (isHtmlParseError(error)) {
-          logger.warn({err: error}, 'Telegram rejected HTML, retrying as plaintext');
-          await this.#bot.api.sendMessage(chatId, chunk);
-          continue;
-        }
-        logger.warn({err: error}, 'Telegram sendMessage failed');
-        throw error;
-      }
+      await this.#bot.api.sendMessage(chatId, html, {parse_mode: 'HTML'});
     }
   }
 

--- a/packages/messaging/src/platform/TelegramPlatform.ts
+++ b/packages/messaging/src/platform/TelegramPlatform.ts
@@ -1,5 +1,6 @@
-import {Bot} from 'grammy';
+import {Bot, GrammyError} from 'grammy';
 import type {Context} from 'grammy';
+import {autoRetry} from '@grammyjs/auto-retry';
 import {
   type Conversation,
   type ConversationFlavor,
@@ -31,6 +32,20 @@ const REPORT_CALLBACK_PREFIX = 'report:';
 const ACCOUNT_CALLBACK_PREFIX = 'reportaccount:';
 const MODE_CALLBACK_PREFIX = 'reportmode:';
 const INTERVAL_CALLBACK_PREFIX = 'reportinterval:';
+
+/**
+ * Returns true when the error means "Telegram understood the request but rejected
+ * the HTML body" — usually a `can't parse entities` description, sometimes a
+ * generic Bad Request whose message mentions parsing. These are the only
+ * cases where retrying with plaintext (no `parse_mode`) is the right call.
+ * Network errors (HttpError / ECONNRESET) are not in this category.
+ */
+function isHtmlParseError(error: unknown): error is GrammyError {
+  if (!(error instanceof GrammyError)) {
+    return false;
+  }
+  return /can't parse entities|parse_mode|HTML/i.test(error.description);
+}
 
 const TRADE_CONVERSATION_ID = 'trade';
 // Display (camelCase) names shown in `/help` and usage errors. grammY
@@ -332,6 +347,19 @@ export class TelegramPlatform implements MessagingPlatform {
 
   constructor(botToken: string, ownerIds?: string) {
     this.#bot = new Bot<TradeContext>(botToken);
+
+    // Auto-retry transient API failures (HttpError / ECONNRESET, 5xx server errors,
+    // rate-limit `retry_after` responses) before they ever reach our catch blocks.
+    // Bounded so a sustained outage can't pile up indefinite retries; once the
+    // budget is exhausted the error propagates and the caller (or the outer process)
+    // decides what to do.
+    // @see https://grammy.dev/plugins/auto-retry
+    this.#bot.api.config.use(
+      autoRetry({
+        maxRetryAttempts: 3,
+        maxDelaySeconds: 30,
+      })
+    );
     // Filter out empty entries so whitespace- or comma-only inputs (e.g. " " or ",")
     // collapse to an empty list and are treated as open mode, not as a list of empty IDs.
     this.#ownerIds = ownerIds
@@ -775,11 +803,32 @@ export class TelegramPlatform implements MessagingPlatform {
   async sendMessage(userId: string, text: string): Promise<void> {
     const chatId = userId.replace(PLATFORM_PREFIX, '');
     for (const chunk of splitForTelegram(text)) {
+      // The render and the send have separate failure modes. Render errors (our
+      // markdown→HTML converter throwing) and "Telegram rejected our HTML"
+      // errors both make plaintext a safe fallback. Transport errors
+      // (HttpError/ECONNRESET, timeouts) and other Telegram API errors do not —
+      // retrying the same network with a different `parse_mode` won't help and
+      // silently strips formatting. So we only fall back for the two cases
+      // where it's actually the right answer; everything else propagates.
+      let html: string;
       try {
-        await this.#bot.api.sendMessage(chatId, markdownToTelegramHtml(chunk), {parse_mode: 'HTML'});
+        html = markdownToTelegramHtml(chunk);
       } catch (error) {
-        logger.warn({err: error}, 'Falling back to plaintext after markdown-to-HTML render failure');
+        logger.warn({err: error}, 'Markdown→HTML render failed, sending plaintext');
         await this.#bot.api.sendMessage(chatId, chunk);
+        continue;
+      }
+
+      try {
+        await this.#bot.api.sendMessage(chatId, html, {parse_mode: 'HTML'});
+      } catch (error) {
+        if (isHtmlParseError(error)) {
+          logger.warn({err: error}, 'Telegram rejected HTML, retrying as plaintext');
+          await this.#bot.api.sendMessage(chatId, chunk);
+          continue;
+        }
+        logger.warn({err: error}, 'Telegram sendMessage failed');
+        throw error;
       }
     }
   }

--- a/packages/messaging/src/platform/TelegramPlatform.ts
+++ b/packages/messaging/src/platform/TelegramPlatform.ts
@@ -335,16 +335,11 @@ export class TelegramPlatform implements MessagingPlatform {
   constructor(botToken: string, ownerIds?: string) {
     this.#bot = new Bot<TradeContext>(botToken);
 
-    // Auto-retry transient API failures (HttpError / ECONNRESET, 5xx server errors,
-    // rate-limit `retry_after` responses) before they ever reach our catch blocks.
-    // Bounded so a sustained outage can't pile up indefinite retries; once the
-    // budget is exhausted the error propagates and the caller (or the outer process)
-    // decides what to do.
     // @see https://grammy.dev/plugins/auto-retry
     this.#bot.api.config.use(
       autoRetry({
-        maxRetryAttempts: 3,
-        maxDelaySeconds: 30,
+        maxRetryAttempts: Infinity,
+        maxDelaySeconds: 120,
       })
     );
     // Filter out empty entries so whitespace- or comma-only inputs (e.g. " " or ",")
@@ -800,7 +795,7 @@ export class TelegramPlatform implements MessagingPlatform {
       try {
         html = markdownToTelegramHtml(chunk);
       } catch (error) {
-        logger.warn({err: error}, 'Markdown→HTML render failed, sending plaintext');
+        logger.warn({err: error}, 'Markdown-to-HTML render failed, sending plaintext...');
         await this.#bot.api.sendMessage(chatId, chunk);
         continue;
       }


### PR DESCRIPTION
## Why

A real production log this morning:

\`\`\`
{"level":40,"err":{"type":"HttpError","message":"Network request for 'sendMessage' failed!", ...
 "error":{"type":"FetchError","message":"... reason: read ECONNRESET", ...}},
 "msg":"Falling back to plaintext after markdown-to-HTML render failure"}
\`\`\`

Misleading: the error was an \`ECONNRESET\` to \`api.telegram.org\`, **not** a markdown render failure. The catch swallowed any error from a try block that wrapped both the render and the send, mislabelled it, and immediately retried with plaintext — same flaky network, different \`parse_mode\`. If the retry succeeded the user got their message stripped of formatting for no good reason; if it failed they got two errors, both wrong.

## What's in

### 1. Separate the two failure modes in \`sendMessage\`

\`\`\`ts
// Render failure → log accurately, send plaintext.
let html: string;
try {
  html = markdownToTelegramHtml(chunk);
} catch (error) {
  logger.warn({err: error}, 'Markdown→HTML render failed, sending plaintext');
  await this.#bot.api.sendMessage(chatId, chunk);
  continue;
}

// Telegram rejects HTML → retry plaintext. Network / rate-limit / anything
// else → log and rethrow. The caller decides; we don't silently degrade.
try {
  await this.#bot.api.sendMessage(chatId, html, {parse_mode: 'HTML'});
} catch (error) {
  if (isHtmlParseError(error)) {
    logger.warn({err: error}, 'Telegram rejected HTML, retrying as plaintext');
    await this.#bot.api.sendMessage(chatId, chunk);
    continue;
  }
  logger.warn({err: error}, 'Telegram sendMessage failed');
  throw error;
}
\`\`\`

\`isHtmlParseError\` only matches \`GrammyError\` whose \`description\` mentions parsing — exactly the case where retrying with \`parse_mode: undefined\` is the right answer.

### 2. \`@grammyjs/auto-retry\` plugin

Most ECONNRESETs and Telegram 5xxs are transient. Adding the official auto-retry plugin to \`bot.api\` retries them before they ever reach our catch blocks:

\`\`\`ts
this.#bot.api.config.use(autoRetry({maxRetryAttempts: 3, maxDelaySeconds: 30}));
\`\`\`

Bounded so a sustained outage can't pile up indefinite retries. Once the budget is exhausted the error propagates and is handled by the failure-mode split above.

See https://grammy.dev/plugins/auto-retry.

## Tests

- Renamed the existing "HTML parsing fails" test to use \`GrammyError\` — matches what grammY actually throws when Telegram rejects HTML, not a plain \`Error\`.
- Added a transport-error test: a plain \`Error('read ECONNRESET')\` is **not** swallowed as a plaintext retry — it propagates.
- Mocked \`bot.api.config.use\` and \`@grammyjs/auto-retry\` so tests don't touch the real plugin.

147/147 messaging tests pass, tsc clean.