### PR TITLE
feat(trading-strategies): anchor S&P 500 momentum to exchange time and add rank deltas

### DIFF
--- a/packages/trading-strategies/src/report-sp500-momentum/SP500MomentumReport.test.ts
+++ b/packages/trading-strategies/src/report-sp500-momentum/SP500MomentumReport.test.ts
@@ -113,4 +113,12 @@ describe('rankDeltaIcon', () => {
     expect(rankDeltaIcon(0), 'held').toBe('');
     expect(rankDeltaIcon(null), 'new entry, unranked last month').toBe('★');
   });
+
+  it('inverts the arrow for the worst-first losers list', () => {
+    // In the losers table a stock that got worse rises toward #1, so the arrow flips.
+    expect(rankDeltaIcon(-2, true), 'got worse → rises in the losers list').toBe('▲');
+    expect(rankDeltaIcon(3, true), 'recovered → falls in the losers list').toBe('▼');
+    expect(rankDeltaIcon(0, true), 'held').toBe('');
+    expect(rankDeltaIcon(null, true), 'new entry').toBe('★');
+  });
 });

--- a/packages/trading-strategies/src/report-sp500-momentum/SP500MomentumReport.test.ts
+++ b/packages/trading-strategies/src/report-sp500-momentum/SP500MomentumReport.test.ts
@@ -1,9 +1,27 @@
 import {describe, expect, it} from 'vitest';
 import {AlpacaAPI} from '@typedtrader/exchange';
-import {SP500MomentumReport, SP500MomentumSchema} from './SP500MomentumReport.js';
+import {SP500_TIMEZONE} from '../util/sp500Tickers.js';
+import {
+  getExchangeYearMonth,
+  getMomentumWindow,
+  rankDeltaIcon,
+  SP500MomentumReport,
+  SP500MomentumSchema,
+  withRankDeltas,
+} from './SP500MomentumReport.js';
 
 function createApi(): AlpacaAPI {
   return new AlpacaAPI({apiKey: 'test-key', apiSecret: 'test-secret', usePaperTrading: true});
+}
+
+/** Builds a ranking (best first) from tickers; only ticker and order matter to the delta logic. */
+function ranking(...tickers: string[]) {
+  return tickers.map((ticker, index) => ({
+    price12MonthsAgo: 100,
+    priceNow: 100,
+    returnPct: tickers.length - index,
+    ticker,
+  }));
 }
 
 describe('SP500MomentumReport', () => {
@@ -19,5 +37,80 @@ describe('SP500MomentumReport', () => {
     const config = SP500MomentumSchema.parse({});
     const report = new SP500MomentumReport(config, createApi());
     expect(report.config).toEqual({});
+  });
+});
+
+describe('getExchangeYearMonth', () => {
+  it('reads the month at the exchange, not in UTC', () => {
+    // 23:30 EDT on Jun 30 is already Jul 1 in UTC — a UTC read would roll the report a day early.
+    const result = getExchangeYearMonth('2025-06-30T23:30:00-04:00', SP500_TIMEZONE);
+    expect(result, 'late-June evening in New York still belongs to June').toEqual({month: 6, year: 2025});
+  });
+
+  it('handles the winter offset across a year boundary', () => {
+    // 23:00 EST on Jan 31 is Feb 1 in UTC; the exchange-local month is still January.
+    const result = getExchangeYearMonth('2025-01-31T23:00:00-05:00', SP500_TIMEZONE);
+    expect(result, 'late-January evening in New York still belongs to January').toEqual({month: 1, year: 2025});
+  });
+});
+
+describe('getMomentumWindow', () => {
+  it('skips the current month and spans the prior twelve', () => {
+    const {pastDate, recentDate} = getMomentumWindow(2025, 6);
+    expect(recentDate.toISOString(), 'formation ends at the start of May (prior month)').toBe(
+      '2025-05-01T00:00:00.000Z'
+    );
+    expect(pastDate.toISOString(), 'formation begins twelve months earlier').toBe('2024-05-01T00:00:00.000Z');
+  });
+
+  it('rolls back across the year boundary in January', () => {
+    const {pastDate, recentDate} = getMomentumWindow(2025, 1);
+    // Dec 1, 2024 is a Sunday, so the first trading day shifts to Monday the 2nd.
+    expect(recentDate.toISOString(), 'prior month of January is the preceding December').toBe(
+      '2024-12-02T00:00:00.000Z'
+    );
+    expect(pastDate.toISOString()).toBe('2023-12-01T00:00:00.000Z');
+  });
+
+  it('advances a weekend first-of-month to the next trading day', () => {
+    const {recentDate} = getMomentumWindow(2025, 12);
+    // Nov 1, 2025 is a Saturday → skip to Monday the 3rd.
+    expect(recentDate.toISOString(), 'a Saturday first-of-month resolves to Monday').toBe('2025-11-03T00:00:00.000Z');
+  });
+
+  it('previous-month window is exactly one month behind the current one', () => {
+    // Current eval month June → previous eval month May, so the window ends Apr (M-2), starts Apr prior year (M-14).
+    const previous = getMomentumWindow(2025, 5);
+    expect(previous.recentDate.toISOString(), 'previous window ends one month earlier').toBe(
+      '2025-04-01T00:00:00.000Z'
+    );
+    expect(previous.pastDate.toISOString(), 'previous window starts one month earlier').toBe(
+      '2024-04-01T00:00:00.000Z'
+    );
+  });
+});
+
+describe('withRankDeltas', () => {
+  it('computes rank movement against the previous month, flagging newcomers', () => {
+    const previous = ranking('A', 'B', 'C', 'D'); // A=1, B=2, C=3, D=4
+    const current = ranking('C', 'A', 'B', 'E'); // C=1, A=2, B=3, E=4
+
+    const result = withRankDeltas(current, previous).map(r => [r.ticker, r.rank, r.rankDelta]);
+
+    expect(result).toEqual([
+      ['C', 1, 2], // 3 → 1, climbed two spots
+      ['A', 2, -1], // 1 → 2, slipped one
+      ['B', 3, -1], // 2 → 3, slipped one
+      ['E', 4, null], // not ranked last month
+    ]);
+  });
+});
+
+describe('rankDeltaIcon', () => {
+  it('shows a direction arrow only when the rank moved', () => {
+    expect(rankDeltaIcon(3), 'climbed').toBe('▲');
+    expect(rankDeltaIcon(-2), 'slipped').toBe('▼');
+    expect(rankDeltaIcon(0), 'held').toBe('');
+    expect(rankDeltaIcon(null), 'new entry, unranked last month').toBe('★');
   });
 });

--- a/packages/trading-strategies/src/report-sp500-momentum/SP500MomentumReport.ts
+++ b/packages/trading-strategies/src/report-sp500-momentum/SP500MomentumReport.ts
@@ -106,15 +106,20 @@ export function withRankDeltas(current: MomentumResult[], previous: MomentumResu
   });
 }
 
-/** A marker for the rank column: `▲` climbed, `▼` slipped, `★` new entry (unranked last month), empty when held. */
-export function rankDeltaIcon(rankDelta: number | null) {
+/**
+ * Arrow for the rank column, pointing the way the row moved *within its own table* since last month:
+ * `▲` rose, `▼` fell, `★` new entry, empty when unchanged. Pass `invert` for the losers table — its
+ * worst-first numbering runs opposite to the overall ranking, so a stock that got worse rises in it.
+ */
+export function rankDeltaIcon(rankDelta: number | null, invert = false) {
   if (rankDelta === null) {
     return '★';
   }
   if (rankDelta === 0) {
     return '';
   }
-  return rankDelta > 0 ? '▲' : '▼';
+  const roseInList = invert ? rankDelta < 0 : rankDelta > 0;
+  return roseInList ? '▲' : '▼';
 }
 
 export class SP500MomentumReport extends Report<SP500MomentumConfig> {
@@ -212,9 +217,9 @@ export class SP500MomentumReport extends Report<SP500MomentumConfig> {
     const header = `Rank  ${'Stock'.padEnd(stockColWidth)}  ${'12m Ret'.padStart(9)}  ${'Price'.padStart(9)}`;
     const divider = `----  ${'-'.repeat(stockColWidth)}  ---------  ---------`;
 
-    const renderRow = (displayRank: number, r: RankedMomentum) => {
+    const renderRow = (displayRank: number, r: RankedMomentum, invertArrow = false) => {
       // Rank number right-aligned, then a single arrow slot so columns stay aligned with or without movement.
-      const rank = String(displayRank).padStart(3) + (rankDeltaIcon(r.rankDelta) || ' ');
+      const rank = String(displayRank).padStart(3) + (rankDeltaIcon(r.rankDelta, invertArrow) || ' ');
       const stock = formatSymbolWithName(r.ticker, names, TELEGRAM_TABLE_NAME_MAX).padEnd(stockColWidth);
       const ret = (r.returnPct.toFixed(2) + '%').padStart(9);
       const price = ('$' + r.priceNow.toFixed(2)).padStart(9);
@@ -236,7 +241,8 @@ export class SP500MomentumReport extends Report<SP500MomentumConfig> {
     lines.push(header);
     lines.push(divider);
     for (let i = 0; i < losers.length; i++) {
-      lines.push(renderRow(i + 1, losers[i]));
+      // Invert the arrow: the losers list is worst-first, so "got worse" means rising toward #1.
+      lines.push(renderRow(i + 1, losers[i], true));
     }
     lines.push('```');
 
@@ -244,7 +250,7 @@ export class SP500MomentumReport extends Report<SP500MomentumConfig> {
     lines.push(
       `Price = close on ${toDate} (formation-window end), not the live quote — the 12-1 window skips the most recent month.`
     );
-    lines.push('Next to the rank: ▲/▼ = moved up/down vs last month, ★ = new entry.');
+    lines.push('Next to the rank: ▲/▼ = moved up/down in this list vs last month, ★ = new entry.');
     lines.push(`Stocks ranked: ${results.length} / ${SP500_TICKERS.length}`);
 
     lines.push('');

--- a/packages/trading-strategies/src/report-sp500-momentum/SP500MomentumReport.ts
+++ b/packages/trading-strategies/src/report-sp500-momentum/SP500MomentumReport.ts
@@ -2,8 +2,8 @@ import {z} from 'zod';
 import type {AlpacaAPI} from '@typedtrader/exchange';
 import {MESSAGE_BREAK, Report} from '../report/Report.js';
 import {fetchUsEquityNames, formatSymbolWithName, TELEGRAM_TABLE_NAME_MAX} from '../util/formatSymbolWithName.js';
-import {findFirstTradingDay, getDateString} from '../util/TimeUtil.js';
-import {SP500_TICKERS} from '../util/sp500Tickers.js';
+import {getDateString} from '../util/TimeUtil.js';
+import {SP500_TICKERS, SP500_TIMEZONE} from '../util/sp500Tickers.js';
 
 export const SP500MomentumSchema = z.object({});
 
@@ -18,6 +18,99 @@ interface MomentumResult {
 
 const BATCH_SIZE = 1000;
 
+const WEEKEND_SHIFT_TO_MONDAY: Record<number, number> = {
+  0: 1, // Sunday → Monday
+  6: 2, // Saturday → Monday
+};
+
+/**
+ * Anchored in UTC on purpose: the result must not drift with the server's local
+ * timezone. Skips weekends only — market holidays are absorbed by the multi-day
+ * price-fetch window, which takes the first available bar at or after this date.
+ */
+function firstTradingDayOfMonth(year: number, monthIndex: number): Date {
+  const date = new Date(Date.UTC(year, monthIndex, 1));
+  date.setUTCDate(date.getUTCDate() + (WEEKEND_SHIFT_TO_MONDAY[date.getUTCDay()] ?? 0));
+  return date;
+}
+
+/**
+ * Reads which calendar month an instant falls in *at the exchange*, not on the server.
+ * Late on the 31st in New York is already the 1st in UTC, so a server-local read would
+ * roll the report a day early; resolving in {@link SP500_TIMEZONE} keeps it on the US
+ * market calendar.
+ */
+export function getExchangeYearMonth(isoTimestamp: string, timeZone: string): {month: number; year: number} {
+  const fields = Object.fromEntries(
+    new Intl.DateTimeFormat('en-CA', {month: '2-digit', timeZone, year: 'numeric'})
+      .formatToParts(new Date(isoTimestamp))
+      .map(part => [part.type, part.value])
+  );
+  return {month: Number(fields.month), year: Number(fields.year)};
+}
+
+/**
+ * The 12-1 window of Jegadeesh & Titman (1993): drop the most recent (current) month to
+ * sidestep short-term reversal, end the formation window at the start of the prior month,
+ * and begin it twelve months earlier.
+ */
+export function getMomentumWindow(exchangeYear: number, exchangeMonth: number): {pastDate: Date; recentDate: Date} {
+  const recentDate = firstTradingDayOfMonth(exchangeYear, exchangeMonth - 2);
+  const pastDate = firstTradingDayOfMonth(recentDate.getUTCFullYear() - 1, recentDate.getUTCMonth());
+  return {pastDate, recentDate};
+}
+
+interface RankedMomentum extends MomentumResult {
+  /** 1-based position in the current full ranking. */
+  rank: number;
+  /**
+   * Movement versus last month's ranking: positive means the stock climbed toward #1, negative
+   * means it slipped. `null` when it wasn't ranked last month (no comparable price), shown as "new".
+   */
+  rankDelta: number | null;
+}
+
+/** Ranks every ticker with a usable price pair by its window return, best first. */
+function rankByMomentum(endPrices: Map<string, number>, startPrices: Map<string, number>): MomentumResult[] {
+  const results: MomentumResult[] = [];
+  for (const ticker of SP500_TICKERS) {
+    const priceNow = endPrices.get(ticker);
+    const priceThen = startPrices.get(ticker);
+    if (priceNow != null && priceThen != null && priceThen > 0) {
+      results.push({
+        price12MonthsAgo: priceThen,
+        priceNow,
+        returnPct: ((priceNow - priceThen) / priceThen) * 100,
+        ticker,
+      });
+    }
+  }
+  results.sort((a, b) => b.returnPct - a.returnPct);
+  return results;
+}
+
+/** Annotates the current ranking with each ticker's rank movement against the previous month's ranking. */
+export function withRankDeltas(current: MomentumResult[], previous: MomentumResult[]): RankedMomentum[] {
+  const previousRank = new Map<string, number>();
+  previous.forEach((result, index) => previousRank.set(result.ticker, index + 1));
+  return current.map((result, index) => {
+    const rank = index + 1;
+    const priorRank = previousRank.get(result.ticker);
+    return {...result, rank, rankDelta: priorRank === undefined ? null : priorRank - rank};
+  });
+}
+
+/** A marker for the rank column: `▲` climbed, `▼` slipped, `★` new entry (unranked last month), empty when held. */
+export function rankDeltaIcon(rankDelta: number | null) {
+  if (rankDelta === null) {
+    return '★';
+  }
+  if (rankDelta === 0) {
+    return '';
+  }
+  return rankDelta > 0 ? '▲' : '▼';
+}
+
 export class SP500MomentumReport extends Report<SP500MomentumConfig> {
   static override NAME = '@typedtrader/report-sp500-momentum';
 
@@ -29,42 +122,27 @@ export class SP500MomentumReport extends Report<SP500MomentumConfig> {
   }
 
   async run() {
-    const now = new Date();
+    const clock = await this.#api.getClock();
+    const {month, year} = getExchangeYearMonth(clock.timestamp, SP500_TIMEZONE);
 
-    // 12-1 momentum: skip the most recent month, look back 12 months from there
-    const recentMonth = new Date(now.getFullYear(), now.getMonth() - 1, 1);
-    const pastMonth = new Date(recentMonth.getFullYear() - 1, recentMonth.getMonth(), 1);
+    // The current ranking and the one a month earlier, so the report can show how ranks moved.
+    const current = getMomentumWindow(year, month);
+    const previous = getMomentumWindow(year, month - 1);
 
-    const recentDate = findFirstTradingDay(recentMonth);
-    const pastDate = findFirstTradingDay(pastMonth);
+    const toDate = getDateString(current.recentDate);
+    const fromDate = getDateString(current.pastDate);
 
-    const toDate = getDateString(recentDate);
-    const fromDate = getDateString(pastDate);
-
-    const [currentPrices, pastPrices, names] = await Promise.all([
-      this.#getClosingPrices(SP500_TICKERS, recentDate),
-      this.#getClosingPrices(SP500_TICKERS, pastDate),
+    const [currentEnd, currentStart, previousEnd, previousStart, names] = await Promise.all([
+      this.#getClosingPrices(SP500_TICKERS, current.recentDate),
+      this.#getClosingPrices(SP500_TICKERS, current.pastDate),
+      this.#getClosingPrices(SP500_TICKERS, previous.recentDate),
+      this.#getClosingPrices(SP500_TICKERS, previous.pastDate),
       fetchUsEquityNames(this.#api),
     ]);
 
-    const results: MomentumResult[] = [];
+    const ranked = withRankDeltas(rankByMomentum(currentEnd, currentStart), rankByMomentum(previousEnd, previousStart));
 
-    for (const ticker of SP500_TICKERS) {
-      const priceNow = currentPrices.get(ticker);
-      const priceThen = pastPrices.get(ticker);
-      if (priceNow != null && priceThen != null && priceThen > 0) {
-        results.push({
-          price12MonthsAgo: priceThen,
-          priceNow,
-          returnPct: ((priceNow - priceThen) / priceThen) * 100,
-          ticker,
-        });
-      }
-    }
-
-    results.sort((a, b) => b.returnPct - a.returnPct);
-
-    return this.#formatResults(results, fromDate, toDate, names);
+    return this.#formatResults(ranked, fromDate, toDate, names);
   }
 
   async #getClosingPrices(symbols: string[], targetDate: Date): Promise<Map<string, number>> {
@@ -109,7 +187,7 @@ export class SP500MomentumReport extends Report<SP500MomentumConfig> {
     return result;
   }
 
-  #formatResults(results: MomentumResult[], fromDate: string, toDate: string, names: Map<string, string>) {
+  #formatResults(results: RankedMomentum[], fromDate: string, toDate: string, names: Map<string, string>) {
     const top = 20;
     const lines: string[] = [];
 
@@ -125,31 +203,42 @@ export class SP500MomentumReport extends Report<SP500MomentumConfig> {
       ...losers.map(r => formatSymbolWithName(r.ticker, names, TELEGRAM_TABLE_NAME_MAX).length)
     );
 
-    const renderRow = (index: number, r: MomentumResult) => {
+    const header = `Rank  ${'Stock'.padEnd(stockColWidth)}  ${'12m Ret'.padStart(9)}  ${'Price'.padStart(9)}`;
+    const divider = `----  ${'-'.repeat(stockColWidth)}  ---------  ---------`;
+
+    const renderRow = (displayRank: number, r: RankedMomentum) => {
+      // Rank number right-aligned, then a single arrow slot so columns stay aligned with or without movement.
+      const rank = String(displayRank).padStart(3) + (rankDeltaIcon(r.rankDelta) || ' ');
       const stock = formatSymbolWithName(r.ticker, names, TELEGRAM_TABLE_NAME_MAX).padEnd(stockColWidth);
-      return `${String(index).padStart(4)}  ${stock}  ${(r.returnPct.toFixed(2) + '%').padStart(9)}  ${('$' + r.priceNow.toFixed(2)).padStart(9)}`;
+      const ret = (r.returnPct.toFixed(2) + '%').padStart(9);
+      const price = ('$' + r.priceNow.toFixed(2)).padStart(9);
+      return `${rank}  ${stock}  ${ret}  ${price}`;
     };
 
     lines.push(`**Top ${winners.length} Winners (12m return)**`);
     lines.push('```');
-    lines.push(`Rank  ${'Stock'.padEnd(stockColWidth)}  12m Ret    Price`);
-    lines.push(`----  ${'-'.repeat(stockColWidth)}  ---------  ---------`);
-    for (let i = 0; i < winners.length; i++) {
-      lines.push(renderRow(i + 1, winners[i]));
+    lines.push(header);
+    lines.push(divider);
+    for (const winner of winners) {
+      lines.push(renderRow(winner.rank, winner));
     }
     lines.push('```');
 
     lines.push(MESSAGE_BREAK);
     lines.push(`**Bottom ${losers.length} Losers (12m return)**`);
     lines.push('```');
-    lines.push(`Rank  ${'Stock'.padEnd(stockColWidth)}  12m Ret    Price`);
-    lines.push(`----  ${'-'.repeat(stockColWidth)}  ---------  ---------`);
+    lines.push(header);
+    lines.push(divider);
     for (let i = 0; i < losers.length; i++) {
       lines.push(renderRow(i + 1, losers[i]));
     }
     lines.push('```');
 
     lines.push('');
+    lines.push(
+      `Price = close on ${toDate} (formation-window end), not the live quote — the 12-1 window skips the most recent month.`
+    );
+    lines.push('Next to the rank: ▲/▼ = moved up/down vs last month, ★ = new entry.');
     lines.push(`Stocks ranked: ${results.length} / ${SP500_TICKERS.length}`);
 
     lines.push('');

--- a/packages/trading-strategies/src/report-sp500-momentum/SP500MomentumReport.ts
+++ b/packages/trading-strategies/src/report-sp500-momentum/SP500MomentumReport.ts
@@ -42,7 +42,13 @@ function firstTradingDayOfMonth(year: number, monthIndex: number): Date {
  */
 export function getExchangeYearMonth(isoTimestamp: string, timeZone: string): {month: number; year: number} {
   const fields = Object.fromEntries(
-    new Intl.DateTimeFormat('en-CA', {month: '2-digit', timeZone, year: 'numeric'})
+    new Intl.DateTimeFormat('en-US', {
+      calendar: 'gregory',
+      month: '2-digit',
+      numberingSystem: 'latn',
+      timeZone,
+      year: 'numeric',
+    })
       .formatToParts(new Date(isoTimestamp))
       .map(part => [part.type, part.value])
   );

--- a/packages/trading-strategies/src/util/TimeUtil.ts
+++ b/packages/trading-strategies/src/util/TimeUtil.ts
@@ -1,25 +1,3 @@
 export function getDateString(date: Date) {
   return date.toISOString().split('T')[0];
 }
-
-export function findLastTradingDay(date: Date): Date {
-  const d = new Date(date);
-  const day = d.getDay();
-  if (day === 0) {
-    d.setDate(d.getDate() - 2);
-  } else if (day === 6) {
-    d.setDate(d.getDate() - 1);
-  }
-  return d;
-}
-
-export function findFirstTradingDay(date: Date): Date {
-  const d = new Date(date);
-  const day = d.getDay();
-  if (day === 0) {
-    d.setDate(d.getDate() + 1);
-  } else if (day === 6) {
-    d.setDate(d.getDate() + 2);
-  }
-  return d;
-}

--- a/packages/trading-strategies/src/util/sp500Tickers.ts
+++ b/packages/trading-strategies/src/util/sp500Tickers.ts
@@ -1,3 +1,10 @@
+/**
+ * IANA zone of the S&P 500's listing venues (NYSE/Nasdaq). Calendar boundaries
+ * (e.g. which month a report belongs to) resolve here so a report rolls over on
+ * the US market clock instead of whatever timezone the server happens to run in.
+ */
+export const SP500_TIMEZONE = 'America/New_York';
+
 /** S&P 500 constituent tickers (as of early 2026). Update periodically. */
 export const SP500_TICKERS = [
   'AAPL',


### PR DESCRIPTION
## What

Two improvements to the S&P 500 momentum report (12-1 strategy of Jegadeesh & Titman, 1993).

### Exchange-time month boundary
The report's 12-1 window was anchored on `new Date()`, so the monthly rollover happened on the **server's** local clock. Late on the 31st in New York is already the 1st in UTC, which could roll the report a day early. It now resolves the current month from the **broker clock** (`AlpacaAPI.getClock()`) in the exchange timezone via `Intl.DateTimeFormat`, and computes the window anchors in UTC so they no longer drift with the server's timezone.

- New `SP500_TIMEZONE` domain constant (`America/New_York`) lives with the other S&P 500 facts in `sp500Tickers.ts`.

### Monthly rank deltas
The report now also computes the **previous month's** ranking (the `M-2 / M-14` window) and shows month-over-month movement inline next to each rank:

```
Rank  Stock                   12m Ret      Price
----  --------------------  ---------  ---------
  3▲  Micron Tech… (MU)       597.53%    $542.26
  4▲  Intel Corpo… (INTC)     399.30%     $99.66
  6▼  Amcor plc O… (AMCR)     315.64%     $37.74
```

- `▲` climbed, `▼` slipped, `★` new entry, blank = held.
- Footer now also clarifies that `Price` is the formation-window close, not the live quote (the 12-1 window skips the most recent month).

### Cleanup
- Removed now-dead `findFirstTradingDay` / `findLastTradingDay` from `TimeUtil`.

## Notes
Pure helpers (`getExchangeYearMonth`, `getMomentumWindow`, `withRankDeltas`, `rankDeltaIcon`) are unit-tested, including the timezone edge cases (late-night EDT/EST crossing the UTC date) and window math across year boundaries and weekends.