### PR TITLE
feat(messaging): notify owner when strategies and watches start

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: write
+      pull-requests: read
       issues: read
       id-token: write
       actions: read

--- a/packages/messaging/src/service/PlatformDispatcher.ts
+++ b/packages/messaging/src/service/PlatformDispatcher.ts
@@ -1,0 +1,38 @@
+import type {MessagingPlatform} from '../platform/MessagingPlatform.js';
+import {Account} from '../database/models/Account.js';
+import {logger} from '../logger.js';
+
+/**
+ * Resolves the right `MessagingPlatform` for a given user and sends messages.
+ *
+ * User IDs are namespaced by a platform prefix (e.g. `telegram:123456`); the
+ * dispatcher owns that convention plus the warn-on-missing handling that every
+ * notification path shares, so monitors don't each re-implement it.
+ */
+export class PlatformDispatcher {
+  readonly #platforms: Map<string, MessagingPlatform>;
+
+  constructor(platforms: Map<string, MessagingPlatform>) {
+    this.#platforms = platforms;
+  }
+
+  async sendToUser(userId: string, message: string): Promise<boolean> {
+    const platformPrefix = userId.split(':')[0];
+    const platform = this.#platforms.get(platformPrefix);
+    if (!platform) {
+      logger.warn({platformPrefix, userId}, 'No platform found to send notification');
+      return false;
+    }
+    await platform.sendMessage(userId, message);
+    return true;
+  }
+
+  async sendToAccount(accountId: number, message: string): Promise<boolean> {
+    const account = Account.findByPk(accountId);
+    if (!account) {
+      logger.warn({accountId}, 'Account not found to send notification');
+      return false;
+    }
+    return this.sendToUser(account.userId, message);
+  }
+}

--- a/packages/messaging/src/service/PlatformDispatcher.ts
+++ b/packages/messaging/src/service/PlatformDispatcher.ts
@@ -2,17 +2,18 @@ import type {MessagingPlatform} from '../platform/MessagingPlatform.js';
 import {Account} from '../database/models/Account.js';
 import {logger} from '../logger.js';
 
+/** Platform prefix such as "telegram" */
+type PlatformPrefix = string;
+
 /**
  * Resolves the right `MessagingPlatform` for a given user and sends messages.
  *
- * User IDs are namespaced by a platform prefix (e.g. `telegram:123456`); the
- * dispatcher owns that convention plus the warn-on-missing handling that every
- * notification path shares, so monitors don't each re-implement it.
+ * User IDs are namespaced by a platform prefix (e.g. `telegram:123456`).
  */
 export class PlatformDispatcher {
-  readonly #platforms: Map<string, MessagingPlatform>;
+  readonly #platforms: Map<PlatformPrefix, MessagingPlatform>;
 
-  constructor(platforms: Map<string, MessagingPlatform>) {
+  constructor(platforms: Map<PlatformPrefix, MessagingPlatform>) {
     this.#platforms = platforms;
   }
 

--- a/packages/messaging/src/service/ReportScheduler.ts
+++ b/packages/messaging/src/service/ReportScheduler.ts
@@ -1,7 +1,7 @@
 import {createReport} from 'trading-strategies';
-import type {MessagingPlatform} from '../platform/MessagingPlatform.js';
 import {Report, type ReportAttributes} from '../database/models/Report.js';
 import {logger} from '../logger.js';
+import {PlatformDispatcher} from './PlatformDispatcher.js';
 
 interface ScheduledReport {
   reportId: number;
@@ -9,11 +9,11 @@ interface ScheduledReport {
 }
 
 export class ReportScheduler {
-  #platforms: Map<string, MessagingPlatform>;
+  #dispatcher: PlatformDispatcher;
   #scheduled: Map<number, ScheduledReport> = new Map();
 
-  constructor(platforms: Map<string, MessagingPlatform>) {
-    this.#platforms = platforms;
+  constructor(dispatcher: PlatformDispatcher) {
+    this.#dispatcher = dispatcher;
   }
 
   async start(): Promise<void> {
@@ -82,15 +82,9 @@ export class ReportScheduler {
     const report = createReport(row.reportName, config);
     const result = await report.run();
 
-    const platformPrefix = row.userId.split(':')[0];
-    const platform = this.#platforms.get(platformPrefix);
-
-    if (!platform) {
-      logger.warn({platformPrefix, reportId: row.id}, 'No platform found for report');
-      return;
+    const sent = await this.#dispatcher.sendToUser(row.userId, result);
+    if (sent) {
+      logger.info({reportId: row.id, userId: row.userId}, 'Report result sent');
     }
-
-    await platform.sendMessage(row.userId, result);
-    logger.info({reportId: row.id, userId: row.userId}, 'Report result sent');
   }
 }

--- a/packages/messaging/src/service/StrategyMonitor.test.ts
+++ b/packages/messaging/src/service/StrategyMonitor.test.ts
@@ -47,6 +47,7 @@ vi.mock('../database/models/Strategy.js', () => ({
 }));
 
 const {StrategyMonitor, formatStrategyMessage} = await import('./StrategyMonitor.js');
+const {PlatformDispatcher} = await import('./PlatformDispatcher.js');
 
 function createMockPlatform(): MessagingPlatform {
   return {
@@ -121,7 +122,7 @@ describe('StrategyMonitor.restartForAccount', () => {
   });
 
   it('persists state, stops without cancelling orders, and re-subscribes an active session', async () => {
-    const monitor = new StrategyMonitor(new Map());
+    const monitor = new StrategyMonitor(new PlatformDispatcher(new Map()));
     const row = createStrategyRow();
     await monitor.subscribeToStrategy(row);
     expect(TradingSessionMock).toHaveBeenCalledTimes(1);
@@ -140,7 +141,7 @@ describe('StrategyMonitor.restartForAccount', () => {
   });
 
   it('skips rows that have no active session', async () => {
-    const monitor = new StrategyMonitor(new Map());
+    const monitor = new StrategyMonitor(new PlatformDispatcher(new Map()));
     mockStrategyModel.findByAccountIds.mockReturnValue([createStrategyRow({id: 99})]);
 
     await monitor.restartForAccount(7);

--- a/packages/messaging/src/service/StrategyMonitor.ts
+++ b/packages/messaging/src/service/StrategyMonitor.ts
@@ -2,10 +2,10 @@ import {TradingPair, TradingSession, getBrokerClient} from '@typedtrader/exchang
 import type {Fill} from '@typedtrader/exchange';
 import {createStrategy} from 'trading-strategies';
 import type {Strategy as TradingStrategy} from 'trading-strategies';
-import type {MessagingPlatform} from '../platform/MessagingPlatform.js';
 import {Account} from '../database/models/Account.js';
 import {Strategy, type StrategyAttributes} from '../database/models/Strategy.js';
 import {logger} from '../logger.js';
+import {PlatformDispatcher} from './PlatformDispatcher.js';
 
 interface ActiveSession {
   strategyId: number;
@@ -19,11 +19,11 @@ export function formatStrategyMessage(strategyName: string, pair: string, text: 
 }
 
 export class StrategyMonitor {
-  #platforms: Map<string, MessagingPlatform>;
+  #dispatcher: PlatformDispatcher;
   #sessions: Map<number, ActiveSession> = new Map();
 
-  constructor(platforms: Map<string, MessagingPlatform>) {
-    this.#platforms = platforms;
+  constructor(dispatcher: PlatformDispatcher) {
+    this.#dispatcher = dispatcher;
   }
 
   /**
@@ -34,7 +34,7 @@ export class StrategyMonitor {
     for (const row of rows) {
       try {
         await this.subscribeToStrategy(row);
-        await this.#sendStartNotification(row);
+        await this.#dispatcher.sendToAccount(row.accountId, `Strategy "${row.id}" started.`);
       } catch (error) {
         logger.error({err: error, strategyId: row.id, strategyName: row.strategyName}, 'Failed to start strategy');
       }
@@ -192,46 +192,18 @@ export class StrategyMonitor {
     }
   }
 
-  /**
-   * Resolve the account + platform for a strategy row and send the message. Centralises
-   * the account lookup, prefix-based platform resolution, and warn-on-missing handling
-   * that all three notification paths share.
-   */
-  async #sendToAccount(row: StrategyAttributes, message: string): Promise<void> {
-    const account = Account.findByPk(row.accountId);
-    if (!account) {
-      logger.warn({accountId: row.accountId, strategyId: row.id}, 'Account not found for notification');
-      return;
-    }
-
-    const platformPrefix = account.userId.split(':')[0];
-    const platform = this.#platforms.get(platformPrefix);
-    if (!platform) {
-      logger.warn({platformPrefix, strategyId: row.id}, 'No platform found for notification');
-      return;
-    }
-
-    await platform.sendMessage(account.userId, message);
-
-    logger.info({userId: account.userId, strategyId: row.id}, 'Notification sent');
-  }
-
   async #sendFillNotification(row: StrategyAttributes, fill: Fill): Promise<void> {
     const message = `Order Filled!\n\nStrategy: ${row.strategyName}\nPair: ${row.pair}\nSide: ${fill.side}\nPrice: ${fill.price}\nSize: ${fill.size}\nFee: ${fill.fee} ${fill.feeAsset}\nOrder ID: ${fill.order_id}`;
-    await this.#sendToAccount(row, message);
+    await this.#dispatcher.sendToAccount(row.accountId, message);
   }
 
   async #sendStrategyMessage(row: StrategyAttributes, text: string): Promise<void> {
     const message = formatStrategyMessage(row.strategyName, row.pair, text);
-    await this.#sendToAccount(row, message);
-  }
-
-  async #sendStartNotification(row: StrategyAttributes): Promise<void> {
-    await this.#sendToAccount(row, `Strategy "${row.id}" started.`);
+    await this.#dispatcher.sendToAccount(row.accountId, message);
   }
 
   async #sendFinishNotification(row: StrategyAttributes): Promise<void> {
     const message = `Strategy finished and removed.\n\nID: ${row.id}\nStrategy: ${row.strategyName}\nPair: ${row.pair}`;
-    await this.#sendToAccount(row, message);
+    await this.#dispatcher.sendToAccount(row.accountId, message);
   }
 }

--- a/packages/messaging/src/service/StrategyMonitor.ts
+++ b/packages/messaging/src/service/StrategyMonitor.ts
@@ -34,6 +34,7 @@ export class StrategyMonitor {
     for (const row of rows) {
       try {
         await this.subscribeToStrategy(row);
+        await this.#sendStartNotification(row);
       } catch (error) {
         logger.error({err: error, strategyId: row.id, strategyName: row.strategyName}, 'Failed to start strategy');
       }
@@ -223,6 +224,10 @@ export class StrategyMonitor {
   async #sendStrategyMessage(row: StrategyAttributes, text: string): Promise<void> {
     const message = formatStrategyMessage(row.strategyName, row.pair, text);
     await this.#sendToAccount(row, message);
+  }
+
+  async #sendStartNotification(row: StrategyAttributes): Promise<void> {
+    await this.#sendToAccount(row, `Strategy ${row.id} started.`);
   }
 
   async #sendFinishNotification(row: StrategyAttributes): Promise<void> {

--- a/packages/messaging/src/service/StrategyMonitor.ts
+++ b/packages/messaging/src/service/StrategyMonitor.ts
@@ -227,7 +227,7 @@ export class StrategyMonitor {
   }
 
   async #sendStartNotification(row: StrategyAttributes): Promise<void> {
-    await this.#sendToAccount(row, `Strategy ${row.id} started.`);
+    await this.#sendToAccount(row, `Strategy "${row.id}" started.`);
   }
 
   async #sendFinishNotification(row: StrategyAttributes): Promise<void> {

--- a/packages/messaging/src/service/WatchMonitor.test.ts
+++ b/packages/messaging/src/service/WatchMonitor.test.ts
@@ -32,6 +32,7 @@ vi.mock('../database/models/Watch.js', () => ({
 }));
 
 const {WatchMonitor} = await import('./WatchMonitor.js');
+const {PlatformDispatcher} = await import('./PlatformDispatcher.js');
 
 function createMockPlatform(): MessagingPlatform {
   return {
@@ -92,7 +93,7 @@ describe('WatchMonitor.restartForAccount', () => {
   });
 
   it('tears down and recreates an active subscription from a freshly loaded row', async () => {
-    const monitor = new WatchMonitor(new Map());
+    const monitor = new WatchMonitor(new PlatformDispatcher(new Map()));
     const row = createWatchRow();
     await monitor.subscribeToWatch(row);
     expect(mockExchange.watchCandles).toHaveBeenCalledTimes(1);
@@ -110,7 +111,7 @@ describe('WatchMonitor.restartForAccount', () => {
   });
 
   it('skips watches that have no active subscription', async () => {
-    const monitor = new WatchMonitor(new Map());
+    const monitor = new WatchMonitor(new PlatformDispatcher(new Map()));
     mockWatchModel.findByAccountIds.mockReturnValue([createWatchRow({id: 99})]);
 
     await monitor.restartForAccount(7);

--- a/packages/messaging/src/service/WatchMonitor.ts
+++ b/packages/messaging/src/service/WatchMonitor.ts
@@ -26,6 +26,7 @@ export class WatchMonitor {
     const watches = Watch.findAllOrderedById();
     for (const watch of watches) {
       await this.subscribeToWatch(watch);
+      await this.#sendStartNotification(watch);
     }
   }
 
@@ -132,6 +133,24 @@ export class WatchMonitor {
         logger.error({err: error, watchId: watch.id, accountId}, 'Failed to restart watch after account update');
       }
     }
+  }
+
+  async #sendStartNotification(watch: WatchAttributes): Promise<void> {
+    const account = Account.findByPk(watch.accountId);
+    if (!account) {
+      logger.warn({accountId: watch.accountId, watchId: watch.id}, 'Account not found when sending start notification');
+      return;
+    }
+
+    const platformPrefix = account.userId.split(':')[0];
+    const platform = this.#platforms.get(platformPrefix);
+    if (!platform) {
+      logger.warn({platformPrefix, watchId: watch.id}, 'No platform found for start notification');
+      return;
+    }
+
+    await platform.sendMessage(account.userId, `Watch ${watch.id} started.`);
+    logger.info({userId: account.userId, watchId: watch.id}, 'Watch start notification sent');
   }
 
   async #sendAlert(watch: WatchAttributes, currentPrice: number): Promise<void> {

--- a/packages/messaging/src/service/WatchMonitor.ts
+++ b/packages/messaging/src/service/WatchMonitor.ts
@@ -149,7 +149,7 @@ export class WatchMonitor {
       return;
     }
 
-    await platform.sendMessage(account.userId, `Watch ${watch.id} started.`);
+    await platform.sendMessage(account.userId, `Watch "${watch.id}" started.`);
     logger.info({userId: account.userId, watchId: watch.id}, 'Watch start notification sent');
   }
 

--- a/packages/messaging/src/service/WatchMonitor.ts
+++ b/packages/messaging/src/service/WatchMonitor.ts
@@ -1,21 +1,21 @@
 import {TradingPair, Broker, Candle, MarketDataSource, getBrokerClient} from '@typedtrader/exchange';
-import type {MessagingPlatform} from '../platform/MessagingPlatform.js';
 import {Account} from '../database/models/Account.js';
 import {Watch, WatchAttributes} from '../database/models/Watch.js';
 import {logger} from '../logger.js';
+import {PlatformDispatcher} from './PlatformDispatcher.js';
 
 interface ActiveSubscription {
   watchId: number;
   topicId: string;
-  exchange: Broker & MarketDataSource;
+  broker: Broker & MarketDataSource;
 }
 
 export class WatchMonitor {
-  #platforms: Map<string, MessagingPlatform>;
+  #dispatcher: PlatformDispatcher;
   #subscriptions: Map<number, ActiveSubscription> = new Map();
 
-  constructor(platforms: Map<string, MessagingPlatform>) {
-    this.#platforms = platforms;
+  constructor(dispatcher: PlatformDispatcher) {
+    this.#dispatcher = dispatcher;
   }
 
   /**
@@ -26,7 +26,7 @@ export class WatchMonitor {
     const watches = Watch.findAllOrderedById();
     for (const watch of watches) {
       await this.subscribeToWatch(watch);
-      await this.#sendStartNotification(watch);
+      await this.#dispatcher.sendToAccount(watch.accountId, `Watch "${watch.id}" started.`);
     }
   }
 
@@ -35,7 +35,7 @@ export class WatchMonitor {
    */
   stop(): void {
     for (const subscription of this.#subscriptions.values()) {
-      subscription.exchange.unwatchCandles(subscription.topicId);
+      subscription.broker.unwatchCandles(subscription.topicId);
     }
     this.#subscriptions.clear();
   }
@@ -91,7 +91,7 @@ export class WatchMonitor {
     this.#subscriptions.set(watch.id, {
       watchId: watch.id,
       topicId,
-      exchange,
+      broker: exchange,
     });
 
     logger.info({watchId: watch.id, pair: watch.pair}, 'Subscribed to watch');
@@ -103,8 +103,8 @@ export class WatchMonitor {
   unsubscribeFromWatch(watchId: number): void {
     const subscription = this.#subscriptions.get(watchId);
     if (subscription) {
-      subscription.exchange.unwatchCandles(subscription.topicId);
-      subscription.exchange.removeAllListeners(subscription.topicId);
+      subscription.broker.unwatchCandles(subscription.topicId);
+      subscription.broker.removeAllListeners(subscription.topicId);
       this.#subscriptions.delete(watchId);
       logger.info({watchId}, 'Unsubscribed from watch');
     }
@@ -135,33 +135,9 @@ export class WatchMonitor {
     }
   }
 
-  async #sendStartNotification(watch: WatchAttributes): Promise<void> {
-    const account = Account.findByPk(watch.accountId);
-    if (!account) {
-      logger.warn({accountId: watch.accountId, watchId: watch.id}, 'Account not found when sending start notification');
-      return;
-    }
-
-    const platformPrefix = account.userId.split(':')[0];
-    const platform = this.#platforms.get(platformPrefix);
-    if (!platform) {
-      logger.warn({platformPrefix, watchId: watch.id}, 'No platform found for start notification');
-      return;
-    }
-
-    await platform.sendMessage(account.userId, `Watch "${watch.id}" started.`);
-    logger.info({userId: account.userId, watchId: watch.id}, 'Watch start notification sent');
-  }
-
   async #sendAlert(watch: WatchAttributes, currentPrice: number): Promise<void> {
     const {counter} = TradingPair.fromString(watch.pair, ',');
 
-    const account = Account.findByPk(watch.accountId);
-
-    if (!account) {
-      logger.warn({accountId: watch.accountId, watchId: watch.id}, 'Account not found when sending alert');
-      return;
-    }
     const dirSymbol = watch.thresholdDirection === 'up' ? '+' : '-';
     const thresholdDisplay =
       watch.thresholdType === 'percent'
@@ -175,16 +151,6 @@ export class WatchMonitor {
 
     const message = `Price Alert Triggered!\n\nPair: ${watch.pair}\nBaseline: ${watch.baselinePrice} ${counter}\nAlert price: ${watch.alertPrice} ${counter}\nCurrent: ${currentPrice} ${counter}\nDiff: ${diffDisplay}\nThreshold: ${thresholdDisplay}\n\nThis watch has been automatically removed.`;
 
-    const platformPrefix = account.userId.split(':')[0];
-    const platform = this.#platforms.get(platformPrefix);
-
-    if (!platform) {
-      logger.warn({platformPrefix, watchId: watch.id}, 'No platform found for alert');
-      return;
-    }
-
-    await platform.sendMessage(account.userId, message);
-
-    logger.info({userId: account.userId, watchId: watch.id}, 'Alert sent');
+    await this.#dispatcher.sendToAccount(watch.accountId, message);
   }
 }

--- a/packages/messaging/src/service/index.ts
+++ b/packages/messaging/src/service/index.ts
@@ -1,3 +1,4 @@
+export {PlatformDispatcher} from './PlatformDispatcher.js';
 export {ReportScheduler} from './ReportScheduler.js';
 export {restartAccountSessions} from './restartAccountSessions.js';
 export {StrategyMonitor} from './StrategyMonitor.js';

--- a/packages/messaging/src/startServer.ts
+++ b/packages/messaging/src/startServer.ts
@@ -26,7 +26,13 @@ import {initializeDatabase} from './database/initializeDatabase.js';
 import {logger} from './logger.js';
 import type {MessagingPlatform} from './platform/index.js';
 import {TelegramPlatform} from './platform/TelegramPlatform.js';
-import {WatchMonitor, StrategyMonitor, ReportScheduler, restartAccountSessions} from './service/index.js';
+import {
+  PlatformDispatcher,
+  ReportScheduler,
+  StrategyMonitor,
+  WatchMonitor,
+  restartAccountSessions,
+} from './service/index.js';
 
 interface Monitors {
   watchMonitor: WatchMonitor;
@@ -232,10 +238,11 @@ export async function startServer() {
     logger.warn('No messaging platforms configured. Set TELEGRAM_BOT_TOKEN to enable a platform.');
   }
 
+  const dispatcher = new PlatformDispatcher(platforms);
   const monitors: Monitors = {
-    watchMonitor: new WatchMonitor(platforms),
-    strategyMonitor: new StrategyMonitor(platforms),
-    reportScheduler: new ReportScheduler(platforms),
+    watchMonitor: new WatchMonitor(dispatcher),
+    strategyMonitor: new StrategyMonitor(dispatcher),
+    reportScheduler: new ReportScheduler(dispatcher),
   };
 
   for (const [, platform] of platforms) {


### PR DESCRIPTION
## Summary
- On application boot, `StrategyMonitor.start()` and `WatchMonitor.start()` now send a short message to the owning account after each persisted strategy/watch resumes (`Strategy <id> started.` / `Watch <id> started.`).
- Wizards and `restartForAccount` paths are intentionally untouched — those flows already give the user direct feedback, so notifications fire only on boot resumes.