### PR TITLE
test(messaging): surface assertion intent via expect() messages

### DIFF
--- a/packages/messaging/src/service/StrategyMonitor.test.ts
+++ b/packages/messaging/src/service/StrategyMonitor.test.ts
@@ -203,10 +203,14 @@ describe('StrategyMonitor session error handling', () => {
 
     await vi.waitFor(() => expect(sendToAccount).toHaveBeenCalledTimes(1));
     expect(mockSession.stop).toHaveBeenCalledWith({cancelOpenOrders: true});
-    // The persisted row is kept so the user can fix the cause and restart.
-    expect(mockStrategyModel.destroy).not.toHaveBeenCalled();
-    // The user is alerted on their account, and the typed error is forwarded intact.
-    expect(logger.error).toHaveBeenCalledWith(
+    expect(
+      mockStrategyModel.destroy,
+      'The persisted row is kept so the user can fix the cause and restart'
+    ).not.toHaveBeenCalled();
+    expect(
+      logger.error,
+      'The user is alerted on their account, and the typed error is forwarded intact'
+    ).toHaveBeenCalledWith(
       expect.objectContaining({err: expect.any(OrderSizeBelowMinimumError)}),
       STRATEGY_ERROR_LOG_MESSAGE
     );


### PR DESCRIPTION
## Summary

Follow-up to #1100. In the `StrategyMonitor` session-error-handling test, two assertions carried an explanatory `//` comment above them. This moves each sentence into vitest's optional `expect(value, message)` label, so the intent shows up in the failure output instead of staying invisible in the source.

```ts
expect(
  mockStrategyModel.destroy,
  'The persisted row is kept so the user can fix the cause and restart'
).not.toHaveBeenCalled();

expect(
  logger.error,
  'The user is alerted on their account, and the typed error is forwarded intact'
).toHaveBeenCalledWith(
  expect.objectContaining({err: expect.any(OrderSizeBelowMinimumError)}),
  STRATEGY_ERROR_LOG_MESSAGE
);
```

Test-only change — no production code touched. `eslint`, `tsc`, and the `messaging` suite (8/8 in this file) pass.