### PR TITLE
feat(trading-strategies): volatility trailing-stop utils

### DIFF
--- a/.claude/rules/comments-add-intent-not-implementation.md
+++ b/.claude/rules/comments-add-intent-not-implementation.md
@@ -1,0 +1,51 @@
+# Comments add intent, not a restatement of the implementation
+
+A comment on a function, type, or member must not re-describe what the code already says — not the formula it computes, not its parameters, not its return value, not a fact the type system already enforces. Those restatements add nothing a reader can't see in the signature, and they rot the moment the code changes.
+
+A comment earns its place only by adding **intent or context that the name doesn't already carry**: why the thing exists, what problem it solves, a non-obvious invariant, a domain term, or a gotcha. If the name already makes the intent clear, the best comment is no comment.
+
+## Don't restate the implementation, the params, or the return
+
+```ts
+// ❌ Bad: restates the formula AND the params — all visible in the signature
+/** Expresses an ATR reading as a percentage of price: `atr / price * 100`. Feed it `{high, low, close}`. */
+function atrToPercent(atr: number, price: number) {
+  return (atr / price) * 100;
+}
+```
+
+```ts
+// ✅ Good: explains WHY the function exists (its intent), not HOW it computes
+/**
+ * Makes volatility comparable across instruments: a raw $52 ATR means nothing without the price,
+ * but "7% per bar" compares directly between a $7 and a $700 stock.
+ */
+function atrToPercent(atr: number, price: number) {
+  return (atr / price) * 100;
+}
+```
+
+```ts
+// ❌ Bad: the name and boolean return already say this
+/** `true` once the underlying ATR has enough data to produce a stable reading. */
+get isReady() {
+  return this.#atr.isStable;
+}
+
+// ✅ Good: no comment needed
+get isReady() {
+  return this.#atr.isStable;
+}
+```
+
+## Prove a claimed intent with a test
+
+When a comment asserts an intent ("makes volatility comparable across instruments"), back it with a test that demonstrates that claim, so the intent is executable and can't silently break.
+
+## Encode invariants in the type system, not in prose
+
+If a comment describes a rule ("must be paired with `atrMultiple`", "at least one is required"), express it with the type system (discriminated unions, branded types) instead of asserting it in a comment the compiler can't enforce.
+
+## Define domain terms once, at the source
+
+Jargon a newcomer can't infer (`risk-on`, `SPY`, `whippy`) should be defined once where it originates — not left bare, and not re-explained at every call site. Use `{@link}` to point back to that definition.

--- a/packages/trading-strategies/src/index.ts
+++ b/packages/trading-strategies/src/index.ts
@@ -37,6 +37,18 @@ export {
   type ProtectedStrategyState,
 } from './strategy-protected/ProtectedStrategy.js';
 export {suggestScalpOffset} from './strategy-scalp/suggestScalpOffset.js';
+export {atrTrailStop, percentTrailStop, trailStop, type TrailStopOptions} from './util/trailStop.js';
+export {TrendFilter} from './util/TrendFilter.js';
+export {AtrPercent, atrToPercent} from './util/AtrPercent.js';
+export {
+  ATR_TRAIL_BANDS,
+  DEFAULT_ATR_TRAIL_MULTIPLE,
+  atrMultipleToPercent,
+  classifyAtrMultiple,
+  percentToAtrMultiple,
+  type AtrRoomVerdict,
+} from './util/atrUnits.js';
+export {MarketRegimeFilter, type MarketRegimeOptions} from './util/MarketRegimeFilter.js';
 export * from './report/index.js';
 export {
   SP500HeatmapReport,

--- a/packages/trading-strategies/src/util/AtrPercent.test.ts
+++ b/packages/trading-strategies/src/util/AtrPercent.test.ts
@@ -6,8 +6,10 @@ describe('atrToPercent', () => {
     expect(atrToPercent(52.64, 740.53)).toBeCloseTo(7.11, 2);
   });
 
-  it('is scale-invariant: the same percentage for proportional price and ATR', () => {
-    expect(atrToPercent(0.7, 10)).toBeCloseTo(atrToPercent(70, 1_000), 10);
+  it('makes volatility comparable across instruments regardless of nominal price', () => {
+    // A $7 stock moving $0.49/bar is exactly as volatile as a $700 stock moving $49/bar.
+    expect(atrToPercent(0.49, 7), 'same % despite a 100x price difference').toBeCloseTo(atrToPercent(49, 700), 10);
+    expect(atrToPercent(0.49, 7), 'both read as ~7% per bar').toBeCloseTo(7, 10);
   });
 });
 

--- a/packages/trading-strategies/src/util/AtrPercent.test.ts
+++ b/packages/trading-strategies/src/util/AtrPercent.test.ts
@@ -1,0 +1,42 @@
+import {describe, expect, it} from 'vitest';
+import {AtrPercent, atrToPercent} from './AtrPercent.js';
+
+describe('atrToPercent', () => {
+  it('expresses ATR as a percentage of price', () => {
+    expect(atrToPercent(52.64, 740.53)).toBeCloseTo(7.11, 2);
+  });
+
+  it('is scale-invariant: the same percentage for proportional price and ATR', () => {
+    expect(atrToPercent(0.7, 10)).toBeCloseTo(atrToPercent(70, 1_000), 10);
+  });
+});
+
+describe('AtrPercent', () => {
+  const candles = [
+    {close: 10, high: 11, low: 9},
+    {close: 11, high: 12, low: 10},
+    {close: 12, high: 13, low: 11},
+    {close: 13, high: 14, low: 12},
+  ] as const;
+
+  it('is not ready until the underlying ATR is stable', () => {
+    const atrPercent = new AtrPercent(3);
+
+    atrPercent.add(candles[0]);
+    atrPercent.add(candles[1]);
+
+    expect(atrPercent.isReady).toBe(false);
+    expect(atrPercent.value).toBeNull();
+    expect(atrPercent.atr).toBeNull();
+  });
+
+  it('returns the ATR as a percent of the latest close once warmed up', () => {
+    const atrPercent = new AtrPercent(3);
+
+    candles.forEach(candle => atrPercent.add(candle));
+
+    // ATR settles at 2 over these candles; latest close is 13 → 2 / 13 * 100.
+    expect(atrPercent.atr).toBe(2);
+    expect(atrPercent.value).toBeCloseTo((2 / 13) * 100, 10);
+  });
+});

--- a/packages/trading-strategies/src/util/AtrPercent.ts
+++ b/packages/trading-strategies/src/util/AtrPercent.ts
@@ -23,7 +23,6 @@ export class AtrPercent {
     this.#atr = new ATR(interval);
   }
 
-  /** Push the next candle. Both the ATR and the reference close are updated. */
   add(candle: HighLowClose<number>): void {
     this.#atr.add(candle);
     this.#lastClose = candle.close;
@@ -33,7 +32,6 @@ export class AtrPercent {
     return this.#atr.isStable;
   }
 
-  /** Raw ATR in price units, or `null` until warmed up. */
   get atr() {
     return this.#atr.isStable ? this.#atr.getResultOrThrow() : null;
   }

--- a/packages/trading-strategies/src/util/AtrPercent.ts
+++ b/packages/trading-strategies/src/util/AtrPercent.ts
@@ -1,0 +1,57 @@
+import {ATR, type HighLowClose} from 'trading-signals';
+
+/**
+ * Expresses an ATR reading as a percentage of price: `atr / price * 100`. Normalizing the raw
+ * (price-unit) ATR makes volatility comparable across instruments and timeframes — a $52 ATR
+ * means nothing without the price, but "7% per bar" is directly comparable between a $7 and a
+ * $700 stock.
+ */
+export function atrToPercent(atr: number, price: number) {
+  return (atr / price) * 100;
+}
+
+/**
+ * Average True Range expressed as a percentage of the latest close — the "usual % move per
+ * bar". Feed it `{high, low, close}` candles; once the underlying ATR is warmed up, {@link value}
+ * returns the typical bar range as a percent of price.
+ *
+ * Built on the `ATR` indicator from `trading-signals`, so it inherits Wilder's smoothing. Useful
+ * for sizing volatility-aware stops (see `atrTrailStop`) without hand-tuning a percentage per
+ * symbol, and for asking "is this dip within the instrument's normal range?".
+ */
+export class AtrPercent {
+  readonly #atr: ATR;
+  #lastClose: number | null = null;
+
+  constructor(interval: number) {
+    this.#atr = new ATR(interval);
+  }
+
+  /** Push the next candle. Both the ATR and the reference close are updated. */
+  add(candle: HighLowClose<number>): void {
+    this.#atr.add(candle);
+    this.#lastClose = candle.close;
+  }
+
+  /** `true` once the underlying ATR has enough data to produce a stable reading. */
+  get isReady() {
+    return this.#atr.isStable;
+  }
+
+  /** Raw ATR in price units, or `null` until warmed up. */
+  get atr() {
+    return this.#atr.isStable ? this.#atr.getResultOrThrow() : null;
+  }
+
+  /**
+   * ATR as a percent of the latest close (e.g. `7.1` for 7.1%), or `null` until warmed up or
+   * before any candle has been added.
+   */
+  get value() {
+    if (!this.#atr.isStable || this.#lastClose === null || this.#lastClose === 0) {
+      return null;
+    }
+
+    return atrToPercent(this.#atr.getResultOrThrow(), this.#lastClose);
+  }
+}

--- a/packages/trading-strategies/src/util/AtrPercent.ts
+++ b/packages/trading-strategies/src/util/AtrPercent.ts
@@ -1,19 +1,15 @@
 import {ATR, type HighLowClose} from 'trading-signals';
 
 /**
- * Expresses an ATR reading as a percentage of price: `atr / price * 100`. Normalizing the raw
- * (price-unit) ATR makes volatility comparable across instruments and timeframes — a $52 ATR
- * means nothing without the price, but "7% per bar" is directly comparable between a $7 and a
- * $700 stock.
+ * Makes volatility comparable across instruments and timeframes: a raw $52 ATR means nothing
+ * without the price, but "7% per bar" is directly comparable between a $7 and a $700 stock.
  */
 export function atrToPercent(atr: number, price: number) {
   return (atr / price) * 100;
 }
 
 /**
- * Average True Range expressed as a percentage of the latest close — the "usual % move per
- * bar". Feed it `{high, low, close}` candles; once the underlying ATR is warmed up, {@link value}
- * returns the typical bar range as a percent of price.
+ * Average True Range expressed as a percentage of the latest close — the "usual % move per bar".
  *
  * Built on the `ATR` indicator from `trading-signals`, so it inherits Wilder's smoothing. Useful
  * for sizing volatility-aware stops (see `atrTrailStop`) without hand-tuning a percentage per
@@ -33,7 +29,6 @@ export class AtrPercent {
     this.#lastClose = candle.close;
   }
 
-  /** `true` once the underlying ATR has enough data to produce a stable reading. */
   get isReady() {
     return this.#atr.isStable;
   }

--- a/packages/trading-strategies/src/util/MarketRegimeFilter.test.ts
+++ b/packages/trading-strategies/src/util/MarketRegimeFilter.test.ts
@@ -3,32 +3,32 @@ import {describe, expect, it} from 'vitest';
 import {MarketRegimeFilter} from './MarketRegimeFilter.js';
 
 describe('MarketRegimeFilter', () => {
-  it('is not ready, and not risk-on, until the trend average is stable', () => {
+  it('does not signal an exit until the trend average is stable', () => {
     const filter = new MarketRegimeFilter({trendMovingAverage: new SMA(2)});
 
     filter.addIndexClose(100);
 
     expect(filter.isReady).toBe(false);
-    expect(filter.isRiskOn).toBe(false);
+    expect(filter.shouldExit, 'an un-warmed filter makes no claim, so it must not force an exit').toBe(false);
   });
 
-  it('is risk-on while the index holds above its trend line', () => {
+  it('does not signal an exit while the index holds above its trend line', () => {
     const filter = new MarketRegimeFilter({trendMovingAverage: new SMA(2)});
 
     filter.addIndexClose(100);
     filter.addIndexClose(102);
 
     expect(filter.isReady).toBe(true);
-    expect(filter.isRiskOn).toBe(true);
+    expect(filter.shouldExit).toBe(false);
   });
 
-  it('is risk-off when the index closes below its trend line', () => {
+  it('signals an exit when the index closes below its trend line', () => {
     const filter = new MarketRegimeFilter({trendMovingAverage: new SMA(2)});
 
     filter.addIndexClose(100);
     filter.addIndexClose(90);
 
-    expect(filter.isRiskOn).toBe(false);
+    expect(filter.shouldExit).toBe(true);
   });
 
   it('tracks drawdown from the running peak close', () => {
@@ -41,7 +41,7 @@ describe('MarketRegimeFilter', () => {
     expect(filter.drawdown).toBeCloseTo(0.495, 3);
   });
 
-  it('flips to risk-off on a deep drawdown even while above the trend line', () => {
+  it('signals an exit on a deep drawdown even while above the trend line', () => {
     const guarded = new MarketRegimeFilter({maxDrawdownPct: 5, trendMovingAverage: new SMA(2)});
     const unguarded = new MarketRegimeFilter({trendMovingAverage: new SMA(2)});
 
@@ -51,7 +51,7 @@ describe('MarketRegimeFilter', () => {
       unguarded.addIndexClose(close);
     });
 
-    expect(unguarded.isRiskOn).toBe(true);
-    expect(guarded.isRiskOn).toBe(false);
+    expect(unguarded.shouldExit).toBe(false);
+    expect(guarded.shouldExit).toBe(true);
   });
 });

--- a/packages/trading-strategies/src/util/MarketRegimeFilter.test.ts
+++ b/packages/trading-strategies/src/util/MarketRegimeFilter.test.ts
@@ -1,0 +1,57 @@
+import {SMA} from 'trading-signals';
+import {describe, expect, it} from 'vitest';
+import {MarketRegimeFilter} from './MarketRegimeFilter.js';
+
+describe('MarketRegimeFilter', () => {
+  it('is not ready, and not risk-on, until the trend average is stable', () => {
+    const filter = new MarketRegimeFilter({trendMovingAverage: new SMA(2)});
+
+    filter.addIndexClose(100);
+
+    expect(filter.isReady).toBe(false);
+    expect(filter.isRiskOn).toBe(false);
+  });
+
+  it('is risk-on while the index holds above its trend line', () => {
+    const filter = new MarketRegimeFilter({trendMovingAverage: new SMA(2)});
+
+    filter.addIndexClose(100);
+    filter.addIndexClose(102);
+
+    expect(filter.isReady).toBe(true);
+    expect(filter.isRiskOn).toBe(true);
+  });
+
+  it('is risk-off when the index closes below its trend line', () => {
+    const filter = new MarketRegimeFilter({trendMovingAverage: new SMA(2)});
+
+    filter.addIndexClose(100);
+    filter.addIndexClose(90);
+
+    expect(filter.isRiskOn).toBe(false);
+  });
+
+  it('tracks drawdown from the running peak close', () => {
+    const filter = new MarketRegimeFilter({trendMovingAverage: new SMA(2)});
+
+    filter.addIndexClose(200);
+    filter.addIndexClose(100);
+    filter.addIndexClose(101);
+
+    expect(filter.drawdown).toBeCloseTo(0.495, 3);
+  });
+
+  it('flips to risk-off on a deep drawdown even while above the trend line', () => {
+    const guarded = new MarketRegimeFilter({maxDrawdownPct: 5, trendMovingAverage: new SMA(2)});
+    const unguarded = new MarketRegimeFilter({trendMovingAverage: new SMA(2)});
+
+    // [100, 101] sits above the SMA(2) of 100.5, but 101 is ~49.5% below the 200 peak.
+    [200, 100, 101].forEach(close => {
+      guarded.addIndexClose(close);
+      unguarded.addIndexClose(close);
+    });
+
+    expect(unguarded.isRiskOn).toBe(true);
+    expect(guarded.isRiskOn).toBe(false);
+  });
+});

--- a/packages/trading-strategies/src/util/MarketRegimeFilter.ts
+++ b/packages/trading-strategies/src/util/MarketRegimeFilter.ts
@@ -1,0 +1,79 @@
+import type {MovingAverage} from 'trading-signals';
+import {TrendFilter} from './TrendFilter.js';
+
+export interface MarketRegimeOptions {
+  /** Moving average over the index that defines the regime trend line (e.g. a 50-period SMA of SPY). */
+  trendMovingAverage: MovingAverage;
+  /**
+   * Optional maximum drawdown from the index's running peak close, in percent. When set, the
+   * regime flips to risk-off once the index closes more than this far below its highest close
+   * seen so far — even while it is still above the trend line. Omit to gate on the trend line
+   * alone.
+   */
+  maxDrawdownPct?: number;
+}
+
+/**
+ * Market-regime gate driven by an index series (e.g. SPY or QQQ). Pure and feed-agnostic: the
+ * caller pushes index closes from wherever it sources them, so the calculation is reusable and
+ * unit-testable without any cross-symbol plumbing in the trading session.
+ *
+ * Reports "risk-on" when the index is above its trend line and (optionally) within
+ * `maxDrawdownPct` of its running peak. This is what distinguishes a broad risk-off selloff
+ * (honor the stop, get out) from an idiosyncratic single-name dip (a stock can wobble while the
+ * index holds its trend — hold through it).
+ */
+export class MarketRegimeFilter {
+  readonly #trend: TrendFilter;
+  readonly #maxDrawdownRatio: number | null;
+  #peakClose = 0;
+  #lastClose = 0;
+  #hasData = false;
+
+  constructor(options: MarketRegimeOptions) {
+    this.#trend = new TrendFilter(options.trendMovingAverage);
+    this.#maxDrawdownRatio = options.maxDrawdownPct === undefined ? null : options.maxDrawdownPct / 100;
+  }
+
+  /** Push the next index closing price into the regime model. */
+  addIndexClose(close: number): void {
+    this.#trend.add(close);
+    this.#lastClose = close;
+    this.#hasData = true;
+
+    if (close > this.#peakClose) {
+      this.#peakClose = close;
+    }
+  }
+
+  /** `true` once the trend moving average is warmed up. */
+  get isReady() {
+    return this.#trend.isReady;
+  }
+
+  /** Drawdown from the running peak close as a positive ratio (`0` = at the peak, `0.1` = 10% below). */
+  get drawdown() {
+    if (!this.#hasData || this.#peakClose === 0) {
+      return 0;
+    }
+
+    return (this.#peakClose - this.#lastClose) / this.#peakClose;
+  }
+
+  /**
+   * `true` when the index is at or above its trend line and within the configured drawdown band.
+   * Returns `false` until the trend moving average is warmed up — an un-warmed filter makes no
+   * claim about the regime.
+   */
+  get isRiskOn() {
+    if (!this.#trend.isAbove(this.#lastClose)) {
+      return false;
+    }
+
+    if (this.#maxDrawdownRatio !== null && this.drawdown > this.#maxDrawdownRatio) {
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/packages/trading-strategies/src/util/MarketRegimeFilter.ts
+++ b/packages/trading-strategies/src/util/MarketRegimeFilter.ts
@@ -21,7 +21,7 @@ export interface MarketRegimeOptions {
  *
  * This is what lets a strategy tell a broad market-wide selloff (honor the stop, get out) apart
  * from a dip in a single stock (one name can wobble while the whole market holds its trend — hold
- * through it). See {@link isRiskOn} for what the regimes mean.
+ * through it). See {@link shouldExit} for the actionable signal.
  */
 export class MarketRegimeFilter {
   readonly #trend: TrendFilter;
@@ -35,7 +35,6 @@ export class MarketRegimeFilter {
     this.#maxDrawdownRatio = options.maxDrawdownPct === undefined ? null : options.maxDrawdownPct / 100;
   }
 
-  /** Push the next index closing price into the regime model. */
   addIndexClose(close: number): void {
     this.#trend.add(close);
     this.#lastClose = close;
@@ -60,21 +59,25 @@ export class MarketRegimeFilter {
   }
 
   /**
-   * `true` in a "risk-on" regime: the broad market is healthy, so a strategy can ride out a single
-   * name's wobble instead of stopping out on it. Turns `false` for "risk-off" (broad weakness —
-   * honor the stop and get out) once the index loses its trend line or falls more than the
-   * configured drawdown below its peak. Stays `false` until the trend moving average is warmed up,
-   * since an un-warmed filter makes no claim about the regime.
+   * `true` when the regime says exit: the broad market has turned risk-off — it closed below its
+   * trend line, or fell more than the configured drawdown below its peak — so a strategy should get
+   * defensive instead of riding the move out. `false` while the market is healthy (a single name
+   * can wobble while the market holds its trend — hold through it), and also while the trend moving
+   * average is still warming up, since an un-warmed filter makes no claim about the regime.
    */
-  get isRiskOn() {
-    if (!this.#trend.isAbove(this.#lastClose)) {
+  get shouldExit() {
+    if (!this.isReady) {
       return false;
+    }
+
+    if (!this.#trend.isAbove(this.#lastClose)) {
+      return true;
     }
 
     if (this.#maxDrawdownRatio !== null && this.drawdown > this.#maxDrawdownRatio) {
-      return false;
+      return true;
     }
 
-    return true;
+    return false;
   }
 }

--- a/packages/trading-strategies/src/util/MarketRegimeFilter.ts
+++ b/packages/trading-strategies/src/util/MarketRegimeFilter.ts
@@ -14,14 +14,14 @@ export interface MarketRegimeOptions {
 }
 
 /**
- * Market-regime gate driven by an index series (e.g. SPY or QQQ). Pure and feed-agnostic: the
- * caller pushes index closes from wherever it sources them, so the calculation is reusable and
- * unit-testable without any cross-symbol plumbing in the trading session.
+ * Market-regime gate driven by a broad-market index series (e.g. SPY or QQQ — ETFs tracking the
+ * S&P 500 and the Nasdaq-100). Pure and feed-agnostic: the caller pushes index closes from
+ * wherever it sources them, so the calculation is reusable and unit-testable without any
+ * cross-symbol plumbing in the trading session.
  *
- * Reports "risk-on" when the index is above its trend line and (optionally) within
- * `maxDrawdownPct` of its running peak. This is what distinguishes a broad risk-off selloff
- * (honor the stop, get out) from an idiosyncratic single-name dip (a stock can wobble while the
- * index holds its trend — hold through it).
+ * This is what lets a strategy tell a broad market-wide selloff (honor the stop, get out) apart
+ * from a dip in a single stock (one name can wobble while the whole market holds its trend — hold
+ * through it). See {@link isRiskOn} for what the regimes mean.
  */
 export class MarketRegimeFilter {
   readonly #trend: TrendFilter;
@@ -46,7 +46,6 @@ export class MarketRegimeFilter {
     }
   }
 
-  /** `true` once the trend moving average is warmed up. */
   get isReady() {
     return this.#trend.isReady;
   }
@@ -61,9 +60,11 @@ export class MarketRegimeFilter {
   }
 
   /**
-   * `true` when the index is at or above its trend line and within the configured drawdown band.
-   * Returns `false` until the trend moving average is warmed up — an un-warmed filter makes no
-   * claim about the regime.
+   * `true` in a "risk-on" regime: the broad market is healthy, so a strategy can ride out a single
+   * name's wobble instead of stopping out on it. Turns `false` for "risk-off" (broad weakness —
+   * honor the stop and get out) once the index loses its trend line or falls more than the
+   * configured drawdown below its peak. Stays `false` until the trend moving average is warmed up,
+   * since an un-warmed filter makes no claim about the regime.
    */
   get isRiskOn() {
     if (!this.#trend.isAbove(this.#lastClose)) {

--- a/packages/trading-strategies/src/util/TrendFilter.test.ts
+++ b/packages/trading-strategies/src/util/TrendFilter.test.ts
@@ -1,0 +1,51 @@
+import {SMA} from 'trading-signals';
+import {describe, expect, it} from 'vitest';
+import {TrendFilter} from './TrendFilter.js';
+
+describe('TrendFilter', () => {
+  it('is not ready until the moving average is stable', () => {
+    const filter = new TrendFilter(new SMA(3));
+
+    filter.add(10);
+    filter.add(20);
+
+    expect(filter.isReady).toBe(false);
+    expect(filter.value).toBeNull();
+  });
+
+  it('exposes the trend line value once warmed up', () => {
+    const filter = new TrendFilter(new SMA(3));
+
+    filter.add(10);
+    filter.add(20);
+    filter.add(30);
+
+    expect(filter.isReady).toBe(true);
+    expect(filter.value).toBe(20);
+  });
+
+  it('reports prices at or above the trend line as above', () => {
+    const filter = new TrendFilter(new SMA(3));
+
+    [10, 20, 30].forEach(close => filter.add(close));
+
+    expect(filter.isAbove(25)).toBe(true);
+    expect(filter.isAbove(20)).toBe(true);
+  });
+
+  it('reports prices below the trend line as not above', () => {
+    const filter = new TrendFilter(new SMA(3));
+
+    [10, 20, 30].forEach(close => filter.add(close));
+
+    expect(filter.isAbove(19)).toBe(false);
+  });
+
+  it('makes no claim before warmup, so isAbove stays false', () => {
+    const filter = new TrendFilter(new SMA(3));
+
+    filter.add(10);
+
+    expect(filter.isAbove(1_000)).toBe(false);
+  });
+});

--- a/packages/trading-strategies/src/util/TrendFilter.ts
+++ b/packages/trading-strategies/src/util/TrendFilter.ts
@@ -1,0 +1,43 @@
+import type {MovingAverage} from 'trading-signals';
+
+/**
+ * Trend gate over a moving average. Feed it closing prices; once the MA is stable it reports
+ * whether the latest price sits above the trend line. Strategies use it to veto noise-level
+ * exits while the instrument is still in an uptrend — the classic fix for a percentage
+ * trailing stop getting whipsawed out on a dip that never breaks the trend.
+ *
+ * Accepts any `trading-signals` moving average (`SMA`, `EMA`, `WSMA`, …) via their shared
+ * {@link MovingAverage} base. The same primitive, fed an index series instead of the position's
+ * own price, is the building block of {@link MarketRegimeFilter}.
+ */
+export class TrendFilter {
+  readonly #ma: MovingAverage;
+
+  constructor(movingAverage: MovingAverage) {
+    this.#ma = movingAverage;
+  }
+
+  /** Push the next closing price into the underlying moving average. */
+  add(close: number): void {
+    this.#ma.add(close);
+  }
+
+  /** `true` once the moving average has enough data to produce a stable trend line. */
+  get isReady() {
+    return this.#ma.isStable;
+  }
+
+  /** Current trend line value, or `null` until the moving average is warmed up. */
+  get value(): number | null {
+    return this.#ma.isStable ? this.#ma.getResultOrThrow() : null;
+  }
+
+  /**
+   * `true` when `price` is at or above the trend line. Returns `false` until the moving average
+   * is stable — an un-warmed filter makes no claim, so callers naturally fall back to their
+   * unfiltered behavior during warmup.
+   */
+  isAbove(price: number) {
+    return this.#ma.isStable && price >= this.#ma.getResultOrThrow();
+  }
+}

--- a/packages/trading-strategies/src/util/TrendFilter.ts
+++ b/packages/trading-strategies/src/util/TrendFilter.ts
@@ -5,10 +5,6 @@ import type {MovingAverage} from 'trading-signals';
  * whether the latest price sits above the trend line. Strategies use it to veto noise-level
  * exits while the instrument is still in an uptrend — the classic fix for a percentage
  * trailing stop getting whipsawed out on a dip that never breaks the trend.
- *
- * Accepts any `trading-signals` moving average (`SMA`, `EMA`, `WSMA`, …) via their shared
- * {@link MovingAverage} base. The same primitive, fed an index series instead of the position's
- * own price, is the building block of {@link MarketRegimeFilter}.
  */
 export class TrendFilter {
   readonly #ma: MovingAverage;
@@ -17,26 +13,18 @@ export class TrendFilter {
     this.#ma = movingAverage;
   }
 
-  /** Push the next closing price into the underlying moving average. */
   add(close: number): void {
     this.#ma.add(close);
   }
 
-  /** `true` once the moving average has enough data to produce a stable trend line. */
   get isReady() {
     return this.#ma.isStable;
   }
 
-  /** Current trend line value, or `null` until the moving average is warmed up. */
   get value(): number | null {
     return this.#ma.isStable ? this.#ma.getResultOrThrow() : null;
   }
 
-  /**
-   * `true` when `price` is at or above the trend line. Returns `false` until the moving average
-   * is stable — an un-warmed filter makes no claim, so callers naturally fall back to their
-   * unfiltered behavior during warmup.
-   */
   isAbove(price: number) {
     return this.#ma.isStable && price >= this.#ma.getResultOrThrow();
   }

--- a/packages/trading-strategies/src/util/atrUnits.test.ts
+++ b/packages/trading-strategies/src/util/atrUnits.test.ts
@@ -1,0 +1,41 @@
+import {describe, expect, it} from 'vitest';
+import {atrMultipleToPercent, classifyAtrMultiple, percentToAtrMultiple} from './atrUnits.js';
+
+describe('percentToAtrMultiple', () => {
+  it('reproduces the STX statement: a 10% trail at 7.11% ATR is ~1.4x ATR', () => {
+    expect(percentToAtrMultiple(10, 7.11)).toBeCloseTo(1.41, 2);
+  });
+
+  it('throws when ATR% is not positive', () => {
+    expect(() => percentToAtrMultiple(10, 0)).toThrowError('atrPercent must be greater than 0');
+  });
+});
+
+describe('atrMultipleToPercent', () => {
+  it('returns the percentage that yields the given ATR multiple', () => {
+    expect(atrMultipleToPercent(3, 7.11)).toBeCloseTo(21.33, 2);
+  });
+
+  it('is the inverse of percentToAtrMultiple', () => {
+    expect(atrMultipleToPercent(percentToAtrMultiple(10, 7.11), 7.11)).toBeCloseTo(10, 10);
+  });
+});
+
+describe('classifyAtrMultiple', () => {
+  it('flags the STX 1.4x trail as whippy', () => {
+    expect(classifyAtrMultiple(1.41)).toBe('whippy');
+  });
+
+  it('treats the Chandelier Exit 3x default as balanced', () => {
+    expect(classifyAtrMultiple(3)).toBe('balanced');
+  });
+
+  it('flags a 4x trail as loose', () => {
+    expect(classifyAtrMultiple(4)).toBe('loose');
+  });
+
+  it('includes the lower edge in balanced and the upper edge in loose', () => {
+    expect(classifyAtrMultiple(2)).toBe('balanced');
+    expect(classifyAtrMultiple(3.5)).toBe('loose');
+  });
+});

--- a/packages/trading-strategies/src/util/atrUnits.ts
+++ b/packages/trading-strategies/src/util/atrUnits.ts
@@ -1,0 +1,72 @@
+/**
+ * Conversions between a percentage stop and ATR multiples, bridged by the instrument's ATR%
+ * (its "usual % move per bar"; see {@link AtrPercent}). This is what turns the observation
+ * "a 10% trail on STX is only ≈1.4× ATR" into a number you can act on.
+ */
+
+/**
+ * How many ATRs of room a percentage stop provides at the given ATR%.
+ * `percentToAtrMultiple(10, 7.11)` → `≈1.41` — i.e. a 10% trail sits just 1.4 average bars away.
+ *
+ * @throws when `atrPercent` is not positive (a flat instrument has no meaningful ATR room).
+ */
+export function percentToAtrMultiple(trailDownPct: number, atrPercent: number) {
+  if (atrPercent <= 0) {
+    throw new Error('atrPercent must be greater than 0');
+  }
+
+  return trailDownPct / atrPercent;
+}
+
+/**
+ * The percentage stop that yields a given ATR multiple at the current ATR%.
+ * `atrMultipleToPercent(3, 7.11)` → `≈21.3` — a 3× ATR trail on STX needs ~21%, not 10%.
+ */
+export function atrMultipleToPercent(atrMultiple: number, atrPercent: number) {
+  return atrMultiple * atrPercent;
+}
+
+/**
+ * Conventional bands for an ATR-based trailing stop. These are heuristics, not laws: the widely
+ * cited Chandelier Exit trails at 3× ATR, and most ATR-stop guidance lives in the 2–3.5× range.
+ * Below ~2× the stop sits inside the instrument's normal noise (whipsaw-prone); above ~3.5× it
+ * gives back a lot of open profit before triggering.
+ */
+export const ATR_TRAIL_BANDS = {
+  /** At or above this multiple the trail is considered loose. */
+  looseAtOrAbove: 3.5,
+  /** Below this multiple the trail sits inside normal volatility and is whipsaw-prone. */
+  whippyBelow: 2,
+} as const;
+
+/** A sensible default ATR multiple for a trend-following trailing stop (Chandelier Exit convention). */
+export const DEFAULT_ATR_TRAIL_MULTIPLE = 3;
+
+/**
+ * How an ATR multiple rates as trailing-stop wiggle room (see {@link ATR_TRAIL_BANDS}):
+ *
+ * - `'whippy'` — below ~2× ATR. The stop sits inside the instrument's normal per-bar range, so
+ *   routine noise trips it; prone to premature stop-outs (the STX 10% ≈ 1.4× trail was here).
+ * - `'balanced'` — ~2× to 3.5× ATR. Enough room to ride normal volatility while still protecting
+ *   the position; the 3× Chandelier Exit default lives here.
+ * - `'loose'` — at or above ~3.5× ATR. Survives deep noise and rides trends through pullbacks,
+ *   but gives back more open profit before triggering on a real reversal.
+ */
+export type AtrRoomVerdict = 'whippy' | 'balanced' | 'loose';
+
+/**
+ * Classifies an ATR multiple against {@link ATR_TRAIL_BANDS}: `'whippy'` (too tight, prone to
+ * noise stop-outs), `'balanced'`, or `'loose'` (wide, gives back more before triggering).
+ * `classifyAtrMultiple(1.41)` → `'whippy'`, which is exactly why the STX 10% trail got whipsawed.
+ */
+export function classifyAtrMultiple(atrMultiple: number): AtrRoomVerdict {
+  if (atrMultiple < ATR_TRAIL_BANDS.whippyBelow) {
+    return 'whippy';
+  }
+
+  if (atrMultiple >= ATR_TRAIL_BANDS.looseAtOrAbove) {
+    return 'loose';
+  }
+
+  return 'balanced';
+}

--- a/packages/trading-strategies/src/util/atrUnits.ts
+++ b/packages/trading-strategies/src/util/atrUnits.ts
@@ -42,23 +42,10 @@ export const ATR_TRAIL_BANDS = {
 /** A sensible default ATR multiple for a trend-following trailing stop (Chandelier Exit convention). */
 export const DEFAULT_ATR_TRAIL_MULTIPLE = 3;
 
-/**
- * How an ATR multiple rates as trailing-stop wiggle room (see {@link ATR_TRAIL_BANDS}):
- *
- * - `'whippy'` — below ~2× ATR. The stop sits inside the instrument's normal per-bar range, so
- *   routine noise trips it; prone to premature stop-outs (the STX 10% ≈ 1.4× trail was here).
- * - `'balanced'` — ~2× to 3.5× ATR. Enough room to ride normal volatility while still protecting
- *   the position; the 3× Chandelier Exit default lives here.
- * - `'loose'` — at or above ~3.5× ATR. Survives deep noise and rides trends through pullbacks,
- *   but gives back more open profit before triggering on a real reversal.
- */
+/** How an ATR multiple rates as trailing-stop wiggle room. See {@link ATR_TRAIL_BANDS} for the thresholds. */
 export type AtrRoomVerdict = 'whippy' | 'balanced' | 'loose';
 
-/**
- * Classifies an ATR multiple against {@link ATR_TRAIL_BANDS}: `'whippy'` (too tight, prone to
- * noise stop-outs), `'balanced'`, or `'loose'` (wide, gives back more before triggering).
- * `classifyAtrMultiple(1.41)` → `'whippy'`, which is exactly why the STX 10% trail got whipsawed.
- */
+/** Classifies an ATR multiple into an {@link AtrRoomVerdict} using the {@link ATR_TRAIL_BANDS} thresholds. */
 export function classifyAtrMultiple(atrMultiple: number): AtrRoomVerdict {
   if (atrMultiple < ATR_TRAIL_BANDS.whippyBelow) {
     return 'whippy';

--- a/packages/trading-strategies/src/util/trailStop.test.ts
+++ b/packages/trading-strategies/src/util/trailStop.test.ts
@@ -1,0 +1,49 @@
+import {describe, expect, it} from 'vitest';
+import {atrTrailStop, percentTrailStop, trailStop} from './trailStop.js';
+
+describe('percentTrailStop', () => {
+  it('places the stop the given percentage below the peak', () => {
+    expect(percentTrailStop(100, 10).toFixed(2)).toBe('90.00');
+  });
+
+  it('reproduces the STX exit: a 10% trail off an 837.6 peak lands at 753.84', () => {
+    expect(percentTrailStop('837.6', '10').toFixed(2)).toBe('753.84');
+  });
+});
+
+describe('atrTrailStop', () => {
+  it('places the stop the ATR multiple below the peak', () => {
+    expect(atrTrailStop(100, 5, 3).toFixed(2)).toBe('85.00');
+  });
+
+  it('widens the stop as volatility grows', () => {
+    const calm = atrTrailStop(100, 1, 3);
+    const volatile = atrTrailStop(100, 8, 3);
+
+    expect(volatile.lt(calm)).toBe(true);
+  });
+});
+
+describe('trailStop', () => {
+  it('behaves like a percentage trail when only trailDownPct is given', () => {
+    expect(trailStop({peak: 100, trailDownPct: 10}).toFixed(2)).toBe('90.00');
+  });
+
+  it('returns the looser (lower) stop when the ATR stop is wider than the percentage stop', () => {
+    // Percentage stop = 90; ATR stop = 100 - 3*8 = 76. The wider ATR stop wins.
+    expect(trailStop({atr: 8, atrMultiple: 3, peak: 100, trailDownPct: 10}).toFixed(2)).toBe('76.00');
+  });
+
+  it('keeps the percentage stop when it is already looser than the ATR stop', () => {
+    // Percentage stop = 80; ATR stop = 100 - 3*1 = 97. The wider percentage stop wins.
+    expect(trailStop({atr: 1, atrMultiple: 3, peak: 100, trailDownPct: 20}).toFixed(2)).toBe('80.00');
+  });
+
+  it('ignores a lone atr without a multiple', () => {
+    expect(trailStop({atr: 8, peak: 100, trailDownPct: 10}).toFixed(2)).toBe('90.00');
+  });
+
+  it('throws when neither a percentage nor a complete ATR pair is supplied', () => {
+    expect(() => trailStop({peak: 100})).toThrowError('trailStop requires trailDownPct, or both atr and atrMultiple');
+  });
+});

--- a/packages/trading-strategies/src/util/trailStop.test.ts
+++ b/packages/trading-strategies/src/util/trailStop.test.ts
@@ -39,11 +39,13 @@ describe('trailStop', () => {
     expect(trailStop({atr: 1, atrMultiple: 3, peak: 100, trailDownPct: 20}).toFixed(2)).toBe('80.00');
   });
 
-  it('ignores a lone atr without a multiple', () => {
-    expect(trailStop({atr: 8, peak: 100, trailDownPct: 10}).toFixed(2)).toBe('90.00');
+  it('rejects a lone atr without its multiple at compile time', () => {
+    // @ts-expect-error - atr and atrMultiple travel as a pair; one without the other is not a valid input
+    expect(() => trailStop({atr: 8, peak: 100, trailDownPct: 10})).not.toThrow();
   });
 
-  it('throws when neither a percentage nor a complete ATR pair is supplied', () => {
+  it('rejects a request with no trail method, and guards untyped callers at runtime', () => {
+    // @ts-expect-error - the type requires a percentage or a complete ATR pair; the throw guards untyped callers
     expect(() => trailStop({peak: 100})).toThrowError('trailStop requires trailDownPct, or both atr and atrMultiple');
   });
 });

--- a/packages/trading-strategies/src/util/trailStop.ts
+++ b/packages/trading-strategies/src/util/trailStop.ts
@@ -1,0 +1,60 @@
+import Big from 'big.js';
+import type {BigSource} from 'big.js';
+
+/**
+ * Percentage trailing stop: `peak * (1 - trailDownPct/100)`. A `trailDownPct` of `10` puts the
+ * stop 10% below the running peak. The percentage is fixed regardless of how volatile the
+ * instrument is, so the same number can sit inside the noise band of a high-volatility name
+ * while being too wide for a calm one.
+ */
+export function percentTrailStop(peak: BigSource, trailDownPct: BigSource): Big {
+  return new Big(peak).mul(new Big(1).minus(new Big(trailDownPct).div(100)));
+}
+
+/**
+ * Volatility-scaled trailing stop: `peak - atrMultiple * atr`. Sizing the stop to the Average
+ * True Range widens it for volatile instruments and tightens it for calm ones, so a single
+ * multiple (commonly 2.5–3.5) works across symbols instead of hand-picking a percentage each
+ * time. Feed it the current ATR reading (e.g. from the `ATR` indicator in `trading-signals`).
+ */
+export function atrTrailStop(peak: BigSource, atr: BigSource, atrMultiple: BigSource): Big {
+  return new Big(peak).minus(new Big(atr).mul(atrMultiple));
+}
+
+export interface TrailStopOptions {
+  /** Running peak the trail is measured down from. */
+  peak: BigSource;
+  /** Percentage distance below the peak. Omit to trail purely on volatility. */
+  trailDownPct?: BigSource;
+  /** Current ATR reading. Must be paired with `atrMultiple` to take effect. */
+  atr?: BigSource;
+  /** ATR multiple. Must be paired with `atr` to take effect. */
+  atrMultiple?: BigSource;
+}
+
+/**
+ * Combined trailing stop. Computes whichever of the percentage and ATR stops the inputs allow
+ * and returns the **lower (looser)** of them, so neither method can force a tighter stop than
+ * the other — volatility can only widen the trail. With just `trailDownPct` it behaves like
+ * {@link percentTrailStop}; with `atr` + `atrMultiple` it adds {@link atrTrailStop} to the mix.
+ *
+ * @throws when neither a percentage nor a complete ATR pair is supplied.
+ */
+export function trailStop(options: TrailStopOptions): Big {
+  const {atr, atrMultiple, peak, trailDownPct} = options;
+  const candidates: Big[] = [];
+
+  if (trailDownPct !== undefined) {
+    candidates.push(percentTrailStop(peak, trailDownPct));
+  }
+
+  if (atr !== undefined && atrMultiple !== undefined) {
+    candidates.push(atrTrailStop(peak, atr, atrMultiple));
+  }
+
+  if (candidates.length === 0) {
+    throw new Error('trailStop requires trailDownPct, or both atr and atrMultiple');
+  }
+
+  return candidates.reduce((lowest, candidate) => (candidate.lt(lowest) ? candidate : lowest));
+}

--- a/packages/trading-strategies/src/util/trailStop.ts
+++ b/packages/trading-strategies/src/util/trailStop.ts
@@ -1,22 +1,12 @@
 import Big from 'big.js';
 import type {BigSource} from 'big.js';
 
-/**
- * Percentage trailing stop: `peak * (1 - trailDownPct/100)`. A `trailDownPct` of `10` puts the
- * stop 10% below the running peak. The percentage is fixed regardless of how volatile the
- * instrument is, so the same number can sit inside the noise band of a high-volatility name
- * while being too wide for a calm one.
- */
+/** Percentage trailing stop: places the stop a fixed percentage below the running peak. */
 export function percentTrailStop(peak: BigSource, trailDownPct: BigSource): Big {
   return new Big(peak).mul(new Big(1).minus(new Big(trailDownPct).div(100)));
 }
 
-/**
- * Volatility-scaled trailing stop: `peak - atrMultiple * atr`. Sizing the stop to the Average
- * True Range widens it for volatile instruments and tightens it for calm ones, so a single
- * multiple (commonly 2.5–3.5) works across symbols instead of hand-picking a percentage each
- * time. Feed it the current ATR reading (e.g. from the `ATR` indicator in `trading-signals`).
- */
+/** Volatility-scaled trailing stop: places the stop a multiple of ATR below the running peak. */
 export function atrTrailStop(peak: BigSource, atr: BigSource, atrMultiple: BigSource): Big {
   return new Big(peak).minus(new Big(atr).mul(atrMultiple));
 }
@@ -28,7 +18,7 @@ export interface TrailStopOptions {
   trailDownPct?: BigSource;
   /** Current ATR reading. Must be paired with `atrMultiple` to take effect. */
   atr?: BigSource;
-  /** ATR multiple. Must be paired with `atr` to take effect. */
+  /** How many ATRs below the peak the stop sits. Must be paired with `atr` to take effect. */
   atrMultiple?: BigSource;
 }
 

--- a/packages/trading-strategies/src/util/trailStop.ts
+++ b/packages/trading-strategies/src/util/trailStop.ts
@@ -11,24 +11,23 @@ export function atrTrailStop(peak: BigSource, atr: BigSource, atrMultiple: BigSo
   return new Big(peak).minus(new Big(atr).mul(atrMultiple));
 }
 
-export interface TrailStopOptions {
+/** An ATR reading is only actionable together with the multiple applied to it, so the two travel as a pair. */
+type AtrInputs = {atr: BigSource; atrMultiple: BigSource};
+
+/**
+ * Trailing-stop inputs. The union requires at least one method — a percentage, an ATR pair, or
+ * both — so an empty or half-specified request (e.g. an ATR with no multiple) won't type-check.
+ */
+export type TrailStopOptions = {
   /** Running peak the trail is measured down from. */
   peak: BigSource;
-  /** Percentage distance below the peak. Omit to trail purely on volatility. */
-  trailDownPct?: BigSource;
-  /** Current ATR reading. Must be paired with `atrMultiple` to take effect. */
-  atr?: BigSource;
-  /** How many ATRs below the peak the stop sits. Must be paired with `atr` to take effect. */
-  atrMultiple?: BigSource;
-}
+} & ({atr?: never; atrMultiple?: never; trailDownPct: BigSource} | (AtrInputs & {trailDownPct?: BigSource}));
 
 /**
  * Combined trailing stop. Computes whichever of the percentage and ATR stops the inputs allow
  * and returns the **lower (looser)** of them, so neither method can force a tighter stop than
  * the other — volatility can only widen the trail. With just `trailDownPct` it behaves like
  * {@link percentTrailStop}; with `atr` + `atrMultiple` it adds {@link atrTrailStop} to the mix.
- *
- * @throws when neither a percentage nor a complete ATR pair is supplied.
  */
 export function trailStop(options: TrailStopOptions): Big {
   const {atr, atrMultiple, peak, trailDownPct} = options;


### PR DESCRIPTION
### 📚 PR stack — #1121 split into 6 (review/merge bottom-up)

- #1122 — fix(exchange): import node:assert in BrokerMock
- #1123 — feat(trading-signals): export MovingAverage base class
- #1124 — feat(exchange): strategy warm-up hook from historical candles
- #1125 — feat(candles): @typedtrader/candles fixtures package
- 👉 **#1126 — feat(trading-strategies): volatility trailing-stop utils** ← this PR
- #1127 — feat(trading-strategies): DynamicTrailStrategy + suitability report

---

Reusable building blocks for sizing a trailing stop to an instrument's own volatility (consumed by the strategy in the next PR):

- **`trailStop`** — percent + ATR trail-price helpers (returns the looser of the two).
- **`AtrPercent`** — ATR as a percent of price (the "usual % move per bar").
- **`atrUnits`** — convert between a percentage stop and ATR multiples, plus a `whippy`/`balanced`/`loose` classification.
- **`TrendFilter`** — price-vs-moving-average gate (uses the `MovingAverage` base from #1123).
- **`MarketRegimeFilter`** — risk-on/off gate driven by an index series.

35 unit tests; typecheck clean.

_5/6 of the stack splitting #1121. Based on #1125._
