### PR TITLE
fix(exchange): bound the Alpaca retry config

### DIFF
--- a/packages/exchange/src/broker/alpaca/api/AlpacaAPI.ts
+++ b/packages/exchange/src/broker/alpaca/api/AlpacaAPI.ts
@@ -27,7 +27,6 @@ export class AlpacaAPI {
 
     const retryConfig: Parameters<typeof axiosRetry>[1] = {
       // Capped so a sustained 429 or network outage can't hang a request forever.
-      // With the linear backoff below, 20 retries spans at most ~3.5 minutes.
       retries: 20,
       retryCondition: error => {
         // Alpaca Error Code 40310100 typically means your order was forbidden by Alpaca's system because it would trigger a Pattern Day Trader (PDT) violation.

--- a/packages/exchange/src/broker/alpaca/api/AlpacaAPI.ts
+++ b/packages/exchange/src/broker/alpaca/api/AlpacaAPI.ts
@@ -26,14 +26,14 @@ export class AlpacaAPI {
     };
 
     const retryConfig: Parameters<typeof axiosRetry>[1] = {
-      // Capped so a sustained 429 or network outage can't hang a request forever.
       retries: 20,
       retryCondition: error => {
         // Alpaca Error Code 40310100 typically means your order was forbidden by Alpaca's system because it would trigger a Pattern Day Trader (PDT) violation.
         if (hasResponseCode(error) && error.response?.data.code === 40310100) {
           return false;
         }
-        // account is not allowed to short
+        // Account is not allowed to short (you must have $2,000 or more)
+        // @see https://docs.alpaca.markets/us/docs/margin-and-short-selling
         if (hasResponseCode(error) && error.response?.data.code === 40310000) {
           return false;
         }

--- a/packages/exchange/src/broker/alpaca/api/AlpacaAPI.ts
+++ b/packages/exchange/src/broker/alpaca/api/AlpacaAPI.ts
@@ -26,7 +26,9 @@ export class AlpacaAPI {
     };
 
     const retryConfig: Parameters<typeof axiosRetry>[1] = {
-      retries: Infinity,
+      // Capped so a sustained 429 or network outage can't hang a request forever.
+      // With the linear backoff below, 20 retries spans at most ~3.5 minutes.
+      retries: 20,
       retryCondition: error => {
         // Alpaca Error Code 40310100 typically means your order was forbidden by Alpaca's system because it would trigger a Pattern Day Trader (PDT) violation.
         if (hasResponseCode(error) && error.response?.data.code === 40310100) {

--- a/packages/exchange/src/broker/alpaca/api/AlpacaAPI.ts
+++ b/packages/exchange/src/broker/alpaca/api/AlpacaAPI.ts
@@ -1,5 +1,6 @@
 import axios, {type AxiosError} from 'axios';
 import axiosRetry from 'axios-retry';
+import {ms} from 'ms';
 import {AccountSchema} from './schema/AccountSchema.js';
 import {AssetSchema} from './schema/AssetSchema.js';
 import {BarsResponseSchema, LatestBarsResponseSchema} from './schema/BarSchema.js';
@@ -38,7 +39,7 @@ export class AlpacaAPI {
         return axiosRetry.isNetworkError(error) || error.response?.status === 429;
       },
       retryDelay: retryCount => {
-        return retryCount * 1_000;
+        return retryCount * ms('1s');
       },
     };
 


### PR DESCRIPTION
## Summary

Two related changes to the Alpaca retry config in `AlpacaAPI.ts`:

1. **Cap retries at 20** — was `retries: Infinity`, which let a request hang forever on a sustained 429 or network outage. With the existing linear backoff (`retryCount * 1s`), 20 retries bounds the worst case to ~3.5 minutes, after which the call rejects and the caller can handle the failure.
2. **Use `ms('1s')` for the retry delay** — replaces the magic `1_000`, matching how durations are expressed across the rest of the `exchange` package.

The retry *condition* is unchanged — still only network errors and 429s, with the PDT / no-short error codes opting out to fail fast.

Now that `client.getTime()` (and every other Alpaca call) is guaranteed to settle, #1081 removes the hand-rolled `Promise.race` timeout that the account wizards used to work around the unbounded retry loop.