### PR TITLE
feat(trading-signals): export MovingAverage base class

### DIFF
--- a/packages/exchange/src/broker/BrokerMock.ts
+++ b/packages/exchange/src/broker/BrokerMock.ts
@@ -1,3 +1,4 @@
+import assert from 'node:assert';
 import {randomUUID} from 'node:crypto';
 import Big from 'big.js';
 import {

--- a/packages/trading-signals/src/trend/index.ts
+++ b/packages/trading-signals/src/trend/index.ts
@@ -6,6 +6,7 @@ export * from './DX/DX.js';
 export * from './EMA/EMA.js';
 export * from './HIGHER_LOW_TRAIL/HigherLowTrail.js';
 export * from './LINREG/LinearRegression.js';
+export * from './MA/MovingAverage.js';
 export * from './PSAR/PSAR.js';
 export * from './RMA/RMA.js';
 export * from './SMA/SMA.js';


### PR DESCRIPTION
### 📚 PR stack — #1121 split into 6 (review/merge bottom-up)

- #1122 — fix(exchange): import node:assert in BrokerMock
- 👉 **#1123 — feat(trading-signals): export MovingAverage base class** ← this PR
- #1124 — feat(exchange): strategy warm-up hook from historical candles
- #1125 — feat(candles): @typedtrader/candles fixtures package
- #1126 — feat(trading-strategies): volatility trailing-stop utils
- #1127 — feat(trading-strategies): DynamicTrailStrategy + suitability report

---

The trend barrel (`src/trend/index.ts`) re-exported every indicator folder **except `MA/`**, so the abstract `MovingAverage` base that `SMA`/`EMA`/`WSMA` extend never reached the package root.

Add `export * from './MA/MovingAverage.js'` so consumers can type against the shared base instead of a non-exported internal.

_2/6 of the stack splitting #1121. Based on #1122._
