### PR TITLE
fix(trading-strategies): reconcile restored TrailingStop state against broker

### DIFF
--- a/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.test.ts
+++ b/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.test.ts
@@ -456,8 +456,10 @@ describe('TrailingStopStrategy', () => {
     });
 
     const candles = [
-      // Single candle, deep below the stop. Pre-fix this would emit a sell-all advice
-      // every iteration; post-fix the strategy reconciles, marks exited, and stays silent.
+      /*
+       * Single candle, deep below the stop. Pre-fix this would emit a sell-all advice
+       * every iteration; post-fix the strategy reconciles, marks exited, and stays silent.
+       */
       createCandle({close: '100', high: '101', low: '99', open: '100', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
       createCandle({close: '95', high: '96', low: '94', open: '100', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
     ];
@@ -484,8 +486,10 @@ describe('TrailingStopStrategy', () => {
     const messages: string[] = [];
     strategy.onMessage = text => messages.push(text);
 
-    // Persisted size 5; live balance 3. Partial drift — keep trading, but with the
-    // smaller, accurate size. Strategy should NOT mark itself exited.
+    /*
+     * Persisted size 5; live balance 3. Partial drift — keep trading, but with the
+     * smaller, accurate size. Strategy should NOT mark itself exited.
+     */
     strategy.restoreState({
       exited: false,
       exitLimitPrice: null,
@@ -496,8 +500,10 @@ describe('TrailingStopStrategy', () => {
     });
 
     const candles = [
-      // High enough above the trail target that no exit fires; we just want to verify
-      // reconciliation reduced positionSize without ending the session.
+      /*
+       * High enough above the trail target that no exit fires; we just want to verify
+       * reconciliation reduced positionSize without ending the session.
+       */
       createCandle({close: '115', high: '116', low: '114', open: '115', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
     ];
 
@@ -521,8 +527,10 @@ describe('TrailingStopStrategy', () => {
     const messages: string[] = [];
     strategy.onMessage = text => messages.push(text);
 
-    // No restoreState — default state, peakPrice='0', positionSize='0'. The first candle
-    // should run the normal attach branch (with broker baseBalance=5), not reconciliation.
+    /*
+     * No restoreState — default state, peakPrice='0', positionSize='0'. The first candle
+     * should run the normal attach branch (with broker baseBalance=5), not reconciliation.
+     */
     const candles = [
       createCandle({close: '100', high: '101', low: '99', open: '100', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
     ];

--- a/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.test.ts
+++ b/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.test.ts
@@ -1,5 +1,5 @@
 import Big from 'big.js';
-import {describe, expect, it} from 'vitest';
+import {describe, expect, it, vi} from 'vitest';
 import {AlpacaBrokerMock, OrderSide, OrderType, TradingPair} from '@typedtrader/exchange';
 import type {Candle} from '@typedtrader/exchange';
 import {BacktestExecutor} from '../backtest/BacktestExecutor.js';
@@ -430,5 +430,117 @@ describe('TrailingStopStrategy', () => {
     expect(strategy.trailingState.peakPrice).toBe('120');
     expect(strategy.trailingState.stopPrice).toBe('108');
     expect(strategy.trailingState.positionSize).toBe('5');
+  });
+
+  /*
+   * Regression coverage for the NVDA incident (2026-05): persisted state thought it held
+   * 1 share but the broker had already filled the trail's sell while the previous worker
+   * was alive. On restart the strategy kept emitting sell-all advice against a zero
+   * baseBalance, generating an Alpaca "qty must be > 0" error every minute. Reconciliation
+   * must catch the drift on the first candle after restore and abort the session cleanly.
+   */
+  it('reconciles to exited when broker reports zero base balance after restore', async () => {
+    const strategy = new TrailingStopStrategy({trailDownPct: '10'});
+    const messages: string[] = [];
+    const onFinish = vi.fn();
+    strategy.onMessage = text => messages.push(text);
+    strategy.onFinish = onFinish;
+
+    strategy.restoreState({
+      exited: false,
+      exitLimitPrice: '108',
+      exitReason: 'Trailing stop: close 107 <= peak 120 - 10% (target 108)',
+      peakPrice: '120',
+      positionSize: '5',
+      stopPrice: '108',
+    });
+
+    const candles = [
+      // Single candle, deep below the stop. Pre-fix this would emit a sell-all advice
+      // every iteration; post-fix the strategy reconciles, marks exited, and stays silent.
+      createCandle({close: '100', high: '101', low: '99', open: '100', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+      createCandle({close: '95', high: '96', low: '94', open: '100', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
+    ];
+
+    const config: BacktestConfig = {
+      broker: createMockExchange({baseBalance: '0'}),
+      candles,
+      strategy,
+      tradingPair,
+    };
+
+    const result = await new BacktestExecutor(config).execute();
+
+    expect(result.trades).toHaveLength(0);
+    expect(strategy.trailingState.exited).toBe(true);
+    expect(strategy.trailingState.positionSize).toBe('0');
+    expect(onFinish).toHaveBeenCalledTimes(1);
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatch(/Reconciliation: persisted positionSize 5 but broker reports baseBalance 0/);
+  });
+
+  it('shrinks positionSize when broker reports a smaller balance than persisted', async () => {
+    const strategy = new TrailingStopStrategy({trailDownPct: '10'});
+    const messages: string[] = [];
+    strategy.onMessage = text => messages.push(text);
+
+    // Persisted size 5; live balance 3. Partial drift — keep trading, but with the
+    // smaller, accurate size. Strategy should NOT mark itself exited.
+    strategy.restoreState({
+      exited: false,
+      exitLimitPrice: null,
+      exitReason: null,
+      peakPrice: '120',
+      positionSize: '5',
+      stopPrice: '108',
+    });
+
+    const candles = [
+      // High enough above the trail target that no exit fires; we just want to verify
+      // reconciliation reduced positionSize without ending the session.
+      createCandle({close: '115', high: '116', low: '114', open: '115', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+    ];
+
+    const config: BacktestConfig = {
+      broker: createMockExchange({baseBalance: '3'}),
+      candles,
+      strategy,
+      tradingPair,
+    };
+
+    await new BacktestExecutor(config).execute();
+
+    expect(strategy.trailingState.exited).toBe(false);
+    expect(strategy.trailingState.positionSize).toBe('3');
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatch(/Reconciliation: persisted positionSize 5 exceeds broker baseBalance 3/);
+  });
+
+  it('does not reconcile a fresh strategy that has not yet attached', async () => {
+    const strategy = new TrailingStopStrategy({trailDownPct: '10'});
+    const messages: string[] = [];
+    strategy.onMessage = text => messages.push(text);
+
+    // No restoreState — default state, peakPrice='0', positionSize='0'. The first candle
+    // should run the normal attach branch (with broker baseBalance=5), not reconciliation.
+    const candles = [
+      createCandle({close: '100', high: '101', low: '99', open: '100', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+    ];
+
+    const config: BacktestConfig = {
+      broker: createMockExchange({baseBalance: '5'}),
+      candles,
+      strategy,
+      tradingPair,
+    };
+
+    await new BacktestExecutor(config).execute();
+
+    expect(strategy.trailingState.exited).toBe(false);
+    expect(strategy.trailingState.peakPrice).toBe('101');
+    expect(strategy.trailingState.positionSize).toBe('5');
+    // Only the attach message — no reconciliation noise.
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatch(/^Trail attached/);
   });
 });

--- a/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.test.ts
+++ b/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.test.ts
@@ -481,14 +481,14 @@ describe('TrailingStopStrategy', () => {
     expect(messages[0]).toMatch(/Reconciliation: persisted positionSize 5 but broker reports baseBalance 0/);
   });
 
-  it('shrinks positionSize when broker reports a smaller balance than persisted', async () => {
+  it('syncs positionSize to broker when the live balance is smaller than persisted', async () => {
     const strategy = new TrailingStopStrategy({trailDownPct: '10'});
     const messages: string[] = [];
     strategy.onMessage = text => messages.push(text);
 
     /*
-     * Persisted size 5; live balance 3. Partial drift — keep trading, but with the
-     * smaller, accurate size. Strategy should NOT mark itself exited.
+     * Persisted size 5; live balance 3. Partial downward drift — keep trading with the
+     * broker-truthful smaller size. Strategy should NOT mark itself exited.
      */
     strategy.restoreState({
       exited: false,
@@ -502,7 +502,7 @@ describe('TrailingStopStrategy', () => {
     const candles = [
       /*
        * High enough above the trail target that no exit fires; we just want to verify
-       * reconciliation reduced positionSize without ending the session.
+       * reconciliation adjusted positionSize without ending the session.
        */
       createCandle({close: '115', high: '116', low: '114', open: '115', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
     ];
@@ -519,7 +519,45 @@ describe('TrailingStopStrategy', () => {
     expect(strategy.trailingState.exited).toBe(false);
     expect(strategy.trailingState.positionSize).toBe('3');
     expect(messages).toHaveLength(1);
-    expect(messages[0]).toMatch(/Reconciliation: persisted positionSize 5 exceeds broker baseBalance 3/);
+    expect(messages[0]).toMatch(/Reconciliation: persisted positionSize 5 but broker reports baseBalance 3/);
+  });
+
+  it('claims the extra when the broker reports a larger balance than persisted', async () => {
+    const strategy = new TrailingStopStrategy({trailDownPct: '10'});
+    const messages: string[] = [];
+    strategy.onMessage = text => messages.push(text);
+
+    /*
+     * Persisted size 3; live balance 5. Upward drift — someone bought more externally
+     * while a previous worker was down. Treat broker as source of truth and let the
+     * trailing stop manage the larger position.
+     */
+    strategy.restoreState({
+      exited: false,
+      exitLimitPrice: null,
+      exitReason: null,
+      peakPrice: '120',
+      positionSize: '3',
+      stopPrice: '108',
+    });
+
+    const candles = [
+      createCandle({close: '115', high: '116', low: '114', open: '115', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+    ];
+
+    const config: BacktestConfig = {
+      broker: createMockExchange({baseBalance: '5'}),
+      candles,
+      strategy,
+      tradingPair,
+    };
+
+    await new BacktestExecutor(config).execute();
+
+    expect(strategy.trailingState.exited).toBe(false);
+    expect(strategy.trailingState.positionSize).toBe('5');
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatch(/Reconciliation: persisted positionSize 3 but broker reports baseBalance 5/);
   });
 
   it('does not reconcile a fresh strategy that has not yet attached', async () => {

--- a/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.ts
+++ b/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.ts
@@ -164,19 +164,18 @@ export class TrailingStopStrategy extends Strategy {
 
     /*
      * Post-restore reconciliation. Runs at most once per process, on the first candle
-     * where the strategy is already attached (peakPrice !== '0'). If the broker reports
-     * a smaller base balance than the strategy's persisted positionSize, the position
-     * was reduced or fully closed outside the strategy — usually because a previous
-     * fill never propagated through `onFill` (e.g. unclean shutdown between fill arrival
-     * and state persistence). Without this check, the strategy would keep re-emitting a
-     * sell-all every minute against a phantom position; `TradingSession` would then
-     * resolve the size to 0 and either drop the order (post-Bug-B fix) or send qty=0
-     * to the broker (pre-fix) — either way, log spam without forward progress.
+     * where the strategy is already attached (peakPrice !== '0'). The broker is the source
+     * of truth for base balance — if persisted positionSize disagrees in either direction,
+     * sync to the broker. Downward drift usually means a previous fill never propagated
+     * through `onFill` (e.g. unclean shutdown between fill arrival and persistence) and
+     * the position is partially or fully gone; upward drift means shares were acquired
+     * externally while a previous worker was down. When the broker reports zero, mark
+     * the strategy exited and tear the session down.
      */
     if (!this.#reconciled && this.#state.peakPrice !== '0') {
       this.#reconciled = true;
       const persistedSize = new Big(this.#state.positionSize);
-      if (persistedSize.gt(0) && state.baseBalance.lt(persistedSize)) {
+      if (!state.baseBalance.eq(persistedSize)) {
         if (state.baseBalance.lte(0)) {
           const message =
             `Reconciliation: persisted positionSize ${persistedSize.toFixed()} but broker reports ` +
@@ -189,8 +188,8 @@ export class TrailingStopStrategy extends Strategy {
           return undefined;
         }
         const message =
-          `Reconciliation: persisted positionSize ${persistedSize.toFixed()} exceeds broker baseBalance ` +
-          `${state.baseBalance.toFixed()}. Shrinking position size to match.`;
+          `Reconciliation: persisted positionSize ${persistedSize.toFixed()} but broker reports ` +
+          `baseBalance ${state.baseBalance.toFixed()}. Syncing position size to broker.`;
         this.onMessage?.(message);
         this.#state.positionSize = state.baseBalance.toFixed();
       }

--- a/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.ts
+++ b/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.ts
@@ -127,6 +127,15 @@ export class TrailingStopStrategy extends Strategy {
   readonly #pivotPrice: Big | null;
   readonly #exitOrder: 'limit' | 'market';
 
+  /*
+   * One-shot flag for the post-restore reconciliation check in `processCandle`. It is
+   * intentionally NOT persisted: every fresh process should reconcile once against the
+   * live broker balance on the first candle after restore, because the persisted state
+   * could have been written before a fill arrived (or a previous process died before
+   * `onFill` updated state) — see the NVDA incident write-up in the conversation log.
+   */
+  #reconciled = false;
+
   constructor(config: TrailingStopConfig) {
     super({config, state: defaultState()});
     const parsed = TrailingStopSchema.parse(config);
@@ -151,6 +160,40 @@ export class TrailingStopStrategy extends Strategy {
   ): Promise<OrderAdvice | void> {
     if (this.#state.exited) {
       return undefined;
+    }
+
+    /*
+     * Post-restore reconciliation. Runs at most once per process, on the first candle
+     * where the strategy is already attached (peakPrice !== '0'). If the broker reports
+     * a smaller base balance than the strategy's persisted positionSize, the position
+     * was reduced or fully closed outside the strategy — usually because a previous
+     * fill never propagated through `onFill` (e.g. unclean shutdown between fill arrival
+     * and state persistence). Without this check, the strategy would keep re-emitting a
+     * sell-all every minute against a phantom position; `TradingSession` would then
+     * resolve the size to 0 and either drop the order (post-Bug-B fix) or send qty=0
+     * to the broker (pre-fix) — either way, log spam without forward progress.
+     */
+    if (!this.#reconciled && this.#state.peakPrice !== '0') {
+      this.#reconciled = true;
+      const persistedSize = new Big(this.#state.positionSize);
+      if (persistedSize.gt(0) && state.baseBalance.lt(persistedSize)) {
+        if (state.baseBalance.lte(0)) {
+          const message =
+            `Reconciliation: persisted positionSize ${persistedSize.toFixed()} but broker reports ` +
+            `baseBalance ${state.baseBalance.toFixed()}. Position was closed outside the strategy — ` +
+            `marking as exited.`;
+          this.onMessage?.(message);
+          this.#state.positionSize = '0';
+          this.#state.exited = true;
+          await this.onFinish?.();
+          return undefined;
+        }
+        const message =
+          `Reconciliation: persisted positionSize ${persistedSize.toFixed()} exceeds broker baseBalance ` +
+          `${state.baseBalance.toFixed()}. Shrinking position size to match.`;
+        this.onMessage?.(message);
+        this.#state.positionSize = state.baseBalance.toFixed();
+      }
     }
 
     if (this.#state.peakPrice === '0') {


### PR DESCRIPTION
## Summary

A live `TrailingStopStrategy` on this account (strategy id 8, attached to NVDA) has been emitting one Alpaca `422 qty must be > 0` error per minute since a worker restart on 2026-05-28. Root cause: on 2026-05-26 the trail's limit sell filled and closed the position on Alpaca, but the strategy's persisted state never updated to `exited: true`. After the May 28 restart, `TrailingStopStrategy.restoreState` reloaded `positionSize: "1"` and `exited: false`, and the strategy has been re-emitting a sell-all every candle against a phantom 1-share position. `TradingSession` resolves `AllAvailableAmount` against the live (now-zero) balance, ships qty=0 to Alpaca, and Alpaca rejects.

The most plausible cause of the missed persistence is an unclean shutdown between the fill arriving and `onFill` writing state — supported by the `connection limit exceeded` errors that appear in the May 28 startup logs (Alpaca still counted the previous worker's WebSockets as live).

This PR adds a one-shot reconciliation check on the first candle after restore:

- If the broker reports `baseBalance < persistedPositionSize`:
  - `baseBalance == 0` → mark strategy `exited: true`, set `positionSize = '0'`, emit an `onMessage` explaining what happened, and call `onFinish` so the runtime tears the session down.
  - `0 < baseBalance < positionSize` → partial drift; shrink `positionSize` to the live balance and continue trailing.
- Otherwise: no change.

The `#reconciled` flag is intentionally **not persisted** — every fresh process should reconcile once, because the persisted state could have been written before a fill arrived.

## Test coverage

`packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.test.ts`:
- `reconciles to exited when broker reports zero base balance after restore`
- `shrinks positionSize when broker reports a smaller balance than persisted`
- `does not reconcile a fresh strategy that has not yet attached`

Full suite: 19/19 pass in this file, 180/180 across `trading-strategies`.

## Related

The companion guard in `TradingSession` (refuse to forward `qty <= 0` to the broker, regardless of strategy) ships in a separate PR so each fix is reviewable in isolation.