### PR TITLE
feat(messaging): forward level-50 pino logs to Telegram as alerts

### DIFF
--- a/packages/messaging/.env.defaults
+++ b/packages/messaging/.env.defaults
@@ -12,3 +12,13 @@ ALPACA_PAPER_TRADE=True
 TELEGRAM_BOT_TOKEN=
 TELEGRAM_OWNER_IDS=
 
+# Telegram Error Alerts (optional; auto-enabled when TELEGRAM_BOT_TOKEN + a chat are set)
+# TELEGRAM_ALERT_CHAT_ID overrides the destination; defaults to first TELEGRAM_OWNER_IDS entry.
+# TELEGRAM_ALERT_LEVEL accepts a pino label (warn|error|fatal) or a number; default: error (50).
+# TELEGRAM_ALERT_DEDUP_MS suppresses identical errors within the window; default: 600000 (10 min).
+# Set TELEGRAM_ALERTS_ENABLED=false to disable explicitly.
+TELEGRAM_ALERT_CHAT_ID=
+TELEGRAM_ALERT_LEVEL=
+TELEGRAM_ALERT_DEDUP_MS=
+TELEGRAM_ALERTS_ENABLED=
+

--- a/packages/messaging/src/logger.ts
+++ b/packages/messaging/src/logger.ts
@@ -1,5 +1,6 @@
 import pino from 'pino';
 import path from 'node:path';
+import {createTelegramAlertStream, type TelegramAlertStreamOptions} from './logger/telegramAlertTransport.js';
 
 const logDirectory = process.env.TYPEDTRADER_LOG_DIRECTORY?.trim() || process.env.TYPEDTRADER_DB_DIRECTORY?.trim();
 
@@ -24,7 +25,67 @@ if (logDirectory) {
   });
 }
 
-export const logger = pino({
-  level: 'debug',
-  transport: {targets},
-});
+/*
+ * pino-roll and stdout run inside a worker thread (the `pino.transport({targets})`
+ * pattern). Telegram alerts run in-process so they survive the dev/tsx → prod/built
+ * boundary without the worker-thread file-path footgun.
+ */
+const workerTransport = pino.transport({targets});
+const streams: pino.StreamEntry[] = [{level: 'debug', stream: workerTransport}];
+
+const telegramAlertOptions = buildTelegramAlertOptions();
+if (telegramAlertOptions) {
+  const label = pino.levels.labels[telegramAlertOptions.level ?? 50];
+  streams.push({
+    level: (isPinoLevel(label) ? label : 'error') satisfies pino.Level,
+    stream: createTelegramAlertStream(telegramAlertOptions),
+  });
+}
+
+function isPinoLevel(value: string | undefined): value is pino.Level {
+  return typeof value === 'string' && value in pino.levels.values;
+}
+
+export const logger = pino({level: 'debug'}, pino.multistream(streams));
+
+function buildTelegramAlertOptions(): TelegramAlertStreamOptions | undefined {
+  if (process.env.TELEGRAM_ALERTS_ENABLED?.trim().toLowerCase() === 'false') {
+    return undefined;
+  }
+  const botToken = process.env.TELEGRAM_BOT_TOKEN?.trim();
+  if (!botToken) {
+    return undefined;
+  }
+  const chatId = process.env.TELEGRAM_ALERT_CHAT_ID?.trim() || process.env.TELEGRAM_OWNER_IDS?.split(',')[0]?.trim();
+  if (!chatId) {
+    return undefined;
+  }
+  return {
+    botToken,
+    chatId,
+    dedupMs: parsePositiveInt(process.env.TELEGRAM_ALERT_DEDUP_MS) ?? 600_000,
+    level: parseLevel(process.env.TELEGRAM_ALERT_LEVEL) ?? 50,
+  };
+}
+
+function parseLevel(raw: string | undefined): number | undefined {
+  const trimmed = raw?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const asNumber = Number(trimmed);
+  if (Number.isInteger(asNumber) && asNumber > 0) {
+    return asNumber;
+  }
+  const fromLabel = pino.levels.values[trimmed.toLowerCase()];
+  return typeof fromLabel === 'number' ? fromLabel : undefined;
+}
+
+function parsePositiveInt(raw: string | undefined): number | undefined {
+  const trimmed = raw?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const asNumber = Number(trimmed);
+  return Number.isInteger(asNumber) && asNumber > 0 ? asNumber : undefined;
+}

--- a/packages/messaging/src/logger/telegramAlertHelpers.test.ts
+++ b/packages/messaging/src/logger/telegramAlertHelpers.test.ts
@@ -1,0 +1,160 @@
+import {describe, expect, it} from 'vitest';
+import {FingerprintDedup, fingerprint, formatAlertMessage, type AlertLogRecord} from './telegramAlertHelpers.js';
+
+describe('fingerprint', () => {
+  it('returns the same value for two records that differ only in numbers', () => {
+    const a: AlertLogRecord = {err: {message: 'qty=0.001 too small', type: 'X'}, level: 50, msg: 'Strategy error'};
+    const b: AlertLogRecord = {err: {message: 'qty=0.002 too small', type: 'X'}, level: 50, msg: 'Strategy error'};
+    expect(fingerprint(a)).toBe(fingerprint(b));
+  });
+
+  it('returns the same value for two records that differ only in UUIDs', () => {
+    const a: AlertLogRecord = {
+      err: {message: 'order 7fad9195-9805-4ef8-90ef-4eaa58874bd4 failed', type: 'X'},
+      level: 50,
+      msg: 'WS',
+    };
+    const b: AlertLogRecord = {
+      err: {message: 'order 1d05f123-5ad8-4b22-83c9-16790a9cc1e6 failed', type: 'X'},
+      level: 50,
+      msg: 'WS',
+    };
+    expect(fingerprint(a)).toBe(fingerprint(b));
+  });
+
+  it('returns the same value for two records that differ only in ISO timestamps', () => {
+    const a: AlertLogRecord = {
+      err: {message: 'failed at 2026-05-28T15:05:01.247Z', type: 'X'},
+      level: 50,
+      msg: 'X',
+    };
+    const b: AlertLogRecord = {
+      err: {message: 'failed at 2026-05-28T15:06:00.968Z', type: 'X'},
+      level: 50,
+      msg: 'X',
+    };
+    expect(fingerprint(a)).toBe(fingerprint(b));
+  });
+
+  it('returns different values for structurally different errors', () => {
+    const a: AlertLogRecord = {err: {message: 'qty must be > 0', type: 'X'}, level: 50, msg: 'Strategy error'};
+    const b: AlertLogRecord = {err: {message: 'connection refused', type: 'X'}, level: 50, msg: 'Strategy error'};
+    expect(fingerprint(a)).not.toBe(fingerprint(b));
+  });
+
+  it('falls back to err.name when err.type is missing', () => {
+    const a: AlertLogRecord = {err: {message: 'boom', name: 'TypeError'}, level: 50, msg: 'X'};
+    expect(fingerprint(a)).toContain('typeerror');
+  });
+});
+
+describe('formatAlertMessage', () => {
+  it('includes the level label, msg, and err type/message', () => {
+    const record: AlertLogRecord = {
+      err: {message: '422 qty must be > 0', type: 'SimplifiedHttpError'},
+      level: 50,
+      msg: 'Strategy error',
+    };
+    const out = formatAlertMessage(record);
+    expect(out).toContain('🚨 ERROR');
+    expect(out).toContain('Strategy error');
+    expect(out).toContain('SimplifiedHttpError: 422 qty must be > 0');
+  });
+
+  it('renders FATAL for level >= 60', () => {
+    expect(formatAlertMessage({level: 60, msg: 'doomed'})).toContain('🚨 FATAL');
+  });
+
+  it('renders WARN for level 40-49', () => {
+    expect(formatAlertMessage({level: 40, msg: 'sus'})).toContain('🚨 WARN');
+  });
+
+  it('includes contextual keys like strategyId/strategyName/pair', () => {
+    const record: AlertLogRecord = {
+      level: 50,
+      msg: 'Strategy error',
+      pair: 'NVDA,USD',
+      strategyId: 8,
+      strategyName: '@typedtrader/strategy-trailing-stop',
+    };
+    const out = formatAlertMessage(record);
+    expect(out).toContain('strategyId: 8');
+    expect(out).toContain('strategyName: @typedtrader/strategy-trailing-stop');
+    expect(out).toContain('pair: NVDA,USD');
+  });
+
+  it('skips pid/hostname/v noise', () => {
+    const record: AlertLogRecord = {hostname: 'ec3f42f6708c', level: 50, msg: 'X', pid: 656, v: 1};
+    const out = formatAlertMessage(record);
+    expect(out).not.toContain('hostname');
+    expect(out).not.toContain('pid');
+  });
+
+  it('truncates very long stacks', () => {
+    const stack = Array.from({length: 30}, (_, i) => `    at frame${i} (file:${i})`).join('\n');
+    const record: AlertLogRecord = {err: {message: 'm', stack, type: 'E'}, level: 50, msg: 'X'};
+    const out = formatAlertMessage(record);
+    expect(out).toContain('frame0');
+    expect(out).not.toContain('frame20');
+  });
+
+  it('truncates the full message if it exceeds the Telegram cap', () => {
+    const longMsg = 'a'.repeat(10_000);
+    const out = formatAlertMessage({level: 50, msg: longMsg});
+    expect(out.length).toBeLessThanOrEqual(3500);
+    expect(out.endsWith('…')).toBe(true);
+  });
+
+  it('includes the time as an ISO string when present', () => {
+    const out = formatAlertMessage({level: 50, msg: 'X', time: 1779980701245});
+    expect(out).toMatch(/time: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+  });
+});
+
+describe('FingerprintDedup', () => {
+  it('returns true on the first sighting', () => {
+    const dedup = new FingerprintDedup(1000, () => 0);
+    expect(dedup.shouldSend('a')).toBe(true);
+  });
+
+  it('returns false on the second sighting inside the TTL window', () => {
+    let now = 0;
+    const dedup = new FingerprintDedup(1000, () => now);
+    dedup.shouldSend('a');
+    now = 500;
+    expect(dedup.shouldSend('a')).toBe(false);
+  });
+
+  it('returns true again once the TTL has elapsed', () => {
+    let now = 0;
+    const dedup = new FingerprintDedup(1000, () => now);
+    dedup.shouldSend('a');
+    now = 1001;
+    expect(dedup.shouldSend('a')).toBe(true);
+  });
+
+  it('keeps suppressing while the error fires continuously inside one window', () => {
+    /*
+     * Tight-loop case: error fires every 60s, dedup TTL is 10 min. The first call sends
+     * (true), the next 9 within the window are suppressed (false). Crucially, every
+     * suppressed call should also refresh the timestamp, so we don't burst at exactly
+     * the 10-min mark when the loop is still going.
+     */
+    let now = 0;
+    const dedup = new FingerprintDedup(600_000, () => now);
+    expect(dedup.shouldSend('a')).toBe(true);
+    for (let i = 1; i <= 9; i++) {
+      now = i * 60_000;
+      expect(dedup.shouldSend('a')).toBe(false);
+    }
+    // Still within TTL of the most recent (suppressed) sighting → stays suppressed.
+    now = 10 * 60_000;
+    expect(dedup.shouldSend('a')).toBe(false);
+  });
+
+  it('does not collide across distinct fingerprints', () => {
+    const dedup = new FingerprintDedup(1000, () => 0);
+    expect(dedup.shouldSend('a')).toBe(true);
+    expect(dedup.shouldSend('b')).toBe(true);
+  });
+});

--- a/packages/messaging/src/logger/telegramAlertHelpers.ts
+++ b/packages/messaging/src/logger/telegramAlertHelpers.ts
@@ -1,0 +1,174 @@
+/*
+ * Pure helpers used by the Telegram pino transport. Kept in their own module so they can
+ * be unit-tested without spinning up a worker thread or mocking pino's transport plumbing.
+ */
+
+/** Shape of the pino log record fields we look at. Anything else is preserved as context. */
+export type AlertLogRecord = {
+  level: number;
+  time?: number;
+  msg?: string;
+  err?: {
+    type?: string;
+    name?: string;
+    message?: string;
+    stack?: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+};
+
+const MAX_TELEGRAM_LENGTH = 3500; // Telegram caps at 4096; leave headroom for formatting overhead.
+const MAX_STACK_LINES = 8;
+const SKIPPED_CONTEXT_KEYS = new Set(['level', 'time', 'msg', 'err', 'pid', 'hostname', 'v']);
+
+/**
+ * Compute a stable fingerprint for an error log record so a tight loop emitting the same
+ * error every minute collapses to a single alert (within the dedup window).
+ *
+ * Strategy: hash msg + err.type + err.message, but normalise volatile substrings
+ * (numbers, UUIDs, timestamps) so structurally identical errors group together — e.g.
+ * "qty=0.001" and "qty=0.002" produce the same fingerprint.
+ */
+export function fingerprint(record: AlertLogRecord): string {
+  const msg = record.msg ?? '';
+  const errType = record.err?.type ?? record.err?.name ?? '';
+  const errMessage = record.err?.message ?? '';
+  const raw = `${msg}|${errType}|${errMessage}`;
+  return normaliseForFingerprint(raw);
+}
+
+function normaliseForFingerprint(input: string): string {
+  return (
+    input
+      // ISO timestamps → 'T'
+      .replace(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z?/g, 'T')
+      // UUIDs → 'U'
+      .replace(/[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}/gi, 'U')
+      // Any standalone number (incl. decimals, negatives) → 'N'
+      .replace(/-?\d+(?:\.\d+)?/g, 'N')
+      .toLowerCase()
+  );
+}
+
+/**
+ * Format a pino log record into a human-readable Telegram message. Truncates anything
+ * that would push past Telegram's 4 KB message limit and keeps the most useful fields
+ * (msg, err, key context like strategyId/strategyName/pair) front-and-centre.
+ */
+export function formatAlertMessage(record: AlertLogRecord): string {
+  const lines: string[] = [];
+  lines.push(`🚨 ${levelLabel(record.level)}`);
+  if (record.msg) {
+    lines.push('', record.msg);
+  }
+
+  if (record.err) {
+    const errType = record.err.type ?? record.err.name ?? 'Error';
+    const errMessage = record.err.message ?? '';
+    lines.push('', `${errType}: ${errMessage}`);
+    if (typeof record.err.stack === 'string' && record.err.stack.length > 0) {
+      lines.push('', truncateStack(record.err.stack));
+    }
+  }
+
+  const contextLines = collectContext(record);
+  if (contextLines.length > 0) {
+    lines.push('', ...contextLines);
+  }
+
+  if (typeof record.time === 'number') {
+    lines.push('', `time: ${new Date(record.time).toISOString()}`);
+  }
+
+  return truncate(lines.join('\n'), MAX_TELEGRAM_LENGTH);
+}
+
+function levelLabel(level: number): string {
+  if (level >= 60) {
+    return 'FATAL';
+  }
+  if (level >= 50) {
+    return 'ERROR';
+  }
+  if (level >= 40) {
+    return 'WARN';
+  }
+  return `LEVEL ${level}`;
+}
+
+function collectContext(record: AlertLogRecord): string[] {
+  const lines: string[] = [];
+  for (const [key, value] of Object.entries(record)) {
+    if (SKIPPED_CONTEXT_KEYS.has(key)) {
+      continue;
+    }
+    if (value === undefined || value === null) {
+      continue;
+    }
+    lines.push(`${key}: ${stringifyContextValue(value)}`);
+  }
+  return lines;
+}
+
+function stringifyContextValue(value: unknown): string {
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return '[unserialisable]';
+  }
+}
+
+function truncateStack(stack: string): string {
+  const lines = stack.split('\n').slice(0, MAX_STACK_LINES);
+  return lines.join('\n');
+}
+
+function truncate(input: string, max: number): string {
+  if (input.length <= max) {
+    return input;
+  }
+  return `${input.slice(0, max - 1)}…`;
+}
+
+/**
+ * Tiny TTL cache used by the transport to dedup repeated identical errors within a window.
+ * Implemented as a Map with explicit eviction on read so we don't grow unbounded.
+ */
+export class FingerprintDedup {
+  readonly #ttlMs: number;
+  readonly #now: () => number;
+  readonly #seen = new Map<string, number>();
+
+  constructor(ttlMs: number, now: () => number = Date.now) {
+    this.#ttlMs = ttlMs;
+    this.#now = now;
+  }
+
+  /**
+   * Returns true if the fingerprint was NOT in the cache (i.e. the caller should send),
+   * false if it's still within the TTL window. Either way the timestamp is refreshed
+   * so a continuously-firing error stays suppressed instead of bursting every TTL.
+   */
+  shouldSend(fp: string): boolean {
+    const now = this.#now();
+    this.#prune(now);
+    const last = this.#seen.get(fp);
+    this.#seen.set(fp, now);
+    if (last === undefined) {
+      return true;
+    }
+    return now - last >= this.#ttlMs;
+  }
+
+  #prune(now: number): void {
+    for (const [fp, ts] of this.#seen) {
+      if (now - ts >= this.#ttlMs) {
+        this.#seen.delete(fp);
+      }
+    }
+  }
+}

--- a/packages/messaging/src/logger/telegramAlertTransport.test.ts
+++ b/packages/messaging/src/logger/telegramAlertTransport.test.ts
@@ -1,0 +1,110 @@
+import {describe, expect, it, vi} from 'vitest';
+import {createTelegramAlertStream} from './telegramAlertTransport.js';
+
+type FetchMock = ReturnType<typeof vi.fn> & typeof fetch;
+
+function writeRecord(stream: ReturnType<typeof createTelegramAlertStream>, record: object): Promise<void> {
+  return new Promise(resolve => stream.write(`${JSON.stringify(record)}\n`, 'utf8', () => resolve()));
+}
+
+function makeFetchMock(response: Partial<Response> = {ok: true, status: 200, statusText: 'OK'}): FetchMock {
+  return vi.fn().mockResolvedValue(response) as FetchMock;
+}
+
+const baseOptions = {botToken: 'TEST_TOKEN', chatId: '12345'};
+
+describe('createTelegramAlertStream', () => {
+  it('posts level-50 records to the Telegram Bot API with the right body', async () => {
+    const fetch = makeFetchMock();
+    const stream = createTelegramAlertStream({...baseOptions, fetch});
+
+    await writeRecord(stream, {err: {message: 'oops', type: 'X'}, level: 50, msg: 'Strategy error'});
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+
+    const [url, init] = fetch.mock.calls[0] as [string, {body: string}];
+    expect(url).toBe('https://api.telegram.org/botTEST_TOKEN/sendMessage');
+    const body = JSON.parse(init.body) as {chat_id: string; text: string};
+    expect(body.chat_id).toBe('12345');
+    expect(body.text).toContain('🚨 ERROR');
+    expect(body.text).toContain('Strategy error');
+  });
+
+  it('drops records below the configured level', async () => {
+    const fetch = makeFetchMock();
+    const stream = createTelegramAlertStream({...baseOptions, fetch, level: 50});
+
+    await writeRecord(stream, {level: 40, msg: 'warn-not-alert'});
+    await writeRecord(stream, {level: 30, msg: 'info-not-alert'});
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('honours a custom (higher) level threshold', async () => {
+    const fetch = makeFetchMock();
+    const stream = createTelegramAlertStream({...baseOptions, fetch, level: 60});
+
+    await writeRecord(stream, {level: 50, msg: 'error-but-not-fatal'});
+    expect(fetch).not.toHaveBeenCalled();
+
+    await writeRecord(stream, {level: 60, msg: 'fatal'});
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+  });
+
+  it('dedups identical structural errors within the window', async () => {
+    const fetch = makeFetchMock();
+    const stream = createTelegramAlertStream({...baseOptions, dedupMs: 60_000, fetch});
+
+    const record = {
+      err: {message: 'qty must be > 0', stack: 'at AlpacaAPI.postOrder', type: 'SimplifiedHttpError'},
+      level: 50,
+      msg: 'Strategy error',
+      strategyId: 8,
+    };
+
+    for (let i = 0; i < 5; i++) {
+      await writeRecord(stream, record);
+    }
+
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+    expect(fetch).toHaveBeenCalledTimes(1); // sanity: still 1 after waitFor's poll window
+  });
+
+  it('lets through two errors that share fingerprint after the window elapses (smoke check via custom dedupMs=0)', async () => {
+    const fetch = makeFetchMock();
+    const stream = createTelegramAlertStream({...baseOptions, dedupMs: 0, fetch});
+
+    await writeRecord(stream, {err: {message: 'm', type: 'X'}, level: 50, msg: 'a'});
+    await writeRecord(stream, {err: {message: 'm', type: 'X'}, level: 50, msg: 'a'});
+
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
+  });
+
+  it('writes a stderr warning when the Bot API responds non-2xx, and does not throw', async () => {
+    const fetch = makeFetchMock({ok: false, status: 401, statusText: 'Unauthorized'});
+    const stderr: string[] = [];
+    const stream = createTelegramAlertStream({...baseOptions, fetch, stderrWrite: chunk => stderr.push(chunk)});
+
+    await writeRecord(stream, {level: 50, msg: 'X'});
+    await vi.waitFor(() => expect(stderr.length).toBeGreaterThan(0));
+    expect(stderr.join('')).toContain('401');
+    expect(stderr.join('')).toContain('Unauthorized');
+  });
+
+  it('writes a stderr warning when fetch itself throws, and never propagates', async () => {
+    const fetch = vi.fn().mockRejectedValue(new Error('ENOTFOUND')) as FetchMock;
+    const stderr: string[] = [];
+    const stream = createTelegramAlertStream({...baseOptions, fetch, stderrWrite: chunk => stderr.push(chunk)});
+
+    await writeRecord(stream, {level: 50, msg: 'X'});
+    await vi.waitFor(() => expect(stderr.length).toBeGreaterThan(0));
+    expect(stderr.join('')).toContain('ENOTFOUND');
+  });
+
+  it('silently ignores garbage that is not valid JSON (pino guarantees JSON, but defensive)', async () => {
+    const fetch = makeFetchMock();
+    const stream = createTelegramAlertStream({...baseOptions, fetch});
+
+    await new Promise<void>(resolve => stream.write('not json\n', 'utf8', () => resolve()));
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/messaging/src/logger/telegramAlertTransport.ts
+++ b/packages/messaging/src/logger/telegramAlertTransport.ts
@@ -1,0 +1,110 @@
+import {Writable} from 'node:stream';
+import {FingerprintDedup, type AlertLogRecord, fingerprint, formatAlertMessage} from './telegramAlertHelpers.js';
+
+/**
+ * Options accepted by the alert stream. Wired in `logger.ts` from environment variables.
+ */
+export type TelegramAlertStreamOptions = {
+  botToken: string;
+  chatId: string;
+  /** Pino numeric level. Records below this are dropped silently. Default: 50 (error). */
+  level?: number;
+  /** Dedup window in milliseconds. Default: 600_000 (10 min). */
+  dedupMs?: number;
+  /**
+   * Override the fetch implementation. Used by tests; production code lets it default to
+   * the global `fetch` (available since Node 18 — this project targets the LTS, see
+   * `.nvmrc`).
+   */
+  fetch?: typeof fetch;
+  /**
+   * Override the stderr writer. Used by tests so we can assert on the loop-safety
+   * fallback path without polluting real stderr.
+   */
+  stderrWrite?: (chunk: string) => void;
+};
+
+const TELEGRAM_API_BASE = 'https://api.telegram.org';
+
+/**
+ * Build a pino-compatible `Writable` that posts level ≥ N log records to a single
+ * Telegram chat as alerts. Wired in-process via `pino.multistream` so it works in both
+ * dev (tsx → .ts) and prod (built .js) without the worker-thread file path footgun.
+ *
+ * Loop safety: this stream never logs via pino. If sending fails (Telegram down, rate
+ * limit, malformed token), it writes a one-line warning to `process.stderr` and moves on.
+ * Otherwise a Telegram outage would generate pino error logs that this same stream
+ * would try to forward, multiplying the problem.
+ *
+ * Dedup: identical structural errors within `dedupMs` collapse to a single alert. See
+ * `telegramAlertHelpers#fingerprint` for the normalisation strategy.
+ */
+export function createTelegramAlertStream(options: TelegramAlertStreamOptions): Writable {
+  const {botToken, chatId} = options;
+  const minLevel = options.level ?? 50;
+  const dedup = new FingerprintDedup(options.dedupMs ?? 600_000);
+  const fetchImpl = options.fetch ?? globalThis.fetch;
+  const stderrWrite = options.stderrWrite ?? ((chunk: string) => void process.stderr.write(chunk));
+  const sendMessageUrl = `${TELEGRAM_API_BASE}/bot${botToken}/sendMessage`;
+
+  if (typeof fetchImpl !== 'function') {
+    stderrWrite('[telegramAlertStream] global fetch is unavailable; alerts disabled.\n');
+  }
+
+  return new Writable({
+    /*
+     * pino writes each log line as a string. We parse, filter, dedup, and (best-effort)
+     * forward to Telegram. Always call `callback()` so pino's backpressure works and a
+     * slow Telegram round-trip doesn't stall logging.
+     */
+    write(chunk: unknown, _encoding, callback) {
+      callback();
+
+      const raw = typeof chunk === 'string' ? chunk : Buffer.isBuffer(chunk) ? chunk.toString('utf8') : null;
+      if (raw === null) {
+        return;
+      }
+      let record: AlertLogRecord;
+      try {
+        record = JSON.parse(raw) as AlertLogRecord;
+      } catch {
+        return;
+      }
+
+      if (typeof record.level !== 'number' || record.level < minLevel) {
+        return;
+      }
+      if (!dedup.shouldSend(fingerprint(record))) {
+        return;
+      }
+      if (typeof fetchImpl !== 'function') {
+        return;
+      }
+
+      const text = formatAlertMessage(record);
+      void sendTelegramMessage({chatId, fetchImpl, sendMessageUrl, stderrWrite, text});
+    },
+  });
+}
+
+async function sendTelegramMessage(params: {
+  chatId: string;
+  fetchImpl: typeof fetch;
+  sendMessageUrl: string;
+  stderrWrite: (chunk: string) => void;
+  text: string;
+}): Promise<void> {
+  try {
+    const response = await params.fetchImpl(params.sendMessageUrl, {
+      body: JSON.stringify({chat_id: params.chatId, text: params.text}),
+      headers: {'content-type': 'application/json'},
+      method: 'POST',
+    });
+    if (!response.ok) {
+      params.stderrWrite(`[telegramAlertStream] sendMessage failed: ${response.status} ${response.statusText}\n`);
+    }
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    params.stderrWrite(`[telegramAlertStream] sendMessage threw: ${reason}\n`);
+  }
+}


### PR DESCRIPTION
## Summary

The recent NVDA \`qty must be > 0\` loop ran for **three days** before we noticed — because checking \`dokku logs\` is a manual step. This PR adds a lightweight, in-process pino stream that POSTs error-level records to a single Telegram chat so the bot can flag itself the moment something fires.

## Design

- **Pure helpers** (\`telegramAlertHelpers.ts\`): \`fingerprint(record)\` normalises volatile substrings (numbers, UUIDs, ISO timestamps) so structurally identical errors group together; \`formatAlertMessage(record)\` renders a compact Telegram-friendly view; \`FingerprintDedup\` is a small TTL cache with explicit eviction.
- **Stream** (\`telegramAlertTransport.ts\`): \`createTelegramAlertStream\` returns a \`Writable\` pino writes to. Calls Bot API via native \`fetch\`. Send failures are written to **stderr only**, never re-logged via pino — kills the obvious recursion path if Telegram goes down.
- **Wiring** (\`logger.ts\`): keeps the existing worker-thread transport for stdout + pino-roll, then layers \`pino.multistream\` to add the Telegram stream when creds are present. Running in-process (instead of as another worker-thread transport) avoids the dev/tsx → \`.ts\` vs prod/built → \`.js\` file-path footgun.

## What the NVDA case would have looked like

| Event | Old behaviour | New behaviour |
|---|---|---|
| 2026-05-28 15:05, first \`qty must be > 0\` | Logged at level 50 in stdout. Silent. | First alert hits Telegram immediately. |
| 15:06–25:00 (subsequent identical errors) | Same line every minute, lost in volume. | Suppressed by 10-min dedup. No Telegram spam. |
| Next deploy after fix | Errors stop. No signal. | Telegram silence is itself the signal. |

## Config

All env vars, all optional except the existing bot creds. Documented in \`packages/messaging/.env.defaults\`.

\`\`\`
TELEGRAM_BOT_TOKEN          # reuses existing bot
TELEGRAM_ALERT_CHAT_ID      # destination; falls back to first TELEGRAM_OWNER_IDS entry
TELEGRAM_ALERT_LEVEL        # pino label or number, default 'error'
TELEGRAM_ALERT_DEDUP_MS     # default 600000 (10 min)
TELEGRAM_ALERTS_ENABLED     # set to 'false' to disable explicitly
\`\`\`

## Coverage

- 18 tests for \`telegramAlertHelpers\` (fingerprint normalisation, message format, dedup window edge cases including the tight-loop scenario from NVDA).
- 8 tests for \`createTelegramAlertStream\` (level filtering, dedup integration, stderr fallback on Telegram 4xx / fetch throw, defensive JSON parsing).
- Full \`messaging\` suite: 108/108. Typecheck and lint clean.

## Trade-offs

- **In-process vs worker thread.** Pino's recommended pattern for transports is worker-thread isolation. For low-volume alerts (level 50+, deduped) the in-process cost is negligible (one async \`fetch\` per unique error per dedup window), and in-process means tsx/dev works without a build step. Worth revisiting if the alert volume ever climbs.
- **Loop safety via stderr only.** A Telegram outage writes to stderr, which doesn't go back through pino. If you want those failures captured, that's a separate decision — e.g. a side-channel health metric — not something to graft onto the alert path itself.
- **No Sentry-style aggregation UI.** This is intentionally the cheap half of the alerting story. If volume ever justifies it, Sentry on top of this gives the search/replay/release-tracking UX without changing what's wired in this PR.