### PR TITLE
fix(trading-strategies): trailing stop guards all available size

### DIFF
--- a/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.test.ts
+++ b/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.test.ts
@@ -1,6 +1,6 @@
 import Big from 'big.js';
 import {describe, expect, it} from 'vitest';
-import {AlpacaBrokerMock, OrderSide, OrderType, TradingPair} from '@typedtrader/exchange';
+import {AlpacaBroker, AlpacaBrokerMock, OrderSide, OrderType, TradingPair} from '@typedtrader/exchange';
 import type {Candle} from '@typedtrader/exchange';
 import {BacktestExecutor} from '../backtest/BacktestExecutor.js';
 import {TrailingStopStrategy} from './TrailingStopStrategy.js';
@@ -24,21 +24,13 @@ function createCandle(overrides: Partial<Candle> & {close: string; open: string}
   };
 }
 
-function createMockExchange(
-  options: {baseBalance?: string; counterBalance?: string; baseMinSize?: string} = {}
-) {
+function createMockExchange(options: {baseBalance?: string; counterBalance?: string; baseMinSize?: string} = {}) {
   const balances = new Map([
     ['BTC', {available: new Big(options.baseBalance ?? '5'), hold: new Big(0)}],
     ['USD', {available: new Big(options.counterBalance ?? '0'), hold: new Big(0)}],
   ]);
   const tradingRules = options.baseMinSize
-    ? {
-        base_increment: '0.000000001',
-        base_max_size: '1000000',
-        base_min_size: options.baseMinSize,
-        counter_increment: '0.01',
-        counter_min_size: '1',
-      }
+    ? {...AlpacaBroker.DEFAULT_CRYPTO_TRADING_RULES, base_min_size: options.baseMinSize}
     : undefined;
   return new AlpacaBrokerMock({balances, tradingRules});
 }

--- a/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.test.ts
+++ b/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.test.ts
@@ -24,12 +24,23 @@ function createCandle(overrides: Partial<Candle> & {close: string; open: string}
   };
 }
 
-function createMockExchange(options: {baseBalance?: string; counterBalance?: string} = {}) {
+function createMockExchange(
+  options: {baseBalance?: string; counterBalance?: string; baseMinSize?: string} = {}
+) {
   const balances = new Map([
     ['BTC', {available: new Big(options.baseBalance ?? '5'), hold: new Big(0)}],
     ['USD', {available: new Big(options.counterBalance ?? '0'), hold: new Big(0)}],
   ]);
-  return new AlpacaBrokerMock({balances});
+  const tradingRules = options.baseMinSize
+    ? {
+        base_increment: '0.000000001',
+        base_max_size: '1000000',
+        base_min_size: options.baseMinSize,
+        counter_increment: '0.01',
+        counter_min_size: '1',
+      }
+    : undefined;
+  return new AlpacaBrokerMock({balances, tradingRules});
 }
 
 describe('TrailingStopStrategy', () => {
@@ -163,6 +174,28 @@ describe('TrailingStopStrategy', () => {
     expect(strategy.trailingState.peakPrice).toBe('0');
   });
 
+  it('does not attach to a dust balance below the exchange minimum order size', async () => {
+    const strategy = new TrailingStopStrategy({trailDownPct: '10'});
+
+    // base_min_size=1 but only 0.5 available → unsellable dust, so no attach, no advice.
+    const candles = [
+      createCandle({close: '100', high: '101', low: '99', open: '100', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+      createCandle({close: '80', high: '101', low: '79', open: '100', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
+    ];
+
+    const config: BacktestConfig = {
+      broker: createMockExchange({baseBalance: '0.5', baseMinSize: '1'}),
+      candles,
+      strategy,
+      tradingPair,
+    };
+
+    const result = await new BacktestExecutor(config).execute();
+
+    expect(result.trades).toHaveLength(0);
+    expect(strategy.trailingState.peakPrice).toBe('0');
+  });
+
   it('seeds the peak from the attach candle high, not from its close', async () => {
     const strategy = new TrailingStopStrategy({trailDownPct: '10'});
 
@@ -272,40 +305,24 @@ describe('TrailingStopStrategy', () => {
     expect(strategy.trailingState.exitLimitPrice).toBe('90');
   });
 
-  it('rejects malformed restored state that would strand the strategy in a no-op', async () => {
+  it('rejects malformed restored state where peakPrice and stopPrice are decoupled', async () => {
     const strategy = new TrailingStopStrategy({trailDownPct: '10'});
 
     /*
-     * peak set but no position and not exited → permanent no-op. Predicate rejects;
-     * the proxied state stays at defaults so the strategy can still attach.
+     * peakPrice set but stopPrice still '0' (or vice versa) is contradictory — the two
+     * are always seeded together. Predicate rejects; the proxied state stays at defaults
+     * so the strategy can still attach.
      */
     strategy.restoreState({
       exited: false,
       exitLimitPrice: null,
       exitReason: null,
       peakPrice: '120',
-      positionSize: '0',
-      stopPrice: '108',
+      stopPrice: '0',
     });
 
     expect(strategy.trailingState.peakPrice).toBe('0');
-    expect(strategy.trailingState.positionSize).toBe('0');
-  });
-
-  it('rejects restored state where exited=true but positionSize is non-zero', async () => {
-    const strategy = new TrailingStopStrategy({trailDownPct: '10'});
-
-    strategy.restoreState({
-      exited: true,
-      exitLimitPrice: null,
-      exitReason: null,
-      peakPrice: '120',
-      positionSize: '5',
-      stopPrice: '108',
-    });
-
-    expect(strategy.trailingState.exited).toBe(false);
-    expect(strategy.trailingState.positionSize).toBe('0');
+    expect(strategy.trailingState.stopPrice).toBe('0');
   });
 
   it('exposes stopPrice in state from the moment the strategy attaches', async () => {
@@ -423,12 +440,10 @@ describe('TrailingStopStrategy', () => {
       exitLimitPrice: null,
       exitReason: null,
       peakPrice: '120',
-      positionSize: '5',
       stopPrice: '108',
     });
 
     expect(strategy.trailingState.peakPrice).toBe('120');
     expect(strategy.trailingState.stopPrice).toBe('108');
-    expect(strategy.trailingState.positionSize).toBe('5');
   });
 });

--- a/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.ts
+++ b/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.ts
@@ -141,16 +141,6 @@ export class TrailingStopStrategy extends Strategy {
     return {...this.#state};
   }
 
-  /**
-   * Whether the available base balance is large enough to place an exit order. Anything
-   * below the exchange's minimum order size (`base_min_size`) is unsellable dust, so the
-   * position counts as effectively closed. Gating on this threshold rather than `> 0`
-   * stops a tiny residue left after a fill from keeping the strategy armed forever.
-   */
-  #hasSellablePosition(state: TradingSessionState): boolean {
-    return state.baseBalance.gte(new Big(state.tradingRules.base_min_size));
-  }
-
   protected override async processCandle(
     candle: OneMinuteBatchedCandle,
     state: TradingSessionState
@@ -160,7 +150,7 @@ export class TrailingStopStrategy extends Strategy {
     }
 
     if (this.#state.peakPrice === '0') {
-      if (!this.#hasSellablePosition(state)) {
+      if (!this.hasSellablePosition(state)) {
         return undefined;
       }
       const peak = this.#pivotPrice ?? candle.high;
@@ -173,7 +163,7 @@ export class TrailingStopStrategy extends Strategy {
       return undefined;
     }
 
-    if (!this.#hasSellablePosition(state)) {
+    if (!this.hasSellablePosition(state)) {
       return undefined;
     }
 
@@ -231,11 +221,13 @@ export class TrailingStopStrategy extends Strategy {
     if (fill.side !== OrderSide.SELL) {
       return;
     }
-    // The exit sells the full available balance, so a SELL fill that drains the live
-    // base balance below the minimum order size means the position is closed — only
-    // unsellable dust remains. Reading the post-fill balance (rather than decrementing a
-    // snapshot) keeps the strategy correct even when size was added after attach.
-    if (!this.#hasSellablePosition(state)) {
+    /*
+     * The exit sells the full available balance, so a SELL fill that drains the live
+     * base balance below the minimum order size means the position is closed — only
+     * unsellable dust remains. Reading the post-fill balance (rather than decrementing a
+     * snapshot) keeps the strategy correct even when size was added after attach.
+     */
+    if (!this.hasSellablePosition(state)) {
       this.#state.exited = true;
     }
   }

--- a/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.ts
+++ b/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.ts
@@ -54,12 +54,6 @@ export type TrailingStopState = {
    */
   exited: boolean;
   /**
-   * Net base quantity currently held. Stored as a Big string. Starts at `'0'`, jumps to
-   * the seeded balance on attach, and decreases on SELL fills of the strategy's own
-   * exit orders. When it reaches zero, `exited` flips to `true`.
-   */
-  positionSize: string;
-  /**
    * Highest candle high observed since attach. Stored as a Big string. Seeded from the
    * configured `pivotPrice` (when set) or otherwise from the attach candle's `high`,
    * then ratchets upward only — falling prices never lower it, so the trail target is
@@ -95,7 +89,6 @@ const defaultState = (): TrailingStopState => ({
   exitLimitPrice: null,
   exitReason: null,
   peakPrice: '0',
-  positionSize: '0',
   stopPrice: '0',
 });
 
@@ -112,11 +105,14 @@ const defaultState = (): TrailingStopState => ({
  * the runtime can tear down the session.
  *
  * Attach behavior: on each candle, if not yet attached and `state.baseBalance > 0`,
- * the strategy claims the full base balance as its position and seeds the peak from
- * the configured `pivotPrice` (when provided) or otherwise from the attach candle's
- * `high`. The position is not modified again until the strategy's own SELL fills
- * arrive — `TradingSession` only forwards fills for orders it placed itself, so any
- * external buys made after attach do not reach `onFill` and are not tracked.
+ * the strategy seeds the peak from the configured `pivotPrice` (when provided) or
+ * otherwise from the attach candle's `high`. It does not snapshot a position size —
+ * the trail always guards whatever base is currently available, read live from
+ * `state.baseBalance` on every candle, so size added after attach (a top-up, another
+ * strategy's buy, a balance carried across a restart) is covered automatically. The
+ * exit liquidates the full available balance (`AllAvailableAmount`); the strategy is
+ * considered exited once a SELL fill drops the live base balance below the exchange's
+ * minimum order size (`base_min_size`), i.e. only unsellable dust remains.
  */
 export class TrailingStopStrategy extends Strategy {
   static override NAME = '@typedtrader/strategy-trailing-stop';
@@ -145,6 +141,16 @@ export class TrailingStopStrategy extends Strategy {
     return {...this.#state};
   }
 
+  /**
+   * Whether the available base balance is large enough to place an exit order. Anything
+   * below the exchange's minimum order size (`base_min_size`) is unsellable dust, so the
+   * position counts as effectively closed. Gating on this threshold rather than `> 0`
+   * stops a tiny residue left after a fill from keeping the strategy armed forever.
+   */
+  #hasSellablePosition(state: TradingSessionState): boolean {
+    return state.baseBalance.gte(new Big(state.tradingRules.base_min_size));
+  }
+
   protected override async processCandle(
     candle: OneMinuteBatchedCandle,
     state: TradingSessionState
@@ -154,12 +160,11 @@ export class TrailingStopStrategy extends Strategy {
     }
 
     if (this.#state.peakPrice === '0') {
-      if (state.baseBalance.lte(0)) {
+      if (!this.#hasSellablePosition(state)) {
         return undefined;
       }
       const peak = this.#pivotPrice ?? candle.high;
       const stopTarget = peak.mul(new Big(1).minus(this.#trailDownPct.div(100)));
-      this.#state.positionSize = state.baseBalance.toFixed();
       this.#state.peakPrice = peak.toFixed();
       this.#state.stopPrice = stopTarget.toFixed();
       this.onMessage?.(
@@ -168,8 +173,7 @@ export class TrailingStopStrategy extends Strategy {
       return undefined;
     }
 
-    const positionSize = new Big(this.#state.positionSize);
-    if (positionSize.lte(0)) {
+    if (!this.#hasSellablePosition(state)) {
       return undefined;
     }
 
@@ -223,18 +227,17 @@ export class TrailingStopStrategy extends Strategy {
     return advice;
   }
 
-  async onFill(fill: Fill, _state: TradingSessionState): Promise<void> {
+  async onFill(fill: Fill, state: TradingSessionState): Promise<void> {
     if (fill.side !== OrderSide.SELL) {
       return;
     }
-    const fillSize = new Big(fill.size);
-    const newSize = new Big(this.#state.positionSize).minus(fillSize);
-    if (newSize.lte(0)) {
-      this.#state.positionSize = '0';
+    // The exit sells the full available balance, so a SELL fill that drains the live
+    // base balance below the minimum order size means the position is closed — only
+    // unsellable dust remains. Reading the post-fill balance (rather than decrementing a
+    // snapshot) keeps the strategy correct even when size was added after attach.
+    if (!this.#hasSellablePosition(state)) {
       this.#state.exited = true;
-      return;
     }
-    this.#state.positionSize = newSize.toFixed();
   }
 
   async onOrderFilled(order: PendingOrder, _state: TradingSessionState): Promise<void> {
@@ -248,7 +251,6 @@ export class TrailingStopStrategy extends Strategy {
     super.restoreState(validated);
     const restored = this.#state;
     restored.exited = validated.exited;
-    restored.positionSize = validated.positionSize;
     restored.peakPrice = validated.peakPrice;
     restored.stopPrice = validated.stopPrice;
     restored.exitReason = validated.exitReason;
@@ -261,9 +263,6 @@ function isTrailingStopState(value: unknown): value is TrailingStopState {
     return false;
   }
   if (!('exited' in value) || typeof value.exited !== 'boolean') {
-    return false;
-  }
-  if (!('positionSize' in value) || typeof value.positionSize !== 'string' || !isValidBigString(value.positionSize)) {
     return false;
   }
   if (!('peakPrice' in value) || typeof value.peakPrice !== 'string' || !isValidBigString(value.peakPrice)) {
@@ -285,27 +284,12 @@ function isTrailingStopState(value: unknown): value is TrailingStopState {
   }
 
   /*
-   * Cross-field invariants. Restoring a state that violates these would strand the
-   * strategy in a no-op or otherwise inconsistent runtime state, so reject and let
-   * restoreState fall back to defaults.
+   * Cross-field invariant. Restoring a state that violates this would strand the
+   * strategy in an inconsistent runtime state, so reject and let restoreState fall
+   * back to defaults.
    */
-  const positionSize = new Big(value.positionSize);
   const peakPrice = new Big(value.peakPrice);
   const stopPrice = new Big(value.stopPrice);
-
-  // Once exited, the position must be zero. Anything else is contradictory.
-  if (value.exited && !positionSize.eq(0)) {
-    return false;
-  }
-
-  /*
-   * Attached (peak set) but not exited and no position left → permanent no-op:
-   * the seed branch is skipped (peak !== '0') and the trail branch returns early
-   * (positionSize <= 0). Treat as corrupt and reset.
-   */
-  if (!peakPrice.eq(0) && !value.exited && positionSize.lte(0)) {
-    return false;
-  }
 
   // peakPrice and stopPrice are coupled — both '0' (not yet attached) or both non-zero.
   if (peakPrice.eq(0) !== stopPrice.eq(0)) {

--- a/packages/trading-strategies/src/strategy/Strategy.ts
+++ b/packages/trading-strategies/src/strategy/Strategy.ts
@@ -1,3 +1,4 @@
+import Big from 'big.js';
 import type {
   OneMinuteBatchedCandle,
   OrderAdvice,
@@ -83,6 +84,16 @@ export abstract class Strategy implements TradingSessionStrategy {
 
   restoreState(persisted: Record<string, unknown>): void {
     this.#_state = persisted;
+  }
+
+  /**
+   * Whether the available base balance is large enough to place an order. Anything below
+   * the exchange's minimum order size (`base_min_size`) is unsellable dust, so for
+   * position/exit purposes it counts as no position. Gating on this threshold rather than
+   * `> 0` stops a tiny residue left after a fill from being treated as an open position.
+   */
+  protected hasSellablePosition(state: TradingSessionState) {
+    return state.baseBalance.gte(new Big(state.tradingRules.base_min_size));
   }
 
   protected getProxiedState<T extends Record<string, unknown>>(): T {


### PR DESCRIPTION
## What

The trailing stop now guards **all available base, read live**, instead of a size snapshotted at attach.

## Why

`positionSize` was snapshotted from `state.baseBalance` at attach and only *decremented* by the strategy's own SELL fills, so any base added afterward — a top-up, another strategy's buy, or balance carried across a restart — went unguarded.

Meanwhile the exit advice already sold `AllAvailableAmount`, so the snapshot never actually sized the order. It only drove the "do I still have a position?" guard and the `exited` flip in `onFill`. The order amount and the bookkeeping were allowed to disagree.

## How

- Remove the `positionSize` field entirely (and its persisted-state validation/invariants).
- Read the live `state.baseBalance` every candle through a single `#hasSellablePosition` predicate.
- Gate on the exchange's `base_min_size` rather than `> 0`, so unsellable **dust** left after a fill no longer keeps the strategy armed forever or triggers under-size exit orders the venue would reject.
- Detect exit from the live post-fill balance in `onFill` instead of decrementing a tracked total.

The same predicate governs all three position checks — attach, trail guard, and exit detection — so there's one source of truth.

## Tests

- Updated the restore/invariant tests for the new state shape (kept the `peakPrice`/`stopPrice` coupling invariant).
- Added a test that a dust balance below `base_min_size` does not attach.
- All 16 tests pass; typecheck clean.