### PR TITLE
fix(exchange): import node:assert in BrokerMock

### DIFF
--- a/packages/exchange/src/broker/BrokerMock.ts
+++ b/packages/exchange/src/broker/BrokerMock.ts
@@ -1,3 +1,4 @@
+import assert from 'node:assert';
 import {randomUUID} from 'node:crypto';
 import Big from 'big.js';
 import {


### PR DESCRIPTION
### 📚 PR stack — #1121 split into 6 (review/merge bottom-up)

- 👉 **#1122 — fix(exchange): import node:assert in BrokerMock** ← this PR
- #1123 — feat(trading-signals): export MovingAverage base class
- #1124 — feat(exchange): strategy warm-up hook from historical candles
- #1125 — feat(candles): @typedtrader/candles fixtures package
- #1126 — feat(trading-strategies): volatility trailing-stop utils
- #1127 — feat(trading-strategies): DynamicTrailStrategy + suitability report

---

`BrokerMock.placeOrder` calls `assert.ok(size)` but never imported `assert`. It only worked because **vitest injects `assert` as a global** — under any other runtime (plain node, tsx, a standalone backtest script) it throws `ReferenceError: assert is not defined` and order placement fails silently.

Fix: import it from `node:assert`. Verified the previously-failing path (place market order outside vitest) now fills, and exchange's existing 97 tests still pass.

_First of a 6-PR stack splitting #1121 (volatility-sized dynamic trailing stop)._
