### PR TITLE
feat(trading-strategies): assessAtrMultiples — sweep to choose the ATR multiple

### DIFF
--- a/packages/trading-strategies/src/index.ts
+++ b/packages/trading-strategies/src/index.ts
@@ -6,6 +6,12 @@ export {
   type AtrTrailConfig,
   type AtrTrailState,
 } from './strategy-atr-trail/AtrTrailStrategy.js';
+export {
+  assessAtrMultiples,
+  type AssessAtrMultiplesOptions,
+  type AtrMultipleAssessment,
+  type AtrMultipleOutcome,
+} from './strategy-atr-trail/assessAtrMultiples.js';
 export {BuyOnceStrategy, BuyOnceSchema, type BuyOnceConfig} from './strategy-buy-once/BuyOnceStrategy.js';
 /** @deprecated Use {@link BuyOnceStrategy} without `buyAt` instead. */
 export {

--- a/packages/trading-strategies/src/strategy-atr-trail/assessAtrMultiples.test.ts
+++ b/packages/trading-strategies/src/strategy-atr-trail/assessAtrMultiples.test.ts
@@ -1,0 +1,49 @@
+import {uptrendStxCandles} from '@typedtrader/candles';
+import {describe, expect, it} from 'vitest';
+import {assessAtrMultiples} from './assessAtrMultiples.js';
+
+const entryIndex = uptrendStxCandles.findIndex(candle => candle.openTimeInISO.startsWith('2026-05-12'));
+const history = uptrendStxCandles.slice(0, entryIndex);
+const candles = uptrendStxCandles.slice(entryIndex);
+
+describe('assessAtrMultiples on STX', () => {
+  it('reports each swept multiple with its band and actual outcome', async () => {
+    const report = await assessAtrMultiples({baseBalance: '5', candles, history, multiples: [1.5, 2, 2.5, 3, 3.5]});
+
+    expect(
+      report.map(row => row.atrMultiple),
+      'one row per multiple, in order'
+    ).toEqual([1.5, 2, 2.5, 3, 3.5]);
+
+    const byMultiple = new Map(report.map(row => [row.atrMultiple, row]));
+    expect(byMultiple.get(1.5)?.band, 'static band: below 2x is whippy').toBe('whippy');
+    expect(byMultiple.get(3)?.band, 'static band: 3x is balanced').toBe('balanced');
+    expect(byMultiple.get(3.5)?.band, 'static band: 3.5x is loose').toBe('loose');
+  });
+
+  it('flags the tight 2x as whipsawed and the wider 3x as held', async () => {
+    const report = await assessAtrMultiples({baseBalance: '5', candles, history, multiples: [2, 3]});
+    const byMultiple = new Map(report.map(row => [row.atrMultiple, row]));
+
+    const tight = byMultiple.get(2);
+    expect(tight?.outcome, '2x exits then STX recovers above the exit -> whipsawed').toBe('whipsawed');
+    expect(tight?.exited).toBe(true);
+
+    const wide = byMultiple.get(3);
+    expect(wide?.outcome, '3x rides through the shakeout').toBe('held');
+    expect(wide?.exited).toBe(false);
+  });
+
+  it('shows the wider trail ending richer (positive edge vs the stopped-out tight one)', async () => {
+    const report = await assessAtrMultiples({baseBalance: '5', candles, history, multiples: [2, 3]});
+    const byMultiple = new Map(report.map(row => [row.atrMultiple, row]));
+
+    const tightValue = byMultiple.get(2)?.finalValue ?? 0;
+    const wideValue = byMultiple.get(3)?.finalValue ?? 0;
+    expect(wideValue).toBeGreaterThan(tightValue);
+  });
+
+  it('throws when there are no candles to assess', async () => {
+    await expect(assessAtrMultiples({candles: [], history})).rejects.toThrow('at least one candle');
+  });
+});

--- a/packages/trading-strategies/src/strategy-atr-trail/assessAtrMultiples.ts
+++ b/packages/trading-strategies/src/strategy-atr-trail/assessAtrMultiples.ts
@@ -1,0 +1,112 @@
+import Big from 'big.js';
+import {AlpacaBroker, AlpacaBrokerMock, OrderSide, TradingPair} from '@typedtrader/exchange';
+import type {Candle} from '@typedtrader/exchange';
+import {BacktestExecutor} from '../backtest/BacktestExecutor.js';
+import {classifyAtrMultiple, type AtrRoomVerdict} from '../util/atrUnits.js';
+import {AtrTrailStrategy} from './AtrTrailStrategy.js';
+
+const DEFAULT_MULTIPLES = [1.5, 2, 2.5, 3, 3.5, 4];
+
+/**
+ * How a single ATR multiple actually behaved on the assessed window:
+ * - `held` — the trail was never breached (rode through to the end).
+ * - `protective` — exited, and price kept falling afterwards (the stop saved downside).
+ * - `whipsawed` — exited, but price recovered above the exit (a premature, noise stop-out).
+ */
+export type AtrMultipleOutcome = 'held' | 'protective' | 'whipsawed';
+
+export interface AtrMultipleAssessment {
+  /** The ATR multiple that was tested. */
+  atrMultiple: number;
+  /** Static band classification from {@link classifyAtrMultiple}: whippy / balanced / loose. */
+  band: AtrRoomVerdict;
+  /** Portfolio value of simply holding the position across the whole window. */
+  buyHoldValue: number;
+  /** `(finalValue - buyHoldValue) / buyHoldValue * 100`: positive = the trail beat holding. */
+  edgeVsHoldPct: number;
+  /** Date (`YYYY-MM-DD`) the trail exited, or `null` if it never did. */
+  exitDate: string | null;
+  /** Fill price of the exit, or `null` if it never exited. */
+  exitPrice: number | null;
+  /** Whether the trail was breached and the position exited. */
+  exited: boolean;
+  /** Final portfolio value after running the trail over the window. */
+  finalValue: number;
+  /** What actually happened — the empirical counterpart to `band`. */
+  outcome: AtrMultipleOutcome;
+  /** The frozen trail width this multiple produced (`atrMultiple * ATR%`), or `null` if it couldn't be sized. */
+  trailDownPct: number | null;
+}
+
+export interface AssessAtrMultiplesOptions {
+  /** ATR lookback. Defaults to 14. */
+  atrInterval?: number;
+  /** Candle size (ms) the ATR is measured on. Defaults to daily. */
+  atrIntervalMillis?: number;
+  /** Base-asset units assumed to be held across the window. Defaults to `'1'`. */
+  baseBalance?: string;
+  /** ATR multiples to sweep. Defaults to `[1.5, 2, 2.5, 3, 3.5, 4]`. */
+  multiples?: number[];
+}
+
+/**
+ * Sweeps a range of ATR multiples over an instrument's candles and reports how each one would have
+ * behaved, so the trail width can be chosen from evidence rather than guessed. For every multiple it
+ * warms `AtrTrailStrategy` from `history`, trails it over `candles` while holding a position, and
+ * records whether it rode through, protected, or got whipsawed — alongside the static whippy/balanced/
+ * loose band. The pair is derived from the first candle.
+ */
+export async function assessAtrMultiples(
+  params: {candles: Candle[]; history: Candle[]} & AssessAtrMultiplesOptions
+): Promise<AtrMultipleAssessment[]> {
+  const {atrInterval = 14, atrIntervalMillis = 86_400_000, baseBalance = '1', candles, history} = params;
+  const multiples = params.multiples ?? DEFAULT_MULTIPLES;
+
+  if (candles.length === 0) {
+    throw new Error('assessAtrMultiples needs at least one candle to assess.');
+  }
+
+  const pair = new TradingPair(candles[0].base, candles[0].counter);
+  const lastClose = parseFloat(candles[candles.length - 1].close);
+  const buyHoldValue = parseFloat(baseBalance) * lastClose;
+
+  return Promise.all(
+    multiples.map(async atrMultiple => {
+      const exchange = new AlpacaBrokerMock({
+        balances: new Map([
+          [pair.base, {available: new Big(baseBalance), hold: new Big(0)}],
+          [pair.counter, {available: new Big(0), hold: new Big(0)}],
+        ]),
+        tradingRules: AlpacaBroker.DEFAULT_CRYPTO_TRADING_RULES,
+      });
+      exchange.setHistoricalCandles(history);
+
+      const strategy = new AtrTrailStrategy({atrInterval, atrIntervalMillis, atrMultiple: String(atrMultiple)});
+      await strategy.init(exchange, pair);
+      const result = await new BacktestExecutor({broker: exchange, candles, strategy, tradingPair: pair}).execute();
+
+      const exit = result.trades.find(trade => trade.side === OrderSide.SELL);
+      const exitPrice = exit ? exit.price.toNumber() : null;
+      const finalValue = result.performance.finalPortfolioValue.toNumber();
+      const trailDownPct = strategy.trailState.trailDownPct === null ? null : Number(strategy.trailState.trailDownPct);
+
+      let outcome: AtrMultipleOutcome = 'held';
+      if (exitPrice !== null) {
+        outcome = lastClose > exitPrice ? 'whipsawed' : 'protective';
+      }
+
+      return {
+        atrMultiple,
+        band: classifyAtrMultiple(atrMultiple),
+        buyHoldValue,
+        edgeVsHoldPct: ((finalValue - buyHoldValue) / buyHoldValue) * 100,
+        exitDate: exit ? exit.openTimeInISO.slice(0, 10) : null,
+        exited: strategy.trailState.exited,
+        exitPrice,
+        finalValue,
+        outcome,
+        trailDownPct,
+      };
+    })
+  );
+}


### PR DESCRIPTION
Stacked on #1131 (it imports `AtrTrailStrategy`). Retargets to `main` once #1131 merges.

## Problem
We had helpers to *classify* a multiple (`classifyAtrMultiple` → whippy/balanced/loose) and *convert* units (`atrMultipleToPercent`), but nothing to **choose** the multiple from an instrument's actual behavior.

## What this adds
`assessAtrMultiples({history, candles, multiples?})` sweeps a range of ATR multiples and, for each, warms `AtrTrailStrategy` from `history`, trails it over `candles`, and reports:
- `band` — static whippy/balanced/loose
- `outcome` — **empirical**: `held` / `protective` (exited then kept falling) / `whipsawed` (exited then recovered)
- `trailDownPct`, `exitPrice`/`exitDate`, `finalValue`, `buyHoldValue`, `edgeVsHoldPct`

So you pick the width from evidence instead of a guess.

## On the real STX window (5 shares, buy & hold ≈ 4628)
```
1.5x  whippy    trail 6.9%   whipsawed  exit@780 05-21  edge -15.8%
2x    balanced  trail 9.2%   whipsawed  exit@761 05-20  edge -17.9%
2.5x  balanced  trail 11.4%  whipsawed  exit@742 05-19  edge -20.0%
3x    balanced  trail 13.7%  held                       edge  0.0%
3.5x  loose     trail 16.0%  held                       edge  0.0%
4x    loose     trail 18.3%  held                       edge  0.0%
```
The knee is between 2.5× and 3×. Note the **empirical outcome corrects the static band**: 2× and 2.5× classify as "balanced" but actually whipsawed on this instrument — which is the whole point of measuring instead of trusting a generic threshold.

## Scope (MVP)
Outcome + edge vs buy & hold. Deliberately does not pull the richer suitability metrics (Kaufman efficiency ratio, max drawdown, full verdict) from the old `assessTrailSuitability` — easy to add later if wanted.

4 tests covering the sweep shape, the 2×-whipsaw / 3×-held outcomes, the edge comparison, and the empty-input guard.