### PR TITLE
fix(exchange): refuse to forward orders with non-positive resolved size

### DIFF
--- a/packages/exchange/src/trader/TradingSession.test.ts
+++ b/packages/exchange/src/trader/TradingSession.test.ts
@@ -13,6 +13,7 @@ import {
   type PendingMarketOrder,
   type TradingRules,
 } from '../broker/Broker.js';
+import {NonPositiveOrderSizeError} from './TradingSessionErrors.js';
 import {AllAvailableAmount} from './TradingSessionTypes.js';
 import type {OrderAdvice, TradingSessionStrategy} from './TradingSessionTypes.js';
 
@@ -472,7 +473,11 @@ describe.sequential('TradingSession', () => {
       exchange.emit('candle-topic-1', sampleCandle);
       await vi.waitFor(() => expect(onError).toHaveBeenCalledTimes(1));
 
-      expect(onError.mock.calls[0][0].message).toContain('non-positive size');
+      const error = onError.mock.calls[0][0];
+      expect(error).toBeInstanceOf(NonPositiveOrderSizeError);
+      expect(error.side).toBe(OrderSide.SELL);
+      expect(error.amountIn).toBe('base');
+      expect(error.size).toBe('0');
       expect(exchange.placeMarketOrder).not.toHaveBeenCalled();
       expect(exchange.placeLimitOrder).not.toHaveBeenCalled();
     });

--- a/packages/exchange/src/trader/TradingSession.test.ts
+++ b/packages/exchange/src/trader/TradingSession.test.ts
@@ -450,9 +450,11 @@ describe.sequential('TradingSession', () => {
     });
 
     it('refuses to place an order when AllAvailableAmount resolves to zero', async () => {
-      // baseBalance=0 → resolved size is 0. This can happen when the position is closed
-      // outside the strategy and the strategy's persisted state hasn't caught up. The
-      // session must drop the advice instead of forwarding qty=0 to the broker.
+      /*
+       * baseBalance=0 → resolved size is 0. This can happen when the position is closed
+       * outside the strategy and the strategy's persisted state hasn't caught up. The
+       * session must drop the advice instead of forwarding qty=0 to the broker.
+       */
       exchange.getAvailableBalances.mockResolvedValue({base: new Big('0'), counter: new Big('5000')});
       const advice: OrderAdvice = {
         amount: AllAvailableAmount,

--- a/packages/exchange/src/trader/TradingSession.test.ts
+++ b/packages/exchange/src/trader/TradingSession.test.ts
@@ -13,7 +13,7 @@ import {
   type PendingMarketOrder,
   type TradingRules,
 } from '../broker/Broker.js';
-import {NonPositiveOrderSizeError} from './TradingSessionErrors.js';
+import {NonPositiveOrderSizeError, OrderSizeBelowMinimumError} from './TradingSessionErrors.js';
 import {AllAvailableAmount} from './TradingSessionTypes.js';
 import type {OrderAdvice, TradingSessionStrategy} from './TradingSessionTypes.js';
 
@@ -446,7 +446,13 @@ describe.sequential('TradingSession', () => {
       exchange.emit('candle-topic-1', sampleCandle);
       await vi.waitFor(() => expect(onError).toHaveBeenCalledTimes(1));
 
-      expect(onError.mock.calls[0][0].message).toContain('below minimum base size');
+      const error = onError.mock.calls[0][0];
+      expect(error).toBeInstanceOf(OrderSizeBelowMinimumError);
+      expect(error.side).toBe(OrderSide.SELL);
+      expect(error.amountIn).toBe('base');
+      // base balance=0.001, base_increment=0.001 → rounds to 0.001 (still below base_min_size=0.01).
+      expect(error.size).toBe('0.001');
+      expect(error.minimumSize).toBe('0.01');
       expect(exchange.placeMarketOrder).not.toHaveBeenCalled();
     });
 

--- a/packages/exchange/src/trader/TradingSession.test.ts
+++ b/packages/exchange/src/trader/TradingSession.test.ts
@@ -449,6 +449,32 @@ describe.sequential('TradingSession', () => {
       expect(exchange.placeMarketOrder).not.toHaveBeenCalled();
     });
 
+    it('refuses to place an order when AllAvailableAmount resolves to zero', async () => {
+      // baseBalance=0 → resolved size is 0. This can happen when the position is closed
+      // outside the strategy and the strategy's persisted state hasn't caught up. The
+      // session must drop the advice instead of forwarding qty=0 to the broker.
+      exchange.getAvailableBalances.mockResolvedValue({base: new Big('0'), counter: new Big('5000')});
+      const advice: OrderAdvice = {
+        amount: AllAvailableAmount,
+        amountIn: 'base',
+        side: OrderSide.SELL,
+        type: OrderType.MARKET,
+      };
+      strategy.onCandle.mockResolvedValue(advice);
+
+      const onError = vi.fn();
+      session.on('error', onError);
+
+      await session.start();
+
+      exchange.emit('candle-topic-1', sampleCandle);
+      await vi.waitFor(() => expect(onError).toHaveBeenCalledTimes(1));
+
+      expect(onError.mock.calls[0][0].message).toContain('non-positive size');
+      expect(exchange.placeMarketOrder).not.toHaveBeenCalled();
+      expect(exchange.placeLimitOrder).not.toHaveBeenCalled();
+    });
+
     it('emits error when strategy.onCandle throws', async () => {
       strategy.onCandle.mockRejectedValue(new Error('Strategy crashed'));
 

--- a/packages/exchange/src/trader/TradingSession.ts
+++ b/packages/exchange/src/trader/TradingSession.ts
@@ -5,7 +5,7 @@ import type {BatchedCandle} from '../candle/BatchedCandle.js';
 import {ONE_MINUTE_IN_MS} from '../candle/BatchedCandle.js';
 import type {Candle, Fill, PendingOrder} from '../broker/Broker.js';
 import {OrderSide, OrderType} from '../broker/Broker.js';
-import {NonPositiveOrderSizeError} from './TradingSessionErrors.js';
+import {NonPositiveOrderSizeError, OrderSizeBelowMinimumError} from './TradingSessionErrors.js';
 import {AllAvailableAmount} from './TradingSessionTypes.js';
 import type {
   OrderAdvice,
@@ -188,14 +188,18 @@ export class TradingSession extends EventEmitter<TradingSessionEventMap> {
     }
 
     const {base_min_size, counter_min_size} = this.#state.tradingRules;
+    const minimumSize = advice.amountIn === 'counter' ? counter_min_size : base_min_size;
 
-    if (advice.amountIn === 'counter') {
-      if (size.lt(counter_min_size)) {
-        this.emit('error', new Error(`Order size "${size}" is below minimum counter size "${counter_min_size}"`));
-        return;
-      }
-    } else if (size.lt(base_min_size)) {
-      this.emit('error', new Error(`Order size "${size}" is below minimum base size "${base_min_size}"`));
+    if (size.lt(minimumSize)) {
+      this.emit(
+        'error',
+        new OrderSizeBelowMinimumError({
+          amountIn: advice.amountIn,
+          minimumSize,
+          side: advice.side,
+          size: size.toFixed(),
+        })
+      );
       return;
     }
 

--- a/packages/exchange/src/trader/TradingSession.ts
+++ b/packages/exchange/src/trader/TradingSession.ts
@@ -191,8 +191,8 @@ export class TradingSession extends EventEmitter<TradingSessionEventMap> {
       this.emit(
         'error',
         new Error(
-          `Refusing to place ${advice.side} order with non-positive size "${size.toFixed()}" ` +
-            `(amountIn=${advice.amountIn}). The strategy's view of the position is likely stale.`
+          `Refusing to place "${advice.side}" order with non-positive size "${size.toFixed()}" ` +
+            `(amountIn="${advice.amountIn}"). The strategy's view of the position is likely stale.`
         )
       );
       return;

--- a/packages/exchange/src/trader/TradingSession.ts
+++ b/packages/exchange/src/trader/TradingSession.ts
@@ -5,6 +5,7 @@ import type {BatchedCandle} from '../candle/BatchedCandle.js';
 import {ONE_MINUTE_IN_MS} from '../candle/BatchedCandle.js';
 import type {Candle, Fill, PendingOrder} from '../broker/Broker.js';
 import {OrderSide, OrderType} from '../broker/Broker.js';
+import {NonPositiveOrderSizeError} from './TradingSessionErrors.js';
 import {AllAvailableAmount} from './TradingSessionTypes.js';
 import type {
   OrderAdvice,
@@ -181,10 +182,7 @@ export class TradingSession extends EventEmitter<TradingSessionEventMap> {
     if (size.lte(0)) {
       this.emit(
         'error',
-        new Error(
-          `Refusing to place "${advice.side}" order with non-positive size "${size.toFixed()}" ` +
-            `(amountIn="${advice.amountIn}"). The strategy's view of the position is likely stale.`
-        )
+        new NonPositiveOrderSizeError({amountIn: advice.amountIn, side: advice.side, size: size.toFixed()})
       );
       return;
     }

--- a/packages/exchange/src/trader/TradingSession.ts
+++ b/packages/exchange/src/trader/TradingSession.ts
@@ -178,6 +178,26 @@ export class TradingSession extends EventEmitter<TradingSessionEventMap> {
       return;
     }
 
+    /*
+     * Defense in depth: a strategy can legitimately request `AllAvailableAmount`, but if the
+     * relevant balance is zero (e.g. the position was closed externally and the strategy's
+     * persisted state is stale) the resolved size is zero. Some brokers — Alpaca for US
+     * equities — set `base_min_size` to "0", so the `< minSize` check below wouldn't catch
+     * this and the order would reach the exchange only to be rejected with 422 "qty must be
+     * > 0" once a minute. Skip the call, surface the situation, and let upstream fix the
+     * strategy state.
+     */
+    if (size.lte(0)) {
+      this.emit(
+        'error',
+        new Error(
+          `Refusing to place ${advice.side} order with non-positive size "${size.toFixed()}" ` +
+            `(amountIn=${advice.amountIn}). The strategy's view of the position is likely stale.`
+        )
+      );
+      return;
+    }
+
     const {base_min_size, counter_min_size} = this.#state.tradingRules;
 
     if (advice.amountIn === 'counter') {

--- a/packages/exchange/src/trader/TradingSession.ts
+++ b/packages/exchange/src/trader/TradingSession.ts
@@ -178,15 +178,6 @@ export class TradingSession extends EventEmitter<TradingSessionEventMap> {
       return;
     }
 
-    /*
-     * Defense in depth: a strategy can legitimately request `AllAvailableAmount`, but if the
-     * relevant balance is zero (e.g. the position was closed externally and the strategy's
-     * persisted state is stale) the resolved size is zero. Some brokers — Alpaca for US
-     * equities — set `base_min_size` to "0", so the `< minSize` check below wouldn't catch
-     * this and the order would reach the exchange only to be rejected with 422 "qty must be
-     * > 0" once a minute. Skip the call, surface the situation, and let upstream fix the
-     * strategy state.
-     */
     if (size.lte(0)) {
       this.emit(
         'error',

--- a/packages/exchange/src/trader/TradingSessionErrors.ts
+++ b/packages/exchange/src/trader/TradingSessionErrors.ts
@@ -1,0 +1,26 @@
+import type {OrderSide} from '../broker/Broker.js';
+import type {OrderAdvice} from './TradingSessionTypes.js';
+
+/**
+ * Thrown / emitted by `TradingSession` when a strategy's advice resolves to a non-positive
+ * order size — typically a `SELL ALL` against a zero base balance or a `BUY ALL` against
+ * a zero counter balance. The strategy's view of the position is out of sync with the
+ * broker; the session refuses to forward the order rather than send `qty=0` to the
+ * exchange (which Alpaca, for example, rejects with HTTP 422 "qty must be > 0").
+ */
+export class NonPositiveOrderSizeError extends Error {
+  readonly side: OrderSide;
+  readonly amountIn: OrderAdvice['amountIn'];
+  readonly size: string;
+
+  constructor(params: {side: OrderSide; amountIn: OrderAdvice['amountIn']; size: string}) {
+    super(
+      `Refusing to place "${params.side}" order with non-positive size "${params.size}" ` +
+        `(amountIn="${params.amountIn}"). The strategy's view of the position is likely stale.`
+    );
+    this.name = 'NonPositiveOrderSizeError';
+    this.side = params.side;
+    this.amountIn = params.amountIn;
+    this.size = params.size;
+  }
+}

--- a/packages/exchange/src/trader/TradingSessionErrors.ts
+++ b/packages/exchange/src/trader/TradingSessionErrors.ts
@@ -24,3 +24,26 @@ export class NonPositiveOrderSizeError extends Error {
     this.size = params.size;
   }
 }
+
+/**
+ * Emitted by `TradingSession` when a strategy's advice resolves to a positive but
+ * sub-minimum order size — the broker would reject it (or the order would be
+ * economically meaningless). Carries `size` and `minimumSize` so listeners can
+ * distinguish "tried to sell 0.005 BTC when the minimum is 0.01" from arbitrary
+ * other failures.
+ */
+export class OrderSizeBelowMinimumError extends Error {
+  readonly side: OrderSide;
+  readonly amountIn: OrderAdvice['amountIn'];
+  readonly size: string;
+  readonly minimumSize: string;
+
+  constructor(params: {side: OrderSide; amountIn: OrderAdvice['amountIn']; size: string; minimumSize: string}) {
+    super(`Order size "${params.size}" is below minimum ${params.amountIn} size "${params.minimumSize}"`);
+    this.name = 'OrderSizeBelowMinimumError';
+    this.side = params.side;
+    this.amountIn = params.amountIn;
+    this.size = params.size;
+    this.minimumSize = params.minimumSize;
+  }
+}

--- a/packages/exchange/src/trader/index.ts
+++ b/packages/exchange/src/trader/index.ts
@@ -1,2 +1,3 @@
 export * from './TradingSession.js';
+export * from './TradingSessionErrors.js';
 export * from './TradingSessionTypes.js';


### PR DESCRIPTION
## Summary

Companion to #1096. When a strategy emits `AllAvailableAmount` advice and the relevant balance is zero, `TradingSession.#resolveOrderSize` returns `0`, and the session forwards it to the broker. Alpaca rejects with HTTP 422 `qty must be > 0` — once a minute, indefinitely, while the level-50 error logs pile up.

The existing `< minSize` check doesn't catch this because Alpaca sets `base_min_size = "0"` for US equities — so `Big(0).lt("0")` is `false` and the zero-sized order slips through.

Adds an explicit `size.lte(0)` guard immediately after `#resolveOrderSize`. The session emits an `'error'` event with a message naming the side and `amountIn`, then returns — no broker call, no HTTP 422 from Alpaca.

The strategy still owns the underlying state-drift bug (handled in #1096); this is defense in depth so any other strategy that ever resolves to zero gets the same protection without depending on the Alpaca-specific min-size value.

## Test coverage

`packages/exchange/src/trader/TradingSession.test.ts`:
- `refuses to place an order when AllAvailableAmount resolves to zero`

Full suite: 19/19 pass in this file, 88/88 across `exchange`.