### PR TITLE
fix(exchange): treat already-filled orders as successfully canceled

### DIFF
--- a/packages/exchange/src/broker/alpaca/AlpacaBroker.test.ts
+++ b/packages/exchange/src/broker/alpaca/AlpacaBroker.test.ts
@@ -59,13 +59,7 @@ vi.mock('./AlpacaTradingWebSocket.js', () => ({
 // Import after mocking
 const {AlpacaBroker} = await import('./AlpacaBroker.js');
 const {AlpacaMarketData} = await import('./AlpacaMarketData.js');
-
-function createAxiosError(status: number, data: unknown) {
-  return Object.assign(new Error(`Request failed with status code ${status}`), {
-    isAxiosError: true,
-    response: {data, status},
-  });
-}
+const {SimplifiedHttpError} = await import('../../util/SimplifiedHttpError.js');
 
 describe.sequential('AlpacaBroker', () => {
   let exchange: InstanceType<typeof AlpacaBroker>;
@@ -363,7 +357,10 @@ describe.sequential('AlpacaBroker', () => {
     it('ignores orders that filled between fetching and canceling them', async () => {
       mockMethods.getOrders.mockResolvedValue([{id: 'open-1'}]);
       mockMethods.deleteOrder.mockRejectedValue(
-        createAxiosError(422, {code: 42210000, message: 'order is already in "filled" state'})
+        new SimplifiedHttpError({
+          data: {code: 42210000, message: 'order is already in "filled" state'},
+          status: 422,
+        })
       );
 
       const pair = new TradingPair('SHOP', 'USD');
@@ -374,11 +371,13 @@ describe.sequential('AlpacaBroker', () => {
 
     it('rethrows unexpected cancellation errors', async () => {
       mockMethods.getOrders.mockResolvedValue([{id: 'open-1'}]);
-      mockMethods.deleteOrder.mockRejectedValue(createAxiosError(500, {message: 'internal server error'}));
+      mockMethods.deleteOrder.mockRejectedValue(
+        new SimplifiedHttpError({data: {message: 'internal server error'}, status: 500})
+      );
 
       const pair = new TradingPair('SHOP', 'USD');
 
-      await expect(exchange.cancelOpenOrders(pair)).rejects.toThrow('Request failed with status code 500');
+      await expect(exchange.cancelOpenOrders(pair)).rejects.toThrow('500 Unknown Error');
     });
   });
 

--- a/packages/exchange/src/broker/alpaca/AlpacaBroker.test.ts
+++ b/packages/exchange/src/broker/alpaca/AlpacaBroker.test.ts
@@ -60,6 +60,13 @@ vi.mock('./AlpacaTradingWebSocket.js', () => ({
 const {AlpacaBroker} = await import('./AlpacaBroker.js');
 const {AlpacaMarketData} = await import('./AlpacaMarketData.js');
 
+function createAxiosError(status: number, data: unknown) {
+  return Object.assign(new Error(`Request failed with status code ${status}`), {
+    isAxiosError: true,
+    response: {data, status},
+  });
+}
+
 describe.sequential('AlpacaBroker', () => {
   let exchange: InstanceType<typeof AlpacaBroker>;
 
@@ -351,6 +358,27 @@ describe.sequential('AlpacaBroker', () => {
       expect(mockMethods.deleteOrder).toHaveBeenCalledTimes(2);
       expect(mockMethods.deleteOrder).toHaveBeenCalledWith('open-1');
       expect(mockMethods.deleteOrder).toHaveBeenCalledWith('open-2');
+    });
+
+    it('ignores orders that filled between fetching and canceling them', async () => {
+      mockMethods.getOrders.mockResolvedValue([{id: 'open-1'}]);
+      mockMethods.deleteOrder.mockRejectedValue(
+        createAxiosError(422, {code: 42210000, message: 'order is already in "filled" state'})
+      );
+
+      const pair = new TradingPair('SHOP', 'USD');
+      const canceledIds = await exchange.cancelOpenOrders(pair);
+
+      expect(canceledIds).toEqual(['open-1']);
+    });
+
+    it('rethrows unexpected cancellation errors', async () => {
+      mockMethods.getOrders.mockResolvedValue([{id: 'open-1'}]);
+      mockMethods.deleteOrder.mockRejectedValue(createAxiosError(500, {message: 'internal server error'}));
+
+      const pair = new TradingPair('SHOP', 'USD');
+
+      await expect(exchange.cancelOpenOrders(pair)).rejects.toThrow('Request failed with status code 500');
     });
   });
 

--- a/packages/exchange/src/broker/alpaca/AlpacaBroker.ts
+++ b/packages/exchange/src/broker/alpaca/AlpacaBroker.ts
@@ -1,4 +1,5 @@
 import {randomUUID} from 'node:crypto';
+import axios from 'axios';
 import Big from 'big.js';
 import {ms} from 'ms';
 import {AlpacaBrokerMapper} from './AlpacaBrokerMapper.js';
@@ -28,6 +29,20 @@ import {AlpacaAPI} from './api/AlpacaAPI.js';
 import {PositionSide} from './api/schema/PositionSchema.js';
 import {alpacaTradingWebSocket, type AlpacaTradingConnection} from './AlpacaTradingWebSocket.js';
 import {TradeUpdateEvent, type TradeUpdateMessage} from './api/schema/TradingStreamSchema.js';
+
+/**
+ * An open order can fill (or be canceled) between fetching it and issuing the cancel. Alpaca then
+ * responds with HTTP 422 "order is already in \"filled\" state" (or "canceled", "expired", ...).
+ */
+function isOrderAlreadyInactiveError(error: unknown): boolean {
+  if (!axios.isAxiosError(error) || error.response?.status !== 422) {
+    return false;
+  }
+  const data = error.response.data;
+  return (
+    !!data && typeof data === 'object' && 'message' in data && typeof data.message === 'string' && data.message.includes('already in')
+  );
+}
 
 export class AlpacaBroker extends Broker implements MarketDataSource {
   readonly #alpacaAPI: AlpacaAPI;
@@ -257,7 +272,14 @@ export class AlpacaBroker extends Broker implements MarketDataSource {
   }
 
   async cancelOrderById(_pair: TradingPair, orderId: string): Promise<void> {
-    await this.#alpacaAPI.deleteOrder(orderId);
+    try {
+      await this.#alpacaAPI.deleteOrder(orderId);
+    } catch (error) {
+      // The order is no longer open, which is the outcome a cancel aims for — treat it as success.
+      if (!isOrderAlreadyInactiveError(error)) {
+        throw error;
+      }
+    }
   }
 
   /** @see https://docs.alpaca.markets/reference/getallorders */

--- a/packages/exchange/src/broker/alpaca/AlpacaBroker.ts
+++ b/packages/exchange/src/broker/alpaca/AlpacaBroker.ts
@@ -34,7 +34,7 @@ import {TradeUpdateEvent, type TradeUpdateMessage} from './api/schema/TradingStr
  * Alpaca rejects to cancel already filled orders with:
  *
  * status: 422 Unprocessable Entity
- * body:   {"code":42210000,"message":"order is already in \"filled\" state"}
+ * body: {"code":42210000,"message":"order is already in \"filled\" state"}
  */
 function isAlreadyFilledOrder(error: unknown): boolean {
   if (!(error instanceof SimplifiedHttpError) || error.status !== 422) {

--- a/packages/exchange/src/broker/alpaca/AlpacaBroker.ts
+++ b/packages/exchange/src/broker/alpaca/AlpacaBroker.ts
@@ -1,7 +1,7 @@
 import {randomUUID} from 'node:crypto';
-import axios from 'axios';
 import Big from 'big.js';
 import {ms} from 'ms';
+import {SimplifiedHttpError} from '../../util/SimplifiedHttpError.js';
 import {AlpacaBrokerMapper} from './AlpacaBrokerMapper.js';
 import {
   Broker,
@@ -31,17 +31,17 @@ import {alpacaTradingWebSocket, type AlpacaTradingConnection} from './AlpacaTrad
 import {TradeUpdateEvent, type TradeUpdateMessage} from './api/schema/TradingStreamSchema.js';
 
 /**
- * An open order can fill (or be canceled) between fetching it and issuing the cancel. Alpaca then
- * responds with HTTP 422 "order is already in \"filled\" state" (or "canceled", "expired", ...).
+ * Alpaca rejects to cancel already filled orders with:
+ *
+ * status: 422 Unprocessable Entity
+ * body:   {"code":42210000,"message":"order is already in \"filled\" state"}
  */
-function isOrderAlreadyInactiveError(error: unknown): boolean {
-  if (!axios.isAxiosError(error) || error.response?.status !== 422) {
+function isAlreadyFilledOrder(error: unknown): boolean {
+  if (!(error instanceof SimplifiedHttpError) || error.status !== 422) {
     return false;
   }
-  const data = error.response.data;
-  return (
-    !!data && typeof data === 'object' && 'message' in data && typeof data.message === 'string' && data.message.includes('already in')
-  );
+  const data = error.data;
+  return !!data && typeof data === 'object' && 'code' in data && data.code === 42210000;
 }
 
 export class AlpacaBroker extends Broker implements MarketDataSource {
@@ -275,8 +275,7 @@ export class AlpacaBroker extends Broker implements MarketDataSource {
     try {
       await this.#alpacaAPI.deleteOrder(orderId);
     } catch (error) {
-      // The order is no longer open, which is the outcome a cancel aims for — treat it as success.
-      if (!isOrderAlreadyInactiveError(error)) {
+      if (!isAlreadyFilledOrder(error)) {
         throw error;
       }
     }
@@ -361,14 +360,8 @@ export class AlpacaBroker extends Broker implements MarketDataSource {
    *
    * @see https://docs.alpaca.markets/docs/working-with-orders#place-new-orders
    */
-  protected override async placeOrder(
-    pair: TradingPair,
-    options: LimitOrderOptions
-  ): Promise<PendingLimitOrder>;
-  protected override async placeOrder(
-    pair: TradingPair,
-    options: MarketOrderOptions
-  ): Promise<PendingMarketOrder>;
+  protected override async placeOrder(pair: TradingPair, options: LimitOrderOptions): Promise<PendingLimitOrder>;
+  protected override async placeOrder(pair: TradingPair, options: MarketOrderOptions): Promise<PendingMarketOrder>;
   protected override async placeOrder(pair: TradingPair, options: OrderOptions): Promise<PendingOrder> {
     const isCrypto = await isAlpacaCryptoSymbol(this.#alpacaAPI, pair);
     const symbol = createAlpacaSymbol(pair, isCrypto);
@@ -415,5 +408,4 @@ export class AlpacaBroker extends Broker implements MarketDataSource {
     const order = await this.#alpacaAPI.postOrder(config);
     return AlpacaBrokerMapper.toPendingOrder(order, pair, options);
   }
-
 }

--- a/packages/exchange/src/broker/alpaca/alpacaSymbol.ts
+++ b/packages/exchange/src/broker/alpaca/alpacaSymbol.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import {SimplifiedHttpError} from '../../util/SimplifiedHttpError.js';
 import type {AlpacaAPI} from './api/AlpacaAPI.js';
 import type {TradingPair} from '../TradingPair.js';
 
@@ -19,8 +19,7 @@ export async function isAlpacaCryptoSymbol(api: AlpacaAPI, pair: TradingPair) {
     const response = await api.getCryptoBarsLatest({symbols: createAlpacaSymbol(pair, true)});
     return Object.keys(response.bars).length > 0;
   } catch (error) {
-    const status = axios.isAxiosError(error) ? error.response?.status : undefined;
-    if (status && status >= 400 && status < 500) {
+    if (error instanceof SimplifiedHttpError && error.status >= 400 && error.status < 500) {
       return false;
     }
     throw error;

--- a/packages/exchange/src/util/SimplifiedHttpError.ts
+++ b/packages/exchange/src/util/SimplifiedHttpError.ts
@@ -1,0 +1,17 @@
+export class SimplifiedHttpError extends Error {
+  readonly status: number;
+  readonly data: unknown;
+  readonly url: string;
+
+  constructor(params: {status: number | undefined; statusText?: string; data: unknown; url?: string}) {
+    const status = params.status ?? 0;
+    const statusText = params.statusText ?? 'Unknown Error';
+    const url = params.url ?? 'Unknown URL';
+    const bodyText = typeof params.data === 'string' ? params.data : JSON.stringify(params.data);
+    super(`${status} ${statusText} at ${url}: ${bodyText}`);
+    this.name = 'SimplifiedHttpError';
+    this.status = status;
+    this.data = params.data;
+    this.url = url;
+  }
+}

--- a/packages/exchange/src/util/simplifyError.test.ts
+++ b/packages/exchange/src/util/simplifyError.test.ts
@@ -1,6 +1,7 @@
 import axios, {AxiosError, AxiosHeaders} from 'axios';
 import {describe, expect, it} from 'vitest';
 import {simplifyError} from './simplifyError.js';
+import {SimplifiedHttpError} from './SimplifiedHttpError.js';
 
 function createClientThatFailsWith(error: AxiosError) {
   const client = axios.create();
@@ -28,6 +29,29 @@ describe('simplifyError', () => {
     simplifyError(client);
 
     await expect(client.get('/whatever')).rejects.toBe(original);
+  });
+
+  it('exposes status, data and url on the rejected error so callers can introspect', async () => {
+    const client = createClientThatFailsWith(
+      buildAxiosError({
+        config: {headers: new AxiosHeaders(), url: 'https://api.alpaca.markets/v2/orders/abc'},
+        response: {
+          config: {headers: new AxiosHeaders()},
+          data: {code: 42210000, message: 'order is already in "filled" state'},
+          headers: {},
+          request: {res: {responseUrl: 'https://api.alpaca.markets/v2/orders/abc'}},
+          status: 422,
+          statusText: 'Unprocessable Entity',
+        },
+      })
+    );
+
+    await expect(client.get('/v2/orders/abc')).rejects.toMatchObject({
+      data: {code: 42210000, message: 'order is already in "filled" state'},
+      status: 422,
+      url: 'https://api.alpaca.markets/v2/orders/abc',
+    });
+    await expect(client.get('/v2/orders/abc')).rejects.toBeInstanceOf(SimplifiedHttpError);
   });
 
   it('does not leak credential headers via the rejected error', async () => {

--- a/packages/exchange/src/util/simplifyError.ts
+++ b/packages/exchange/src/util/simplifyError.ts
@@ -1,7 +1,8 @@
 import axios, {type AxiosInstance} from 'axios';
+import {SimplifiedHttpError} from './SimplifiedHttpError.js';
 
 /**
- * Registers a response interceptor that replaces rejected Axios errors with a plain `Error`.
+ * Registers a response interceptor that replaces rejected Axios errors with a {@link SimplifiedHttpError}.
  *
  * This strips the verbose Axios error bloat which can leak API keys and other
  * sensitive headers into anything that serialises the error (loggers, error trackers, stdout).
@@ -13,12 +14,14 @@ export function simplifyError(client: AxiosInstance) {
       if (!axios.isAxiosError(error)) {
         return Promise.reject(error);
       }
-      const url = error.response?.request?.res?.responseUrl ?? error.config?.url ?? 'Unknown URL';
-      const status = error.response?.status ?? 0;
-      const statusText = error.response?.statusText ?? 'Unknown Error';
-      const body = error.response?.data;
-      const bodyText = typeof body === 'string' ? body : JSON.stringify(body);
-      return Promise.reject(new Error(`${status} ${statusText} at ${url}: ${bodyText}`));
+      return Promise.reject(
+        new SimplifiedHttpError({
+          data: error.response?.data,
+          status: error.response?.status,
+          statusText: error.response?.statusText,
+          url: error.response?.request?.res?.responseUrl ?? error.config?.url,
+        })
+      );
     }
   );
 }


### PR DESCRIPTION
## Summary

While checking Dokku logs for a `@typedtrader/strategy-trailing-stop` run (INTC,USD), the strategy filled its order fine but logged a scary **level-50 error** on finish:

```
AxiosError: Request failed with status code 422
  data: {"code":42210000,"message":"order is already in \"filled\" state"}
  at AlpacaBroker.cancelOrderById (AlpacaBroker.ts:131)
  at AlpacaBroker.cancelOpenOrders (AlpacaBroker.ts:255)
  at TradingSession.stop (TradingSession.ts:82)
```

An open order can fill (or be canceled) in the window between `getOrders({status: 'open'})` and the `DELETE`. Alpaca then returns HTTP 422 "order is already in ... state". The order is no longer open — which is exactly what cancellation aims for — so this shouldn't surface as an error.

## Changes

- `cancelOrderById` now swallows the 422 "already in ... state" response and rethrows everything else, via a new `isOrderAlreadyInactiveError` type guard (matches on 422 + message, not the ambiguous `42210000` code which is reused for other cases).
- Added two `cancelOpenOrders` tests: ignores orders that filled mid-cancel, and still rethrows unexpected errors.