### PR TITLE
chore: lint all monorepo packages in pre-commit hook

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -6,5 +6,5 @@ pre-commit:
       glob: '*.{css,html,json,less,md,scss,yml}'
       run: npx -c "cross-env NODE_OPTIONS=--max_old_space_size=4096 prettier --write --log-level error {staged_files}"
     lint:
-      glob: 'packages/trading-signals/**/*.{js,jsx,ts,tsx}'
-      run: npx eslint --config packages/trading-signals/eslint.config.mjs {staged_files} --fix
+      glob: 'packages/**/*.{js,jsx,ts,tsx}'
+      run: npx eslint {staged_files} --fix


### PR DESCRIPTION
## What

Widen the `pre-commit` lint hook so it covers every workspace package, not just `trading-signals`.

```diff
 lint:
-  glob: 'packages/trading-signals/**/*.{js,jsx,ts,tsx}'
-  run: npx eslint --config packages/trading-signals/eslint.config.mjs {staged_files} --fix
+  glob: 'packages/**/*.{js,jsx,ts,tsx}'
+  run: npx eslint {staged_files} --fix
```

## Why

The lint glob was scoped to `packages/trading-signals/**` and pinned ESLint to that package's config. Any staged change in another package (`trading-strategies`, `exchange`, `messaging`, …) fell outside the glob, so lefthook printed *"lint (skip) no files for inspection"* and the code committed unlinted. CI still caught violations, but only after push — the local hook was a no-op for most of the monorepo.

## How / safety

- Dropping `--config` lets ESLint resolve the root flat config from cwd. All four package `eslint.config.mjs` files already just re-export the same `createConfig()` base, so the ruleset is identical everywhere — no behavior change, just broader coverage.
- The lint is not type-aware (no `parserOptions.project`/`projectService`), so running across packages from the repo root needs no per-package program.

## Verification

Ran the real `pre-commit` hook against a deliberately-broken file in `trading-strategies` (a redundant `: boolean` return type). Before: skipped. After: the `lint` step inspects it and fails with `exit status 1`, as intended.