### PR TITLE
style: enforce object-key sorting across all packages

### DIFF
--- a/packages/exchange/eslint.config.mjs
+++ b/packages/exchange/eslint.config.mjs
@@ -18,7 +18,7 @@ export default defineConfig({
     // companion pattern as an enum replacement. `no-redeclare` misfires on the shared
     // value/type name even though TypeScript allows it; renaming would break public APIs.
     '@typescript-eslint/no-redeclare': 'off',
-    // Object-key sorting is not enforced in this repo for now.
-    'perfectionist/sort-objects': 'off',
+    // Object-key sorting is enforced across all packages.
+    'perfectionist/sort-objects': 'error',
   },
 });

--- a/packages/exchange/src/broker/BrokerMock.test.ts
+++ b/packages/exchange/src/broker/BrokerMock.test.ts
@@ -7,8 +7,8 @@ import {ms} from 'ms';
 
 class TestExchangeMock extends BrokerMock {
   static readonly TEST_FEE_RATES: FeeRate = {
-    [OrderType.MARKET]: new Big(0.0025),
     [OrderType.LIMIT]: new Big(0.0015),
+    [OrderType.MARKET]: new Big(0.0025),
   };
 
   static readonly TEST_TRADING_RULES = {
@@ -48,11 +48,11 @@ function createCandle(overrides: Partial<Candle> & {open: string; close: string}
   const closeNum = parseFloat(overrides.close);
   return {
     base: 'BTC',
+    close: overrides.close,
     counter: 'USD',
     high: overrides.high ?? String(Math.max(openNum, closeNum)),
     low: overrides.low ?? String(Math.min(openNum, closeNum)),
     open: overrides.open,
-    close: overrides.close,
     openTimeInISO: overrides.openTimeInISO ?? '2025-01-01T00:00:00.000Z',
     openTimeInMillis: overrides.openTimeInMillis ?? 1735689600000,
     sizeInMillis: overrides.sizeInMillis ?? 60000,
@@ -75,7 +75,7 @@ describe('BrokerMock', () => {
       const exchange = createExchange('0', '10000');
 
       // Process first candle to set current state
-      exchange.processCandle(createCandle({open: '100', close: '100'}));
+      exchange.processCandle(createCandle({close: '100', open: '100'}));
 
       // Place market buy order
       await exchange.placeMarketOrder(pair, {
@@ -86,7 +86,7 @@ describe('BrokerMock', () => {
 
       // Process next candle — order should fill at this candle's open
       const fills = exchange.processCandle(
-        createCandle({open: '105', close: '110', openTimeInISO: '2025-01-01T00:01:00.000Z'})
+        createCandle({close: '110', open: '105', openTimeInISO: '2025-01-01T00:01:00.000Z'})
       );
 
       expect(fills).toHaveLength(1);
@@ -97,7 +97,7 @@ describe('BrokerMock', () => {
     it('fills market sell order at the next candle open price', async () => {
       const exchange = createExchange('5', '0');
 
-      exchange.processCandle(createCandle({open: '100', close: '100'}));
+      exchange.processCandle(createCandle({close: '100', open: '100'}));
 
       await exchange.placeMarketOrder(pair, {
         side: OrderSide.SELL,
@@ -106,7 +106,7 @@ describe('BrokerMock', () => {
       });
 
       const fills = exchange.processCandle(
-        createCandle({open: '98', close: '95', openTimeInISO: '2025-01-01T00:01:00.000Z'})
+        createCandle({close: '95', open: '98', openTimeInISO: '2025-01-01T00:01:00.000Z'})
       );
 
       expect(fills).toHaveLength(1);
@@ -119,17 +119,17 @@ describe('BrokerMock', () => {
     it('fills limit buy when candle low reaches the limit price', async () => {
       const exchange = createExchange('0', '10000');
 
-      exchange.processCandle(createCandle({open: '100', close: '100'}));
+      exchange.processCandle(createCandle({close: '100', open: '100'}));
 
       await exchange.placeLimitOrder(pair, {
+        price: '95',
         side: OrderSide.BUY,
         size: '1',
-        price: '95',
       });
 
       // Next candle: open=98, low=93 — limit price 95 is reachable
       const fills = exchange.processCandle(
-        createCandle({open: '98', close: '96', low: '93', high: '99', openTimeInISO: '2025-01-01T00:01:00.000Z'})
+        createCandle({close: '96', high: '99', low: '93', open: '98', openTimeInISO: '2025-01-01T00:01:00.000Z'})
       );
 
       expect(fills).toHaveLength(1);
@@ -140,17 +140,17 @@ describe('BrokerMock', () => {
     it('stays pending when limit buy price is not reached', async () => {
       const exchange = createExchange('0', '10000');
 
-      exchange.processCandle(createCandle({open: '100', close: '100'}));
+      exchange.processCandle(createCandle({close: '100', open: '100'}));
 
       await exchange.placeLimitOrder(pair, {
+        price: '90',
         side: OrderSide.BUY,
         size: '1',
-        price: '90',
       });
 
       // Next candle: low=92, doesn't reach limit price of 90
       const fills = exchange.processCandle(
-        createCandle({open: '98', close: '96', low: '92', high: '99', openTimeInISO: '2025-01-01T00:01:00.000Z'})
+        createCandle({close: '96', high: '99', low: '92', open: '98', openTimeInISO: '2025-01-01T00:01:00.000Z'})
       );
 
       expect(fills).toHaveLength(0);
@@ -160,17 +160,17 @@ describe('BrokerMock', () => {
     it('gives price improvement when candle opens below limit buy price', async () => {
       const exchange = createExchange('0', '10000');
 
-      exchange.processCandle(createCandle({open: '500', close: '500'}));
+      exchange.processCandle(createCandle({close: '500', open: '500'}));
 
       await exchange.placeLimitOrder(pair, {
+        price: '500',
         side: OrderSide.BUY,
         size: '1',
-        price: '500',
       });
 
       // Next candle opens at 360, well below limit of 500 → price improvement
       const fills = exchange.processCandle(
-        createCandle({open: '360', close: '380', low: '350', high: '400', openTimeInISO: '2025-01-01T00:01:00.000Z'})
+        createCandle({close: '380', high: '400', low: '350', open: '360', openTimeInISO: '2025-01-01T00:01:00.000Z'})
       );
 
       expect(fills).toHaveLength(1);
@@ -180,17 +180,17 @@ describe('BrokerMock', () => {
     it('fills limit sell when candle high reaches the limit price', async () => {
       const exchange = createExchange('5', '0');
 
-      exchange.processCandle(createCandle({open: '100', close: '100'}));
+      exchange.processCandle(createCandle({close: '100', open: '100'}));
 
       await exchange.placeLimitOrder(pair, {
+        price: '105',
         side: OrderSide.SELL,
         size: '2',
-        price: '105',
       });
 
       // Next candle: open=102, high=108 — limit price 105 is reachable
       const fills = exchange.processCandle(
-        createCandle({open: '102', close: '106', low: '101', high: '108', openTimeInISO: '2025-01-01T00:01:00.000Z'})
+        createCandle({close: '106', high: '108', low: '101', open: '102', openTimeInISO: '2025-01-01T00:01:00.000Z'})
       );
 
       expect(fills).toHaveLength(1);
@@ -201,17 +201,17 @@ describe('BrokerMock', () => {
     it('gives price improvement when candle opens above limit sell price', async () => {
       const exchange = createExchange('5', '0');
 
-      exchange.processCandle(createCandle({open: '100', close: '100'}));
+      exchange.processCandle(createCandle({close: '100', open: '100'}));
 
       await exchange.placeLimitOrder(pair, {
+        price: '400',
         side: OrderSide.SELL,
         size: '2',
-        price: '400',
       });
 
       // Next candle opens at 450, above limit of 400 → price improvement
       const fills = exchange.processCandle(
-        createCandle({open: '450', close: '430', low: '420', high: '460', openTimeInISO: '2025-01-01T00:01:00.000Z'})
+        createCandle({close: '430', high: '460', low: '420', open: '450', openTimeInISO: '2025-01-01T00:01:00.000Z'})
       );
 
       expect(fills).toHaveLength(1);
@@ -223,12 +223,12 @@ describe('BrokerMock', () => {
     it('puts counter on hold when placing a buy order', async () => {
       const exchange = createExchange('0', '10000');
 
-      exchange.processCandle(createCandle({open: '100', close: '100'}));
+      exchange.processCandle(createCandle({close: '100', open: '100'}));
 
       await exchange.placeLimitOrder(pair, {
+        price: '100',
         side: OrderSide.BUY,
         size: '1',
-        price: '100',
       });
 
       const balances = await exchange.listBalances();
@@ -241,12 +241,12 @@ describe('BrokerMock', () => {
     it('puts base on hold when placing a sell order', async () => {
       const exchange = createExchange('5', '0');
 
-      exchange.processCandle(createCandle({open: '100', close: '100'}));
+      exchange.processCandle(createCandle({close: '100', open: '100'}));
 
       await exchange.placeLimitOrder(pair, {
+        price: '100',
         side: OrderSide.SELL,
         size: '2',
-        price: '100',
       });
 
       const balances = await exchange.listBalances();
@@ -258,12 +258,12 @@ describe('BrokerMock', () => {
     it('releases hold on cancel', async () => {
       const exchange = createExchange('5', '0');
 
-      exchange.processCandle(createCandle({open: '100', close: '100'}));
+      exchange.processCandle(createCandle({close: '100', open: '100'}));
 
       const order = await exchange.placeLimitOrder(pair, {
+        price: '100',
         side: OrderSide.SELL,
         size: '2',
-        price: '100',
       });
 
       await exchange.cancelOrderById(pair, order.id);
@@ -277,14 +277,14 @@ describe('BrokerMock', () => {
     it('rejects orders with insufficient balance', async () => {
       const exchange = createExchange('0', '50');
 
-      exchange.processCandle(createCandle({open: '100', close: '100'}));
+      exchange.processCandle(createCandle({close: '100', open: '100'}));
 
       // Trying to buy 1 BTC at $100 = $100 needed, but only $50 available
       await expect(
         exchange.placeLimitOrder(pair, {
+          price: '100',
           side: OrderSide.BUY,
           size: '1',
-          price: '100',
         })
       ).rejects.toThrow('Insufficient');
     });
@@ -294,16 +294,16 @@ describe('BrokerMock', () => {
     it('deducts fees on fill', async () => {
       const exchange = createExchange('5', '0');
 
-      exchange.processCandle(createCandle({open: '100', close: '100'}));
+      exchange.processCandle(createCandle({close: '100', open: '100'}));
 
       await exchange.placeLimitOrder(pair, {
+        price: '100',
         side: OrderSide.SELL,
         size: '1',
-        price: '100',
       });
 
       const fills = exchange.processCandle(
-        createCandle({open: '100', close: '100', low: '100', high: '100', openTimeInISO: '2025-01-01T00:01:00.000Z'})
+        createCandle({close: '100', high: '100', low: '100', open: '100', openTimeInISO: '2025-01-01T00:01:00.000Z'})
       );
 
       expect(fills).toHaveLength(1);
@@ -322,14 +322,14 @@ describe('BrokerMock', () => {
       const exchange = createExchange('5', '0');
 
       // Process initial candle
-      const candle1 = createCandle({open: '100', close: '100', low: '90', high: '110'});
+      const candle1 = createCandle({close: '100', high: '110', low: '90', open: '100'});
       exchange.processCandle(candle1);
 
       // Place sell order — the current candle range would match, but it shouldn't
       await exchange.placeLimitOrder(pair, {
+        price: '100',
         side: OrderSide.SELL,
         size: '1',
-        price: '100',
       });
 
       /*
@@ -340,7 +340,7 @@ describe('BrokerMock', () => {
 
       // Only fills on the NEXT candle
       const fills = exchange.processCandle(
-        createCandle({open: '100', close: '100', low: '100', high: '100', openTimeInISO: '2025-01-01T00:01:00.000Z'})
+        createCandle({close: '100', high: '100', low: '100', open: '100', openTimeInISO: '2025-01-01T00:01:00.000Z'})
       );
 
       expect(fills).toHaveLength(1);

--- a/packages/exchange/src/broker/alpaca/AlpacaBroker.test.ts
+++ b/packages/exchange/src/broker/alpaca/AlpacaBroker.test.ts
@@ -67,7 +67,7 @@ describe.sequential('AlpacaBroker', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     const marketData = new AlpacaMarketData({apiKey: 'test', apiSecret: 'test', usePaperTrading: true});
-    exchange = new AlpacaBroker({apiKey: 'test', apiSecret: 'test', usePaperTrading: true, marketData});
+    exchange = new AlpacaBroker({apiKey: 'test', apiSecret: 'test', marketData, usePaperTrading: true});
     // Default: stock symbol (empty crypto bars)
     mockMethods.getCryptoBarsLatest.mockResolvedValue({bars: {}});
   });
@@ -150,10 +150,10 @@ describe.sequential('AlpacaBroker', () => {
 
       const canceledOrder = {
         ...filledOrder,
-        id: 'order-2',
-        status: AlpacaOrderStatus.CANCELED,
         filled_avg_price: null,
         filled_qty: '0',
+        id: 'order-2',
+        status: AlpacaOrderStatus.CANCELED,
       };
 
       mockMethods.getOrders.mockResolvedValue([filledOrder, canceledOrder]);
@@ -264,9 +264,9 @@ describe.sequential('AlpacaBroker', () => {
 
       const pair = new TradingPair('SHOP', 'USD');
       const order = await exchange.placeLimitOrder(pair, {
+        price: '100',
         side: OrderSide.SELL,
         size: '5',
-        price: '100',
       });
 
       expect(order.type).toBe(OrderType.LIMIT);
@@ -293,9 +293,9 @@ describe.sequential('AlpacaBroker', () => {
 
       const pair = new TradingPair('SHOP', 'USD');
       const order = await exchange.placeLimitOrder(pair, {
+        price: '100',
         side: OrderSide.SELL,
         size: '5.5',
-        price: '100',
       });
 
       expect(order.type).toBe(OrderType.LIMIT);

--- a/packages/exchange/src/broker/alpaca/AlpacaBroker.ts
+++ b/packages/exchange/src/broker/alpaca/AlpacaBroker.ts
@@ -88,8 +88,8 @@ export class AlpacaBroker extends Broker implements MarketDataSource {
    * @see https://files.alpaca.markets/disclosures/library/BrokFeeSched.pdf
    */
   static DEFAULT_FEE_RATES: FeeRate = {
-    [OrderType.MARKET]: new Big(0.0025),
     [OrderType.LIMIT]: new Big(0.0015),
+    [OrderType.MARKET]: new Big(0.0025),
   };
 
   /**

--- a/packages/exchange/src/broker/alpaca/api/schema/StreamSchema.ts
+++ b/packages/exchange/src/broker/alpaca/api/schema/StreamSchema.ts
@@ -35,8 +35,8 @@ export const AuthenticatedMessageSchema = z.looseObject({
 });
 
 export const SubscriptionMessageSchema = z.looseObject({
-  T: z.literal('subscription'),
   bars: z.array(z.string()),
+  T: z.literal('subscription'),
 });
 
 export const StreamMessageSchema = z.union([

--- a/packages/exchange/src/broker/alpaca/api/schema/TradingStreamSchema.ts
+++ b/packages/exchange/src/broker/alpaca/api/schema/TradingStreamSchema.ts
@@ -32,12 +32,12 @@ export const TradeUpdateEvent = {
 export const TradeUpdateMessageSchema = z.looseObject({
   event: z.string(),
   order: OrderSchema,
+  /** Total position size after this event (present on fill/partial_fill events) */
+  position_qty: z.string().optional(),
   /** Per-share fill price (present on fill/partial_fill events) */
   price: z.string().optional(),
   /** Number of shares filled in this event (present on fill/partial_fill events) */
   qty: z.string().optional(),
-  /** Total position size after this event (present on fill/partial_fill events) */
-  position_qty: z.string().optional(),
   /** Timestamp of the fill event */
   timestamp: z.string().optional(),
 });

--- a/packages/exchange/src/broker/alpaca/fetchCandles.ts
+++ b/packages/exchange/src/broker/alpaca/fetchCandles.ts
@@ -9,12 +9,12 @@ import {getAlpacaClient} from './getAlpacaClient.js';
 
 const {values} = parseArgs({
   options: {
-    base: {type: 'string', default: 'ETH'},
-    counter: {type: 'string', default: 'USD'},
-    from: {type: 'string', default: '2025-09-11T00:00:00.000Z'},
-    to: {type: 'string', default: '2025-10-20T00:00:00.000Z'},
-    interval: {type: 'string', default: '1d'},
-    output: {type: 'string', short: 'o'},
+    base: {default: 'ETH', type: 'string'},
+    counter: {default: 'USD', type: 'string'},
+    from: {default: '2025-09-11T00:00:00.000Z', type: 'string'},
+    interval: {default: '1d', type: 'string'},
+    output: {short: 'o', type: 'string'},
+    to: {default: '2025-10-20T00:00:00.000Z', type: 'string'},
   },
 });
 

--- a/packages/exchange/src/broker/trading212/Trading212Broker.ts
+++ b/packages/exchange/src/broker/trading212/Trading212Broker.ts
@@ -36,8 +36,8 @@ export class Trading212Broker extends Broker implements MarketDataSource {
    * @see https://helpcentre.trading212.com/hc/en-us/articles/360008842317
    */
   static readonly DEFAULT_FEE_RATES: FeeRate = {
-    [OrderType.MARKET]: new Big(0),
     [OrderType.LIMIT]: new Big(0),
+    [OrderType.MARKET]: new Big(0),
   };
 
   /**

--- a/packages/exchange/src/trader/TradingSession.test.ts
+++ b/packages/exchange/src/trader/TradingSession.test.ts
@@ -46,15 +46,15 @@ const sampleFill: Fill = {
 
 const sampleCandle: Candle = {
   base: 'TSLA',
+  close: '253.00',
   counter: 'USD',
-  open: '250.00',
   high: '255.00',
   low: '248.00',
-  close: '253.00',
-  volume: '1000',
+  open: '250.00',
   openTimeInISO: '2024-01-01T00:00:00.000Z',
   openTimeInMillis: 1704067200000,
   sizeInMillis: 60_000,
+  volume: '1000',
 };
 
 function createMockExchange() {
@@ -68,10 +68,10 @@ function createMockExchange() {
     placeLimitOrder: vi.fn().mockResolvedValue({
       id: 'order-1',
       pair,
+      price: '253.00',
       side: OrderSide.SELL,
       size: '10',
       type: OrderType.LIMIT,
-      price: '253.00',
     } satisfies PendingLimitOrder),
     placeMarketOrder: vi.fn().mockResolvedValue({
       id: 'order-2',
@@ -137,18 +137,18 @@ describe.sequential('TradingSession', () => {
         {
           id: 'previous-order-1',
           pair,
+          price: '240.00',
           side: OrderSide.BUY,
           size: '5',
           type: OrderType.LIMIT,
-          price: '240.00',
         },
         {
           id: 'previous-order-2',
           pair,
+          price: '260.00',
           side: OrderSide.SELL,
           size: '3',
           type: OrderType.LIMIT,
-          price: '260.00',
         },
       ];
       exchange.getOpenOrders.mockResolvedValue(existingOrders);
@@ -196,10 +196,10 @@ describe.sequential('TradingSession', () => {
   describe('order execution', () => {
     it('places a MARKET BUY when strategy returns advice', async () => {
       const advice: OrderAdvice = {
-        side: OrderSide.BUY,
-        type: OrderType.MARKET,
         amount: AllAvailableAmount,
         amountIn: 'counter',
+        side: OrderSide.BUY,
+        type: OrderType.MARKET,
       };
       strategy.onCandle.mockResolvedValue(advice);
 
@@ -217,11 +217,11 @@ describe.sequential('TradingSession', () => {
 
     it('places a LIMIT SELL with precision-applied price', async () => {
       const advice: OrderAdvice = {
-        side: OrderSide.SELL,
-        type: OrderType.LIMIT,
         amount: '5.5678',
         amountIn: 'base',
         price: '253.456',
+        side: OrderSide.SELL,
+        type: OrderType.LIMIT,
       };
       strategy.onCandle.mockResolvedValue(advice);
 
@@ -235,18 +235,18 @@ describe.sequential('TradingSession', () => {
        * counter_increment=0.01 → 253.456 rounds down to 253.45
        */
       expect(exchange.placeLimitOrder).toHaveBeenCalledWith(pair, {
+        price: '253.45',
         side: OrderSide.SELL,
         size: '5.567',
-        price: '253.45',
       });
     });
 
     it('resolves null amount SELL to full base balance', async () => {
       const advice: OrderAdvice = {
-        side: OrderSide.SELL,
-        type: OrderType.MARKET,
         amount: AllAvailableAmount,
         amountIn: 'base',
+        side: OrderSide.SELL,
+        type: OrderType.MARKET,
       };
       strategy.onCandle.mockResolvedValue(advice);
 
@@ -265,11 +265,11 @@ describe.sequential('TradingSession', () => {
 
     it('resolves null amount LIMIT BUY to counter balance / price', async () => {
       const advice: OrderAdvice = {
-        side: OrderSide.BUY,
-        type: OrderType.LIMIT,
         amount: AllAvailableAmount,
         amountIn: 'base',
         price: '250',
+        side: OrderSide.BUY,
+        type: OrderType.LIMIT,
       };
       strategy.onCandle.mockResolvedValue(advice);
 
@@ -280,19 +280,19 @@ describe.sequential('TradingSession', () => {
 
       // counter=5000, price=250 → 5000/250 = 20, base_increment=0.001 → 20
       expect(exchange.placeLimitOrder).toHaveBeenCalledWith(pair, {
+        price: '250',
         side: OrderSide.BUY,
         size: '20',
-        price: '250',
       });
     });
 
     it('keeps a pending order tracked when it fills in the race window before being canceled', async () => {
       const advice: OrderAdvice = {
-        side: OrderSide.SELL,
-        type: OrderType.LIMIT,
         amount: '1',
         amountIn: 'base',
         price: new Big('250'),
+        side: OrderSide.SELL,
+        type: OrderType.LIMIT,
       };
       strategy.onCandle.mockResolvedValue(advice);
 
@@ -310,10 +310,10 @@ describe.sequential('TradingSession', () => {
       exchange.placeLimitOrder.mockResolvedValueOnce({
         id: 'order-1-replacement',
         pair,
+        price: '253.00',
         side: OrderSide.SELL,
         size: '10',
         type: OrderType.LIMIT,
-        price: '253.00',
       } satisfies PendingLimitOrder);
 
       const onFill = vi.fn();
@@ -336,10 +336,10 @@ describe.sequential('TradingSession', () => {
 
     it('cancels existing order before placing a new one', async () => {
       const advice: OrderAdvice = {
-        side: OrderSide.BUY,
-        type: OrderType.MARKET,
         amount: '100',
         amountIn: 'counter',
+        side: OrderSide.BUY,
+        type: OrderType.MARKET,
       };
       strategy.onCandle.mockResolvedValue(advice);
 
@@ -364,10 +364,10 @@ describe.sequential('TradingSession', () => {
   describe('fill handling', () => {
     it('updates state when matching fill arrives', async () => {
       const advice: OrderAdvice = {
-        side: OrderSide.BUY,
-        type: OrderType.MARKET,
         amount: '100',
         amountIn: 'counter',
+        side: OrderSide.BUY,
+        type: OrderType.MARKET,
       };
       strategy.onCandle.mockResolvedValue(advice);
 
@@ -400,10 +400,10 @@ describe.sequential('TradingSession', () => {
 
     it('ignores fills with non-matching order ID', async () => {
       const advice: OrderAdvice = {
-        side: OrderSide.BUY,
-        type: OrderType.MARKET,
         amount: '100',
         amountIn: 'counter',
+        side: OrderSide.BUY,
+        type: OrderType.MARKET,
       };
       strategy.onCandle.mockResolvedValue(advice);
 
@@ -430,10 +430,10 @@ describe.sequential('TradingSession', () => {
     it('emits error when order size is below minimum', async () => {
       exchange.getAvailableBalances.mockResolvedValue({base: new Big('0.001'), counter: new Big('5000')});
       const advice: OrderAdvice = {
-        side: OrderSide.SELL,
-        type: OrderType.MARKET,
         amount: AllAvailableAmount,
         amountIn: 'base',
+        side: OrderSide.SELL,
+        type: OrderType.MARKET,
       };
       strategy.onCandle.mockResolvedValue(advice);
 

--- a/packages/exchange/src/trader/TradingSession.ts
+++ b/packages/exchange/src/trader/TradingSession.ts
@@ -63,9 +63,9 @@ export class TradingSession extends EventEmitter<TradingSessionEventMap> {
     this.#state = {
       baseBalance: balances.base,
       counterBalance: balances.counter,
+      feeRates,
       lastOrderSide,
       tradingRules,
-      feeRates,
     };
 
     // Subscribe to candles only after state is ready
@@ -195,9 +195,9 @@ export class TradingSession extends EventEmitter<TradingSessionEventMap> {
     if (advice.type === OrderType.LIMIT) {
       const price = this.#applyPrecision(new Big(advice.price), this.#state.tradingRules.counter_increment);
       order = await this.#broker.placeLimitOrder(this.#pair, {
+        price: price.toFixed(),
         side: advice.side,
         size: size.toFixed(),
-        price: price.toFixed(),
       });
     } else {
       order = await this.#broker.placeMarketOrder(this.#pair, {

--- a/packages/messaging/eslint.config.mjs
+++ b/packages/messaging/eslint.config.mjs
@@ -19,7 +19,7 @@ export default defineConfig({
     // companion pattern as an enum replacement. `no-redeclare` misfires on the shared
     // value/type name even though TypeScript allows it; renaming would break public APIs.
     '@typescript-eslint/no-redeclare': 'off',
-    // Object-key sorting is not enforced in this repo for now.
-    'perfectionist/sort-objects': 'off',
+    // Object-key sorting is enforced across all packages.
+    'perfectionist/sort-objects': 'error',
   },
 });

--- a/packages/messaging/src/broker/getAccountBrokerClient.test.ts
+++ b/packages/messaging/src/broker/getAccountBrokerClient.test.ts
@@ -21,20 +21,20 @@ vi.mock('../database/models/Account.js', () => ({
   Account: mockAccountModel,
 }));
 
-const {getAccountBrokerClient, buildMarketDataFromAccount} = await import('./getAccountBrokerClient.js');
+const {buildMarketDataFromAccount, getAccountBrokerClient} = await import('./getAccountBrokerClient.js');
 
 function makeAccount(overrides: Partial<AccountAttributes> = {}): AccountAttributes {
   return {
-    id: 1,
-    userId: 'user-1',
-    name: 'My Account',
-    exchange: 'Alpaca',
-    isPaper: true,
     apiKey: 'key',
     apiSecret: 'secret',
-    marketDataAccountId: null,
     createdAt: null,
+    exchange: 'Alpaca',
+    id: 1,
+    isPaper: true,
+    marketDataAccountId: null,
+    name: 'My Account',
     updatedAt: null,
+    userId: 'user-1',
     ...overrides,
   };
 }
@@ -52,15 +52,15 @@ describe('getAccountBrokerClient', () => {
     expect(mockAccountModel.findByUserIdAndId).not.toHaveBeenCalled();
     expect(AlpacaMarketDataMock).not.toHaveBeenCalled();
     expect(getBrokerClientMock).toHaveBeenCalledWith(
-      {exchangeId: 'Alpaca', apiKey: 'key', apiSecret: 'secret', isPaper: true},
+      {apiKey: 'key', apiSecret: 'secret', exchangeId: 'Alpaca', isPaper: true},
       undefined
     );
   });
 
   it('resolves the referenced account into an AlpacaMarketData and passes it through', () => {
-    const source = makeAccount({id: 7, exchange: 'Alpaca', isPaper: false, apiKey: 'alp-key', apiSecret: 'alp-secret'});
+    const source = makeAccount({apiKey: 'alp-key', apiSecret: 'alp-secret', exchange: 'Alpaca', id: 7, isPaper: false});
     mockAccountModel.findByUserIdAndId.mockReturnValue(source);
-    const account = makeAccount({id: 2, exchange: 'Trading212', userId: 'user-1', marketDataAccountId: 7});
+    const account = makeAccount({exchange: 'Trading212', id: 2, marketDataAccountId: 7, userId: 'user-1'});
 
     getAccountBrokerClient(account);
 
@@ -84,7 +84,7 @@ describe('getAccountBrokerClient', () => {
   });
 
   it('throws when the referenced account cannot serve as a market-data source', () => {
-    const source = makeAccount({id: 5, exchange: 'Trading212'});
+    const source = makeAccount({exchange: 'Trading212', id: 5});
     mockAccountModel.findByUserIdAndId.mockReturnValue(source);
     const account = makeAccount({exchange: 'Trading212', marketDataAccountId: 5});
 

--- a/packages/messaging/src/broker/getAccountBrokerClient.ts
+++ b/packages/messaging/src/broker/getAccountBrokerClient.ts
@@ -68,9 +68,9 @@ export function getAccountBrokerClient(account: AccountAttributes): Broker & Mar
   const marketData = resolveMarketData(account);
   return getBrokerClient(
     {
-      exchangeId: account.exchange,
       apiKey: account.apiKey,
       apiSecret: account.apiSecret,
+      exchangeId: account.exchange,
       isPaper: account.isPaper,
     },
     marketData ? {marketData} : undefined

--- a/packages/messaging/src/command/account/accountAdd.ts
+++ b/packages/messaging/src/command/account/accountAdd.ts
@@ -42,18 +42,18 @@ export async function accountAdd(request: string, userId: string) {
     }
 
     await getAuthenticatedBrokerClient(
-      {exchangeId: exchange, apiKey, apiSecret, isPaper},
+      {apiKey, apiSecret, exchangeId: exchange, isPaper},
       marketData ? {marketData} : undefined
     );
 
     const account = Account.create({
-      userId,
-      name,
-      exchange,
-      isPaper,
       apiKey,
       apiSecret,
+      exchange,
+      isPaper,
       marketDataAccountId,
+      name,
+      userId,
     });
 
     return `Account created successfully with ID "${account.id}". Connection test passed.`;

--- a/packages/messaging/src/command/account/accountEdit.ts
+++ b/packages/messaging/src/command/account/accountEdit.ts
@@ -42,9 +42,9 @@ export async function accountEdit(request: string, userId: string): Promise<Acco
 
     await getAuthenticatedBrokerClient(
       {
-        exchangeId: account.exchange,
         apiKey,
         apiSecret,
+        exchangeId: account.exchange,
         isPaper: account.isPaper,
       },
       marketData ? {marketData} : undefined
@@ -53,8 +53,8 @@ export async function accountEdit(request: string, userId: string): Promise<Acco
     Account.update(accountId, {apiKey, apiSecret});
 
     return {
-      message: `Account "${account.name}" (ID: ${accountId}) updated successfully. Connection test passed.`,
       accountId,
+      message: `Account "${account.name}" (ID: ${accountId}) updated successfully. Connection test passed.`,
     };
   } catch (error) {
     if (error instanceof Error) {

--- a/packages/messaging/src/command/account/accountList.ts
+++ b/packages/messaging/src/command/account/accountList.ts
@@ -10,7 +10,7 @@ export const accountList = async (userId: string) => {
     }
 
     return formatTelegramTable(`Accounts: ${accounts.length}`, accounts, [
-      {header: 'ID', align: 'right', value: acc => String(acc.id)},
+      {align: 'right', header: 'ID', value: acc => String(acc.id)},
       {header: 'Name', value: acc => acc.name},
       {header: 'Broker', value: acc => acc.exchange},
       {header: 'Mode', value: acc => (acc.isPaper ? 'Paper' : 'Live')},

--- a/packages/messaging/src/command/placeOrder.ts
+++ b/packages/messaging/src/command/placeOrder.ts
@@ -39,9 +39,9 @@ export const placeOrder = async (params: PlaceOrderParams): Promise<string> => {
     }
 
     const order = await client.placeLimitOrder(params.pair, {
+      price: params.limitPrice,
       side: params.side,
       size: params.quantity,
-      price: params.limitPrice,
     });
 
     return `Placed LIMIT ${sideLabel} (${order.id}) for ${params.quantity} ${params.pair.base} @ ${params.limitPrice} ${params.pair.counter} on "${account.name}"`;

--- a/packages/messaging/src/command/report/reportAdd.ts
+++ b/packages/messaging/src/command/report/reportAdd.ts
@@ -78,11 +78,11 @@ export const reportAdd = async (
       return {message: `Report "${reportName}" cannot be scheduled without an account.`};
     }
     const row = Report.create({
-      userId,
       accountId: account.id,
-      reportName,
       config: configJson,
       intervalMs,
+      reportName,
+      userId,
     });
 
     return {

--- a/packages/messaging/src/command/report/reportList.ts
+++ b/packages/messaging/src/command/report/reportList.ts
@@ -11,7 +11,7 @@ export const reportList = async (userId: string): Promise<string> => {
     }
 
     return formatTelegramTable(`Your reports: ${reports.length}`, reports, [
-      {header: 'ID', align: 'right', value: r => String(r.id)},
+      {align: 'right', header: 'ID', value: r => String(r.id)},
       {header: 'Report', value: r => r.reportName},
       {header: 'Schedule', value: r => (r.intervalMs ? `every ${ms(r.intervalMs, {long: true})}` : 'one-shot')},
     ]);

--- a/packages/messaging/src/command/strategy/strategyAdd.ts
+++ b/packages/messaging/src/command/strategy/strategyAdd.ts
@@ -51,9 +51,9 @@ export const strategyAdd = async (request: string, userId: string): Promise<Stra
     const pairString = pair.asString(',');
     const row = Strategy.create({
       accountId: account.id,
-      strategyName,
       config: configJson,
       pair: pairString,
+      strategyName,
     });
 
     return {

--- a/packages/messaging/src/command/strategy/strategyCopy.ts
+++ b/packages/messaging/src/command/strategy/strategyCopy.ts
@@ -66,9 +66,9 @@ export const strategyCopy = async (request: string, userId: string): Promise<Str
     const pairString = pair.asString(',');
     const row = Strategy.create({
       accountId: targetAccount.id,
-      strategyName: source.strategyName,
       config: source.config,
       pair: pairString,
+      strategyName: source.strategyName,
     });
 
     return {

--- a/packages/messaging/src/command/strategy/strategyList.ts
+++ b/packages/messaging/src/command/strategy/strategyList.ts
@@ -13,7 +13,7 @@ export const strategyList = async (userId: string) => {
     }
 
     return formatTelegramTable(`Active strategies: ${strategies.length}`, strategies, [
-      {header: 'ID', align: 'right', value: s => String(s.id)},
+      {align: 'right', header: 'ID', value: s => String(s.id)},
       {header: 'Strategy', value: s => s.strategyName},
       {header: 'Pair', value: s => s.pair},
     ]);

--- a/packages/messaging/src/command/watch/watchAdd.ts
+++ b/packages/messaging/src/command/watch/watchAdd.ts
@@ -73,13 +73,13 @@ export const watchAdd = async (request: string, userId: string): Promise<WatchRe
     // Create watch
     const createdWatch = Watch.create({
       accountId,
-      pair: pairPart,
-      intervalMs,
-      thresholdType: threshold.type,
-      thresholdDirection: threshold.direction,
-      thresholdValue: threshold.value.toString(),
-      baselinePrice: baselinePrice.toString(),
       alertPrice: alertPrice.toString(),
+      baselinePrice: baselinePrice.toString(),
+      intervalMs,
+      pair: pairPart,
+      thresholdDirection: threshold.direction,
+      thresholdType: threshold.type,
+      thresholdValue: threshold.value.toString(),
     });
 
     return {

--- a/packages/messaging/src/command/watch/watchList.ts
+++ b/packages/messaging/src/command/watch/watchList.ts
@@ -13,7 +13,7 @@ export const watchList = async (userId: string) => {
     }
 
     return formatTelegramTable(`Active watches: ${watches.length}`, watches, [
-      {header: 'ID', align: 'right', value: w => String(w.id)},
+      {align: 'right', header: 'ID', value: w => String(w.id)},
       {header: 'Pair', value: w => w.pair},
       {header: 'Baseline', value: w => w.baselinePrice},
       {

--- a/packages/messaging/src/database/schema.ts
+++ b/packages/messaging/src/database/schema.ts
@@ -2,13 +2,12 @@ import {sqliteTable, integer, text, type AnySQLiteColumn} from 'drizzle-orm/sqli
 import {sql} from 'drizzle-orm';
 
 export const accounts = sqliteTable('accounts', {
-  id: integer('id').primaryKey({autoIncrement: true}),
-  userId: text('userId').notNull(),
-  name: text('name').notNull().unique(),
-  exchange: text('exchange').notNull(),
-  isPaper: integer('isPaper', {mode: 'boolean'}).notNull().default(true),
   apiKey: text('apiKey').notNull(),
   apiSecret: text('apiSecret').notNull(),
+  createdAt: text('createdAt').default('CURRENT_TIMESTAMP'),
+  exchange: text('exchange').notNull(),
+  id: integer('id').primaryKey({autoIncrement: true}),
+  isPaper: integer('isPaper', {mode: 'boolean'}).notNull().default(true),
   /**
    * Optional reference to another account whose credentials supply market data for this
    * one. Required for brokers without their own data feed (e.g. Trading212, which reuses
@@ -18,57 +17,58 @@ export const accounts = sqliteTable('accounts', {
   marketDataAccountId: integer('marketDataAccountId').references((): AnySQLiteColumn => accounts.id, {
     onDelete: 'set null',
   }),
-  createdAt: text('createdAt').default('CURRENT_TIMESTAMP'),
+  name: text('name').notNull().unique(),
   updatedAt: text('updatedAt').default('CURRENT_TIMESTAMP'),
+  userId: text('userId').notNull(),
 });
 
 export type Account = typeof accounts.$inferSelect;
 export type NewAccount = typeof accounts.$inferInsert;
 
 export const watches = sqliteTable('watches', {
-  id: integer('id').primaryKey({autoIncrement: true}),
   accountId: integer('accountId')
     .notNull()
     .references(() => accounts.id, {onDelete: 'cascade'}),
-  pair: text('pair').notNull(),
-  intervalMs: integer('intervalMs').notNull(),
-  thresholdType: text('thresholdType', {enum: ['percent', 'absolute']}).notNull(),
-  thresholdDirection: text('thresholdDirection', {enum: ['up', 'down']}).notNull(),
-  thresholdValue: text('thresholdValue').notNull(),
-  baselinePrice: text('baselinePrice').notNull(),
   alertPrice: text('alertPrice').notNull(),
+  baselinePrice: text('baselinePrice').notNull(),
   createdAt: text('createdAt').default(sql`(CURRENT_TIMESTAMP)`),
+  id: integer('id').primaryKey({autoIncrement: true}),
+  intervalMs: integer('intervalMs').notNull(),
+  pair: text('pair').notNull(),
+  thresholdDirection: text('thresholdDirection', {enum: ['up', 'down']}).notNull(),
+  thresholdType: text('thresholdType', {enum: ['percent', 'absolute']}).notNull(),
+  thresholdValue: text('thresholdValue').notNull(),
 });
 
 export type Watch = typeof watches.$inferSelect;
 export type NewWatch = typeof watches.$inferInsert;
 
 export const strategies = sqliteTable('strategies', {
-  id: integer('id').primaryKey({autoIncrement: true}),
   accountId: integer('accountId')
     .notNull()
     .references(() => accounts.id, {onDelete: 'cascade'}),
-  strategyName: text('strategyName').notNull(),
   config: text('config').notNull(),
+  createdAt: text('createdAt').default(sql`(CURRENT_TIMESTAMP)`),
+  id: integer('id').primaryKey({autoIncrement: true}),
   pair: text('pair').notNull(),
   state: text('state'),
-  createdAt: text('createdAt').default(sql`(CURRENT_TIMESTAMP)`),
+  strategyName: text('strategyName').notNull(),
 });
 
 export type StrategyRow = typeof strategies.$inferSelect;
 export type NewStrategyRow = typeof strategies.$inferInsert;
 
 export const reports = sqliteTable('reports', {
-  id: integer('id').primaryKey({autoIncrement: true}),
-  userId: text('userId').notNull(),
   accountId: integer('accountId')
     .notNull()
     .references(() => accounts.id, {onDelete: 'cascade'}),
-  reportName: text('reportName').notNull(),
   config: text('config').notNull(),
+  createdAt: text('createdAt').default(sql`(CURRENT_TIMESTAMP)`),
+  id: integer('id').primaryKey({autoIncrement: true}),
   intervalMs: integer('intervalMs'),
   lastRunAt: integer('lastRunAt'),
-  createdAt: text('createdAt').default(sql`(CURRENT_TIMESTAMP)`),
+  reportName: text('reportName').notNull(),
+  userId: text('userId').notNull(),
 });
 
 export type ReportRow = typeof reports.$inferSelect;

--- a/packages/messaging/src/logger.ts
+++ b/packages/messaging/src/logger.ts
@@ -5,22 +5,22 @@ const logDirectory = process.env.TYPEDTRADER_LOG_DIRECTORY?.trim() || process.en
 
 const targets: pino.TransportTargetOptions[] = [
   {
-    target: 'pino/file',
-    options: {destination: 1},
     level: 'info',
+    options: {destination: 1},
+    target: 'pino/file',
   },
 ];
 
 if (logDirectory) {
   targets.push({
-    target: 'pino-roll',
+    level: 'debug',
     options: {
       file: path.join(logDirectory, 'typedtrader.log'),
-      size: '10m',
       limit: {count: 10},
       mkdir: true,
+      size: '10m',
     },
-    level: 'debug',
+    target: 'pino-roll',
   });
 }
 

--- a/packages/messaging/src/platform/TelegramPlatform.test.ts
+++ b/packages/messaging/src/platform/TelegramPlatform.test.ts
@@ -15,8 +15,8 @@ const botInfo = {username: 'testbot'};
 const mockedReportAdd = vi.mocked(reportAdd);
 
 vi.mock('trading-strategies', () => ({
-  MESSAGE_BREAK: '\f',
   getAvailableReportNames: vi.fn().mockReturnValue([]),
+  MESSAGE_BREAK: '\f',
 }));
 
 vi.mock('../command/report/reportAdd.js', () => ({
@@ -40,19 +40,19 @@ vi.mock('@grammyjs/conversations', () => ({
 vi.mock('grammy', () => {
   function Bot() {
     return {
-      command: mockCommand,
-      callbackQuery: mockCallbackQuery,
-      use: mockUse,
-      init: mockInit,
-      start: mockStart,
-      stop: mockStop,
       api: {
-        sendMessage: mockSendMessage,
         config: {use: vi.fn()},
+        sendMessage: mockSendMessage,
       },
       get botInfo() {
         return botInfo;
       },
+      callbackQuery: mockCallbackQuery,
+      command: mockCommand,
+      init: mockInit,
+      start: mockStart,
+      stop: mockStop,
+      use: mockUse,
     };
   }
 
@@ -485,8 +485,8 @@ describe('TelegramPlatform', () => {
     function buildCtx(text: string): Context {
       return {
         message: {
+          entities: [{length: text.split(' ')[0].length, offset: 0, type: 'bot_command'}],
           text,
-          entities: [{type: 'bot_command', offset: 0, length: text.split(' ')[0].length}],
         },
       } as unknown as Context;
     }
@@ -522,7 +522,7 @@ describe('TelegramPlatform', () => {
     });
 
     it('is a no-op when no bot_command entity is present', async () => {
-      const ctx = {message: {text: 'hello world', entities: []}} as unknown as Context;
+      const ctx = {message: {entities: [], text: 'hello world'}} as unknown as Context;
       await lowercaseCommandMiddleware(ctx, async () => {});
       expect(ctx.message?.text).toBe('hello world');
     });

--- a/packages/messaging/src/platform/TelegramPlatform.ts
+++ b/packages/messaging/src/platform/TelegramPlatform.ts
@@ -48,13 +48,13 @@ interface TradeCommandShape {
 function tradeCommandShape(name: TradeCommandName): TradeCommandShape {
   switch (name) {
     case 'buyMarket':
-      return {side: OrderSide.BUY, isLimit: false};
+      return {isLimit: false, side: OrderSide.BUY};
     case 'sellMarket':
-      return {side: OrderSide.SELL, isLimit: false};
+      return {isLimit: false, side: OrderSide.SELL};
     case 'buyLimit':
-      return {side: OrderSide.BUY, isLimit: true};
+      return {isLimit: true, side: OrderSide.BUY};
     case 'sellLimit':
-      return {side: OrderSide.SELL, isLimit: true};
+      return {isLimit: true, side: OrderSide.SELL};
   }
 }
 
@@ -64,7 +64,7 @@ function buildTradeActionLabel(
   quantity: string,
   limitPrice: string | null
 ): string {
-  const {side, isLimit} = tradeCommandShape(cmd);
+  const {isLimit, side} = tradeCommandShape(cmd);
   const sideLabel = side === OrderSide.BUY ? 'BUY' : 'SELL';
   const kindLabel = isLimit ? 'LIMIT' : 'MARKET';
   if (isLimit && limitPrice !== null) {
@@ -133,9 +133,9 @@ async function parseTradeCommandInput(ctx: Context, cmd: TradeCommandName): Prom
 
   return {
     cmd,
+    limitPrice: isLimit ? String(positiveNumber.parse(priceInput)) : undefined,
     pairStr,
     quantity: String(quantityCheck.data),
-    limitPrice: isLimit ? String(positiveNumber.parse(priceInput)) : undefined,
   };
 }
 
@@ -161,10 +161,10 @@ async function tradeWizard(conversation: TradeConversation, ctx: TradeContext, a
    */
   const accounts = await conversation.external(() =>
     Account.findByUserId(userId).map(acc => ({
-      id: acc.id,
-      name: acc.name,
       exchange: acc.exchange,
+      id: acc.id,
       isPaper: acc.isPaper,
+      name: acc.name,
     }))
   );
 
@@ -179,8 +179,8 @@ async function tradeWizard(conversation: TradeConversation, ctx: TradeContext, a
   // Step 1: account picker
   const accountButtons: InlineButton[][] = accounts.map(acc => [
     {
-      text: `${acc.name} (${acc.exchange}${acc.isPaper ? ' paper' : ''})`,
       callback_data: `trade:acc:${acc.id}`,
+      text: `${acc.name} (${acc.exchange}${acc.isPaper ? ' paper' : ''})`,
     },
   ]);
   await ctx.reply(`${actionLabel}\nSelect an account:`, inlineKeyboard(accountButtons));
@@ -211,12 +211,12 @@ async function tradeWizard(conversation: TradeConversation, ctx: TradeContext, a
   await decision.editMessageText('Placing order…');
   const result = await conversation.external(() =>
     placeOrder({
-      userId,
       accountId,
-      pair,
-      side: tradeCommandShape(args.cmd).side,
-      quantity: args.quantity,
       limitPrice: args.limitPrice,
+      pair,
+      quantity: args.quantity,
+      side: tradeCommandShape(args.cmd).side,
+      userId,
     })
   );
   await decision.editMessageText(result);
@@ -231,8 +231,8 @@ async function buildTradeConfirmation(
   const account = Account.findByUserIdAndId(userId, accountId);
   if (!account) {
     return {
-      text: `Account "${accountId}" not found. Run the command again.`,
       keyboard: inlineKeyboard([]),
+      text: `Account "${accountId}" not found. Run the command again.`,
     };
   }
 
@@ -255,12 +255,12 @@ async function buildTradeConfirmation(
   const text = `${actionLabel}\nAccount: ${account.name}${priceContext}\n\nProceed?`;
   const keyboard = inlineKeyboard([
     [
-      {text: '✓ Yes, place order', callback_data: 'trade:cnf:y'},
-      {text: '✗ Cancel', callback_data: 'trade:cnf:n'},
+      {callback_data: 'trade:cnf:y', text: '✓ Yes, place order'},
+      {callback_data: 'trade:cnf:n', text: '✗ Cancel'},
     ],
   ]);
 
-  return {text, keyboard};
+  return {keyboard, text};
 }
 
 interface InlineButton {
@@ -329,8 +329,8 @@ export class TelegramPlatform implements MessagingPlatform {
     // @see https://grammy.dev/plugins/auto-retry
     this.#bot.api.config.use(
       autoRetry({
-        maxRetryAttempts: Infinity,
         maxDelaySeconds: 120,
+        maxRetryAttempts: Infinity,
       })
     );
     /*
@@ -490,12 +490,12 @@ export class TelegramPlatform implements MessagingPlatform {
       const content = commandEnd === -1 ? '' : text.slice(commandEnd + 1);
 
       const messageCtx: MessageContext = {
-        senderId: userId,
-        platformId: 'telegram',
         content,
+        platformId: 'telegram',
         reply: async (replyText: string) => {
           await replyWithMarkdown(ctx, replyText);
         },
+        senderId: userId,
       };
 
       await handler(messageCtx);
@@ -523,7 +523,7 @@ export class TelegramPlatform implements MessagingPlatform {
       return `${PLATFORM_PREFIX}${senderId}`;
     }
     if (!this.#ownerIds.includes(senderId)) {
-      logger.warn({senderId, ownerIds: this.#ownerIds}, 'Ignoring unauthorized Telegram update');
+      logger.warn({ownerIds: this.#ownerIds, senderId}, 'Ignoring unauthorized Telegram update');
       return null;
     }
     return `${PLATFORM_PREFIX}${senderId}`;
@@ -543,7 +543,7 @@ export class TelegramPlatform implements MessagingPlatform {
       }
 
       const rows: InlineButton[][] = available.map(name => [
-        {text: name, callback_data: `${REPORT_CALLBACK_PREFIX}${name}`},
+        {callback_data: `${REPORT_CALLBACK_PREFIX}${name}`, text: name},
       ]);
 
       await ctx.reply('Select a report to run:', inlineKeyboard(rows));
@@ -576,8 +576,8 @@ export class TelegramPlatform implements MessagingPlatform {
 
         const rows: InlineButton[][] = userAccounts.map(acc => [
           {
-            text: `${acc.name} (${acc.exchange}${acc.isPaper ? ' paper' : ''})`,
             callback_data: `${ACCOUNT_CALLBACK_PREFIX}${acc.id}:${reportName}`,
+            text: `${acc.name} (${acc.exchange}${acc.isPaper ? ' paper' : ''})`,
           },
         ]);
 
@@ -588,8 +588,8 @@ export class TelegramPlatform implements MessagingPlatform {
       await ctx.editMessageText(
         `Report: ${reportName}\nRun once or schedule recurring?`,
         inlineKeyboard([
-          [{text: 'Run once', callback_data: `${MODE_CALLBACK_PREFIX}once:${reportName}`}],
-          [{text: 'Schedule recurring', callback_data: `${MODE_CALLBACK_PREFIX}schedule:${reportName}`}],
+          [{callback_data: `${MODE_CALLBACK_PREFIX}once:${reportName}`, text: 'Run once'}],
+          [{callback_data: `${MODE_CALLBACK_PREFIX}schedule:${reportName}`, text: 'Schedule recurring'}],
         ])
       );
     });
@@ -627,8 +627,8 @@ export class TelegramPlatform implements MessagingPlatform {
       await ctx.editMessageText(
         `Report: ${reportName} (account ${accountId})\nRun once or schedule recurring?`,
         inlineKeyboard([
-          [{text: 'Run once', callback_data: `${MODE_CALLBACK_PREFIX}once:${reportWithAccount}`}],
-          [{text: 'Schedule recurring', callback_data: `${MODE_CALLBACK_PREFIX}schedule:${reportWithAccount}`}],
+          [{callback_data: `${MODE_CALLBACK_PREFIX}once:${reportWithAccount}`, text: 'Run once'}],
+          [{callback_data: `${MODE_CALLBACK_PREFIX}schedule:${reportWithAccount}`, text: 'Schedule recurring'}],
         ])
       );
     });
@@ -676,14 +676,14 @@ export class TelegramPlatform implements MessagingPlatform {
         `Report: ${validation.reportName}\nSelect interval:`,
         inlineKeyboard([
           [
-            {text: '1m', callback_data: `${INTERVAL_CALLBACK_PREFIX}1m:${reportInput}`},
-            {text: '1h', callback_data: `${INTERVAL_CALLBACK_PREFIX}1h:${reportInput}`},
-            {text: '6h', callback_data: `${INTERVAL_CALLBACK_PREFIX}6h:${reportInput}`},
+            {callback_data: `${INTERVAL_CALLBACK_PREFIX}1m:${reportInput}`, text: '1m'},
+            {callback_data: `${INTERVAL_CALLBACK_PREFIX}1h:${reportInput}`, text: '1h'},
+            {callback_data: `${INTERVAL_CALLBACK_PREFIX}6h:${reportInput}`, text: '6h'},
           ],
           [
-            {text: '12h', callback_data: `${INTERVAL_CALLBACK_PREFIX}12h:${reportInput}`},
-            {text: '1d', callback_data: `${INTERVAL_CALLBACK_PREFIX}1d:${reportInput}`},
-            {text: '1w', callback_data: `${INTERVAL_CALLBACK_PREFIX}1w:${reportInput}`},
+            {callback_data: `${INTERVAL_CALLBACK_PREFIX}12h:${reportInput}`, text: '12h'},
+            {callback_data: `${INTERVAL_CALLBACK_PREFIX}1d:${reportInput}`, text: '1d'},
+            {callback_data: `${INTERVAL_CALLBACK_PREFIX}1w:${reportInput}`, text: '1w'},
           ],
         ])
       );
@@ -745,15 +745,15 @@ export class TelegramPlatform implements MessagingPlatform {
     const accountIdStr = parts[1];
 
     if (!this.#isKnownReport(reportName)) {
-      return {ok: false, message: `Unknown report "${reportName}".`};
+      return {message: `Unknown report "${reportName}".`, ok: false};
     }
 
     if (accountIdStr !== undefined) {
       const accountId = Number.parseInt(accountIdStr, 10);
       if (!Number.isFinite(accountId) || !Account.findByUserIdAndId(userId, accountId)) {
-        return {ok: false, message: 'Account not found.'};
+        return {message: 'Account not found.', ok: false};
       }
-      return {ok: true, reportName, accountId};
+      return {accountId, ok: true, reportName};
     }
 
     return {ok: true, reportName};
@@ -766,7 +766,7 @@ export class TelegramPlatform implements MessagingPlatform {
         return;
       }
       const activeBefore = Object.keys(ctx.conversation.active());
-      logger.info({commandName, conversationId, activeBefore}, 'wizard command invoked');
+      logger.info({activeBefore, commandName, conversationId}, 'wizard command invoked');
       try {
         /*
          * Auto-cancel any wizard already in progress for this user. Only
@@ -780,7 +780,7 @@ export class TelegramPlatform implements MessagingPlatform {
         await ctx.conversation.enter(conversationId, {userId});
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Unknown error';
-        logger.error({message, conversationId}, 'wizard entry failed');
+        logger.error({conversationId, message}, 'wizard entry failed');
         await ctx.reply('Could not start the wizard — please try again in a moment.');
       }
     });

--- a/packages/messaging/src/platform/wizards/accountAddWizard.ts
+++ b/packages/messaging/src/platform/wizards/accountAddWizard.ts
@@ -30,7 +30,7 @@ export function makeAccountAddWizard() {
     args: AccountAddWizardArgs
   ): Promise<void> {
     const exchangeButtons: InlineButton[][] = EXCHANGES.map(name => [
-      {text: name, callback_data: `accountadd:ex:${name}`},
+      {callback_data: `accountadd:ex:${name}`, text: name},
     ]);
     await ctx.reply('Pick an exchange:', inlineKeyboard(exchangeButtons));
 
@@ -42,8 +42,8 @@ export function makeAccountAddWizard() {
       `Broker: ${exchange}\nChoose account mode:`,
       inlineKeyboard([
         [
-          {text: '📝 Paper', callback_data: 'accountadd:mode:paper'},
-          {text: '💵 Live', callback_data: 'accountadd:mode:live'},
+          {callback_data: 'accountadd:mode:paper', text: '📝 Paper'},
+          {callback_data: 'accountadd:mode:live', text: '💵 Live'},
         ],
       ])
     );
@@ -79,8 +79,8 @@ export function makeAccountAddWizard() {
 
       const dataSourceButtons: InlineButton[][] = dataSourceAccounts.map(candidate => [
         {
-          text: `${candidate.name} (${candidate.isPaper ? 'Paper' : 'Live'})`,
           callback_data: `accountadd:mds:${candidate.id}`,
+          text: `${candidate.name} (${candidate.isPaper ? 'Paper' : 'Live'})`,
         },
       ]);
       await modeCb.editMessageText(
@@ -138,8 +138,8 @@ export function makeAccountAddWizard() {
     }
 
     await deleteSecretMessages(conversation, ctx, 'accountAdd', [
-      {chatId: apiKeyChatId, messageId: apiKeyMessageId, label: 'API key'},
-      {chatId: apiSecretChatId, messageId: apiSecretMessageId, label: 'API secret'},
+      {chatId: apiKeyChatId, label: 'API key', messageId: apiKeyMessageId},
+      {chatId: apiSecretChatId, label: 'API secret', messageId: apiSecretMessageId},
     ]);
 
     await ctx.reply('Validating credentials…');
@@ -154,29 +154,29 @@ export function makeAccountAddWizard() {
         if (marketDataAccountId !== null) {
           const source = Account.findByUserIdAndId(args.userId, marketDataAccountId);
           if (!source) {
-            return {ok: false as const, error: 'Selected market-data account was not found.'};
+            return {error: 'Selected market-data account was not found.', ok: false as const};
           }
           marketData = buildMarketDataFromAccount(source);
         }
 
         await getAuthenticatedBrokerClient(
-          {exchangeId: exchange, apiKey, apiSecret, isPaper},
+          {apiKey, apiSecret, exchangeId: exchange, isPaper},
           marketData ? {marketData} : undefined
         );
         const account = Account.create({
-          userId: args.userId,
-          name,
-          exchange,
-          isPaper,
           apiKey,
           apiSecret,
+          exchange,
+          isPaper,
           marketDataAccountId,
+          name,
+          userId: args.userId,
         });
-        return {ok: true as const, id: account.id};
+        return {id: account.id, ok: true as const};
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Unknown error';
         logger.error({err: error}, 'accountAdd wizard failed');
-        return {ok: false as const, error: message};
+        return {error: message, ok: false as const};
       }
     });
 

--- a/packages/messaging/src/platform/wizards/accountEditWizard.ts
+++ b/packages/messaging/src/platform/wizards/accountEditWizard.ts
@@ -33,8 +33,8 @@ export function makeAccountEditWizard(deps: {
 
     const accountButtons: InlineButton[][] = accounts.map(account => [
       {
-        text: `${account.name} (${account.exchange}, ${account.isPaper ? 'Paper' : 'Live'})`,
         callback_data: `accountedit:acc:${account.id}`,
+        text: `${account.name} (${account.exchange}, ${account.isPaper ? 'Paper' : 'Live'})`,
       },
     ]);
     await ctx.reply('Pick an account to update:', inlineKeyboard(accountButtons));
@@ -75,8 +75,8 @@ export function makeAccountEditWizard(deps: {
     }
 
     await deleteSecretMessages(conversation, ctx, 'accountEdit', [
-      {chatId: apiKeyChatId, messageId: apiKeyMessageId, label: 'API key'},
-      {chatId: apiSecretChatId, messageId: apiSecretMessageId, label: 'API secret'},
+      {chatId: apiKeyChatId, label: 'API key', messageId: apiKeyMessageId},
+      {chatId: apiSecretChatId, label: 'API secret', messageId: apiSecretMessageId},
     ]);
 
     await ctx.reply('Validating credentials…');
@@ -92,15 +92,15 @@ export function makeAccountEditWizard(deps: {
           const source = Account.findByUserIdAndId(args.userId, account.marketDataAccountId);
           if (!source) {
             return {
-              ok: false as const,
               error: `Market-data account (ID: ${account.marketDataAccountId}) was not found.`,
+              ok: false as const,
             };
           }
           marketData = buildMarketDataFromAccount(source);
         }
 
         await getAuthenticatedBrokerClient(
-          {exchangeId: account.exchange, apiKey, apiSecret, isPaper: account.isPaper},
+          {apiKey, apiSecret, exchangeId: account.exchange, isPaper: account.isPaper},
           marketData ? {marketData} : undefined
         );
         Account.update(account.id, {apiKey, apiSecret});
@@ -108,7 +108,7 @@ export function makeAccountEditWizard(deps: {
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Unknown error';
         logger.error({err: error}, 'accountEdit wizard failed');
-        return {ok: false as const, error: message};
+        return {error: message, ok: false as const};
       }
     });
 

--- a/packages/messaging/src/platform/wizards/shared.ts
+++ b/packages/messaging/src/platform/wizards/shared.ts
@@ -41,9 +41,9 @@ export async function waitForTextOrCancel(
   if (text.startsWith('/')) {
     const isExplicitCancel = text.toLowerCase().startsWith('/cancel');
     await ctx.reply(isExplicitCancel ? 'Cancelled.' : 'Wizard cancelled. Resend your command to start fresh.');
-    return {text: '', cancelled: true};
+    return {cancelled: true, text: ''};
   }
-  return {text, cancelled: false};
+  return {cancelled: false, text};
 }
 
 /**
@@ -58,7 +58,7 @@ export async function deleteSecretMessages(
   messages: SecretMessage[]
 ): Promise<void> {
   await conversation.external(async () => {
-    for (const {chatId, messageId, label} of messages) {
+    for (const {chatId, label, messageId} of messages) {
       try {
         await ctx.api.deleteMessage(chatId, messageId);
       } catch (error) {

--- a/packages/messaging/src/platform/wizards/strategyAddWizard.ts
+++ b/packages/messaging/src/platform/wizards/strategyAddWizard.ts
@@ -35,7 +35,7 @@ export function makeStrategyAddWizard(deps: {strategyMonitor: () => StrategyMoni
      * once prefixed.
      */
     const strategyButtons: InlineButton[][] = strategies.map((name, idx) => [
-      {text: name, callback_data: `strategyadd:strat:${idx}`},
+      {callback_data: `strategyadd:strat:${idx}`, text: name},
     ]);
     await ctx.reply('Pick a strategy:', inlineKeyboard(strategyButtons));
 
@@ -45,7 +45,7 @@ export function makeStrategyAddWizard(deps: {strategyMonitor: () => StrategyMoni
     const strategyName = strategies[stratIdx] ?? '';
 
     const accounts = await conversation.external(() =>
-      Account.findByUserId(args.userId).map(a => ({id: a.id, name: a.name, exchange: a.exchange, isPaper: a.isPaper}))
+      Account.findByUserId(args.userId).map(a => ({exchange: a.exchange, id: a.id, isPaper: a.isPaper, name: a.name}))
     );
     if (accounts.length === 0) {
       await stratCb.editMessageText(`Strategy: ${strategyName}\nNo account found. Use /accountAdd first.`);
@@ -53,7 +53,7 @@ export function makeStrategyAddWizard(deps: {strategyMonitor: () => StrategyMoni
     }
 
     const accountButtons: InlineButton[][] = accounts.map(a => [
-      {text: `${a.name} (${a.exchange}${a.isPaper ? ' paper' : ''})`, callback_data: `strategyadd:acc:${a.id}`},
+      {callback_data: `strategyadd:acc:${a.id}`, text: `${a.name} (${a.exchange}${a.isPaper ? ' paper' : ''})`},
     ]);
     await stratCb.editMessageText(`Strategy: ${strategyName}\nPick an account:`, inlineKeyboard(accountButtons));
 
@@ -97,20 +97,20 @@ export function makeStrategyAddWizard(deps: {strategyMonitor: () => StrategyMoni
       try {
         const account = Account.findByPk(accountId);
         if (!account || account.userId !== args.userId) {
-          return {ok: false as const, error: 'Account not found.'};
+          return {error: 'Account not found.', ok: false as const};
         }
         createStrategy(strategyName, config);
         const row = Strategy.create({
           accountId,
-          strategyName,
           config: configJson,
           pair: pairStr,
+          strategyName,
         });
-        return {ok: true as const, strategy: row, accountName: account.name};
+        return {accountName: account.name, ok: true as const, strategy: row};
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Unknown error';
         logger.error({message}, 'strategyAdd wizard failed');
-        return {ok: false as const, error: message};
+        return {error: message, ok: false as const};
       }
     });
 

--- a/packages/messaging/src/platform/wizards/watchAddWizard.ts
+++ b/packages/messaging/src/platform/wizards/watchAddWizard.ts
@@ -29,7 +29,7 @@ export function makeWatchAddWizard(deps: {watchMonitor: () => WatchMonitor | und
     args: WatchAddWizardArgs
   ): Promise<void> {
     const accounts = await conversation.external(() =>
-      Account.findByUserId(args.userId).map(a => ({id: a.id, name: a.name, exchange: a.exchange, isPaper: a.isPaper}))
+      Account.findByUserId(args.userId).map(a => ({exchange: a.exchange, id: a.id, isPaper: a.isPaper, name: a.name}))
     );
     if (accounts.length === 0) {
       await ctx.reply('No account found. Use /accountAdd first.');
@@ -37,7 +37,7 @@ export function makeWatchAddWizard(deps: {watchMonitor: () => WatchMonitor | und
     }
 
     const accountButtons: InlineButton[][] = accounts.map(a => [
-      {text: `${a.name} (${a.exchange}${a.isPaper ? ' paper' : ''})`, callback_data: `watchadd:acc:${a.id}`},
+      {callback_data: `watchadd:acc:${a.id}`, text: `${a.name} (${a.exchange}${a.isPaper ? ' paper' : ''})`},
     ]);
     await ctx.reply('Pick an account:', inlineKeyboard(accountButtons));
 
@@ -62,8 +62,8 @@ export function makeWatchAddWizard(deps: {watchMonitor: () => WatchMonitor | und
     await ctx.reply(
       `Pair: ${pairStr}\nSelect check interval:`,
       inlineKeyboard([
-        INTERVALS.slice(0, 4).map(i => ({text: i, callback_data: `watchadd:int:${i}`})),
-        INTERVALS.slice(4).map(i => ({text: i, callback_data: `watchadd:int:${i}`})),
+        INTERVALS.slice(0, 4).map(i => ({callback_data: `watchadd:int:${i}`, text: i})),
+        INTERVALS.slice(4).map(i => ({callback_data: `watchadd:int:${i}`, text: i})),
       ])
     );
     const intervalCb = await conversation.waitForCallbackQuery(INTERVALS.map(i => `watchadd:int:${i}`));
@@ -74,8 +74,8 @@ export function makeWatchAddWizard(deps: {watchMonitor: () => WatchMonitor | und
       `Pair: ${pairStr}\nInterval: ${interval}\nAlert direction:`,
       inlineKeyboard([
         [
-          {text: '⬆️ Up', callback_data: 'watchadd:dir:up'},
-          {text: '⬇️ Down', callback_data: 'watchadd:dir:down'},
+          {callback_data: 'watchadd:dir:up', text: '⬆️ Up'},
+          {callback_data: 'watchadd:dir:down', text: '⬇️ Down'},
         ],
       ])
     );
@@ -87,8 +87,8 @@ export function makeWatchAddWizard(deps: {watchMonitor: () => WatchMonitor | und
       `Pair: ${pairStr}\nInterval: ${interval}\nDirection: ${direction}\nThreshold type:`,
       inlineKeyboard([
         [
-          {text: '% Percent', callback_data: 'watchadd:type:percent'},
-          {text: '# Absolute', callback_data: 'watchadd:type:absolute'},
+          {callback_data: 'watchadd:type:percent', text: '% Percent'},
+          {callback_data: 'watchadd:type:absolute', text: '# Absolute'},
         ],
       ])
     );
@@ -117,15 +117,15 @@ export function makeWatchAddWizard(deps: {watchMonitor: () => WatchMonitor | und
       try {
         const account = Account.findByPk(accountId);
         if (!account || account.userId !== args.userId) {
-          return {ok: false as const, error: 'Account not found.'};
+          return {error: 'Account not found.', ok: false as const};
         }
         const client = getAccountBrokerClient(account);
         const smallestInterval = client.getSmallestInterval();
         const intervalMs = assertInterval(interval);
         if (intervalMs < smallestInterval) {
           return {
-            ok: false as const,
             error: `Minimum interval for ${account.exchange} is ${ms(smallestInterval, {long: true})}.`,
+            ok: false as const,
           };
         }
         const candle = await client.getLatestCandle(pair, smallestInterval);
@@ -137,15 +137,15 @@ export function makeWatchAddWizard(deps: {watchMonitor: () => WatchMonitor | und
             : new Big(baselinePrice).plus(multiplier.times(threshold.value));
         const watch = Watch.create({
           accountId,
-          pair: pairStr,
-          intervalMs,
-          thresholdType: threshold.type,
-          thresholdDirection: threshold.direction,
-          thresholdValue: threshold.value.toString(),
-          baselinePrice: baselinePrice.toString(),
           alertPrice: alertPrice.toString(),
+          baselinePrice: baselinePrice.toString(),
+          intervalMs,
+          pair: pairStr,
+          thresholdDirection: threshold.direction,
+          thresholdType: threshold.type,
+          thresholdValue: threshold.value.toString(),
         });
-        return {ok: true as const, watch, baselinePrice, alertPrice: alertPrice.toString(), counter: pair.counter};
+        return {alertPrice: alertPrice.toString(), baselinePrice, counter: pair.counter, ok: true as const, watch};
       } catch (error) {
         /*
          * Log ONLY the message — axios errors carry the API key and secret
@@ -153,7 +153,7 @@ export function makeWatchAddWizard(deps: {watchMonitor: () => WatchMonitor | und
          */
         const message = error instanceof Error ? error.message : 'Unknown error';
         logger.error({message}, 'watchAdd wizard failed');
-        return {ok: false as const, error: message};
+        return {error: message, ok: false as const};
       }
     });
 

--- a/packages/messaging/src/service/ReportScheduler.ts
+++ b/packages/messaging/src/service/ReportScheduler.ts
@@ -65,7 +65,7 @@ export class ReportScheduler {
 
     this.#scheduled.set(row.id, {reportId: row.id, timer: setTimeout(tick, initialDelay)});
     logger.info(
-      {reportId: row.id, reportName: row.reportName, intervalMs, initialDelay, lastRunAt: row.lastRunAt},
+      {initialDelay, intervalMs, lastRunAt: row.lastRunAt, reportId: row.id, reportName: row.reportName},
       'Scheduled report'
     );
   }
@@ -89,7 +89,7 @@ export class ReportScheduler {
         api = new AlpacaAPI({apiKey: account.apiKey, apiSecret: account.apiSecret, usePaperTrading: account.isPaper});
       } catch (error) {
         logger.warn(
-          {err: error, reportId: row.id, accountId: row.accountId, userId: row.userId},
+          {accountId: row.accountId, err: error, reportId: row.id, userId: row.userId},
           'Account not available for report — skipping run'
         );
         return;

--- a/packages/messaging/src/service/StrategyMonitor.test.ts
+++ b/packages/messaging/src/service/StrategyMonitor.test.ts
@@ -2,16 +2,25 @@ import {describe, it, expect, vi, beforeEach} from 'vitest';
 import type {MessagingPlatform} from '../platform/MessagingPlatform.js';
 import type {StrategyAttributes} from '../database/models/Strategy.js';
 
-const {mockSession, mockStrategy, TradingSessionMock, mockAccountModel, mockStrategyModel} = vi.hoisted(() => {
-  const session = {start: vi.fn(), stop: vi.fn(), on: vi.fn()};
+const {mockAccountModel, mockSession, mockStrategy, mockStrategyModel, TradingSessionMock} = vi.hoisted(() => {
+  const session = {on: vi.fn(), start: vi.fn(), stop: vi.fn()};
   return {
+    mockAccountModel: {findByPk: vi.fn()},
     mockSession: session,
     mockStrategy: {
-      restoreState: vi.fn(),
-      onSave: undefined as (() => void) | undefined,
-      onFinish: undefined as (() => void) | undefined,
-      state: {position: 'long'},
       config: {threshold: 10},
+      onFinish: undefined as (() => void) | undefined,
+      onSave: undefined as (() => void) | undefined,
+      restoreState: vi.fn(),
+      state: {position: 'long'},
+    },
+    mockStrategyModel: {
+      destroy: vi.fn(),
+      findAllOrderedById: vi.fn(() => []),
+      findByAccountIds: vi.fn(),
+      findByPk: vi.fn(),
+      updateConfig: vi.fn(),
+      updateState: vi.fn(),
     },
     /*
      * Must stay a regular function: the code under test calls `new TradingSession(...)`,
@@ -21,22 +30,13 @@ const {mockSession, mockStrategy, TradingSessionMock, mockAccountModel, mockStra
     TradingSessionMock: vi.fn(function () {
       return session;
     }),
-    mockAccountModel: {findByPk: vi.fn()},
-    mockStrategyModel: {
-      findByAccountIds: vi.fn(),
-      findByPk: vi.fn(),
-      findAllOrderedById: vi.fn(() => []),
-      updateState: vi.fn(),
-      updateConfig: vi.fn(),
-      destroy: vi.fn(),
-    },
   };
 });
 
 vi.mock('@typedtrader/exchange', () => ({
-  TradingSession: TradingSessionMock,
-  TradingPair: {fromString: vi.fn(() => ({base: 'BTC', counter: 'USD'}))},
   getBrokerClient: vi.fn(() => ({})),
+  TradingPair: {fromString: vi.fn(() => ({base: 'BTC', counter: 'USD'}))},
+  TradingSession: TradingSessionMock,
 }));
 
 vi.mock('trading-strategies', () => ({
@@ -51,29 +51,29 @@ vi.mock('../database/models/Strategy.js', () => ({
   Strategy: mockStrategyModel,
 }));
 
-const {StrategyMonitor, formatStrategyMessage} = await import('./StrategyMonitor.js');
+const {formatStrategyMessage, StrategyMonitor} = await import('./StrategyMonitor.js');
 const {PlatformDispatcher} = await import('./PlatformDispatcher.js');
 
 function createMockPlatform(): MessagingPlatform {
   return {
-    start: vi.fn(),
-    stop: vi.fn(),
-    sendMessage: vi.fn(),
-    registerCommand: vi.fn(),
     commandList: [],
     platformInfo: {botAddress: '', sdkVersion: ''},
+    registerCommand: vi.fn(),
+    sendMessage: vi.fn(),
+    start: vi.fn(),
+    stop: vi.fn(),
   };
 }
 
 function createStrategyRow(overrides: Partial<StrategyAttributes> = {}): StrategyAttributes {
   return {
-    id: 1,
     accountId: 7,
-    strategyName: '@typedtrader/strategy-trailing-stop',
-    pair: 'BTC,USD',
     config: '{"threshold":10}',
-    state: null,
     createdAt: null,
+    id: 1,
+    pair: 'BTC,USD',
+    state: null,
+    strategyName: '@typedtrader/strategy-trailing-stop',
     ...overrides,
   };
 }
@@ -118,9 +118,9 @@ describe('StrategyMonitor.restartForAccount', () => {
     mockStrategy.state = {position: 'long'};
     mockStrategy.config = {threshold: 10};
     mockAccountModel.findByPk.mockReturnValue({
-      exchange: 'alpaca',
       apiKey: 'key',
       apiSecret: 'secret',
+      exchange: 'alpaca',
       isPaper: true,
       userId: 'telegram:42',
     });

--- a/packages/messaging/src/service/StrategyMonitor.ts
+++ b/packages/messaging/src/service/StrategyMonitor.ts
@@ -136,8 +136,8 @@ export class StrategyMonitor {
 
     await session.start();
 
-    this.#sessions.set(row.id, {strategyId: row.id, session, strategy});
-    logger.info({strategyId: row.id, strategyName: row.strategyName, pair: row.pair}, 'Started strategy');
+    this.#sessions.set(row.id, {session, strategy, strategyId: row.id});
+    logger.info({pair: row.pair, strategyId: row.id, strategyName: row.strategyName}, 'Started strategy');
   }
 
   /**
@@ -174,9 +174,9 @@ export class StrategyMonitor {
         if (freshRow) {
           await this.subscribeToStrategy(freshRow);
         }
-        logger.info({strategyId: row.id, accountId}, 'Restarted strategy after account update');
+        logger.info({accountId, strategyId: row.id}, 'Restarted strategy after account update');
       } catch (error) {
-        logger.error({err: error, strategyId: row.id, accountId}, 'Failed to restart strategy after account update');
+        logger.error({accountId, err: error, strategyId: row.id}, 'Failed to restart strategy after account update');
       }
     }
   }

--- a/packages/messaging/src/service/WatchMonitor.test.ts
+++ b/packages/messaging/src/service/WatchMonitor.test.ts
@@ -2,25 +2,25 @@ import {describe, it, expect, vi, beforeEach} from 'vitest';
 import type {MessagingPlatform} from '../platform/MessagingPlatform.js';
 import type {WatchAttributes} from '../database/models/Watch.js';
 
-const {mockExchange, mockAccountModel, mockWatchModel} = vi.hoisted(() => ({
-  mockExchange: {
-    watchCandles: vi.fn(),
-    on: vi.fn(),
-    unwatchCandles: vi.fn(),
-    removeAllListeners: vi.fn(),
-  },
+const {mockAccountModel, mockExchange, mockWatchModel} = vi.hoisted(() => ({
   mockAccountModel: {findByPk: vi.fn()},
+  mockExchange: {
+    on: vi.fn(),
+    removeAllListeners: vi.fn(),
+    unwatchCandles: vi.fn(),
+    watchCandles: vi.fn(),
+  },
   mockWatchModel: {
+    destroy: vi.fn(),
+    findAllOrderedById: vi.fn(() => []),
     findByAccountIds: vi.fn(),
     findByPk: vi.fn(),
-    findAllOrderedById: vi.fn(() => []),
-    destroy: vi.fn(),
   },
 }));
 
 vi.mock('@typedtrader/exchange', () => ({
-  TradingPair: {fromString: vi.fn(() => ({base: 'BTC', counter: 'USD'}))},
   getBrokerClient: vi.fn(() => mockExchange),
+  TradingPair: {fromString: vi.fn(() => ({base: 'BTC', counter: 'USD'}))},
 }));
 
 vi.mock('../database/models/Account.js', () => ({
@@ -36,27 +36,27 @@ const {PlatformDispatcher} = await import('./PlatformDispatcher.js');
 
 function createMockPlatform(): MessagingPlatform {
   return {
-    start: vi.fn(),
-    stop: vi.fn(),
-    sendMessage: vi.fn(),
-    registerCommand: vi.fn(),
     commandList: [],
     platformInfo: {botAddress: '', sdkVersion: ''},
+    registerCommand: vi.fn(),
+    sendMessage: vi.fn(),
+    start: vi.fn(),
+    stop: vi.fn(),
   };
 }
 
 function createWatchRow(overrides: Partial<WatchAttributes> = {}): WatchAttributes {
   return {
-    id: 1,
     accountId: 7,
-    pair: 'BTC,USD',
-    intervalMs: 60_000,
     alertPrice: '50000',
     baselinePrice: '49000',
+    createdAt: '2026-05-14T00:00:00.000Z',
+    id: 1,
+    intervalMs: 60_000,
+    pair: 'BTC,USD',
     thresholdDirection: 'up',
     thresholdType: 'percent',
     thresholdValue: '2',
-    createdAt: '2026-05-14T00:00:00.000Z',
     ...overrides,
   };
 }
@@ -85,9 +85,9 @@ describe('WatchMonitor.restartForAccount', () => {
     vi.clearAllMocks();
     mockExchange.watchCandles.mockResolvedValue('topic-1');
     mockAccountModel.findByPk.mockReturnValue({
-      exchange: 'alpaca',
       apiKey: 'key',
       apiSecret: 'secret',
+      exchange: 'alpaca',
       isPaper: true,
     });
   });

--- a/packages/messaging/src/service/WatchMonitor.ts
+++ b/packages/messaging/src/service/WatchMonitor.ts
@@ -37,7 +37,7 @@ export class WatchMonitor {
         await this.subscribeToWatch(watch);
         await this.#dispatcher.sendToAccount(watch.accountId, `Watch "${watch.id}" started.`);
       } catch (error) {
-        logger.error({err: error, watchId: watch.id, accountId: watch.accountId}, 'Failed to start watch');
+        logger.error({accountId: watch.accountId, err: error, watchId: watch.id}, 'Failed to start watch');
       }
     }
   }
@@ -96,12 +96,12 @@ export class WatchMonitor {
     });
 
     this.#subscriptions.set(watch.id, {
-      watchId: watch.id,
-      topicId,
       broker: exchange,
+      topicId,
+      watchId: watch.id,
     });
 
-    logger.info({watchId: watch.id, pair: watch.pair}, 'Subscribed to watch');
+    logger.info({pair: watch.pair, watchId: watch.id}, 'Subscribed to watch');
   }
 
   /**
@@ -135,9 +135,9 @@ export class WatchMonitor {
         if (freshWatch) {
           await this.subscribeToWatch(freshWatch);
         }
-        logger.info({watchId: watch.id, accountId}, 'Restarted watch after account update');
+        logger.info({accountId, watchId: watch.id}, 'Restarted watch after account update');
       } catch (error) {
-        logger.error({err: error, watchId: watch.id, accountId}, 'Failed to restart watch after account update');
+        logger.error({accountId, err: error, watchId: watch.id}, 'Failed to restart watch after account update');
       }
     }
   }

--- a/packages/messaging/src/startServer.ts
+++ b/packages/messaging/src/startServer.ts
@@ -240,9 +240,9 @@ export async function startServer() {
 
   const dispatcher = new PlatformDispatcher(platforms);
   const monitors: Monitors = {
-    watchMonitor: new WatchMonitor(dispatcher),
-    strategyMonitor: new StrategyMonitor(dispatcher),
     reportScheduler: new ReportScheduler(dispatcher),
+    strategyMonitor: new StrategyMonitor(dispatcher),
+    watchMonitor: new WatchMonitor(dispatcher),
   };
 
   for (const [, platform] of platforms) {

--- a/packages/messaging/src/validation/parseThreshold.test.ts
+++ b/packages/messaging/src/validation/parseThreshold.test.ts
@@ -5,24 +5,24 @@ describe('parseThreshold', () => {
   describe('percent thresholds', () => {
     it('parses positive percent', () => {
       expect(parseThreshold('+5%')).toEqual({
-        type: 'percent',
         direction: 'up',
+        type: 'percent',
         value: 5,
       });
     });
 
     it('parses negative percent', () => {
       expect(parseThreshold('-10%')).toEqual({
-        type: 'percent',
         direction: 'down',
+        type: 'percent',
         value: 10,
       });
     });
 
     it('parses decimal percent', () => {
       expect(parseThreshold('+2.5%')).toEqual({
-        type: 'percent',
         direction: 'up',
+        type: 'percent',
         value: 2.5,
       });
     });
@@ -31,24 +31,24 @@ describe('parseThreshold', () => {
   describe('absolute thresholds', () => {
     it('parses positive absolute', () => {
       expect(parseThreshold('+100')).toEqual({
-        type: 'absolute',
         direction: 'up',
+        type: 'absolute',
         value: 100,
       });
     });
 
     it('parses negative absolute', () => {
       expect(parseThreshold('-50')).toEqual({
-        type: 'absolute',
         direction: 'down',
+        type: 'absolute',
         value: 50,
       });
     });
 
     it('parses decimal absolute', () => {
       expect(parseThreshold('-50.5')).toEqual({
-        type: 'absolute',
         direction: 'down',
+        type: 'absolute',
         value: 50.5,
       });
     });
@@ -57,8 +57,8 @@ describe('parseThreshold', () => {
   describe('whitespace handling', () => {
     it('trims leading and trailing whitespace', () => {
       expect(parseThreshold('  +5%  ')).toEqual({
-        type: 'percent',
         direction: 'up',
+        type: 'percent',
         value: 5,
       });
     });

--- a/packages/messaging/src/validation/parseThreshold.ts
+++ b/packages/messaging/src/validation/parseThreshold.ts
@@ -21,8 +21,8 @@ export function parseThreshold(thresholdStr: string): ParsedThreshold | null {
     }
 
     return {
-      type: 'percent',
       direction: sign === '+' ? 'up' : 'down',
+      type: 'percent',
       value,
     };
   }
@@ -37,8 +37,8 @@ export function parseThreshold(thresholdStr: string): ParsedThreshold | null {
     }
 
     return {
-      type: 'absolute',
       direction: sign === '+' ? 'up' : 'down',
+      type: 'absolute',
       value,
     };
   }

--- a/packages/trading-signals/eslint.config.mjs
+++ b/packages/trading-signals/eslint.config.mjs
@@ -14,7 +14,7 @@ export default defineConfig({
     'eslint.config.mjs',
   ],
   rules: {
-    // Object-key sorting is not enforced in this repo for now.
-    'perfectionist/sort-objects': 'off',
+    // Object-key sorting is enforced across all packages.
+    'perfectionist/sort-objects': 'error',
   },
 });

--- a/packages/trading-signals/src/momentum/AO/AO.ts
+++ b/packages/trading-signals/src/momentum/AO/AO.ts
@@ -38,7 +38,7 @@ export class AO extends TrendIndicatorSeries<HighLow<number>> {
     return this.long.getRequiredInputs();
   }
 
-  update({low, high}: HighLow<number>, replace: boolean) {
+  update({high, low}: HighLow<number>, replace: boolean) {
     const medianPrice = (low + high) / 2;
 
     this.short.update(medianPrice, replace);

--- a/packages/trading-signals/src/momentum/CCI/CCI.ts
+++ b/packages/trading-signals/src/momentum/CCI/CCI.ts
@@ -59,7 +59,7 @@ export class CCI extends TrendIndicatorSeries<HighLowClose<number>> {
     return null;
   }
 
-  #cacheTypicalPrice({high, low, close}: HighLowClose<number>, replace: boolean) {
+  #cacheTypicalPrice({close, high, low}: HighLowClose<number>, replace: boolean) {
     const typicalPrice = (high + low + close) / 3;
     pushUpdate(this.#typicalPrices, replace, typicalPrice, this.interval);
     return typicalPrice;

--- a/packages/trading-signals/src/trend/DMA/DMA.test.ts
+++ b/packages/trading-signals/src/trend/DMA/DMA.test.ts
@@ -84,7 +84,7 @@ describe('DMA', () => {
         dma.add(Number(price));
       }
 
-      const {short, long} = dma.getResultOrThrow();
+      const {long, short} = dma.getResultOrThrow();
       expect(dma.getRequiredInputs()).toBe(longInterval);
       expect(dma.isStable).toBe(true);
       expect(short > long).toBe(true);

--- a/packages/trading-signals/src/util/getGrid.ts
+++ b/packages/trading-signals/src/util/getGrid.ts
@@ -6,7 +6,7 @@ export type GridConfig = {
   tickSize?: number;
 };
 
-export function getGrid({lower, upper, levels, tickSize, spacing}: GridConfig): number[] {
+export function getGrid({levels, lower, spacing, tickSize, upper}: GridConfig): number[] {
   const prices: number[] = [];
 
   if (spacing === 'arithmetic') {

--- a/packages/trading-signals/src/volatility/ABANDS/AccelerationBands.ts
+++ b/packages/trading-signals/src/volatility/ABANDS/AccelerationBands.ts
@@ -48,7 +48,7 @@ export class AccelerationBands extends TechnicalIndicator<BandsResult, HighLowCl
     return this.#middleBand.getRequiredInputs();
   }
 
-  update({high, low, close}: HighLowClose<number>, replace: boolean) {
+  update({close, high, low}: HighLowClose<number>, replace: boolean) {
     const highPlusLow = high + low;
     const coefficient = highPlusLow === 0 ? 0 : ((high - low) / highPlusLow) * this.width;
 

--- a/packages/trading-signals/src/volatility/BBANDS/BollingerBands.test.ts
+++ b/packages/trading-signals/src/volatility/BBANDS/BollingerBands.test.ts
@@ -35,7 +35,7 @@ describe('BollingerBands', () => {
         const resLower = Number(data.lower[index]);
         const resUpper = Number(data.upper[index]);
 
-        const {middle, upper, lower} = bb.getResultOrThrow();
+        const {lower, middle, upper} = bb.getResultOrThrow();
 
         expect(middle.toPrecision(12)).toEqual(resMiddle.toPrecision(12));
         expect(lower.toPrecision(12)).toEqual(resLower.toPrecision(12));

--- a/packages/trading-strategies/eslint.config.mjs
+++ b/packages/trading-strategies/eslint.config.mjs
@@ -18,7 +18,7 @@ export default defineConfig({
     // companion pattern as an enum replacement. `no-redeclare` misfires on the shared
     // value/type name even though TypeScript allows it; renaming would break public APIs.
     '@typescript-eslint/no-redeclare': 'off',
-    // Object-key sorting is not enforced in this repo for now.
-    'perfectionist/sort-objects': 'off',
+    // Object-key sorting is enforced across all packages.
+    'perfectionist/sort-objects': 'error',
   },
 });

--- a/packages/trading-strategies/src/backtest/BacktestExecutor.test.ts
+++ b/packages/trading-strategies/src/backtest/BacktestExecutor.test.ts
@@ -15,11 +15,11 @@ function createCandle(overrides: Partial<Candle> & {close: string; open: string}
 
   return {
     base: 'BTC',
+    close: overrides.close,
     counter: 'USD',
     high: overrides.high ?? String(Math.max(openNum, closeNum)),
     low: overrides.low ?? String(Math.min(openNum, closeNum)),
     open: overrides.open,
-    close: overrides.close,
     openTimeInISO: overrides.openTimeInISO ?? '2025-01-01T00:00:00.000Z',
     openTimeInMillis: overrides.openTimeInMillis ?? 1735689600000,
     sizeInMillis: overrides.sizeInMillis ?? 60000,
@@ -51,11 +51,11 @@ describe('BacktestExecutor', () => {
         }
       }
 
-      const candles = [createCandle({open: '100', close: '105'}), createCandle({open: '105', close: '110'})] as const;
+      const candles = [createCandle({close: '105', open: '100'}), createCandle({close: '110', open: '105'})] as const;
 
       const config: BacktestConfig = {
-        candles: [...candles],
         broker: createMockExchange({baseBalance: '1', counterBalance: '1000'}),
+        candles: [...candles],
         strategy: new NoOpStrategy(),
         tradingPair,
       };
@@ -73,8 +73,8 @@ describe('BacktestExecutor', () => {
       const strategy = new BuyBelowSellAboveStrategy({buyBelow: '50'});
 
       const config: BacktestConfig = {
-        candles: [],
         broker: createMockExchange(),
+        candles: [],
         strategy,
         tradingPair,
       };
@@ -94,13 +94,13 @@ describe('BacktestExecutor', () => {
        * Candle 2: order fills at candle 2 (1-candle delay)
        */
       const candles = [
-        createCandle({open: '95', close: '90', low: '88', high: '95', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
-        createCandle({open: '92', close: '95', low: '88', high: '95', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
+        createCandle({close: '90', high: '95', low: '88', open: '95', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+        createCandle({close: '95', high: '95', low: '88', open: '92', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
       ];
 
       const config: BacktestConfig = {
-        candles,
         broker: createMockExchange(),
+        candles,
         strategy,
         tradingPair,
       };
@@ -123,13 +123,13 @@ describe('BacktestExecutor', () => {
        * Candle 2: order fills at candle 2
        */
       const candles = [
-        createCandle({open: '105', close: '110', low: '105', high: '115', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
-        createCandle({open: '108', close: '112', low: '106', high: '115', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
+        createCandle({close: '110', high: '115', low: '105', open: '105', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+        createCandle({close: '112', high: '115', low: '106', open: '108', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
       ];
 
       const config: BacktestConfig = {
-        candles,
         broker: createMockExchange({baseBalance: '2', counterBalance: '0'}),
+        candles,
         strategy,
         tradingPair,
       };
@@ -151,13 +151,13 @@ describe('BacktestExecutor', () => {
        * Candle 2: order fills
        */
       const candles = [
-        createCandle({open: '100', close: '100', low: '100', high: '100', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
-        createCandle({open: '100', close: '100', low: '100', high: '100', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
+        createCandle({close: '100', high: '100', low: '100', open: '100', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+        createCandle({close: '100', high: '100', low: '100', open: '100', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
       ];
 
       const config: BacktestConfig = {
-        candles,
         broker: createMockExchange({baseBalance: '10', counterBalance: '0'}),
+        candles,
         strategy,
         tradingPair,
       };
@@ -191,10 +191,10 @@ describe('BacktestExecutor', () => {
           this.#bought = true;
 
           return {
-            side: OrderSide.BUY,
-            type: OrderType.MARKET,
             amount: AllAvailableAmount,
             amountIn: 'counter',
+            side: OrderSide.BUY,
+            type: OrderType.MARKET,
           };
         }
       }
@@ -204,13 +204,13 @@ describe('BacktestExecutor', () => {
        * Candle 2: market order fills at candle 2's open price
        */
       const candles = [
-        createCandle({open: '50', close: '50', low: '50', high: '50', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
-        createCandle({open: '50', close: '50', low: '50', high: '50', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
+        createCandle({close: '50', high: '50', low: '50', open: '50', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+        createCandle({close: '50', high: '50', low: '50', open: '50', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
       ];
 
       const config: BacktestConfig = {
-        candles,
         broker: createMockExchange(),
+        candles,
         strategy: new AlwaysBuyMarket(),
         tradingPair,
       };
@@ -240,16 +240,16 @@ describe('BacktestExecutor', () => {
        * Candle 5: sell fills
        */
       const candles = [
-        createCandle({open: '80', close: '80', low: '78', high: '82', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
-        createCandle({open: '82', close: '85', low: '78', high: '90', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
-        createCandle({open: '110', close: '115', low: '108', high: '118', openTimeInISO: '2025-01-01T00:02:00.000Z'}),
-        createCandle({open: '120', close: '130', low: '118', high: '135', openTimeInISO: '2025-01-01T00:03:00.000Z'}),
-        createCandle({open: '128', close: '132', low: '125', high: '135', openTimeInISO: '2025-01-01T00:04:00.000Z'}),
+        createCandle({close: '80', high: '82', low: '78', open: '80', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+        createCandle({close: '85', high: '90', low: '78', open: '82', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
+        createCandle({close: '115', high: '118', low: '108', open: '110', openTimeInISO: '2025-01-01T00:02:00.000Z'}),
+        createCandle({close: '130', high: '135', low: '118', open: '120', openTimeInISO: '2025-01-01T00:03:00.000Z'}),
+        createCandle({close: '132', high: '135', low: '125', open: '128', openTimeInISO: '2025-01-01T00:04:00.000Z'}),
       ];
 
       const config: BacktestConfig = {
-        candles,
         broker: createMockExchange(),
+        candles,
         strategy,
         tradingPair,
       };
@@ -268,13 +268,13 @@ describe('BacktestExecutor', () => {
       const strategy = new BuyBelowSellAboveStrategy({sellAbove: '50'});
 
       const candles = [
-        createCandle({open: '100', close: '100', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
-        createCandle({open: '100', close: '100', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
+        createCandle({close: '100', open: '100', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+        createCandle({close: '100', open: '100', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
       ];
 
       const config: BacktestConfig = {
-        candles,
         broker: createMockExchange({baseBalance: '0', counterBalance: '1000'}),
+        candles,
         strategy,
         tradingPair,
       };
@@ -291,16 +291,16 @@ describe('BacktestExecutor', () => {
       const strategy = new BuyBelowSellAboveStrategy({buyBelow: '1000'});
 
       const candles = [
-        createCandle({open: '50', close: '50', low: '48', high: '52', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
-        createCandle({open: '55', close: '55', low: '48', high: '58', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
-        createCandle({open: '60', close: '60', low: '58', high: '62', openTimeInISO: '2025-01-01T00:02:00.000Z'}),
-        createCandle({open: '65', close: '65', low: '63', high: '67', openTimeInISO: '2025-01-01T00:03:00.000Z'}),
-        createCandle({open: '70', close: '70', low: '68', high: '72', openTimeInISO: '2025-01-01T00:04:00.000Z'}),
+        createCandle({close: '50', high: '52', low: '48', open: '50', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+        createCandle({close: '55', high: '58', low: '48', open: '55', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
+        createCandle({close: '60', high: '62', low: '58', open: '60', openTimeInISO: '2025-01-01T00:02:00.000Z'}),
+        createCandle({close: '65', high: '67', low: '63', open: '65', openTimeInISO: '2025-01-01T00:03:00.000Z'}),
+        createCandle({close: '70', high: '72', low: '68', open: '70', openTimeInISO: '2025-01-01T00:04:00.000Z'}),
       ];
 
       const config: BacktestConfig = {
-        candles,
         broker: createMockExchange({counterBalance: '500'}),
+        candles,
         strategy,
         tradingPair,
       };
@@ -324,11 +324,11 @@ describe('BacktestExecutor', () => {
           }
           this.#sold = true;
           return {
-            side: OrderSide.SELL,
-            type: OrderType.LIMIT,
             amount: new Big(100),
             amountIn: 'base',
             price: candle.close,
+            side: OrderSide.SELL,
+            type: OrderType.LIMIT,
           };
         }
       }
@@ -338,13 +338,13 @@ describe('BacktestExecutor', () => {
        * Candle 2: order fills
        */
       const candles = [
-        createCandle({open: '50', close: '50', low: '50', high: '50', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
-        createCandle({open: '50', close: '50', low: '50', high: '50', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
+        createCandle({close: '50', high: '50', low: '50', open: '50', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+        createCandle({close: '50', high: '50', low: '50', open: '50', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
       ];
 
       const config: BacktestConfig = {
-        candles,
         broker: createMockExchange({baseBalance: '5', counterBalance: '0'}),
+        candles,
         strategy: new SellTooMuch(),
         tradingPair,
       };
@@ -428,10 +428,10 @@ describe('BacktestExecutor', () => {
 
         candles.push(
           createCandle({
-            open: price,
             close: price,
             high: String(priceNum + 2),
             low: String(priceNum - 2),
+            open: price,
             openTimeInISO: time.toISOString(),
             openTimeInMillis: time.getTime(),
             sizeInMillis: 7 * 24 * 60 * 60 * 1000,
@@ -440,8 +440,8 @@ describe('BacktestExecutor', () => {
       });
 
       const config: BacktestConfig = {
-        candles,
         broker: createMockExchange({counterBalance: '10000'}),
+        candles,
         strategy,
         tradingPair,
       };
@@ -472,19 +472,19 @@ describe('BacktestExecutor', () => {
 
       // With 1-candle delay, we need pairs of candles for each trade to fill
       const candles = [
-        createCandle({open: '40', close: '40', low: '38', high: '42', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
-        createCandle({open: '42', close: '45', low: '38', high: '48', openTimeInISO: '2025-01-15T00:00:00.000Z'}),
-        createCandle({open: '90', close: '90', low: '88', high: '95', openTimeInISO: '2025-02-01T00:00:00.000Z'}),
-        createCandle({open: '88', close: '85', low: '82', high: '92', openTimeInISO: '2025-02-15T00:00:00.000Z'}),
-        createCandle({open: '35', close: '35', low: '33', high: '38', openTimeInISO: '2025-03-01T00:00:00.000Z'}),
-        createCandle({open: '37', close: '40', low: '33', high: '42', openTimeInISO: '2025-03-15T00:00:00.000Z'}),
-        createCandle({open: '85', close: '85', low: '83', high: '90', openTimeInISO: '2025-04-01T00:00:00.000Z'}),
-        createCandle({open: '83', close: '80', low: '78', high: '88', openTimeInISO: '2025-04-15T00:00:00.000Z'}),
+        createCandle({close: '40', high: '42', low: '38', open: '40', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+        createCandle({close: '45', high: '48', low: '38', open: '42', openTimeInISO: '2025-01-15T00:00:00.000Z'}),
+        createCandle({close: '90', high: '95', low: '88', open: '90', openTimeInISO: '2025-02-01T00:00:00.000Z'}),
+        createCandle({close: '85', high: '92', low: '82', open: '88', openTimeInISO: '2025-02-15T00:00:00.000Z'}),
+        createCandle({close: '35', high: '38', low: '33', open: '35', openTimeInISO: '2025-03-01T00:00:00.000Z'}),
+        createCandle({close: '40', high: '42', low: '33', open: '37', openTimeInISO: '2025-03-15T00:00:00.000Z'}),
+        createCandle({close: '85', high: '90', low: '83', open: '85', openTimeInISO: '2025-04-01T00:00:00.000Z'}),
+        createCandle({close: '80', high: '88', low: '78', open: '83', openTimeInISO: '2025-04-15T00:00:00.000Z'}),
       ];
 
       const config: BacktestConfig = {
-        candles,
         broker: createMockExchange(),
+        candles,
         strategy,
         tradingPair,
       };
@@ -514,10 +514,10 @@ describe('BacktestExecutor', () => {
           this.#bought = true;
 
           return {
-            side: OrderSide.BUY,
-            type: OrderType.MARKET,
             amount: AllAvailableAmount,
             amountIn: 'counter',
+            side: OrderSide.BUY,
+            type: OrderType.MARKET,
           };
         }
       }
@@ -527,13 +527,13 @@ describe('BacktestExecutor', () => {
        * Candle 2: market order fills at open=100, then price goes to 150
        */
       const candles = [
-        createCandle({open: '100', close: '100', low: '100', high: '100', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
-        createCandle({open: '100', close: '150', low: '100', high: '150', openTimeInISO: '2025-06-01T00:00:00.000Z'}),
+        createCandle({close: '100', high: '100', low: '100', open: '100', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+        createCandle({close: '150', high: '150', low: '100', open: '100', openTimeInISO: '2025-06-01T00:00:00.000Z'}),
       ];
 
       const config: BacktestConfig = {
-        candles,
         broker: createMockExchange(),
+        candles,
         strategy: new BuyOnce(),
         tradingPair,
       };
@@ -565,14 +565,14 @@ describe('BacktestExecutor', () => {
 
       // firstOpen=50, lastClose=200 — they differ so the test distinguishes which is used
       const candles = [
-        createCandle({open: '50', close: '80', low: '48', high: '82', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
-        createCandle({open: '120', close: '200', low: '115', high: '205', openTimeInISO: '2025-01-02T00:00:00.000Z'}),
+        createCandle({close: '80', high: '82', low: '48', open: '50', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+        createCandle({close: '200', high: '205', low: '115', open: '120', openTimeInISO: '2025-01-02T00:00:00.000Z'}),
       ];
 
       const config: BacktestConfig = {
-        candles,
         // 2 BTC initial base balance so the open price matters for valuation
         broker: createMockExchange({baseBalance: '2', counterBalance: '0'}),
+        candles,
         strategy: new NoOpStrategy(),
         tradingPair,
       };
@@ -599,11 +599,11 @@ describe('BacktestExecutor', () => {
         }
       }
 
-      const candles = [createCandle({open: '100', close: '100'})];
+      const candles = [createCandle({close: '100', open: '100'})];
 
       const config: BacktestConfig = {
-        candles,
         broker: createMockExchange(),
+        candles,
         strategy: new NoOpStrategy(),
         tradingPair,
       };
@@ -646,10 +646,10 @@ describe('BacktestExecutor', () => {
           _state: TradingSessionState
         ): Promise<OrderAdvice | void> {
           return {
-            side: OrderSide.BUY,
-            type: OrderType.MARKET,
             amount: AllAvailableAmount,
             amountIn: 'counter',
+            side: OrderSide.BUY,
+            type: OrderType.MARKET,
           };
         }
       }
@@ -657,25 +657,25 @@ describe('BacktestExecutor', () => {
       // Two candles: advice on candle 1, would fill on candle 2
       const candles = [
         createCandle({
-          open: '50000',
           close: '50000',
-          low: '50000',
           high: '50000',
+          low: '50000',
+          open: '50000',
           openTimeInISO: '2025-01-01T00:00:00.000Z',
         }),
         createCandle({
-          open: '50000',
           close: '50000',
-          low: '50000',
           high: '50000',
+          low: '50000',
+          open: '50000',
           openTimeInISO: '2025-01-01T00:01:00.000Z',
         }),
       ];
 
       const config: BacktestConfig = {
-        candles,
         // Only $1 at price $50,000 can buy 0.00002 BTC, below min 0.0001
         broker: createMockWithRules({counterBalance: '1'}),
+        candles,
         strategy: new AlwaysBuyMarket(),
         tradingPair,
       };
@@ -694,34 +694,34 @@ describe('BacktestExecutor', () => {
           _state: TradingSessionState
         ): Promise<OrderAdvice | void> {
           return {
-            side: OrderSide.SELL,
-            type: OrderType.MARKET,
             amount: AllAvailableAmount,
             amountIn: 'base',
+            side: OrderSide.SELL,
+            type: OrderType.MARKET,
           };
         }
       }
 
       const candles = [
         createCandle({
-          open: '50000',
           close: '50000',
-          low: '50000',
           high: '50000',
+          low: '50000',
+          open: '50000',
           openTimeInISO: '2025-01-01T00:00:00.000Z',
         }),
         createCandle({
-          open: '50000',
           close: '50000',
-          low: '50000',
           high: '50000',
+          low: '50000',
+          open: '50000',
           openTimeInISO: '2025-01-01T00:01:00.000Z',
         }),
       ];
 
       const config: BacktestConfig = {
-        candles,
         broker: createMockWithRules({baseBalance: '0.00005'}),
+        candles,
         strategy: new AlwaysSellMarket(),
         tradingPair,
       };
@@ -739,15 +739,15 @@ describe('BacktestExecutor', () => {
 
       // With 1-candle delay: buy advice on c1, fills c2, sell advice on c3, fills c4
       const candles = [
-        createCandle({open: '80', close: '80', low: '78', high: '82', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
-        createCandle({open: '82', close: '85', low: '78', high: '90', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
-        createCandle({open: '130', close: '130', low: '128', high: '135', openTimeInISO: '2025-01-02T00:00:00.000Z'}),
-        createCandle({open: '128', close: '132', low: '125', high: '135', openTimeInISO: '2025-01-02T00:01:00.000Z'}),
+        createCandle({close: '80', high: '82', low: '78', open: '80', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+        createCandle({close: '85', high: '90', low: '78', open: '82', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
+        createCandle({close: '130', high: '135', low: '128', open: '130', openTimeInISO: '2025-01-02T00:00:00.000Z'}),
+        createCandle({close: '132', high: '135', low: '125', open: '128', openTimeInISO: '2025-01-02T00:01:00.000Z'}),
       ];
 
       const config: BacktestConfig = {
-        candles,
         broker: createMockWithRules(),
+        candles,
         strategy,
         tradingPair,
       };
@@ -786,11 +786,11 @@ describe('BacktestExecutor', () => {
           }
           this.#advised = true;
           return {
-            side: OrderSide.BUY,
-            type: OrderType.LIMIT,
             amount: AllAvailableAmount,
             amountIn: 'base',
             price: candle.close,
+            side: OrderSide.BUY,
+            type: OrderType.LIMIT,
           };
         }
       }
@@ -807,17 +807,17 @@ describe('BacktestExecutor', () => {
        */
       const candles = [
         createCandle({
-          open: '100.10',
           close: '100.10',
-          low: '100.10',
           high: '105.00',
+          low: '100.10',
+          open: '100.10',
           openTimeInISO: '2025-01-01T00:00:00.000Z',
         }),
         createCandle({
-          open: '101.00',
           close: '102.00',
-          low: '100.10',
           high: '105.00',
+          low: '100.10',
+          open: '101.00',
           openTimeInISO: '2025-01-01T00:01:00.000Z',
         }),
       ];

--- a/packages/trading-strategies/src/backtest/BacktestExecutor.ts
+++ b/packages/trading-strategies/src/backtest/BacktestExecutor.ts
@@ -13,7 +13,7 @@ export class BacktestExecutor {
   }
 
   async execute(): Promise<BacktestResult> {
-    const {candles, broker: exchange, strategy, tradingPair} = this.#config;
+    const {broker: exchange, candles, strategy, tradingPair} = this.#config;
 
     const initialBalances = await exchange.getAvailableBalances(tradingPair);
     const initialBaseBalance = initialBalances.base;
@@ -103,10 +103,10 @@ export class BacktestExecutor {
     if (!advice) {
       // Fallback: shouldn't happen in normal flow
       return {
-        side: OrderSide.BUY,
-        type: OrderType.MARKET,
         amount: AllAvailableAmount,
         amountIn: 'counter',
+        side: OrderSide.BUY,
+        type: OrderType.MARKET,
       };
     }
     return advice;
@@ -120,9 +120,9 @@ export class BacktestExecutor {
     return {
       baseBalance: balances.base,
       counterBalance: balances.counter,
-      tradingRules,
       feeRates,
       lastOrderSide,
+      tradingRules,
     };
   }
 
@@ -256,7 +256,7 @@ export class BacktestExecutor {
 
     const winRate = PerformanceCalculator.calculateWinRate(trades);
     const buyAndHoldReturnPercentage = PerformanceCalculator.calculateBuyAndHoldReturn(candles);
-    const {maxWinStreak, maxLossStreak} = PerformanceCalculator.calculateStreaks(trades);
+    const {maxLossStreak, maxWinStreak} = PerformanceCalculator.calculateStreaks(trades);
 
     return {
       buyAndHoldReturnPercentage,

--- a/packages/trading-strategies/src/backtest/PerformanceCalculator.ts
+++ b/packages/trading-strategies/src/backtest/PerformanceCalculator.ts
@@ -60,7 +60,7 @@ export class PerformanceCalculator {
       }
     }
 
-    return {maxWinStreak, maxLossStreak};
+    return {maxLossStreak, maxWinStreak};
   }
 
   static #buildCycles(trades: BacktestTrade[]): {buyAvgPrice: Big; sellAvgPrice: Big}[] {

--- a/packages/trading-strategies/src/report-scalp-scanner/ScalpScannerReport.test.ts
+++ b/packages/trading-strategies/src/report-scalp-scanner/ScalpScannerReport.test.ts
@@ -21,9 +21,9 @@ describe('ScalpScannerReport', () => {
 
   it('accepts custom symbols and lookbackDays', () => {
     const config = ScalpScannerSchema.parse({
-      symbols: ['AMD', 'INTC', 'TSLA'],
-      lookbackDays: 30,
       erThreshold: 0.3,
+      lookbackDays: 30,
+      symbols: ['AMD', 'INTC', 'TSLA'],
     });
 
     expect(config.symbols).toEqual(['AMD', 'INTC', 'TSLA']);

--- a/packages/trading-strategies/src/report-scalp-scanner/ScalpScannerReport.ts
+++ b/packages/trading-strategies/src/report-scalp-scanner/ScalpScannerReport.ts
@@ -9,12 +9,12 @@ import {suggestScalpOffset} from '../strategy-scalp/suggestScalpOffset.js';
 import {fetchUsEquityNames, formatSymbolWithName, TELEGRAM_TABLE_NAME_MAX} from '../util/formatSymbolWithName.js';
 
 export const ScalpScannerSchema = z.object({
-  /** Stock symbols to scan (defaults to S&P 500) */
-  symbols: z.array(z.string()).optional(),
-  /** Number of trading days to analyze (default: 60, ~3 months) */
-  lookbackDays: z.number().int().positive().optional().default(60),
   /** ER threshold below which a stock is considered scalp-friendly (default: 0.4) */
   erThreshold: z.number().positive().optional().default(ScalpStrategy.ER_THRESHOLD),
+  /** Number of trading days to analyze (default: 60, ~3 months) */
+  lookbackDays: z.number().int().positive().optional().default(60),
+  /** Stock symbols to scan (defaults to S&P 500) */
+  symbols: z.array(z.string()).optional(),
 });
 
 export type ScalpScannerConfig = z.infer<typeof ScalpScannerSchema>;
@@ -107,10 +107,10 @@ export class ScalpScannerReport extends Report<ScalpScannerConfig> {
       const atrPct = (avgRange / avgPrice) * 100;
 
       results.push({
-        symbol,
-        er: erValue,
         atrPct,
+        er: erValue,
         suggestedOffset: offsetStr,
+        symbol,
       });
     }
 
@@ -143,13 +143,13 @@ export class ScalpScannerReport extends Report<ScalpScannerConfig> {
 
     do {
       const response = await this.#api.getStockBars({
-        symbols: symbols.join(','),
-        timeframe: '1Day',
-        start: start.toISOString(),
         end: end.toISOString(),
         feed: 'iex',
         limit: 10_000,
         page_token: pageToken,
+        start: start.toISOString(),
+        symbols: symbols.join(','),
+        timeframe: '1Day',
       });
 
       for (const [symbol, symbolBars] of Object.entries(response.bars)) {

--- a/packages/trading-strategies/src/report-sp500-heatmap/SP500HeatmapReport.ts
+++ b/packages/trading-strategies/src/report-sp500-heatmap/SP500HeatmapReport.ts
@@ -50,8 +50,8 @@ export class SP500HeatmapReport extends Report<SP500HeatmapConfig> {
     for (let i = 0; i < symbols.length; i += BATCH_SIZE) {
       const batch = symbols.slice(i, i + BATCH_SIZE);
       const response = await this.#api.getStockSnapshots({
-        symbols: batch.join(','),
         feed: 'iex',
+        symbols: batch.join(','),
       });
 
       for (const [ticker, snapshot] of Object.entries(response)) {
@@ -59,10 +59,10 @@ export class SP500HeatmapReport extends Report<SP500HeatmapConfig> {
         const prevClose = snapshot.prevDailyBar?.c;
         if (price != null && prevClose != null && prevClose > 0) {
           results.push({
-            ticker,
+            changePct: ((price - prevClose) / prevClose) * 100,
             prevClose,
             price,
-            changePct: ((price - prevClose) / prevClose) * 100,
+            ticker,
           });
         }
       }

--- a/packages/trading-strategies/src/report-sp500-momentum/SP500MomentumReport.ts
+++ b/packages/trading-strategies/src/report-sp500-momentum/SP500MomentumReport.ts
@@ -54,10 +54,10 @@ export class SP500MomentumReport extends Report<SP500MomentumConfig> {
       const priceThen = pastPrices.get(ticker);
       if (priceNow != null && priceThen != null && priceThen > 0) {
         results.push({
-          ticker,
-          priceNow,
           price12MonthsAgo: priceThen,
+          priceNow,
           returnPct: ((priceNow - priceThen) / priceThen) * 100,
+          ticker,
         });
       }
     }
@@ -91,12 +91,12 @@ export class SP500MomentumReport extends Report<SP500MomentumConfig> {
     const result = new Map<string, number>();
 
     const response = await this.#api.getStockBars({
-      symbols: symbols.join(','),
-      timeframe: '1Day',
-      start: start.toISOString(),
       end: end.toISOString(),
       feed: 'iex',
       limit: 10_000,
+      start: start.toISOString(),
+      symbols: symbols.join(','),
+      timeframe: '1Day',
     });
 
     for (const [symbol, symbolBars] of Object.entries(response.bars)) {

--- a/packages/trading-strategies/src/report/ReportRegistry.ts
+++ b/packages/trading-strategies/src/report/ReportRegistry.ts
@@ -33,26 +33,26 @@ function requireApi(name: string, api: AlpacaAPI | undefined): AlpacaAPI {
 }
 
 const registry: Record<string, ReportEntry> = {
+  [ScalpScannerReport.NAME]: {
+    create: (config, api) =>
+      new ScalpScannerReport(ScalpScannerSchema.parse(config), requireApi(ScalpScannerReport.NAME, api)),
+    requiresAccount: true,
+    resolveConfig: () => ({}),
+    schema: ScalpScannerSchema,
+  },
   [SP500HeatmapReport.NAME]: {
     create: (config, api) =>
       new SP500HeatmapReport(SP500HeatmapSchema.parse(config), requireApi(SP500HeatmapReport.NAME, api)),
-    schema: SP500HeatmapSchema,
     requiresAccount: true,
     resolveConfig: () => ({}),
+    schema: SP500HeatmapSchema,
   },
   [SP500MomentumReport.NAME]: {
     create: (config, api) =>
       new SP500MomentumReport(SP500MomentumSchema.parse(config), requireApi(SP500MomentumReport.NAME, api)),
+    requiresAccount: true,
+    resolveConfig: () => ({}),
     schema: SP500MomentumSchema,
-    requiresAccount: true,
-    resolveConfig: () => ({}),
-  },
-  [ScalpScannerReport.NAME]: {
-    create: (config, api) =>
-      new ScalpScannerReport(ScalpScannerSchema.parse(config), requireApi(ScalpScannerReport.NAME, api)),
-    schema: ScalpScannerSchema,
-    requiresAccount: true,
-    resolveConfig: () => ({}),
   },
 };
 

--- a/packages/trading-strategies/src/start/runBacktest.ts
+++ b/packages/trading-strategies/src/start/runBacktest.ts
@@ -8,10 +8,10 @@ import {createStrategy, getStrategyNames} from '../strategy/StrategyRegistry.js'
 
 const {values} = parseArgs({
   options: {
-    data: {type: 'string', short: 'd'},
-    strategy: {type: 'string', short: 's'},
-    config: {type: 'string', short: 'c', default: '{}'},
-    balance: {type: 'string', short: 'b', default: '10000'},
+    balance: {default: '10000', short: 'b', type: 'string'},
+    config: {default: '{}', short: 'c', type: 'string'},
+    data: {short: 'd', type: 'string'},
+    strategy: {short: 's', type: 'string'},
   },
 });
 
@@ -87,8 +87,8 @@ const exchange = new AlpacaBrokerMock({
     [tradingPair.counter, {available: startingBalance, hold: new Big(0)}],
   ]),
   feeRates: {
-    [OrderType.MARKET]: new Big(0),
     [OrderType.LIMIT]: new Big(0),
+    [OrderType.MARKET]: new Big(0),
   },
 });
 

--- a/packages/trading-strategies/src/start/runStrategy.ts
+++ b/packages/trading-strategies/src/start/runStrategy.ts
@@ -6,7 +6,7 @@ import {BuyOnceStrategy} from '../strategy-buy-once/BuyOnceStrategy.js';
  * The exchange package owns the credentials. Load its env so this script can run from
  * trading-strategies/ without duplicating secrets.
  */
-config({path: '../exchange/.env', defaults: '../exchange/.env.defaults'});
+config({defaults: '../exchange/.env.defaults', path: '../exchange/.env'});
 
 const marketData = new AlpacaMarketData({
   apiKey: process.env.ALPACA_LIVE_API_KEY!,
@@ -21,8 +21,8 @@ const broker = getTrading212Client({
 });
 
 const strategy = new BuyOnceStrategy({
-  quantity: '1',
   protected: {takeProfitNominal: '0.10'},
+  quantity: '1',
 });
 
 const pair = new TradingPair('AMD_US_EQ', 'USD');

--- a/packages/trading-strategies/src/strategy-buy-and-hold/BuyAndHoldStrategy.test.ts
+++ b/packages/trading-strategies/src/strategy-buy-and-hold/BuyAndHoldStrategy.test.ts
@@ -29,6 +29,10 @@ const pair = new TradingPair('AAPL', 'USD');
 const mockState: TradingSessionState = {
   baseBalance: new Big(0),
   counterBalance: new Big(1000),
+  feeRates: {
+    [OrderType.LIMIT]: new Big('0.001'),
+    [OrderType.MARKET]: new Big('0.002'),
+  },
   tradingRules: {
     base_increment: '0.01',
     base_max_size: '10000',
@@ -36,10 +40,6 @@ const mockState: TradingSessionState = {
     counter_increment: '0.01',
     counter_min_size: '1',
     pair,
-  },
-  feeRates: {
-    [OrderType.LIMIT]: new Big('0.001'),
-    [OrderType.MARKET]: new Big('0.002'),
   },
 };
 

--- a/packages/trading-strategies/src/strategy-buy-below-sell-above/BuyBelowSellAboveStrategy.ts
+++ b/packages/trading-strategies/src/strategy-buy-below-sell-above/BuyBelowSellAboveStrategy.ts
@@ -41,11 +41,11 @@ export class BuyBelowSellAboveStrategy extends ProtectedStrategy {
 
       if (closePrice.lt(buyBelowPrice)) {
         return {
-          side: OrderSide.BUY,
-          type: OrderType.LIMIT,
           amount: AllAvailableAmount,
           amountIn: 'base',
           price: closePrice,
+          side: OrderSide.BUY,
+          type: OrderType.LIMIT,
         };
       }
     }
@@ -55,11 +55,11 @@ export class BuyBelowSellAboveStrategy extends ProtectedStrategy {
 
       if (closePrice.gt(sellAbovePrice)) {
         return {
-          side: OrderSide.SELL,
-          type: OrderType.LIMIT,
           amount: AllAvailableAmount,
           amountIn: 'base',
           price: closePrice,
+          side: OrderSide.SELL,
+          type: OrderType.LIMIT,
         };
       }
     }

--- a/packages/trading-strategies/src/strategy-buy-once/BuyOnceStrategy.test.ts
+++ b/packages/trading-strategies/src/strategy-buy-once/BuyOnceStrategy.test.ts
@@ -13,11 +13,11 @@ function createCandle(overrides: Partial<Candle> & {close: string; open: string}
 
   return {
     base: 'BTC',
+    close: overrides.close,
     counter: 'USD',
     high: overrides.high ?? String(Math.max(openNum, closeNum)),
     low: overrides.low ?? String(Math.min(openNum, closeNum)),
     open: overrides.open,
-    close: overrides.close,
     openTimeInISO: overrides.openTimeInISO ?? '2025-01-01T00:00:00.000Z',
     openTimeInMillis: overrides.openTimeInMillis ?? 1735689600000,
     sizeInMillis: overrides.sizeInMillis ?? 60000,
@@ -40,16 +40,16 @@ describe('BuyOnceStrategy', () => {
     const strategy = new BuyOnceStrategy({buyAt: '100'});
 
     const candles = [
-      createCandle({open: '110', close: '110', low: '108', high: '112', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+      createCandle({close: '110', high: '112', low: '108', open: '110', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
       // Price drops through 100 — target is within [95, 105]
-      createCandle({open: '105', close: '95', low: '95', high: '105', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
+      createCandle({close: '95', high: '105', low: '95', open: '105', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
       // Order fills on this candle
-      createCandle({open: '98', close: '90', low: '88', high: '102', openTimeInISO: '2025-01-01T00:02:00.000Z'}),
+      createCandle({close: '90', high: '102', low: '88', open: '98', openTimeInISO: '2025-01-01T00:02:00.000Z'}),
     ];
 
     const config: BacktestConfig = {
-      candles,
       broker: createMockExchange(),
+      candles,
       strategy,
       tradingPair,
     };
@@ -66,14 +66,14 @@ describe('BuyOnceStrategy', () => {
     const strategy = new BuyOnceStrategy({buyAt: '50'});
 
     const candles = [
-      createCandle({open: '100', close: '100', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
-      createCandle({open: '90', close: '80', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
-      createCandle({open: '70', close: '60', openTimeInISO: '2025-01-01T00:02:00.000Z'}),
+      createCandle({close: '100', open: '100', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+      createCandle({close: '80', open: '90', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
+      createCandle({close: '60', open: '70', openTimeInISO: '2025-01-01T00:02:00.000Z'}),
     ];
 
     const config: BacktestConfig = {
-      candles,
       broker: createMockExchange(),
+      candles,
       strategy,
       tradingPair,
     };
@@ -89,15 +89,15 @@ describe('BuyOnceStrategy', () => {
 
     const candles = [
       // Close at 80, below 100 — advice triggers
-      createCandle({open: '110', close: '80', low: '80', high: '110', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+      createCandle({close: '80', high: '110', low: '80', open: '110', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
       // Fill happens here, strategy already bought so no new advice
-      createCandle({open: '90', close: '70', low: '70', high: '105', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
-      createCandle({open: '80', close: '60', low: '60', high: '105', openTimeInISO: '2025-01-01T00:02:00.000Z'}),
+      createCandle({close: '70', high: '105', low: '70', open: '90', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
+      createCandle({close: '60', high: '105', low: '60', open: '80', openTimeInISO: '2025-01-01T00:02:00.000Z'}),
     ];
 
     const config: BacktestConfig = {
-      candles,
       broker: createMockExchange(),
+      candles,
       strategy,
       tradingPair,
     };
@@ -115,13 +115,13 @@ describe('BuyOnceStrategy', () => {
      * Candle 2: order fills
      */
     const candles = [
-      createCandle({open: '50', close: '50', low: '48', high: '52', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
-      createCandle({open: '50', close: '50', low: '48', high: '52', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
+      createCandle({close: '50', high: '52', low: '48', open: '50', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+      createCandle({close: '50', high: '52', low: '48', open: '50', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
     ];
 
     const config: BacktestConfig = {
-      candles,
       broker: createMockExchange(),
+      candles,
       strategy,
       tradingPair,
     };
@@ -142,13 +142,13 @@ describe('BuyOnceStrategy', () => {
      * Candle 2: low=88 <= 95, order fills. Open=92 < 95, so price improvement: fills at 92
      */
     const candles = [
-      createCandle({open: '100', close: '90', low: '88', high: '102', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
-      createCandle({open: '92', close: '88', low: '85', high: '96', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
+      createCandle({close: '90', high: '102', low: '88', open: '100', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+      createCandle({close: '88', high: '96', low: '85', open: '92', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
     ];
 
     const config: BacktestConfig = {
-      candles,
       broker: createMockExchange(),
+      candles,
       strategy,
       tradingPair,
     };
@@ -164,6 +164,10 @@ describe('BuyOnceStrategy', () => {
     const mockState: TradingSessionState = {
       baseBalance: new Big(0),
       counterBalance: new Big(1000),
+      feeRates: {
+        [OrderType.LIMIT]: new Big('0.001'),
+        [OrderType.MARKET]: new Big('0.002'),
+      },
       tradingRules: {
         base_increment: '0.01',
         base_max_size: '10000',
@@ -172,17 +176,13 @@ describe('BuyOnceStrategy', () => {
         counter_min_size: '1',
         pair: tradingPair,
       },
-      feeRates: {
-        [OrderType.LIMIT]: new Big('0.001'),
-        [OrderType.MARKET]: new Big('0.002'),
-      },
     };
 
     const strategy = new BuyOnceStrategy({buyAt: '100'});
     strategy.restoreState({bought: true});
 
     // Close price is below buyAt — would normally trigger a buy, but state is restored as already bought
-    const candle = createCandle({open: '80', close: '80', openTimeInISO: '2025-01-01T00:00:00.000Z'});
+    const candle = createCandle({close: '80', open: '80', openTimeInISO: '2025-01-01T00:00:00.000Z'});
     const advice = await strategy.onCandle(CandleBatcher.createOneMinuteBatchedCandle([candle]), mockState);
 
     expect(advice).toBeUndefined();

--- a/packages/trading-strategies/src/strategy-buy-once/BuyOnceStrategy.ts
+++ b/packages/trading-strategies/src/strategy-buy-once/BuyOnceStrategy.ts
@@ -57,17 +57,17 @@ export class BuyOnceStrategy extends ProtectedStrategy {
       this.#state.bought = true;
       if (quantity) {
         return {
-          side: OrderSide.BUY,
-          type: OrderType.MARKET,
           amount: quantity,
           amountIn: 'base',
+          side: OrderSide.BUY,
+          type: OrderType.MARKET,
         };
       }
       return {
-        side: OrderSide.BUY,
-        type: OrderType.MARKET,
         amount: spend ?? AllAvailableAmount,
         amountIn: 'counter',
+        side: OrderSide.BUY,
+        type: OrderType.MARKET,
       };
     }
 
@@ -87,11 +87,11 @@ export class BuyOnceStrategy extends ProtectedStrategy {
     }
 
     return {
-      side: OrderSide.BUY,
-      type: OrderType.LIMIT,
       amount,
       amountIn: 'base',
       price: buyAtPrice,
+      side: OrderSide.BUY,
+      type: OrderType.LIMIT,
     };
   }
 

--- a/packages/trading-strategies/src/strategy-coin-flip/CoinFlipStrategy.ts
+++ b/packages/trading-strategies/src/strategy-coin-flip/CoinFlipStrategy.ts
@@ -26,17 +26,17 @@ export class CoinFlipStrategy extends ProtectedStrategy {
     }
 
     const buyMarket: OrderAdvice = {
-      side: OrderSide.BUY,
-      type: OrderType.MARKET,
       amount: AllAvailableAmount,
       amountIn: 'counter',
+      side: OrderSide.BUY,
+      type: OrderType.MARKET,
     };
 
     const sellMarket: OrderAdvice = {
-      side: OrderSide.SELL,
-      type: OrderType.MARKET,
       amount: AllAvailableAmount,
       amountIn: 'base',
+      side: OrderSide.SELL,
+      type: OrderType.MARKET,
     };
 
     /*

--- a/packages/trading-strategies/src/strategy-mean-reversion/MeanReversionStrategy.ts
+++ b/packages/trading-strategies/src/strategy-mean-reversion/MeanReversionStrategy.ts
@@ -83,17 +83,17 @@ export class MeanReversionStrategy extends ProtectedStrategy {
       return;
     }
 
-    const {upper, middle} = this.#bbands.getResultOrThrow();
+    const {middle, upper} = this.#bbands.getResultOrThrow();
 
     if (this.#state.phase === 'watching') {
       if (closePrice > upper) {
         this.#state.phase = 'waitingForRebuy';
         return {
-          side: OrderSide.SELL,
-          type: OrderType.MARKET,
           amount: AllAvailableAmount,
           amountIn: 'base',
           reason: `Price ${closePrice.toFixed(2)} broke above upper band ${upper.toFixed(2)}`,
+          side: OrderSide.SELL,
+          type: OrderType.MARKET,
         };
       }
     }
@@ -102,11 +102,11 @@ export class MeanReversionStrategy extends ProtectedStrategy {
       if (closePrice <= middle) {
         this.#state.phase = 'watching';
         return {
-          side: OrderSide.BUY,
-          type: OrderType.MARKET,
           amount: AllAvailableAmount,
           amountIn: 'counter',
           reason: `Price ${closePrice.toFixed(2)} returned to middle band ${middle.toFixed(2)}`,
+          side: OrderSide.BUY,
+          type: OrderType.MARKET,
         };
       }
     }

--- a/packages/trading-strategies/src/strategy-multi-indicator-confluence/MultiIndicatorConfluenceSchema.ts
+++ b/packages/trading-strategies/src/strategy-multi-indicator-confluence/MultiIndicatorConfluenceSchema.ts
@@ -2,26 +2,26 @@ import {z} from 'zod';
 import {ProtectedStrategySchema} from '../strategy-protected/ProtectedStrategy.js';
 
 export const MultiIndicatorConfluenceSchema = ProtectedStrategySchema.extend({
-  /** EMA short period for trend detection. */
-  emaShortPeriod: z.number().int().positive(),
-  /** EMA long period for trend detection. */
-  emaLongPeriod: z.number().int().positive(),
-  /** MACD short EMA period. */
-  macdShortPeriod: z.number().int().positive(),
-  /** MACD long EMA period. */
-  macdLongPeriod: z.number().int().positive(),
-  /** MACD signal EMA period. */
-  macdSignalPeriod: z.number().int().positive(),
-  /** Bollinger Bands period. */
-  bollingerPeriod: z.number().int().positive(),
   /** Bollinger Bands standard deviation multiplier. */
   bollingerDeviationMultiplier: z.number().positive(),
-  /** RSI period. */
-  rsiPeriod: z.number().int().positive(),
+  /** Bollinger Bands period. */
+  bollingerPeriod: z.number().int().positive(),
+  /** EMA long period for trend detection. */
+  emaLongPeriod: z.number().int().positive(),
+  /** EMA short period for trend detection. */
+  emaShortPeriod: z.number().int().positive(),
+  /** MACD long EMA period. */
+  macdLongPeriod: z.number().int().positive(),
+  /** MACD short EMA period. */
+  macdShortPeriod: z.number().int().positive(),
+  /** MACD signal EMA period. */
+  macdSignalPeriod: z.number().int().positive(),
   /** RSI overbought threshold (veto BUY above this). */
   rsiOverbought: z.number().positive().max(100),
   /** RSI oversold threshold (veto SELL below this). */
   rsiOversold: z.number().positive().max(100),
+  /** RSI period. */
+  rsiPeriod: z.number().int().positive(),
 })
   .refine(data => data.emaShortPeriod < data.emaLongPeriod, {
     message: 'emaShortPeriod must be less than emaLongPeriod',

--- a/packages/trading-strategies/src/strategy-multi-indicator-confluence/MultiIndicatorConfluenceStrategy.test.ts
+++ b/packages/trading-strategies/src/strategy-multi-indicator-confluence/MultiIndicatorConfluenceStrategy.test.ts
@@ -40,6 +40,10 @@ const signalConfig: MultiIndicatorConfluenceConfig = {
 const mockState: TradingSessionState = {
   baseBalance: new Big(0),
   counterBalance: new Big(1000),
+  feeRates: {
+    [OrderType.LIMIT]: new Big('0.0015'),
+    [OrderType.MARKET]: new Big('0.0025'),
+  },
   tradingRules: {
     base_increment: '0.0001',
     base_max_size: '100',
@@ -47,10 +51,6 @@ const mockState: TradingSessionState = {
     counter_increment: '0.01',
     counter_min_size: '1',
     pair: {base: 'BTC', counter: 'USD'} as any,
-  },
-  feeRates: {
-    [OrderType.LIMIT]: new Big('0.0015'),
-    [OrderType.MARKET]: new Big('0.0025'),
   },
 };
 
@@ -103,28 +103,28 @@ describe('MultiIndicatorConfluenceSchema', () => {
 
   it('rejects rsiOversold >= rsiOverbought', () => {
     expect(() =>
-      MultiIndicatorConfluenceSchema.parse({...defaultConfig, rsiOversold: 70, rsiOverbought: 70})
+      MultiIndicatorConfluenceSchema.parse({...defaultConfig, rsiOverbought: 70, rsiOversold: 70})
     ).toThrow();
     expect(() =>
-      MultiIndicatorConfluenceSchema.parse({...defaultConfig, rsiOversold: 80, rsiOverbought: 70})
+      MultiIndicatorConfluenceSchema.parse({...defaultConfig, rsiOverbought: 70, rsiOversold: 80})
     ).toThrow();
   });
 
   it('rejects emaShortPeriod >= emaLongPeriod', () => {
     expect(() =>
-      MultiIndicatorConfluenceSchema.parse({...defaultConfig, emaShortPeriod: 5, emaLongPeriod: 5})
+      MultiIndicatorConfluenceSchema.parse({...defaultConfig, emaLongPeriod: 5, emaShortPeriod: 5})
     ).toThrow();
     expect(() =>
-      MultiIndicatorConfluenceSchema.parse({...defaultConfig, emaShortPeriod: 10, emaLongPeriod: 5})
+      MultiIndicatorConfluenceSchema.parse({...defaultConfig, emaLongPeriod: 5, emaShortPeriod: 10})
     ).toThrow();
   });
 
   it('rejects macdShortPeriod >= macdLongPeriod', () => {
     expect(() =>
-      MultiIndicatorConfluenceSchema.parse({...defaultConfig, macdShortPeriod: 5, macdLongPeriod: 5})
+      MultiIndicatorConfluenceSchema.parse({...defaultConfig, macdLongPeriod: 5, macdShortPeriod: 5})
     ).toThrow();
     expect(() =>
-      MultiIndicatorConfluenceSchema.parse({...defaultConfig, macdShortPeriod: 10, macdLongPeriod: 5})
+      MultiIndicatorConfluenceSchema.parse({...defaultConfig, macdLongPeriod: 5, macdShortPeriod: 10})
     ).toThrow();
   });
 

--- a/packages/trading-strategies/src/strategy-multi-indicator-confluence/MultiIndicatorConfluenceStrategy.ts
+++ b/packages/trading-strategies/src/strategy-multi-indicator-confluence/MultiIndicatorConfluenceStrategy.ts
@@ -109,11 +109,11 @@ export class MultiIndicatorConfluenceStrategy extends ProtectedStrategy {
       ].join('; ');
 
       return {
-        side: OrderSide.BUY,
-        type: OrderType.MARKET,
         amount: AllAvailableAmount,
         amountIn: 'counter',
         reason,
+        side: OrderSide.BUY,
+        type: OrderType.MARKET,
       };
     }
 
@@ -127,11 +127,11 @@ export class MultiIndicatorConfluenceStrategy extends ProtectedStrategy {
       ].join('; ');
 
       return {
-        side: OrderSide.SELL,
-        type: OrderType.MARKET,
         amount: AllAvailableAmount,
         amountIn: 'base',
         reason,
+        side: OrderSide.SELL,
+        type: OrderType.MARKET,
       };
     }
   }

--- a/packages/trading-strategies/src/strategy-noop/NoopStrategy.test.ts
+++ b/packages/trading-strategies/src/strategy-noop/NoopStrategy.test.ts
@@ -7,11 +7,11 @@ import {NoopStrategy} from './NoopStrategy.js';
 function createCandle(): Candle {
   return {
     base: 'BTC',
-    counter: 'USD',
-    open: '100',
     close: '101',
+    counter: 'USD',
     high: '102',
     low: '99',
+    open: '100',
     openTimeInISO: '2025-01-01T00:00:00.000Z',
     openTimeInMillis: 1735689600000,
     sizeInMillis: 60000,
@@ -23,6 +23,10 @@ function createState(): TradingSessionState {
   return {
     baseBalance: new Big(0),
     counterBalance: new Big(1000),
+    feeRates: {
+      [OrderType.LIMIT]: new Big('0.001'),
+      [OrderType.MARKET]: new Big('0.002'),
+    },
     tradingRules: {
       base_increment: '0.01',
       base_max_size: '10000',
@@ -30,10 +34,6 @@ function createState(): TradingSessionState {
       counter_increment: '0.01',
       counter_min_size: '1',
       pair: new TradingPair('BTC', 'USD'),
-    },
-    feeRates: {
-      [OrderType.LIMIT]: new Big('0.001'),
-      [OrderType.MARKET]: new Big('0.002'),
     },
   };
 }

--- a/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.test.ts
+++ b/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.test.ts
@@ -39,6 +39,10 @@ const pair = new TradingPair('AAPL', 'USD');
 const mockState: TradingSessionState = {
   baseBalance: new Big(0),
   counterBalance: new Big(1000),
+  feeRates: {
+    [OrderType.LIMIT]: new Big('0.001'),
+    [OrderType.MARKET]: new Big('0.002'),
+  },
   tradingRules: {
     base_increment: '0.01',
     base_max_size: '10000',
@@ -46,10 +50,6 @@ const mockState: TradingSessionState = {
     counter_increment: '0.01',
     counter_min_size: '1',
     pair,
-  },
-  feeRates: {
-    [OrderType.LIMIT]: new Big('0.001'),
-    [OrderType.MARKET]: new Big('0.002'),
   },
 };
 
@@ -88,7 +88,7 @@ function makeFill(price: string, size: string, side: OrderSide): Fill {
 
 function makeOrder(side: OrderSide, type: OrderType = OrderType.LIMIT): PendingOrder {
   if (type === OrderType.LIMIT) {
-    return {id: 'order-1', pair, side, size: '10', price: '100', type: OrderType.LIMIT};
+    return {id: 'order-1', pair, price: '100', side, size: '10', type: OrderType.LIMIT};
   }
   return {id: 'order-1', pair, side, size: '10', type: OrderType.MARKET};
 }
@@ -124,11 +124,11 @@ class TestProtectedStrategy extends ProtectedStrategy {
     const shouldSignal = storedConfig !== null && storedConfig.signalAdvice === true;
     if (shouldSignal) {
       return {
-        side: OrderSide.BUY,
-        type: OrderType.MARKET,
         amount: AllAvailableAmount,
         amountIn: 'counter',
         reason: 'test buy',
+        side: OrderSide.BUY,
+        type: OrderType.MARKET,
       };
     }
   }
@@ -333,7 +333,7 @@ describe('ProtectedStrategy', () => {
     };
 
     it('seeds position from account balance and first candle close', async () => {
-      const strategy = new TestProtectedStrategy({protected: {stopLossPct: '5', seedFromBalance: true}});
+      const strategy = new TestProtectedStrategy({protected: {seedFromBalance: true, stopLossPct: '5'}});
 
       // First candle at 100 with 10 shares in account → seeds avgEntry=100, size=10
       await strategy.onCandle(makeCandle(100), stateWithPosition);
@@ -343,7 +343,7 @@ describe('ProtectedStrategy', () => {
     });
 
     it('fires stop-loss relative to the seeded baseline price', async () => {
-      const strategy = new TestProtectedStrategy({protected: {stopLossPct: '5', seedFromBalance: true}});
+      const strategy = new TestProtectedStrategy({protected: {seedFromBalance: true, stopLossPct: '5'}});
 
       // Seed at 100
       await strategy.onCandle(makeCandle(100), stateWithPosition);
@@ -355,7 +355,7 @@ describe('ProtectedStrategy', () => {
     });
 
     it('fires take-profit relative to the seeded baseline price', async () => {
-      const strategy = new TestProtectedStrategy({protected: {takeProfitPct: '10', seedFromBalance: true}});
+      const strategy = new TestProtectedStrategy({protected: {seedFromBalance: true, takeProfitPct: '10'}});
 
       // Seed at 100
       await strategy.onCandle(makeCandle(100), stateWithPosition);
@@ -368,7 +368,7 @@ describe('ProtectedStrategy', () => {
 
     it('does not seed when baseBalance is zero', async () => {
       const strategy = new TestProtectedStrategy({
-        protected: {stopLossPct: '5', seedFromBalance: true},
+        protected: {seedFromBalance: true, stopLossPct: '5'},
         signalAdvice: true,
       });
 
@@ -390,7 +390,7 @@ describe('ProtectedStrategy', () => {
     });
 
     it('does not re-seed after position was already tracked via onFill', async () => {
-      const strategy = new TestProtectedStrategy({protected: {stopLossPct: '5', seedFromBalance: true}});
+      const strategy = new TestProtectedStrategy({protected: {seedFromBalance: true, stopLossPct: '5'}});
 
       // Position tracked via fill at 80
       await strategy.onFill(makeFill('80', '10', OrderSide.BUY), mockState);
@@ -403,12 +403,12 @@ describe('ProtectedStrategy', () => {
     });
 
     it('persists seeded state through restoreState', async () => {
-      const strategy = new TestProtectedStrategy({protected: {stopLossPct: '5', seedFromBalance: true}});
+      const strategy = new TestProtectedStrategy({protected: {seedFromBalance: true, stopLossPct: '5'}});
       await strategy.onCandle(makeCandle(100), stateWithPosition);
 
       const snapshot = strategy.state;
 
-      const restored = new TestProtectedStrategy({protected: {stopLossPct: '5', seedFromBalance: true}});
+      const restored = new TestProtectedStrategy({protected: {seedFromBalance: true, stopLossPct: '5'}});
       restored.restoreState(snapshot!);
 
       expect(restored.protectedState.totalPositionSize).toBe('10');
@@ -567,13 +567,13 @@ describe('ProtectedStrategy', () => {
 
   describe('mutual exclusion', () => {
     it('rejects setting both stopLossPct and stopLossNominal', () => {
-      expect(() => new TestProtectedStrategy({protected: {stopLossPct: '5', stopLossNominal: '10'}})).toThrow(
+      expect(() => new TestProtectedStrategy({protected: {stopLossNominal: '10', stopLossPct: '5'}})).toThrow(
         /stopLossPct, stopLossNominal, and stopLossPrice are mutually exclusive/
       );
     });
 
     it('rejects setting both takeProfitPct and takeProfitNominal', () => {
-      expect(() => new TestProtectedStrategy({protected: {takeProfitPct: '10', takeProfitNominal: '5'}})).toThrow(
+      expect(() => new TestProtectedStrategy({protected: {takeProfitNominal: '5', takeProfitPct: '10'}})).toThrow(
         /takeProfitPct, takeProfitNominal, and takeProfitPrice are mutually exclusive/
       );
     });
@@ -604,7 +604,7 @@ describe('ProtectedStrategy', () => {
 
     it('rejects setting all three stop-loss variants', () => {
       expect(
-        () => new TestProtectedStrategy({protected: {stopLossPct: '5', stopLossNominal: '10', stopLossPrice: '95'}})
+        () => new TestProtectedStrategy({protected: {stopLossNominal: '10', stopLossPct: '5', stopLossPrice: '95'}})
       ).toThrow(/stopLossPct, stopLossNominal, and stopLossPrice are mutually exclusive/);
     });
 
@@ -712,9 +712,9 @@ describe('ProtectedStrategy', () => {
       strategy.restoreState({
         protected: {
           killed: true,
-          killedReason: 'stale',
-          killedOrderType: null,
           killedLimitPrice: null,
+          killedOrderType: null,
+          killedReason: 'stale',
           totalCostBasis: '1000',
           totalPositionSize: '10',
         },
@@ -730,9 +730,9 @@ describe('ProtectedStrategy', () => {
       strategy.restoreState({
         protected: {
           killed: true,
-          killedReason: 'stale',
-          killedOrderType: 'limit',
           killedLimitPrice: null,
+          killedOrderType: 'limit',
+          killedReason: 'stale',
           totalCostBasis: '1000',
           totalPositionSize: '10',
         },
@@ -747,9 +747,9 @@ describe('ProtectedStrategy', () => {
       strategy.restoreState({
         protected: {
           killed: true,
-          killedReason: 'Stop-loss fired',
-          killedOrderType: 'market',
           killedLimitPrice: null,
+          killedOrderType: 'market',
+          killedReason: 'Stop-loss fired',
           totalCostBasis: '1000',
           totalPositionSize: '10',
         },
@@ -766,9 +766,9 @@ describe('ProtectedStrategy', () => {
       strategy.restoreState({
         protected: {
           killed: false,
-          killedReason: null,
-          killedOrderType: null,
           killedLimitPrice: null,
+          killedOrderType: null,
+          killedReason: null,
           totalCostBasis: 'not-a-number',
           totalPositionSize: '10',
         },
@@ -784,9 +784,9 @@ describe('ProtectedStrategy', () => {
       strategy.restoreState({
         protected: {
           killed: true,
-          killedReason: null,
-          killedOrderType: 'limit',
           killedLimitPrice: 'garbage',
+          killedOrderType: 'limit',
+          killedReason: null,
           totalCostBasis: '1000',
           totalPositionSize: '10',
         },
@@ -874,7 +874,7 @@ describe('ProtectedStrategy', () => {
     });
 
     it('fires a MARKET sell when stopLossOrder is "market"', async () => {
-      const strategy = new TestProtectedStrategy({protected: {stopLossPct: '5', stopLossOrder: 'market'}});
+      const strategy = new TestProtectedStrategy({protected: {stopLossOrder: 'market', stopLossPct: '5'}});
       await strategy.onFill(makeFill('100', '10', OrderSide.BUY), mockState);
 
       const advice = await strategy.onCandle(makeCandle(95), mockState);
@@ -890,7 +890,7 @@ describe('ProtectedStrategy', () => {
     });
 
     it('fires a MARKET sell when takeProfitOrder is "market"', async () => {
-      const strategy = new TestProtectedStrategy({protected: {takeProfitPct: '10', takeProfitOrder: 'market'}});
+      const strategy = new TestProtectedStrategy({protected: {takeProfitOrder: 'market', takeProfitPct: '10'}});
       await strategy.onFill(makeFill('100', '10', OrderSide.BUY), mockState);
 
       const advice = await strategy.onCandle(makeCandle(110), mockState);
@@ -904,8 +904,8 @@ describe('ProtectedStrategy', () => {
     it('can mix a market stop-loss with a limit take-profit', async () => {
       const strategy = new TestProtectedStrategy({
         protected: {
-          stopLossPct: '5',
           stopLossOrder: 'market',
+          stopLossPct: '5',
           takeProfitPct: '10',
           // takeProfitOrder defaults to 'limit'
         },
@@ -920,8 +920,8 @@ describe('ProtectedStrategy', () => {
       const strategy = new TestProtectedStrategy({
         protected: {
           stopLossPct: '5',
-          takeProfitPct: '10',
           takeProfitOrder: 'market',
+          takeProfitPct: '10',
         },
       });
       await strategy.onFill(makeFill('100', '10', OrderSide.BUY), mockState);
@@ -932,7 +932,7 @@ describe('ProtectedStrategy', () => {
 
     it('retries market advice on subsequent candles while the position is not exited', async () => {
       const strategy = new TestProtectedStrategy({
-        protected: {stopLossPct: '5', stopLossOrder: 'market'},
+        protected: {stopLossOrder: 'market', stopLossPct: '5'},
         signalAdvice: true,
       });
       await strategy.onFill(makeFill('100', '10', OrderSide.BUY), mockState);
@@ -948,13 +948,13 @@ describe('ProtectedStrategy', () => {
     });
 
     it('persists killedOrderType across restoreState', async () => {
-      const strategy = new TestProtectedStrategy({protected: {stopLossPct: '5', stopLossOrder: 'market'}});
+      const strategy = new TestProtectedStrategy({protected: {stopLossOrder: 'market', stopLossPct: '5'}});
       await strategy.onFill(makeFill('100', '10', OrderSide.BUY), mockState);
       await strategy.onCandle(makeCandle(95), mockState); // fire
 
       const snapshot = strategy.state;
 
-      const restored = new TestProtectedStrategy({protected: {stopLossPct: '5', stopLossOrder: 'market'}});
+      const restored = new TestProtectedStrategy({protected: {stopLossOrder: 'market', stopLossPct: '5'}});
       restored.restoreState(snapshot!);
       expect(restored.protectedState.killedOrderType).toBe('market');
       expect(restored.protectedState.killedLimitPrice).toBeNull();

--- a/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.ts
+++ b/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.ts
@@ -19,41 +19,18 @@ import {positiveNumberString} from '../util/validators.js';
  */
 export const ProtectedConfigSchema = z.object({
   /**
-   * Stop-loss as a percentage of avg entry. "5" = sell everything at avgEntry * 0.95.
-   * Mutually exclusive with `stopLossNominal` and `stopLossPrice`. Omit all three to
-   * disable the stop-loss guard.
+   * When `true`, the strategy seeds its position tracking from the account's existing
+   * base balance and the first candle's close price. This allows attaching guard
+   * protection to a position that was opened externally (manual trade, another strategy).
+   * Percentage and nominal guards will be relative to the price at attach time.
    */
-  stopLossPct: positiveNumberString.optional(),
+  seedFromBalance: z.boolean().default(false),
   /**
    * Stop-loss as an absolute unrealized loss in counter currency. "10" on a 10-share
    * position bought at $100 → fires at $99 (unrealized loss = $10). Mutually exclusive
    * with `stopLossPct` and `stopLossPrice`.
    */
   stopLossNominal: positiveNumberString.optional(),
-  /**
-   * Stop-loss as an absolute price target. "95" → fires as soon as the candle close
-   * drops to $95 or below, placing a limit sell at $95. Mutually exclusive with
-   * `stopLossPct` and `stopLossNominal`.
-   */
-  stopLossPrice: positiveNumberString.optional(),
-  /**
-   * Take-profit as a percentage of avg entry. "10" = sell everything at avgEntry * 1.10.
-   * Mutually exclusive with `takeProfitNominal` and `takeProfitPrice`. Omit all three to
-   * disable the take-profit guard.
-   */
-  takeProfitPct: positiveNumberString.optional(),
-  /**
-   * Take-profit as an absolute unrealized gain in counter currency. "10" on a 10-share
-   * position bought at $100 → fires at $101 (unrealized gain = $10). Mutually exclusive
-   * with `takeProfitPct` and `takeProfitPrice`.
-   */
-  takeProfitNominal: positiveNumberString.optional(),
-  /**
-   * Take-profit as an absolute price target. "105" → fires as soon as the candle close
-   * reaches $105 or above, placing a limit sell at $105. Mutually exclusive with
-   * `takeProfitPct` and `takeProfitNominal`.
-   */
-  takeProfitPrice: positiveNumberString.optional(),
   /**
    * Order type used to execute the stop-loss kill switch. `"limit"` (default) places a
    * limit sell at the nominal target price — guaranteed exit price, but may not fill if
@@ -62,17 +39,40 @@ export const ProtectedConfigSchema = z.object({
    */
   stopLossOrder: z.enum(['limit', 'market']).default('limit'),
   /**
+   * Stop-loss as a percentage of avg entry. "5" = sell everything at avgEntry * 0.95.
+   * Mutually exclusive with `stopLossNominal` and `stopLossPrice`. Omit all three to
+   * disable the stop-loss guard.
+   */
+  stopLossPct: positiveNumberString.optional(),
+  /**
+   * Stop-loss as an absolute price target. "95" → fires as soon as the candle close
+   * drops to $95 or below, placing a limit sell at $95. Mutually exclusive with
+   * `stopLossPct` and `stopLossNominal`.
+   */
+  stopLossPrice: positiveNumberString.optional(),
+  /**
+   * Take-profit as an absolute unrealized gain in counter currency. "10" on a 10-share
+   * position bought at $100 → fires at $101 (unrealized gain = $10). Mutually exclusive
+   * with `takeProfitPct` and `takeProfitPrice`.
+   */
+  takeProfitNominal: positiveNumberString.optional(),
+  /**
    * Order type used to execute the take-profit kill switch. See `stopLossOrder` for the
    * trade-off between `"limit"` (default) and `"market"`.
    */
   takeProfitOrder: z.enum(['limit', 'market']).default('limit'),
   /**
-   * When `true`, the strategy seeds its position tracking from the account's existing
-   * base balance and the first candle's close price. This allows attaching guard
-   * protection to a position that was opened externally (manual trade, another strategy).
-   * Percentage and nominal guards will be relative to the price at attach time.
+   * Take-profit as a percentage of avg entry. "10" = sell everything at avgEntry * 1.10.
+   * Mutually exclusive with `takeProfitNominal` and `takeProfitPrice`. Omit all three to
+   * disable the take-profit guard.
    */
-  seedFromBalance: z.boolean().default(false),
+  takeProfitPct: positiveNumberString.optional(),
+  /**
+   * Take-profit as an absolute price target. "105" → fires as soon as the candle close
+   * reaches $105 or above, placing a limit sell at $105. Mutually exclusive with
+   * `takeProfitPct` and `takeProfitNominal`.
+   */
+  takeProfitPrice: positiveNumberString.optional(),
 });
 
 /** All of the kill-switch settings, nested under a single namespaced `protected` key. */
@@ -104,9 +104,9 @@ const PROTECTED_STATE_KEY = 'protected';
 
 const defaultProtectedState = (): ProtectedStrategyState => ({
   killed: false,
-  killedReason: null,
-  killedOrderType: null,
   killedLimitPrice: null,
+  killedOrderType: null,
+  killedReason: null,
   totalCostBasis: '0',
   totalPositionSize: '0',
 });
@@ -305,9 +305,9 @@ export class ProtectedStrategy extends Strategy {
         const reason = this.#stopLossReason(avgEntry, currentPrice, positionSize, targetPrice, orderType);
         this.#setProtectedState({
           killed: true,
-          killedReason: reason,
-          killedOrderType: orderType,
           killedLimitPrice: orderType === 'limit' ? targetPrice.toFixed() : null,
+          killedOrderType: orderType,
+          killedReason: reason,
         });
         return this.#killSwitchAdvice(reason, orderType, orderType === 'limit' ? targetPrice : null);
       }
@@ -320,9 +320,9 @@ export class ProtectedStrategy extends Strategy {
         const reason = this.#takeProfitReason(avgEntry, currentPrice, positionSize, targetPrice, orderType);
         this.#setProtectedState({
           killed: true,
-          killedReason: reason,
-          killedOrderType: orderType,
           killedLimitPrice: orderType === 'limit' ? targetPrice.toFixed() : null,
+          killedOrderType: orderType,
+          killedReason: reason,
         });
         return this.#killSwitchAdvice(reason, orderType, orderType === 'limit' ? targetPrice : null);
       }
@@ -475,23 +475,23 @@ export class ProtectedStrategy extends Strategy {
   #killSwitchAdvice(reason: string, orderType: GuardOrderType, limitPrice: Big | null): OrderAdvice {
     if (orderType === 'market') {
       return {
-        side: OrderSide.SELL,
-        type: OrderType.MARKET,
         amount: AllAvailableAmount,
         amountIn: 'base',
         reason: `[KILL SWITCH] ${reason}`,
+        side: OrderSide.SELL,
+        type: OrderType.MARKET,
       };
     }
     if (!limitPrice) {
       throw new Error('ProtectedStrategy: limit order type requires a limit price');
     }
     const advice: LimitOrderAdvice = {
-      side: OrderSide.SELL,
-      type: OrderType.LIMIT,
       amount: AllAvailableAmount,
       amountIn: 'base',
       price: limitPrice,
       reason: `[KILL SWITCH] ${reason}`,
+      side: OrderSide.SELL,
+      type: OrderType.LIMIT,
     };
     return advice;
   }

--- a/packages/trading-strategies/src/strategy-scalp/ScalpStrategy.test.ts
+++ b/packages/trading-strategies/src/strategy-scalp/ScalpStrategy.test.ts
@@ -10,6 +10,10 @@ const pair = new TradingPair('AAPL', 'USD');
 const mockState: TradingSessionState = {
   baseBalance: new Big(0),
   counterBalance: new Big(1000),
+  feeRates: {
+    [OrderType.LIMIT]: new Big('0.001'),
+    [OrderType.MARKET]: new Big('0.002'),
+  },
   tradingRules: {
     base_increment: '0.01',
     base_max_size: '10000',
@@ -17,10 +21,6 @@ const mockState: TradingSessionState = {
     counter_increment: '0.01',
     counter_min_size: '1',
     pair,
-  },
-  feeRates: {
-    [OrderType.LIMIT]: new Big('0.001'),
-    [OrderType.MARKET]: new Big('0.002'),
   },
 };
 
@@ -64,7 +64,7 @@ describe('ScalpSchema', () => {
   });
 
   it('accepts config with custom emaPeriod', () => {
-    const config = ScalpSchema.parse({offset: '0.50', emaPeriod: 10});
+    const config = ScalpSchema.parse({emaPeriod: 10, offset: '0.50'});
     expect(config.emaPeriod).toBe(10);
   });
 
@@ -81,7 +81,7 @@ describe('ScalpSchema', () => {
 
 describe('ScalpStrategy', () => {
   it('returns no advice during EMA warmup', async () => {
-    const strategy = new ScalpStrategy({offset: '0.10', emaPeriod: 5});
+    const strategy = new ScalpStrategy({emaPeriod: 5, offset: '0.10'});
 
     // Feed 4 candles (need 5 for EMA to stabilize)
     for (let i = 0; i < 4; i++) {
@@ -91,7 +91,7 @@ describe('ScalpStrategy', () => {
   });
 
   it('returns no advice when price is below EMA', async () => {
-    const strategy = new ScalpStrategy({offset: '0.10', emaPeriod: 3});
+    const strategy = new ScalpStrategy({emaPeriod: 3, offset: '0.10'});
 
     // Rising prices to warm up EMA, then a drop
     const prices = [100, 102, 104, 98] as const;
@@ -107,7 +107,7 @@ describe('ScalpStrategy', () => {
   });
 
   it('enters with a market buy when price crosses above EMA', async () => {
-    const strategy = new ScalpStrategy({offset: '0.10', emaPeriod: 3});
+    const strategy = new ScalpStrategy({emaPeriod: 3, offset: '0.10'});
 
     // Steady rise so price stays above EMA
     const prices = [100, 101, 102, 103] as const;
@@ -129,7 +129,7 @@ describe('ScalpStrategy', () => {
   });
 
   it('places a limit sell at fill + offset after buy fills', async () => {
-    const strategy = new ScalpStrategy({offset: '0.50', emaPeriod: 3});
+    const strategy = new ScalpStrategy({emaPeriod: 3, offset: '0.50'});
 
     // Warm up and trigger entry
     const prices = [100, 101, 102, 103] as const;
@@ -155,7 +155,7 @@ describe('ScalpStrategy', () => {
   });
 
   it('places a limit buy at fill - offset after sell fills', async () => {
-    const strategy = new ScalpStrategy({offset: '0.50', emaPeriod: 3});
+    const strategy = new ScalpStrategy({emaPeriod: 3, offset: '0.50'});
 
     // Warm up and trigger entry
     for (let i = 0; i < 4; i++) {
@@ -181,7 +181,7 @@ describe('ScalpStrategy', () => {
   });
 
   it('returns no advice while waiting for a fill', async () => {
-    const strategy = new ScalpStrategy({offset: '0.50', emaPeriod: 3});
+    const strategy = new ScalpStrategy({emaPeriod: 3, offset: '0.50'});
 
     // Trigger entry
     for (let i = 0; i < 4; i++) {
@@ -198,7 +198,7 @@ describe('ScalpStrategy', () => {
   });
 
   it('includes a reason in the entry advice', async () => {
-    const strategy = new ScalpStrategy({offset: '0.10', emaPeriod: 3});
+    const strategy = new ScalpStrategy({emaPeriod: 3, offset: '0.10'});
 
     let entryAdvice;
 
@@ -216,7 +216,7 @@ describe('ScalpStrategy', () => {
   });
 
   it('pre-seeds EMA via init() to skip warmup', async () => {
-    const strategy = new ScalpStrategy({offset: '0.10', emaPeriod: 3});
+    const strategy = new ScalpStrategy({emaPeriod: 3, offset: '0.10'});
 
     // Pre-seed with 3 candles
     const historicalCandles = [makeCandle(100, 0), makeCandle(101, 1), makeCandle(102, 2)] as const;
@@ -231,7 +231,7 @@ describe('ScalpStrategy', () => {
   });
 
   it('restores state across restarts', async () => {
-    const strategy = new ScalpStrategy({offset: '0.50', emaPeriod: 3});
+    const strategy = new ScalpStrategy({emaPeriod: 3, offset: '0.50'});
 
     strategy.restoreState({
       lastFillPrice: '103',

--- a/packages/trading-strategies/src/strategy-scalp/ScalpStrategy.ts
+++ b/packages/trading-strategies/src/strategy-scalp/ScalpStrategy.ts
@@ -9,13 +9,13 @@ import {positiveNumberString} from '../util/validators.js';
 import {suggestScalpOffset} from './suggestScalpOffset.js';
 
 export const ScalpSchema = ProtectedStrategySchema.extend({
+  /** EMA period used for the initial entry filter. Default: 5. */
+  emaPeriod: z.number().int().positive().optional().default(5),
   /**
    * Nominal price offset for each leg of the scalp (e.g., "0.10" means sell at fill+0.10, re-buy at fill-0.10).
    *  When omitted, the offset is auto-computed from historical candles passed to `init()`.
    */
   offset: positiveNumberString.optional(),
-  /** EMA period used for the initial entry filter. Default: 5. */
-  emaPeriod: z.number().int().positive().optional().default(5),
 });
 
 export type ScalpConfig = z.infer<typeof ScalpSchema>;
@@ -39,7 +39,7 @@ export class ScalpStrategy extends ProtectedStrategy {
   constructor(config: ScalpConfig) {
     super({
       config,
-      state: {phase: 'entry', lastFillPrice: null, lastFillSide: null},
+      state: {lastFillPrice: null, lastFillSide: null, phase: 'entry'},
     });
     this.#ema = new EMA(this.#config.emaPeriod);
   }
@@ -96,7 +96,7 @@ export class ScalpStrategy extends ProtectedStrategy {
         let b = dayMap.get(day);
 
         if (!b) {
-          b = {high: -Infinity, low: Infinity, close: 0};
+          b = {close: 0, high: -Infinity, low: Infinity};
           dayMap.set(day, b);
         }
 
@@ -208,11 +208,11 @@ export class ScalpStrategy extends ProtectedStrategy {
     this.#state.phase = 'waitingForFill';
 
     return {
-      side: OrderSide.BUY,
-      type: OrderType.MARKET,
       amount: AllAvailableAmount,
       amountIn: 'counter',
       reason: `Entry: price ${closePrice.toFixed(2)} above EMA(${this.#ema.interval}) ${emaValue.toFixed(2)}`,
+      side: OrderSide.BUY,
+      type: OrderType.MARKET,
     };
   }
 
@@ -231,12 +231,12 @@ export class ScalpStrategy extends ProtectedStrategy {
       const sellPrice = lastFillPrice.plus(offset);
 
       return {
-        side: OrderSide.SELL,
-        type: OrderType.LIMIT,
         amount: AllAvailableAmount,
         amountIn: 'base',
         price: sellPrice,
         reason: `Scalp sell: fill ${lastFillPrice.toFixed(2)} + offset ${offset.toFixed(2)}`,
+        side: OrderSide.SELL,
+        type: OrderType.LIMIT,
       };
     }
 
@@ -244,12 +244,12 @@ export class ScalpStrategy extends ProtectedStrategy {
     const buyPrice = lastFillPrice.minus(offset);
 
     return {
-      side: OrderSide.BUY,
-      type: OrderType.LIMIT,
       amount: AllAvailableAmount,
       amountIn: 'base',
       price: buyPrice,
       reason: `Scalp buy: fill ${lastFillPrice.toFixed(2)} - offset ${offset.toFixed(2)}`,
+      side: OrderSide.BUY,
+      type: OrderType.LIMIT,
     };
   }
 }

--- a/packages/trading-strategies/src/strategy-scalp/suggestScalpOffset.ts
+++ b/packages/trading-strategies/src/strategy-scalp/suggestScalpOffset.ts
@@ -89,9 +89,9 @@ export function suggestScalpOffset(candles: Candle[], atrPeriod: number = 14): B
 
   for (const candle of effectiveCandles) {
     atr.add({
+      close: parseFloat(candle.close),
       high: parseFloat(candle.high),
       low: parseFloat(candle.low),
-      close: parseFloat(candle.close),
     });
   }
 

--- a/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.test.ts
+++ b/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.test.ts
@@ -12,11 +12,11 @@ function createCandle(overrides: Partial<Candle> & {close: string; open: string}
 
   return {
     base: 'BTC',
+    close: overrides.close,
     counter: 'USD',
     high: overrides.high ?? String(Math.max(openNum, closeNum)),
     low: overrides.low ?? String(Math.min(openNum, closeNum)),
     open: overrides.open,
-    close: overrides.close,
     openTimeInISO: overrides.openTimeInISO ?? '2025-01-01T00:00:00.000Z',
     openTimeInMillis: overrides.openTimeInMillis ?? 1735689600000,
     sizeInMillis: overrides.sizeInMillis ?? 60000,
@@ -45,15 +45,15 @@ describe('TrailingStopStrategy', () => {
      * C4: limit sell fills (low=105 <= 108).
      */
     const candles = [
-      createCandle({open: '100', close: '100', low: '99', high: '101', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
-      createCandle({open: '105', close: '118', low: '104', high: '120', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
-      createCandle({open: '118', close: '107', low: '106', high: '120', openTimeInISO: '2025-01-01T00:02:00.000Z'}),
-      createCandle({open: '107', close: '107', low: '105', high: '108', openTimeInISO: '2025-01-01T00:03:00.000Z'}),
+      createCandle({close: '100', high: '101', low: '99', open: '100', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+      createCandle({close: '118', high: '120', low: '104', open: '105', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
+      createCandle({close: '107', high: '120', low: '106', open: '118', openTimeInISO: '2025-01-01T00:02:00.000Z'}),
+      createCandle({close: '107', high: '108', low: '105', open: '107', openTimeInISO: '2025-01-01T00:03:00.000Z'}),
     ];
 
     const config: BacktestConfig = {
-      candles,
       broker: createMockExchange({baseBalance: '5'}),
+      candles,
       strategy,
       tradingPair,
     };
@@ -72,15 +72,15 @@ describe('TrailingStopStrategy', () => {
 
     // peak ratchets up; close never breaches peak * 0.95.
     const candles = [
-      createCandle({open: '100', close: '100', low: '99', high: '101', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
-      createCandle({open: '101', close: '105', low: '100', high: '106', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
-      createCandle({open: '105', close: '110', low: '104', high: '112', openTimeInISO: '2025-01-01T00:02:00.000Z'}),
-      createCandle({open: '110', close: '108', low: '107', high: '112', openTimeInISO: '2025-01-01T00:03:00.000Z'}),
+      createCandle({close: '100', high: '101', low: '99', open: '100', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+      createCandle({close: '105', high: '106', low: '100', open: '101', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
+      createCandle({close: '110', high: '112', low: '104', open: '105', openTimeInISO: '2025-01-01T00:02:00.000Z'}),
+      createCandle({close: '108', high: '112', low: '107', open: '110', openTimeInISO: '2025-01-01T00:03:00.000Z'}),
     ];
 
     const config: BacktestConfig = {
-      candles,
       broker: createMockExchange({baseBalance: '5'}),
+      candles,
       strategy,
       tradingPair,
     };
@@ -96,16 +96,16 @@ describe('TrailingStopStrategy', () => {
     const strategy = new TrailingStopStrategy({trailDownPct: '10'});
 
     const candles = [
-      createCandle({open: '100', close: '100', low: '99', high: '101', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
-      createCandle({open: '105', close: '115', low: '104', high: '120', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
-      createCandle({open: '115', close: '110', low: '110', high: '116', openTimeInISO: '2025-01-01T00:02:00.000Z'}),
-      createCandle({open: '110', close: '107', low: '107', high: '111', openTimeInISO: '2025-01-01T00:03:00.000Z'}),
-      createCandle({open: '107', close: '107', low: '105', high: '108', openTimeInISO: '2025-01-01T00:04:00.000Z'}),
+      createCandle({close: '100', high: '101', low: '99', open: '100', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+      createCandle({close: '115', high: '120', low: '104', open: '105', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
+      createCandle({close: '110', high: '116', low: '110', open: '115', openTimeInISO: '2025-01-01T00:02:00.000Z'}),
+      createCandle({close: '107', high: '111', low: '107', open: '110', openTimeInISO: '2025-01-01T00:03:00.000Z'}),
+      createCandle({close: '107', high: '108', low: '105', open: '107', openTimeInISO: '2025-01-01T00:04:00.000Z'}),
     ];
 
     const config: BacktestConfig = {
-      candles,
       broker: createMockExchange({baseBalance: '5'}),
+      candles,
       strategy,
       tradingPair,
     };
@@ -118,18 +118,18 @@ describe('TrailingStopStrategy', () => {
   });
 
   it('uses a market sell when exitOrder is "market"', async () => {
-    const strategy = new TrailingStopStrategy({trailDownPct: '10', exitOrder: 'market'});
+    const strategy = new TrailingStopStrategy({exitOrder: 'market', trailDownPct: '10'});
 
     const candles = [
-      createCandle({open: '100', close: '100', low: '99', high: '101', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
-      createCandle({open: '105', close: '118', low: '104', high: '120', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
-      createCandle({open: '118', close: '107', low: '106', high: '120', openTimeInISO: '2025-01-01T00:02:00.000Z'}),
-      createCandle({open: '107', close: '107', low: '105', high: '108', openTimeInISO: '2025-01-01T00:03:00.000Z'}),
+      createCandle({close: '100', high: '101', low: '99', open: '100', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+      createCandle({close: '118', high: '120', low: '104', open: '105', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
+      createCandle({close: '107', high: '120', low: '106', open: '118', openTimeInISO: '2025-01-01T00:02:00.000Z'}),
+      createCandle({close: '107', high: '108', low: '105', open: '107', openTimeInISO: '2025-01-01T00:03:00.000Z'}),
     ];
 
     const config: BacktestConfig = {
-      candles,
       broker: createMockExchange({baseBalance: '5'}),
+      candles,
       strategy,
       tradingPair,
     };
@@ -146,13 +146,13 @@ describe('TrailingStopStrategy', () => {
 
     // Empty balance → no attach, no advice.
     const candles = [
-      createCandle({open: '100', close: '100', low: '99', high: '101', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
-      createCandle({open: '100', close: '100', low: '99', high: '101', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
+      createCandle({close: '100', high: '101', low: '99', open: '100', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+      createCandle({close: '100', high: '101', low: '99', open: '100', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
     ];
 
     const config: BacktestConfig = {
-      candles,
       broker: createMockExchange({baseBalance: '0', counterBalance: '0'}),
+      candles,
       strategy,
       tradingPair,
     };
@@ -168,16 +168,16 @@ describe('TrailingStopStrategy', () => {
 
     const candles = [
       // Attach: high=160 (intra-candle high), close=150. Peak=160 (from high). Target=144.
-      createCandle({open: '150', close: '150', low: '149', high: '160', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+      createCandle({close: '150', high: '160', low: '149', open: '150', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
       // close=143 <= 144 → exit fires. high=150 doesn't ratchet peak above 160.
-      createCandle({open: '150', close: '143', low: '140', high: '150', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
+      createCandle({close: '143', high: '150', low: '140', open: '150', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
       // Limit fills (low=140 <= 144).
-      createCandle({open: '143', close: '143', low: '140', high: '145', openTimeInISO: '2025-01-01T00:02:00.000Z'}),
+      createCandle({close: '143', high: '145', low: '140', open: '143', openTimeInISO: '2025-01-01T00:02:00.000Z'}),
     ];
 
     const config: BacktestConfig = {
-      candles,
       broker: createMockExchange({baseBalance: '5'}),
+      candles,
       strategy,
       tradingPair,
     };
@@ -190,20 +190,20 @@ describe('TrailingStopStrategy', () => {
   });
 
   it('seeds the peak from a configured pivotPrice instead of the attach candle high', async () => {
-    const strategy = new TrailingStopStrategy({trailDownPct: '10', pivotPrice: '200'});
+    const strategy = new TrailingStopStrategy({pivotPrice: '200', trailDownPct: '10'});
 
     const candles = [
       // Attach candle high=160, but pivotPrice=200 wins. Peak=200, target=180.
-      createCandle({open: '150', close: '150', low: '149', high: '160', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+      createCandle({close: '150', high: '160', low: '149', open: '150', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
       // close=179 <= 180 → exit fires at limit 180. high=150 doesn't ratchet peak.
-      createCandle({open: '150', close: '179', low: '178', high: '150', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
+      createCandle({close: '179', high: '150', low: '178', open: '150', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
       // Limit fills (low=178 <= 180).
-      createCandle({open: '179', close: '179', low: '178', high: '181', openTimeInISO: '2025-01-01T00:02:00.000Z'}),
+      createCandle({close: '179', high: '181', low: '178', open: '179', openTimeInISO: '2025-01-01T00:02:00.000Z'}),
     ];
 
     const config: BacktestConfig = {
-      candles,
       broker: createMockExchange({baseBalance: '5'}),
+      candles,
       strategy,
       tradingPair,
     };
@@ -220,22 +220,22 @@ describe('TrailingStopStrategy', () => {
 
     const candles = [
       // Attach. peak=100, ratchet threshold=105 (peak * 1.05).
-      createCandle({open: '100', close: '100', low: '99', high: '100', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+      createCandle({close: '100', high: '100', low: '99', open: '100', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
       // high=104 < 105 → does NOT ratchet. Peak stays at 100.
-      createCandle({open: '100', close: '102', low: '99', high: '104', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
+      createCandle({close: '102', high: '104', low: '99', open: '100', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
       // high=110 >= 105 → ratchets. Peak jumps to 110. New threshold=115.5.
-      createCandle({open: '102', close: '108', low: '101', high: '110', openTimeInISO: '2025-01-01T00:02:00.000Z'}),
+      createCandle({close: '108', high: '110', low: '101', open: '102', openTimeInISO: '2025-01-01T00:02:00.000Z'}),
       // high=114 < 115.5 → does NOT ratchet. Peak stays at 110.
-      createCandle({open: '108', close: '112', low: '107', high: '114', openTimeInISO: '2025-01-01T00:03:00.000Z'}),
+      createCandle({close: '112', high: '114', low: '107', open: '108', openTimeInISO: '2025-01-01T00:03:00.000Z'}),
       // close=98 <= 99 (110 * 0.9) → exit fires at limit 99.
-      createCandle({open: '112', close: '98', low: '97', high: '113', openTimeInISO: '2025-01-01T00:04:00.000Z'}),
+      createCandle({close: '98', high: '113', low: '97', open: '112', openTimeInISO: '2025-01-01T00:04:00.000Z'}),
       // Limit fills (low=97 <= 99).
-      createCandle({open: '98', close: '98', low: '97', high: '100', openTimeInISO: '2025-01-01T00:05:00.000Z'}),
+      createCandle({close: '98', high: '100', low: '97', open: '98', openTimeInISO: '2025-01-01T00:05:00.000Z'}),
     ];
 
     const config: BacktestConfig = {
-      candles,
       broker: createMockExchange({baseBalance: '5'}),
+      candles,
       strategy,
       tradingPair,
     };
@@ -252,16 +252,16 @@ describe('TrailingStopStrategy', () => {
 
     const candles = [
       // Attach: peak=100. Default 10% trail → target=90.
-      createCandle({open: '100', close: '100', low: '99', high: '100', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+      createCandle({close: '100', high: '100', low: '99', open: '100', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
       // close=90 <= 90 → exit fires at limit 90.
-      createCandle({open: '100', close: '90', low: '89', high: '100', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
+      createCandle({close: '90', high: '100', low: '89', open: '100', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
       // Limit fills (low=89 <= 90).
-      createCandle({open: '90', close: '90', low: '89', high: '91', openTimeInISO: '2025-01-01T00:02:00.000Z'}),
+      createCandle({close: '90', high: '91', low: '89', open: '90', openTimeInISO: '2025-01-01T00:02:00.000Z'}),
     ];
 
     const config: BacktestConfig = {
-      candles,
       broker: createMockExchange({baseBalance: '5'}),
+      candles,
       strategy,
       tradingPair,
     };
@@ -281,11 +281,11 @@ describe('TrailingStopStrategy', () => {
      */
     strategy.restoreState({
       exited: false,
-      positionSize: '0',
-      peakPrice: '120',
-      stopPrice: '108',
-      exitReason: null,
       exitLimitPrice: null,
+      exitReason: null,
+      peakPrice: '120',
+      positionSize: '0',
+      stopPrice: '108',
     });
 
     expect(strategy.trailingState.peakPrice).toBe('0');
@@ -297,11 +297,11 @@ describe('TrailingStopStrategy', () => {
 
     strategy.restoreState({
       exited: true,
-      positionSize: '5',
-      peakPrice: '120',
-      stopPrice: '108',
-      exitReason: null,
       exitLimitPrice: null,
+      exitReason: null,
+      peakPrice: '120',
+      positionSize: '5',
+      stopPrice: '108',
     });
 
     expect(strategy.trailingState.exited).toBe(false);
@@ -313,14 +313,14 @@ describe('TrailingStopStrategy', () => {
 
     const candles = [
       // Attach: peak=100. stopPrice should be 90.
-      createCandle({open: '100', close: '100', low: '99', high: '100', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+      createCandle({close: '100', high: '100', low: '99', open: '100', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
       // Peak ratchets to 120. stopPrice should refresh to 108.
-      createCandle({open: '100', close: '115', low: '100', high: '120', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
+      createCandle({close: '115', high: '120', low: '100', open: '100', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
     ];
 
     const config: BacktestConfig = {
-      candles,
       broker: createMockExchange({baseBalance: '5'}),
+      candles,
       strategy,
       tradingPair,
     };
@@ -337,12 +337,12 @@ describe('TrailingStopStrategy', () => {
     strategy.onMessage = text => messages.push(text);
 
     const candles = [
-      createCandle({open: '100', close: '100', low: '99', high: '100', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+      createCandle({close: '100', high: '100', low: '99', open: '100', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
     ];
 
     const config: BacktestConfig = {
-      candles,
       broker: createMockExchange({baseBalance: '5'}),
+      candles,
       strategy,
       tradingPair,
     };
@@ -360,18 +360,18 @@ describe('TrailingStopStrategy', () => {
 
     const candles = [
       // Attach: peak=100. attach message.
-      createCandle({open: '100', close: '100', low: '99', high: '100', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+      createCandle({close: '100', high: '100', low: '99', open: '100', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
       // high=120 → ratchet. peak=120, stop=108.
-      createCandle({open: '100', close: '115', low: '100', high: '120', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
+      createCandle({close: '115', high: '120', low: '100', open: '100', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
       // high=120 (no new peak). No ratchet message.
-      createCandle({open: '115', close: '118', low: '115', high: '120', openTimeInISO: '2025-01-01T00:02:00.000Z'}),
+      createCandle({close: '118', high: '120', low: '115', open: '115', openTimeInISO: '2025-01-01T00:02:00.000Z'}),
       // high=130 → ratchet. peak=130, stop=117.
-      createCandle({open: '120', close: '125', low: '119', high: '130', openTimeInISO: '2025-01-01T00:03:00.000Z'}),
+      createCandle({close: '125', high: '130', low: '119', open: '120', openTimeInISO: '2025-01-01T00:03:00.000Z'}),
     ];
 
     const config: BacktestConfig = {
-      candles,
       broker: createMockExchange({baseBalance: '5'}),
+      candles,
       strategy,
       tradingPair,
     };
@@ -392,18 +392,18 @@ describe('TrailingStopStrategy', () => {
 
     const candles = [
       // Attach: peak=100. target=90. (Emits attach message.)
-      createCandle({open: '100', close: '100', low: '99', high: '100', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+      createCandle({close: '100', high: '100', low: '99', open: '100', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
       // close=90 <= 90 → first breach, fires message + emits limit advice.
-      createCandle({open: '100', close: '90', low: '89', high: '100', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
+      createCandle({close: '90', high: '100', low: '89', open: '100', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
       // close=85 <= 90, advice re-emitted but message must NOT fire again.
-      createCandle({open: '90', close: '85', low: '84', high: '90', openTimeInISO: '2025-01-01T00:02:00.000Z'}),
+      createCandle({close: '85', high: '90', low: '84', open: '90', openTimeInISO: '2025-01-01T00:02:00.000Z'}),
       // Limit fills (low=84 <= 90).
-      createCandle({open: '85', close: '85', low: '84', high: '86', openTimeInISO: '2025-01-01T00:03:00.000Z'}),
+      createCandle({close: '85', high: '86', low: '84', open: '85', openTimeInISO: '2025-01-01T00:03:00.000Z'}),
     ];
 
     const config: BacktestConfig = {
-      candles,
       broker: createMockExchange({baseBalance: '5'}),
+      candles,
       strategy,
       tradingPair,
     };
@@ -420,11 +420,11 @@ describe('TrailingStopStrategy', () => {
 
     strategy.restoreState({
       exited: false,
-      positionSize: '5',
-      peakPrice: '120',
-      stopPrice: '108',
-      exitReason: null,
       exitLimitPrice: null,
+      exitReason: null,
+      peakPrice: '120',
+      positionSize: '5',
+      stopPrice: '108',
     });
 
     expect(strategy.trailingState.peakPrice).toBe('120');

--- a/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.ts
+++ b/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.ts
@@ -15,6 +15,20 @@ import {positiveNumberString} from '../util/validators.js';
 
 export const TrailingStopSchema = z.object({
   /**
+   * Order type used to exit. `"limit"` (default) places the sell at the trail target —
+   * guaranteed price, but may not fill on a gap. `"market"` guarantees fill at the
+   * prevailing price.
+   */
+  exitOrder: z.enum(['limit', 'market']).default('limit'),
+  /**
+   * Optional initial pivot price. When set, the peak seeds from this value on attach
+   * instead of the attach candle's `high`. From there the peak ratchets up normally on
+   * subsequent candle highs. Useful when you know the right anchor (e.g. cost basis or
+   * a recent swing high) and don't want the strategy to seed from whatever candle
+   * happens to be first.
+   */
+  pivotPrice: positiveNumberString.optional(),
+  /**
    * Exit threshold as a percentage of the running peak. "5" → exit when close drops to
    * peak * 0.95. Defaults to "10" (10%).
    */
@@ -28,20 +42,6 @@ export const TrailingStopSchema = z.object({
    * When omitted, the peak ratchets on every candle high that exceeds the previous one.
    */
   trailUpPct: positiveNumberString.optional(),
-  /**
-   * Optional initial pivot price. When set, the peak seeds from this value on attach
-   * instead of the attach candle's `high`. From there the peak ratchets up normally on
-   * subsequent candle highs. Useful when you know the right anchor (e.g. cost basis or
-   * a recent swing high) and don't want the strategy to seed from whatever candle
-   * happens to be first.
-   */
-  pivotPrice: positiveNumberString.optional(),
-  /**
-   * Order type used to exit. `"limit"` (default) places the sell at the trail target —
-   * guaranteed price, but may not fill on a gap. `"market"` guarantees fill at the
-   * prevailing price.
-   */
-  exitOrder: z.enum(['limit', 'market']).default('limit'),
 });
 
 export type TrailingStopConfig = z.input<typeof TrailingStopSchema>;
@@ -92,11 +92,11 @@ export type TrailingStopState = {
 
 const defaultState = (): TrailingStopState => ({
   exited: false,
-  positionSize: '0',
-  peakPrice: '0',
-  stopPrice: '0',
-  exitReason: null,
   exitLimitPrice: null,
+  exitReason: null,
+  peakPrice: '0',
+  positionSize: '0',
+  stopPrice: '0',
 });
 
 /**
@@ -203,22 +203,22 @@ export class TrailingStopStrategy extends Strategy {
     if (this.#exitOrder === 'market') {
       this.#state.exitLimitPrice = null;
       return {
-        side: OrderSide.SELL,
-        type: OrderType.MARKET,
         amount: AllAvailableAmount,
         amountIn: 'base',
         reason,
+        side: OrderSide.SELL,
+        type: OrderType.MARKET,
       };
     }
 
     this.#state.exitLimitPrice = trailTarget.toFixed();
     const advice: LimitOrderAdvice = {
-      side: OrderSide.SELL,
-      type: OrderType.LIMIT,
       amount: AllAvailableAmount,
       amountIn: 'base',
       price: trailTarget,
       reason,
+      side: OrderSide.SELL,
+      type: OrderType.LIMIT,
     };
     return advice;
   }

--- a/packages/trading-strategies/src/strategy/MarketType.ts
+++ b/packages/trading-strategies/src/strategy/MarketType.ts
@@ -4,14 +4,14 @@
  * (e.g. a confluence strategy that trades both up- and downtrends).
  */
 export const MarketType = {
-  /** Up-trending market: higher highs and higher lows. */
-  BULLISH: 'bullish',
   /** Down-trending market: lower highs and lower lows. */
   BEARISH: 'bearish',
-  /** Sideways market: price oscillates between support and resistance. */
-  RANGING: 'ranging',
   /** Reference strategy used to measure other strategies against (e.g. random or no-op baselines). */
   BENCHMARK: 'benchmark',
+  /** Up-trending market: higher highs and higher lows. */
+  BULLISH: 'bullish',
+  /** Sideways market: price oscillates between support and resistance. */
+  RANGING: 'ranging',
   /** Pipeline utility / base class — provides shared behavior, not a tradable view of the market. */
   UTILITY: 'utility',
 } as const;

--- a/packages/trading-strategies/src/strategy/StrategyRegistry.ts
+++ b/packages/trading-strategies/src/strategy/StrategyRegistry.ts
@@ -22,29 +22,25 @@ interface StrategyEntry {
 }
 
 const registry: Record<string, StrategyEntry> = {
-  [BuyOnceStrategy.NAME]: {
-    create: (config: unknown) => new BuyOnceStrategy(BuyOnceSchema.parse(config ?? {})),
-    schema: BuyOnceSchema,
-  },
   [BuyBelowSellAboveStrategy.NAME]: {
     create: (config: unknown) => new BuyBelowSellAboveStrategy(BuyBelowSellAboveSchema.parse(config)),
     schema: BuyBelowSellAboveSchema,
+  },
+  [BuyOnceStrategy.NAME]: {
+    create: (config: unknown) => new BuyOnceStrategy(BuyOnceSchema.parse(config ?? {})),
+    schema: BuyOnceSchema,
   },
   [CoinFlipStrategy.NAME]: {
     create: (config: unknown) => new CoinFlipStrategy(CoinFlipSchema.parse(config ?? {})),
     schema: CoinFlipSchema,
   },
-  [MultiIndicatorConfluenceStrategy.NAME]: {
-    create: (config: unknown) => new MultiIndicatorConfluenceStrategy(MultiIndicatorConfluenceSchema.parse(config)),
-    schema: MultiIndicatorConfluenceSchema,
-  },
-  [ScalpStrategy.NAME]: {
-    create: (config: unknown) => new ScalpStrategy(ScalpSchema.parse(config)),
-    schema: ScalpSchema,
-  },
   [MeanReversionStrategy.NAME]: {
     create: (config: unknown) => new MeanReversionStrategy({config: MeanReversionSchema.parse(config ?? {})}),
     schema: MeanReversionSchema,
+  },
+  [MultiIndicatorConfluenceStrategy.NAME]: {
+    create: (config: unknown) => new MultiIndicatorConfluenceStrategy(MultiIndicatorConfluenceSchema.parse(config)),
+    schema: MultiIndicatorConfluenceSchema,
   },
   [NoopStrategy.NAME]: {
     create: (config: unknown) => new NoopStrategy(NoopSchema.parse(config ?? {})),
@@ -53,6 +49,10 @@ const registry: Record<string, StrategyEntry> = {
   [ProtectedStrategy.NAME]: {
     create: (config: unknown) => new ProtectedStrategy({config: ProtectedStrategySchema.parse(config ?? {})}),
     schema: ProtectedStrategySchema,
+  },
+  [ScalpStrategy.NAME]: {
+    create: (config: unknown) => new ScalpStrategy(ScalpSchema.parse(config)),
+    schema: ScalpSchema,
   },
   [TrailingStopStrategy.NAME]: {
     create: (config: unknown) => new TrailingStopStrategy(TrailingStopSchema.parse(config ?? {})),

--- a/packages/trading-strategies/src/util/validators.ts
+++ b/packages/trading-strategies/src/util/validators.ts
@@ -8,6 +8,6 @@ export const positiveNumberString = z
 /** Mutually exclusive buy sizing: set `quantity` (base) OR `spend` (counter), or neither for all available. */
 export const BuyAmountSchema = z.union([
   z.object({quantity: positiveNumberString, spend: z.never().optional()}),
-  z.object({spend: positiveNumberString, quantity: z.never().optional()}),
+  z.object({quantity: z.never().optional(), spend: positiveNumberString}),
   z.object({quantity: z.never().optional(), spend: z.never().optional()}),
 ]);


### PR DESCRIPTION
## Summary
- Enables `perfectionist/sort-objects` (`off` → `error`) in all four package ESLint configs and re-applies object-key sorting across the codebase via autofix.
- Replaces the closed #1089, rebased on the latest `main` (which had already shipped the per-package `eslint.config.mjs` files), so the diff is much smaller and conflict-free.

All packages pass `npm run lint` and `npm test`.