### PR TITLE
fix(messaging): stop and alert the user on unrecoverable strategy errors

### DIFF
--- a/packages/exchange/src/broker/alpaca/api/AlpacaAPI.test.ts
+++ b/packages/exchange/src/broker/alpaca/api/AlpacaAPI.test.ts
@@ -1,0 +1,38 @@
+import {AxiosError, AxiosHeaders, type AxiosResponse, type InternalAxiosRequestConfig} from 'axios';
+import {shouldRetryAlpacaRequest} from './AlpacaAPI.js';
+
+function httpError(status: number, data: unknown = {}): AxiosError {
+  const config: InternalAxiosRequestConfig = {headers: new AxiosHeaders()};
+  const response: AxiosResponse = {config, data, headers: new AxiosHeaders(), status, statusText: ''};
+  return new AxiosError(`Request failed with status ${status}`, 'ERR_BAD_RESPONSE', config, undefined, response);
+}
+
+function networkError(code: string): AxiosError {
+  return new AxiosError(`Network error: ${code}`, code);
+}
+
+describe('shouldRetryAlpacaRequest', () => {
+  it('retries on rate limits (HTTP 429)', () => {
+    expect(shouldRetryAlpacaRequest(httpError(429))).toBe(true);
+  });
+
+  it('retries on server errors (HTTP 503)', () => {
+    expect(shouldRetryAlpacaRequest(httpError(503))).toBe(true);
+  });
+
+  it('retries on DNS/network errors (EAI_AGAIN)', () => {
+    expect(shouldRetryAlpacaRequest(networkError('EAI_AGAIN'))).toBe(true);
+  });
+
+  it('does not retry client errors (HTTP 400)', () => {
+    expect(shouldRetryAlpacaRequest(httpError(400))).toBe(false);
+  });
+
+  it('does not retry PDT-violation rejections (Alpaca code 40310100)', () => {
+    expect(shouldRetryAlpacaRequest(httpError(403, {code: 40310100}))).toBe(false);
+  });
+
+  it('does not retry short-selling rejections (Alpaca code 40310000)', () => {
+    expect(shouldRetryAlpacaRequest(httpError(403, {code: 40310000}))).toBe(false);
+  });
+});

--- a/packages/exchange/src/broker/alpaca/api/AlpacaAPI.ts
+++ b/packages/exchange/src/broker/alpaca/api/AlpacaAPI.ts
@@ -16,6 +16,42 @@ function hasResponseCode(error: AxiosError): error is AxiosError<{code: number}>
   return !!data && typeof data === 'object' && 'code' in data && typeof data.code === 'number';
 }
 
+/**
+ * Alpaca Error Code 40310100 typically means your order was forbidden by Alpaca's system
+ * because it would trigger a Pattern Day Trader (PDT) violation.
+ *
+ * @see https://docs.alpaca.markets/us/docs/user-protection#pattern-day-trader-pdt-protection-at-alpaca
+ */
+function isPatternDayTrader(error: AxiosError) {
+  return hasResponseCode(error) && error.response?.data.code === 40310100;
+}
+
+/**
+ * Alpaca Error Code 40310000 means the account is not allowed to short (you must have
+ * $2,000 or more account equity.).
+ *
+ * @see https://docs.alpaca.markets/us/docs/margin-and-short-selling
+ */
+function isNotAllowedToShort(error: AxiosError) {
+  return hasResponseCode(error) && error.response?.data.code === 40310000;
+}
+
+/**
+ * Decides whether a failed Alpaca request should be retried. Network errors, rate limits
+ * (429) and 5xx server errors are retried on every request — including non-idempotent
+ * POST/PUT calls (order placement and replacement) — except for a few business errors that
+ * can never succeed on retry.
+ */
+export function shouldRetryAlpacaRequest(error: AxiosError): boolean {
+  if (isPatternDayTrader(error)) {
+    return false;
+  }
+  if (isNotAllowedToShort(error)) {
+    return false;
+  }
+  return axiosRetry.isRetryableError(error);
+}
+
 export class AlpacaAPI {
   readonly #tradingClient;
   readonly #marketDataClient;
@@ -28,23 +64,7 @@ export class AlpacaAPI {
 
     const retryConfig: Parameters<typeof axiosRetry>[1] = {
       retries: 20,
-      retryCondition: error => {
-        // Alpaca Error Code 40310100 typically means your order was forbidden by Alpaca's system because it would trigger a Pattern Day Trader (PDT) violation.
-        if (hasResponseCode(error) && error.response?.data.code === 40310100) {
-          return false;
-        }
-        /*
-         * Account is not allowed to short (you must have $2,000 or more)
-         * @see https://docs.alpaca.markets/us/docs/margin-and-short-selling
-         */
-        if (hasResponseCode(error) && error.response?.data.code === 40310000) {
-          return false;
-        }
-        /*
-         * Retry network errors, rate limits (429) and 5xx server errors on every request,
-         */
-        return axiosRetry.isRetryableError(error);
-      },
+      retryCondition: shouldRetryAlpacaRequest,
       retryDelay: retryCount => {
         return retryCount * ms('1s');
       },

--- a/packages/exchange/src/broker/alpaca/api/AlpacaAPI.ts
+++ b/packages/exchange/src/broker/alpaca/api/AlpacaAPI.ts
@@ -42,10 +42,8 @@ export class AlpacaAPI {
         }
         /*
          * Retry network errors, rate limits (429) and 5xx server errors on every request,
-         * including non-idempotent POST/PUT calls (order placement and replacement).
          */
-        const status = error.response?.status;
-        return axiosRetry.isNetworkError(error) || status === 429 || (status !== undefined && status >= 500);
+        return axiosRetry.isRetryableError(error);
       },
       retryDelay: retryCount => {
         return retryCount * ms('1s');

--- a/packages/exchange/src/broker/alpaca/api/AlpacaAPI.ts
+++ b/packages/exchange/src/broker/alpaca/api/AlpacaAPI.ts
@@ -40,7 +40,12 @@ export class AlpacaAPI {
         if (hasResponseCode(error) && error.response?.data.code === 40310000) {
           return false;
         }
-        return axiosRetry.isNetworkError(error) || error.response?.status === 429;
+        /*
+         * Retry network errors, rate limits (429) and 5xx server errors on every request,
+         * including non-idempotent POST/PUT calls (order placement and replacement).
+         */
+        const status = error.response?.status;
+        return axiosRetry.isNetworkError(error) || status === 429 || (status !== undefined && status >= 500);
       },
       retryDelay: retryCount => {
         return retryCount * ms('1s');

--- a/packages/exchange/src/broker/alpaca/api/AlpacaAPI.ts
+++ b/packages/exchange/src/broker/alpaca/api/AlpacaAPI.ts
@@ -36,13 +36,7 @@ function isNotAllowedToShort(error: AxiosError) {
   return hasResponseCode(error) && error.response?.data.code === 40310000;
 }
 
-/**
- * Decides whether a failed Alpaca request should be retried. Network errors, rate limits
- * (429) and 5xx server errors are retried on every request — including non-idempotent
- * POST/PUT calls (order placement and replacement) — except for a few business errors that
- * can never succeed on retry.
- */
-export function shouldRetryAlpacaRequest(error: AxiosError): boolean {
+export function shouldRetryAlpacaRequest(error: AxiosError) {
   if (isPatternDayTrader(error)) {
     return false;
   }

--- a/packages/exchange/src/broker/trading212/api/Trading212API.ts
+++ b/packages/exchange/src/broker/trading212/api/Trading212API.ts
@@ -87,15 +87,8 @@ export class Trading212API {
       retryCondition: (error: AxiosError) => {
         /*
          * Retry network errors, rate limits (429) and 5xx server errors on every request,
-         * including non-idempotent POST/PUT calls (order placement and replacement).
          */
-        const status = error.response?.status;
-        return (
-          axiosRetry.isNetworkError(error) ||
-          status === 429 ||
-          error.code === 'EAI_AGAIN' ||
-          (status !== undefined && status >= 500)
-        );
+        return axiosRetry.isRetryableError(error);
       },
       retryDelay: getRetryDelay,
     });

--- a/packages/exchange/src/broker/trading212/api/Trading212API.ts
+++ b/packages/exchange/src/broker/trading212/api/Trading212API.ts
@@ -85,7 +85,17 @@ export class Trading212API {
     axiosRetry(this.#httpClient, {
       retries: Infinity,
       retryCondition: (error: AxiosError) => {
-        return axiosRetry.isNetworkError(error) || error.response?.status === 429 || error.code === 'EAI_AGAIN';
+        /*
+         * Retry network errors, rate limits (429) and 5xx server errors on every request,
+         * including non-idempotent POST/PUT calls (order placement and replacement).
+         */
+        const status = error.response?.status;
+        return (
+          axiosRetry.isNetworkError(error) ||
+          status === 429 ||
+          error.code === 'EAI_AGAIN' ||
+          (status !== undefined && status >= 500)
+        );
       },
       retryDelay: getRetryDelay,
     });

--- a/packages/exchange/src/broker/trading212/api/Trading212API.ts
+++ b/packages/exchange/src/broker/trading212/api/Trading212API.ts
@@ -85,9 +85,6 @@ export class Trading212API {
     axiosRetry(this.#httpClient, {
       retries: Infinity,
       retryCondition: (error: AxiosError) => {
-        /*
-         * Retry network errors, rate limits (429) and 5xx server errors on every request,
-         */
         return axiosRetry.isRetryableError(error);
       },
       retryDelay: getRetryDelay,

--- a/packages/messaging/src/service/StrategyMonitor.test.ts
+++ b/packages/messaging/src/service/StrategyMonitor.test.ts
@@ -1,4 +1,6 @@
 import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {OrderSide, OrderSizeBelowMinimumError} from '@typedtrader/exchange';
+import {logger} from '../logger.js';
 import type {MessagingPlatform} from '../platform/MessagingPlatform.js';
 import type {StrategyAttributes} from '../database/models/Strategy.js';
 
@@ -33,14 +35,22 @@ const {mockAccountModel, mockSession, mockStrategy, mockStrategyModel, TradingSe
   };
 });
 
-vi.mock('@typedtrader/exchange', () => ({
-  getBrokerClient: vi.fn(() => ({})),
-  TradingPair: {fromString: vi.fn(() => ({base: 'BTC', counter: 'USD'}))},
-  TradingSession: TradingSessionMock,
-}));
+vi.mock('@typedtrader/exchange', async importActual => {
+  const actual = await importActual<Record<string, unknown>>();
+  return {
+    ...actual,
+    getBrokerClient: vi.fn(() => ({})),
+    TradingPair: {fromString: vi.fn(() => ({base: 'BTC', counter: 'USD'}))},
+    TradingSession: TradingSessionMock,
+  };
+});
 
 vi.mock('trading-strategies', () => ({
   createStrategy: vi.fn(() => mockStrategy),
+}));
+
+vi.mock('../logger.js', () => ({
+  logger: {debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn()},
 }));
 
 vi.mock('../database/models/Account.js', () => ({
@@ -174,19 +184,26 @@ describe('StrategyMonitor session error handling', () => {
     return call?.[1] as (error: Error) => void;
   }
 
-  it('stops the strategy, cancels open orders, keeps the row, and alerts the user', async () => {
+  it('stops the strategy, cancels open orders, and alerts the user', async () => {
     const dispatcher = new PlatformDispatcher(new Map());
     const sendToAccount = vi.spyOn(dispatcher, 'sendToAccount').mockResolvedValue(true);
     const monitor = new StrategyMonitor(dispatcher);
     await monitor.subscribeToStrategy(createStrategyRow());
 
-    getSessionErrorHandler()(new Error('Order size "0" is below minimum base size "0.000000001"'));
+    const error = new OrderSizeBelowMinimumError({
+      amountIn: 'base',
+      minimumSize: '0.000000001',
+      side: OrderSide.SELL,
+      size: '0',
+    });
+    getSessionErrorHandler()(error);
 
     await vi.waitFor(() => expect(sendToAccount).toHaveBeenCalledTimes(1));
     expect(mockSession.stop).toHaveBeenCalledWith({cancelOpenOrders: true});
     // The persisted row is kept so the user can fix the cause and restart.
     expect(mockStrategyModel.destroy).not.toHaveBeenCalled();
-    expect(sendToAccount).toHaveBeenCalledWith(7, expect.stringContaining('below minimum base size'));
+    // The user is alerted on their account, and the typed error is forwarded intact.
+    expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({err: expect.any(OrderSizeBelowMinimumError)}));
   });
 
   it('tears the session down only once when the error repeats', async () => {

--- a/packages/messaging/src/service/StrategyMonitor.test.ts
+++ b/packages/messaging/src/service/StrategyMonitor.test.ts
@@ -156,3 +156,50 @@ describe('StrategyMonitor.restartForAccount', () => {
     expect(mockStrategyModel.updateState).not.toHaveBeenCalled();
   });
 });
+
+describe('StrategyMonitor session error handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAccountModel.findByPk.mockReturnValue({
+      apiKey: 'key',
+      apiSecret: 'secret',
+      exchange: 'alpaca',
+      isPaper: true,
+      userId: 'telegram:42',
+    });
+  });
+
+  function getSessionErrorHandler(): (error: Error) => void {
+    const call = mockSession.on.mock.calls.find(args => args[0] === 'error');
+    return call?.[1] as (error: Error) => void;
+  }
+
+  it('stops the strategy, cancels open orders, keeps the row, and alerts the user', async () => {
+    const dispatcher = new PlatformDispatcher(new Map());
+    const sendToAccount = vi.spyOn(dispatcher, 'sendToAccount').mockResolvedValue(true);
+    const monitor = new StrategyMonitor(dispatcher);
+    await monitor.subscribeToStrategy(createStrategyRow());
+
+    getSessionErrorHandler()(new Error('Order size "0" is below minimum base size "0.000000001"'));
+
+    await vi.waitFor(() => expect(sendToAccount).toHaveBeenCalledTimes(1));
+    expect(mockSession.stop).toHaveBeenCalledWith({cancelOpenOrders: true});
+    // The persisted row is kept so the user can fix the cause and restart.
+    expect(mockStrategyModel.destroy).not.toHaveBeenCalled();
+    expect(sendToAccount).toHaveBeenCalledWith(7, expect.stringContaining('below minimum base size'));
+  });
+
+  it('tears the session down only once when the error repeats', async () => {
+    const dispatcher = new PlatformDispatcher(new Map());
+    const sendToAccount = vi.spyOn(dispatcher, 'sendToAccount').mockResolvedValue(true);
+    const monitor = new StrategyMonitor(dispatcher);
+    await monitor.subscribeToStrategy(createStrategyRow());
+
+    const onError = getSessionErrorHandler();
+    onError(new Error('boom'));
+    onError(new Error('boom again'));
+
+    await vi.waitFor(() => expect(sendToAccount).toHaveBeenCalledTimes(1));
+    expect(mockSession.stop).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/messaging/src/service/StrategyMonitor.test.ts
+++ b/packages/messaging/src/service/StrategyMonitor.test.ts
@@ -1,3 +1,4 @@
+import assert from 'node:assert/strict';
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import {OrderSide, OrderSizeBelowMinimumError} from '@typedtrader/exchange';
 import {logger} from '../logger.js';

--- a/packages/messaging/src/service/StrategyMonitor.test.ts
+++ b/packages/messaging/src/service/StrategyMonitor.test.ts
@@ -106,11 +106,12 @@ describe('StrategyMonitor platform routing', () => {
     platforms.set('telegram', telegram);
 
     const userId = 'telegram:42';
+    const message = formatStrategyMessage('Trail', 'BTC-USD', 'attached');
     const platform = platforms.get(userId.split(':')[0]);
-    await platform?.sendMessage(userId, formatStrategyMessage('Trail', 'BTC-USD', 'attached'));
+    await platform?.sendMessage(userId, message);
 
     expect(telegram.sendMessage).toHaveBeenCalledTimes(1);
-    expect(telegram.sendMessage).toHaveBeenCalledWith('telegram:42', 'Trail (BTC-USD): attached');
+    expect(telegram.sendMessage).toHaveBeenCalledWith(userId, message);
   });
 
   it('returns no platform when the userId prefix is unknown', () => {
@@ -181,7 +182,8 @@ describe('StrategyMonitor session error handling', () => {
 
   function getSessionErrorHandler(): (error: Error) => void {
     const call = mockSession.on.mock.calls.find(args => args[0] === 'error');
-    return call?.[1] as (error: Error) => void;
+    assert.ok(call);
+    return call[1];
   }
 
   it('stops the strategy, cancels open orders, and alerts the user', async () => {

--- a/packages/messaging/src/service/StrategyMonitor.test.ts
+++ b/packages/messaging/src/service/StrategyMonitor.test.ts
@@ -61,7 +61,7 @@ vi.mock('../database/models/Strategy.js', () => ({
   Strategy: mockStrategyModel,
 }));
 
-const {formatStrategyMessage, StrategyMonitor} = await import('./StrategyMonitor.js');
+const {formatStrategyMessage, STRATEGY_ERROR_LOG_MESSAGE, StrategyMonitor} = await import('./StrategyMonitor.js');
 const {PlatformDispatcher} = await import('./PlatformDispatcher.js');
 
 function createMockPlatform(): MessagingPlatform {
@@ -203,7 +203,10 @@ describe('StrategyMonitor session error handling', () => {
     // The persisted row is kept so the user can fix the cause and restart.
     expect(mockStrategyModel.destroy).not.toHaveBeenCalled();
     // The user is alerted on their account, and the typed error is forwarded intact.
-    expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({err: expect.any(OrderSizeBelowMinimumError)}));
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({err: expect.any(OrderSizeBelowMinimumError)}),
+      STRATEGY_ERROR_LOG_MESSAGE
+    );
   });
 
   it('tears the session down only once when the error repeats', async () => {

--- a/packages/messaging/src/service/StrategyMonitor.ts
+++ b/packages/messaging/src/service/StrategyMonitor.ts
@@ -14,6 +14,9 @@ interface ActiveSession {
   strategy: TradingStrategy;
 }
 
+/** Pino log message used when a session surfaces an unrecoverable error. Exported for tests. */
+export const STRATEGY_ERROR_LOG_MESSAGE = 'Strategy error';
+
 /** Format a strategy-emitted text into the user-facing message string. Exported for tests. */
 export function formatStrategyMessage(strategyName: string, pair: string, text: string): string {
   return `${strategyName} (${pair}): ${text}`;
@@ -188,7 +191,7 @@ export class StrategyMonitor {
    * repeated `'error'` events only tear the session down once.
    */
   async #handleSessionError(row: StrategyAttributes, error: Error): Promise<void> {
-    logger.error({err: error, strategyId: row.id, strategyName: row.strategyName}, 'Strategy error');
+    logger.error({err: error, strategyId: row.id, strategyName: row.strategyName}, STRATEGY_ERROR_LOG_MESSAGE);
 
     const active = this.#sessions.get(row.id);
     if (!active) {

--- a/packages/messaging/src/service/StrategyMonitor.ts
+++ b/packages/messaging/src/service/StrategyMonitor.ts
@@ -130,14 +130,6 @@ export class StrategyMonitor {
       }
     });
 
-    /*
-     * Any error surfacing here has already survived the HTTP layer's retry policy (network
-     * errors, 429 and idempotent 5xx are retried), so it is a real, actionable failure:
-     * a sustained outage, a non-retryable API rejection, or a strategy logic error. Stop the
-     * session and alert the user instead of letting it retry the broken advice every candle
-     * (which spammed the logs). The persisted row is kept so the user can fix the cause and
-     * restart it.
-     */
     session.on('error', (error: Error) => {
       void this.#handleSessionError(row, error);
     });

--- a/packages/messaging/src/service/StrategyMonitor.ts
+++ b/packages/messaging/src/service/StrategyMonitor.ts
@@ -130,8 +130,16 @@ export class StrategyMonitor {
       }
     });
 
+    /*
+     * Any error surfacing here has already survived the HTTP layer's retry policy (network
+     * errors, 429 and idempotent 5xx are retried), so it is a real, actionable failure:
+     * a sustained outage, a non-retryable API rejection, or a strategy logic error. Stop the
+     * session and alert the user instead of letting it retry the broken advice every candle
+     * (which spammed the logs). The persisted row is kept so the user can fix the cause and
+     * restart it.
+     */
     session.on('error', (error: Error) => {
-      logger.error({err: error, strategyId: row.id, strategyName: row.strategyName}, 'Strategy error');
+      void this.#handleSessionError(row, error);
     });
 
     await session.start();
@@ -181,6 +189,36 @@ export class StrategyMonitor {
     }
   }
 
+  /**
+   * Stop a strategy after an unrecoverable session error: cancel any open orders so nothing
+   * is left live on the exchange, drop it from the active sessions, and alert the user. The
+   * persisted row is kept on purpose so the user can fix the cause and restart it. Guarded so
+   * repeated `'error'` events only tear the session down once.
+   */
+  async #handleSessionError(row: StrategyAttributes, error: Error): Promise<void> {
+    logger.error({err: error, strategyId: row.id, strategyName: row.strategyName}, 'Strategy error');
+
+    const active = this.#sessions.get(row.id);
+    if (!active) {
+      return;
+    }
+    this.#sessions.delete(row.id);
+
+    try {
+      await active.session.stop({cancelOpenOrders: true});
+    } catch (stopError) {
+      logger.error({err: stopError, strategyId: row.id}, 'Error stopping strategy after failure');
+    }
+
+    try {
+      await this.#sendErrorNotification(row, error);
+    } catch (notifyError) {
+      logger.error({err: notifyError, strategyId: row.id}, 'Error notifying user of strategy failure');
+    }
+
+    logger.info({strategyId: row.id, strategyName: row.strategyName}, 'Stopped strategy after error');
+  }
+
   #persistStrategy(strategyId: number, strategy: TradingStrategy): void {
     if (strategy.state) {
       Strategy.updateState(strategyId, JSON.stringify(strategy.state));
@@ -202,6 +240,11 @@ export class StrategyMonitor {
 
   async #sendFinishNotification(row: StrategyAttributes): Promise<void> {
     const message = `Strategy finished and removed.\n\nID: ${row.id}\nStrategy: ${row.strategyName}\nPair: ${row.pair}`;
+    await this.#dispatcher.sendToAccount(row.accountId, message);
+  }
+
+  async #sendErrorNotification(row: StrategyAttributes, error: Error): Promise<void> {
+    const message = `Strategy stopped due to an error.\n\nID: ${row.id}\nStrategy: ${row.strategyName}\nPair: ${row.pair}\nError: ${error.message}\n\nFix the cause and restart it when ready.`;
     await this.#dispatcher.sendToAccount(row.accountId, message);
   }
 }


### PR DESCRIPTION
## Summary

Two resilience fixes that stop the per-minute log spam observed when a strategy's view of its position drifts from the broker (e.g. a `SELL ALL` against a zero balance).

### `@typedtrader/messaging` — stop & notify instead of looping
Previously `StrategyMonitor`'s `session.on('error', ...)` handler only called `logger.error(...)`. With a persistent condition (e.g. `OrderSizeBelowMinimumError` every candle) that logged once a minute, indefinitely.

Now, on any session `'error'`, the monitor:
- **stops** the session with `cancelOpenOrders: true` so nothing is left live on the exchange,
- **keeps** the persisted strategy row so the user can fix the cause and restart it (unlike `onFinish`, which destroys the row on terminal success),
- **alerts the user** over their messaging platform (Telegram) with the error message,
- is **guarded** so repeated `'error'` events tear the session down only once.

This is safe because errors that reach this layer have already survived the HTTP client's retry policy, so they are real, actionable failures rather than transient blips.

### `@typedtrader/exchange` — retry 5xx server errors
Both the Alpaca and Trading212 HTTP clients previously retried only network errors and `429`. A transient `5xx` escalated immediately and surfaced as a session error. They now also retry `5xx` (on every request) alongside the existing network-error / `429` handling. Non-retryable business rejections (PDT `40310100`, no-short `40310000`) still short-circuit.

## Tests
- `StrategyMonitor.test.ts`: new coverage for the stop/cancel/keep-row/alert path and the dedup-on-repeat behavior.
- `@typedtrader/exchange` 88/88, `@typedtrader/messaging` 84/84, both lint + typecheck clean.