### PR TITLE
feat(trading-strategies): deterministic momentum "too-late" scorecard (+ FMP data client)

### DIFF
--- a/packages/exchange/src/data/fmp/FmpAPI.ts
+++ b/packages/exchange/src/data/fmp/FmpAPI.ts
@@ -4,6 +4,7 @@ import {ms} from 'ms';
 import {z} from 'zod';
 import {FmpAnalystEstimateSchema} from './schema/FmpAnalystEstimateSchema.js';
 import {FmpPriceTargetConsensusSchema} from './schema/FmpPriceTargetConsensusSchema.js';
+import {FmpPriceTargetSummarySchema} from './schema/FmpPriceTargetSummarySchema.js';
 import {FmpQuoteSchema} from './schema/FmpQuoteSchema.js';
 import {FmpRatingsSnapshotSchema} from './schema/FmpRatingsSnapshotSchema.js';
 import {simplifyError} from '../../util/simplifyError.js';
@@ -53,5 +54,11 @@ export class FmpAPI {
   async getRatingsSnapshot(symbol: string) {
     const response = await this.#client.get('/ratings-snapshot', {params: {symbol}});
     return z.array(FmpRatingsSnapshotSchema).parse(response.data)[0];
+  }
+
+  /** @see https://site.financialmodelingprep.com/developer/docs/stable#price-target-summary */
+  async getPriceTargetSummary(symbol: string) {
+    const response = await this.#client.get('/price-target-summary', {params: {symbol}});
+    return z.array(FmpPriceTargetSummarySchema).parse(response.data)[0];
   }
 }

--- a/packages/exchange/src/data/fmp/FmpAPI.ts
+++ b/packages/exchange/src/data/fmp/FmpAPI.ts
@@ -1,0 +1,57 @@
+import axios from 'axios';
+import axiosRetry from 'axios-retry';
+import {ms} from 'ms';
+import {z} from 'zod';
+import {FmpAnalystEstimateSchema} from './schema/FmpAnalystEstimateSchema.js';
+import {FmpPriceTargetConsensusSchema} from './schema/FmpPriceTargetConsensusSchema.js';
+import {FmpQuoteSchema} from './schema/FmpQuoteSchema.js';
+import {FmpRatingsSnapshotSchema} from './schema/FmpRatingsSnapshotSchema.js';
+import {simplifyError} from '../../util/simplifyError.js';
+
+/**
+ * Read-only client for Financial Modeling Prep's "stable" REST API. Covers the handful of
+ * research endpoints the momentum scorecard needs: quotes, analyst price-target consensus,
+ * forward EPS estimates, and the aggregate rating. The API key is sent as the `apikey` query
+ * parameter on every request, per FMP's convention.
+ *
+ * @see https://site.financialmodelingprep.com/developer/docs/stable
+ */
+export class FmpAPI {
+  readonly #client;
+
+  constructor(options: {apiKey: string}) {
+    this.#client = axios.create({
+      baseURL: 'https://financialmodelingprep.com/stable',
+      params: {apikey: options.apiKey},
+    });
+    axiosRetry(this.#client, {
+      retries: 5,
+      retryDelay: retryCount => retryCount * ms('1s'),
+    });
+    simplifyError(this.#client);
+  }
+
+  /** @see https://site.financialmodelingprep.com/developer/docs/stable#quote */
+  async getQuote(symbol: string) {
+    const response = await this.#client.get('/quote', {params: {symbol}});
+    return z.array(FmpQuoteSchema).parse(response.data)[0];
+  }
+
+  /** @see https://site.financialmodelingprep.com/developer/docs/stable#price-target-consensus */
+  async getPriceTargetConsensus(symbol: string) {
+    const response = await this.#client.get('/price-target-consensus', {params: {symbol}});
+    return z.array(FmpPriceTargetConsensusSchema).parse(response.data)[0];
+  }
+
+  /** @see https://site.financialmodelingprep.com/developer/docs/stable#analyst-estimates */
+  async getAnalystEstimates(symbol: string, period: 'annual' | 'quarter' = 'annual') {
+    const response = await this.#client.get('/analyst-estimates', {params: {period, symbol}});
+    return z.array(FmpAnalystEstimateSchema).parse(response.data);
+  }
+
+  /** @see https://site.financialmodelingprep.com/developer/docs/stable#ratings-snapshot */
+  async getRatingsSnapshot(symbol: string) {
+    const response = await this.#client.get('/ratings-snapshot', {params: {symbol}});
+    return z.array(FmpRatingsSnapshotSchema).parse(response.data)[0];
+  }
+}

--- a/packages/exchange/src/data/fmp/index.ts
+++ b/packages/exchange/src/data/fmp/index.ts
@@ -1,5 +1,6 @@
 export * from './FmpAPI.js';
 export * from './schema/FmpQuoteSchema.js';
 export * from './schema/FmpPriceTargetConsensusSchema.js';
+export * from './schema/FmpPriceTargetSummarySchema.js';
 export * from './schema/FmpAnalystEstimateSchema.js';
 export * from './schema/FmpRatingsSnapshotSchema.js';

--- a/packages/exchange/src/data/fmp/index.ts
+++ b/packages/exchange/src/data/fmp/index.ts
@@ -1,0 +1,5 @@
+export * from './FmpAPI.js';
+export * from './schema/FmpQuoteSchema.js';
+export * from './schema/FmpPriceTargetConsensusSchema.js';
+export * from './schema/FmpAnalystEstimateSchema.js';
+export * from './schema/FmpRatingsSnapshotSchema.js';

--- a/packages/exchange/src/data/fmp/schema/FmpAnalystEstimateSchema.ts
+++ b/packages/exchange/src/data/fmp/schema/FmpAnalystEstimateSchema.ts
@@ -1,0 +1,10 @@
+import {z} from 'zod';
+
+/** @see https://site.financialmodelingprep.com/developer/docs/stable#analyst-estimates */
+export const FmpAnalystEstimateSchema = z.looseObject({
+  date: z.string(),
+  epsAvg: z.number(),
+  symbol: z.string(),
+});
+
+export type FmpAnalystEstimate = z.infer<typeof FmpAnalystEstimateSchema>;

--- a/packages/exchange/src/data/fmp/schema/FmpPriceTargetConsensusSchema.ts
+++ b/packages/exchange/src/data/fmp/schema/FmpPriceTargetConsensusSchema.ts
@@ -1,0 +1,12 @@
+import {z} from 'zod';
+
+/** @see https://site.financialmodelingprep.com/developer/docs/stable#price-target-consensus */
+export const FmpPriceTargetConsensusSchema = z.looseObject({
+  symbol: z.string(),
+  targetConsensus: z.number(),
+  targetHigh: z.number(),
+  targetLow: z.number(),
+  targetMedian: z.number(),
+});
+
+export type FmpPriceTargetConsensus = z.infer<typeof FmpPriceTargetConsensusSchema>;

--- a/packages/exchange/src/data/fmp/schema/FmpPriceTargetSummarySchema.ts
+++ b/packages/exchange/src/data/fmp/schema/FmpPriceTargetSummarySchema.ts
@@ -1,0 +1,10 @@
+import {z} from 'zod';
+
+/** @see https://site.financialmodelingprep.com/developer/docs/stable#price-target-summary */
+export const FmpPriceTargetSummarySchema = z.looseObject({
+  lastMonthAvgPriceTarget: z.number(),
+  lastQuarterAvgPriceTarget: z.number(),
+  symbol: z.string(),
+});
+
+export type FmpPriceTargetSummary = z.infer<typeof FmpPriceTargetSummarySchema>;

--- a/packages/exchange/src/data/fmp/schema/FmpQuoteSchema.ts
+++ b/packages/exchange/src/data/fmp/schema/FmpQuoteSchema.ts
@@ -1,0 +1,11 @@
+import {z} from 'zod';
+
+/** @see https://site.financialmodelingprep.com/developer/docs/stable#quote */
+export const FmpQuoteSchema = z.looseObject({
+  price: z.number(),
+  priceAvg50: z.number(),
+  priceAvg200: z.number(),
+  symbol: z.string(),
+});
+
+export type FmpQuote = z.infer<typeof FmpQuoteSchema>;

--- a/packages/exchange/src/data/fmp/schema/FmpRatingsSnapshotSchema.ts
+++ b/packages/exchange/src/data/fmp/schema/FmpRatingsSnapshotSchema.ts
@@ -1,0 +1,9 @@
+import {z} from 'zod';
+
+/** @see https://site.financialmodelingprep.com/developer/docs/stable#ratings-snapshot */
+export const FmpRatingsSnapshotSchema = z.looseObject({
+  rating: z.string(),
+  symbol: z.string(),
+});
+
+export type FmpRatingsSnapshot = z.infer<typeof FmpRatingsSnapshotSchema>;

--- a/packages/exchange/src/data/index.ts
+++ b/packages/exchange/src/data/index.ts
@@ -1,0 +1,1 @@
+export * from './fmp/index.js';

--- a/packages/exchange/src/index.ts
+++ b/packages/exchange/src/index.ts
@@ -1,5 +1,6 @@
 export * from './candle/index.js';
 export * from './broker/index.js';
+export * from './data/index.js';
 export * from './broker/alpaca/index.js';
 export * from './broker/trading212/index.js';
 export * from './trader/index.js';

--- a/packages/trading-strategies/src/index.ts
+++ b/packages/trading-strategies/src/index.ts
@@ -1,4 +1,5 @@
 export * from './backtest/index.js';
+export * from './scorecard/index.js';
 export * from './strategy/index.js';
 export {BuyOnceStrategy, BuyOnceSchema, type BuyOnceConfig} from './strategy-buy-once/BuyOnceStrategy.js';
 /** @deprecated Use {@link BuyOnceStrategy} without `buyAt` instead. */

--- a/packages/trading-strategies/src/scorecard/MomentumScorecard.ts
+++ b/packages/trading-strategies/src/scorecard/MomentumScorecard.ts
@@ -33,6 +33,7 @@ export class MomentumScorecard {
     return {
       epsForwardYear1,
       epsForwardYear2,
+      movingAverage50: quote.priceAvg50,
       movingAverage200: quote.priceAvg200,
       price: quote.price,
       rating: ratings.rating,

--- a/packages/trading-strategies/src/scorecard/MomentumScorecard.ts
+++ b/packages/trading-strategies/src/scorecard/MomentumScorecard.ts
@@ -20,11 +20,12 @@ export class MomentumScorecard {
   }
 
   async #fetchInput(ticker: string, now: Date): Promise<ScorecardInput> {
-    const [quote, target, estimates, ratings] = await Promise.all([
+    const [quote, target, estimates, ratings, targetSummary] = await Promise.all([
       this.#fmp.getQuote(ticker),
       this.#fmp.getPriceTargetConsensus(ticker),
       this.#fmp.getAnalystEstimates(ticker, 'annual'),
       this.#fmp.getRatingsSnapshot(ticker),
+      this.#fmp.getPriceTargetSummary(ticker),
     ]);
 
     const {epsForwardYear1, epsForwardYear2} = selectForwardEps(estimates, now);
@@ -36,6 +37,8 @@ export class MomentumScorecard {
       price: quote.price,
       rating: ratings.rating,
       targetConsensus: target.targetConsensus,
+      targetLastMonth: targetSummary.lastMonthAvgPriceTarget,
+      targetLastQuarter: targetSummary.lastQuarterAvgPriceTarget,
       ticker,
     };
   }

--- a/packages/trading-strategies/src/scorecard/MomentumScorecard.ts
+++ b/packages/trading-strategies/src/scorecard/MomentumScorecard.ts
@@ -1,0 +1,42 @@
+import type {FmpAPI} from '@typedtrader/exchange';
+import {computeScorecard, selectForwardEps, type ScorecardInput, type ScorecardRow} from './computeScorecard.js';
+
+/**
+ * Builds the deterministic momentum scorecard from live Financial Modeling Prep data: it fetches the
+ * raw figures per ticker, then hands them to {@link computeScorecard} for the actual scoring. All
+ * judgement lives in the pure rubric — this class is only I/O.
+ */
+export class MomentumScorecard {
+  readonly #fmp: FmpAPI;
+
+  constructor(fmp: FmpAPI) {
+    this.#fmp = fmp;
+  }
+
+  /** Scores each ticker (e.g. the momentum report's top winners), best-first. `now` anchors forward-year selection. */
+  async build(tickers: string[], now: Date): Promise<ScorecardRow[]> {
+    const inputs = await Promise.all(tickers.map(ticker => this.#fetchInput(ticker, now)));
+    return computeScorecard(inputs);
+  }
+
+  async #fetchInput(ticker: string, now: Date): Promise<ScorecardInput> {
+    const [quote, target, estimates, ratings] = await Promise.all([
+      this.#fmp.getQuote(ticker),
+      this.#fmp.getPriceTargetConsensus(ticker),
+      this.#fmp.getAnalystEstimates(ticker, 'annual'),
+      this.#fmp.getRatingsSnapshot(ticker),
+    ]);
+
+    const {epsForwardYear1, epsForwardYear2} = selectForwardEps(estimates, now);
+
+    return {
+      epsForwardYear1,
+      epsForwardYear2,
+      movingAverage200: quote.priceAvg200,
+      price: quote.price,
+      rating: ratings.rating,
+      targetConsensus: target.targetConsensus,
+      ticker,
+    };
+  }
+}

--- a/packages/trading-strategies/src/scorecard/computeScorecard.test.ts
+++ b/packages/trading-strategies/src/scorecard/computeScorecard.test.ts
@@ -5,6 +5,7 @@ import {
   scoreForwardPE,
   scoreGrowth,
   scoreRating,
+  scoreRevisionMomentum,
   scoreUpside,
   selectForwardEps,
 } from './computeScorecard.js';
@@ -57,6 +58,15 @@ describe('scoreRating', () => {
   });
 });
 
+describe('scoreRevisionMomentum', () => {
+  it('rewards rising targets and punishes cuts', () => {
+    expect(scoreRevisionMomentum(4), 'targets raised sharply').toBe(2);
+    expect(scoreRevisionMomentum(1), 'targets nudged up').toBe(1);
+    expect(scoreRevisionMomentum(0), 'flat').toBe(0);
+    expect(scoreRevisionMomentum(-2), 'targets being cut').toBe(-2);
+  });
+});
+
 describe('computeScorecard', () => {
   it('ranks a clean entry above an overextended momentum name', () => {
     /*
@@ -71,6 +81,8 @@ describe('computeScorecard', () => {
         price: 675.39,
         rating: 'B+',
         targetConsensus: 479.29,
+        targetLastMonth: 479.29,
+        targetLastQuarter: 479.29,
         ticker: 'WDC',
       },
       {
@@ -80,6 +92,8 @@ describe('computeScorecard', () => {
         price: 343.71,
         rating: 'B+',
         targetConsensus: 411.8,
+        targetLastMonth: 411.8,
+        targetLastQuarter: 411.8,
         ticker: 'GOOGL',
       },
     ]);
@@ -100,14 +114,50 @@ describe('computeScorecard', () => {
         price: 26.98,
         rating: 'C',
         targetConsensus: 30.8,
+        targetLastMonth: 30.8,
+        targetLastQuarter: 30.8,
         ticker: 'WBD',
       },
     ]);
 
     expect(row.forwardPE, 'no multiple when EPS is negative').toBeNull();
     expect(row.epsGrowthPct, 'no growth ratio when base EPS is negative').toBeNull();
-    // upside +14% (+1), extension +6% (+2), PE null (-1), growth null (-2), rating C (-1) = -1
+    // upside +14% (+1), extension +6% (+2), PE null (-1), growth null (-2), rating C (-1), revision flat (0) = -1
     expect(row.score).toBe(-1);
+  });
+
+  it('lifts a name whose analysts are still raising targets', () => {
+    const base = {
+      epsForwardYear1: 10,
+      epsForwardYear2: 12,
+      movingAverage200: 100,
+      price: 110,
+      rating: 'B',
+      targetConsensus: 120,
+      ticker: 'AAA',
+    };
+    const [flat] = computeScorecard([{...base, targetLastMonth: 120, targetLastQuarter: 120}]);
+    const [rising] = computeScorecard([{...base, targetLastMonth: 126, targetLastQuarter: 120}]); // +5%
+
+    expect(rising.revisionPct, 'targets up 5%').toBeCloseTo(5);
+    expect(rising.score - flat.score, 'rising targets add the +2 band').toBe(2);
+  });
+
+  it('treats a missing last-month target as neutral, not a 100% cut', () => {
+    const [row] = computeScorecard([
+      {
+        epsForwardYear1: 10,
+        epsForwardYear2: 12,
+        movingAverage200: 100,
+        price: 110,
+        rating: 'B',
+        targetConsensus: 120,
+        targetLastMonth: 0, // no analyst issued a target in the last month
+        targetLastQuarter: 120,
+        ticker: 'AAA',
+      },
+    ]);
+    expect(row.revisionPct, 'no recent target → neutral, not -100%').toBe(0);
   });
 
   it('is order-independent: shuffled inputs produce the same ranking', () => {
@@ -119,6 +169,8 @@ describe('computeScorecard', () => {
         price: 1213,
         rating: 'A-',
         targetConsensus: 1496,
+        targetLastMonth: 1438,
+        targetLastQuarter: 1389,
         ticker: 'MU',
       },
       {
@@ -128,6 +180,8 @@ describe('computeScorecard', () => {
         price: 343,
         rating: 'B+',
         targetConsensus: 411,
+        targetLastMonth: 411,
+        targetLastQuarter: 411,
         ticker: 'GOOGL',
       },
       {
@@ -137,6 +191,8 @@ describe('computeScorecard', () => {
         price: 132,
         rating: 'C-',
         targetConsensus: 91,
+        targetLastMonth: 91,
+        targetLastQuarter: 95,
         ticker: 'INTC',
       },
     ];

--- a/packages/trading-strategies/src/scorecard/computeScorecard.test.ts
+++ b/packages/trading-strategies/src/scorecard/computeScorecard.test.ts
@@ -1,0 +1,172 @@
+import {describe, expect, it} from 'vitest';
+import {
+  computeScorecard,
+  scoreExtension,
+  scoreForwardPE,
+  scoreGrowth,
+  scoreRating,
+  scoreUpside,
+  selectForwardEps,
+} from './computeScorecard.js';
+
+describe('scoreUpside', () => {
+  it('rewards room left and punishes overshoot', () => {
+    expect(scoreUpside(20), 'clear upside').toBe(2);
+    expect(scoreUpside(15), 'boundary is still the lower band').toBe(1);
+    expect(scoreUpside(0), 'at target').toBe(1);
+    expect(scoreUpside(-5), 'mild overshoot').toBe(0);
+    expect(scoreUpside(-11), 'badly overshot').toBe(-2);
+  });
+});
+
+describe('scoreExtension', () => {
+  it('punishes a stretched chart', () => {
+    expect(scoreExtension(10), 'close to the 200-day').toBe(2);
+    expect(scoreExtension(40), 'moderately extended').toBe(1);
+    expect(scoreExtension(80), 'extended').toBe(0);
+    expect(scoreExtension(150), 'parabolic').toBe(-2);
+  });
+});
+
+describe('scoreForwardPE', () => {
+  it('rewards cheap-vs-growth and flags loss-making', () => {
+    expect(scoreForwardPE(10)).toBe(2);
+    expect(scoreForwardPE(30)).toBe(1);
+    expect(scoreForwardPE(50)).toBe(0);
+    expect(scoreForwardPE(80), 'rich').toBe(-1);
+    expect(scoreForwardPE(null), 'loss-making').toBe(-1);
+  });
+});
+
+describe('scoreGrowth', () => {
+  it('rewards acceleration and punishes shrinkage', () => {
+    expect(scoreGrowth(95)).toBe(2);
+    expect(scoreGrowth(20)).toBe(1);
+    expect(scoreGrowth(5)).toBe(0);
+    expect(scoreGrowth(-34), 'earnings falling').toBe(-2);
+    expect(scoreGrowth(null), 'loss-making').toBe(-2);
+  });
+});
+
+describe('scoreRating', () => {
+  it('maps the leading letter grade', () => {
+    expect(scoreRating('A-')).toBe(1);
+    expect(scoreRating('B+')).toBe(0);
+    expect(scoreRating('C')).toBe(-1);
+    expect(scoreRating('b (3)'), 'case-insensitive, ignores trailing detail').toBe(0);
+  });
+});
+
+describe('computeScorecard', () => {
+  it('ranks a clean entry above an overextended momentum name', () => {
+    /*
+     * GOOGL: room left, barely extended, reasonable multiple → high score.
+     * WDC: overshot its target and ~146% over its 200-day → low score.
+     */
+    const rows = computeScorecard([
+      {
+        epsForwardYear1: 9.98737,
+        epsForwardYear2: 17.79608,
+        movingAverage200: 275.00195,
+        price: 675.39,
+        rating: 'B+',
+        targetConsensus: 479.29,
+        ticker: 'WDC',
+      },
+      {
+        epsForwardYear1: 14.24199,
+        epsForwardYear2: 14.71419,
+        movingAverage200: 312.8154,
+        price: 343.71,
+        rating: 'B+',
+        targetConsensus: 411.8,
+        ticker: 'GOOGL',
+      },
+    ]);
+
+    expect(
+      rows.map(r => r.ticker),
+      'cleaner entry ranks first'
+    ).toEqual(['GOOGL', 'WDC']);
+    expect(rows[0].score).toBeGreaterThan(rows[1].score);
+  });
+
+  it('treats a loss-making name as not meaningful for PE and growth', () => {
+    const [row] = computeScorecard([
+      {
+        epsForwardYear1: -1.31671,
+        epsForwardYear2: -0.050203,
+        movingAverage200: 25.3797,
+        price: 26.98,
+        rating: 'C',
+        targetConsensus: 30.8,
+        ticker: 'WBD',
+      },
+    ]);
+
+    expect(row.forwardPE, 'no multiple when EPS is negative').toBeNull();
+    expect(row.epsGrowthPct, 'no growth ratio when base EPS is negative').toBeNull();
+    // upside +14% (+1), extension +6% (+2), PE null (-1), growth null (-2), rating C (-1) = -1
+    expect(row.score).toBe(-1);
+  });
+
+  it('is order-independent: shuffled inputs produce the same ranking', () => {
+    const inputs = [
+      {
+        epsForwardYear1: 68,
+        epsForwardYear2: 133,
+        movingAverage200: 415,
+        price: 1213,
+        rating: 'A-',
+        targetConsensus: 1496,
+        ticker: 'MU',
+      },
+      {
+        epsForwardYear1: 14,
+        epsForwardYear2: 14,
+        movingAverage200: 312,
+        price: 343,
+        rating: 'B+',
+        targetConsensus: 411,
+        ticker: 'GOOGL',
+      },
+      {
+        epsForwardYear1: 1.08,
+        epsForwardYear2: 1.57,
+        movingAverage200: 57,
+        price: 132,
+        rating: 'C-',
+        targetConsensus: 91,
+        ticker: 'INTC',
+      },
+    ];
+    const forward = computeScorecard(inputs).map(r => r.ticker);
+    const reversed = computeScorecard([...inputs].reverse()).map(r => r.ticker);
+    expect(forward).toEqual(reversed);
+  });
+});
+
+describe('selectForwardEps', () => {
+  const estimates = [
+    {date: '2024-08-28', epsAvg: 1.21},
+    {date: '2025-08-28', epsAvg: 8.09},
+    {date: '2026-08-28', epsAvg: 68.12},
+    {date: '2027-08-28', epsAvg: 133.02},
+  ];
+
+  it('picks the two nearest fiscal years after now', () => {
+    const result = selectForwardEps(estimates, new Date('2026-06-26T00:00:00Z'));
+    expect(result).toEqual({epsForwardYear1: 68.12, epsForwardYear2: 133.02});
+  });
+
+  it('ignores the ordering of the input list', () => {
+    const result = selectForwardEps([...estimates].reverse(), new Date('2026-06-26T00:00:00Z'));
+    expect(result).toEqual({epsForwardYear1: 68.12, epsForwardYear2: 133.02});
+  });
+
+  it('throws when fewer than two forward years are available', () => {
+    expect(() => selectForwardEps(estimates, new Date('2027-01-01T00:00:00Z'))).toThrow(
+      /at least two forward estimates/
+    );
+  });
+});

--- a/packages/trading-strategies/src/scorecard/computeScorecard.test.ts
+++ b/packages/trading-strategies/src/scorecard/computeScorecard.test.ts
@@ -6,6 +6,7 @@ import {
   scoreGrowth,
   scoreRating,
   scoreRevisionMomentum,
+  scoreTrendBreak,
   scoreUpside,
   selectForwardEps,
 } from './computeScorecard.js';
@@ -67,6 +68,14 @@ describe('scoreRevisionMomentum', () => {
   });
 });
 
+describe('scoreTrendBreak', () => {
+  it('penalizes a real break but spares an ordinary wobble', () => {
+    expect(scoreTrendBreak(91, 110), '~17% below — broken').toBe(-3);
+    expect(scoreTrendBreak(108, 110), '~2% below — normal dip').toBe(0);
+    expect(scoreTrendBreak(120, 110), 'above the 50-day').toBe(0);
+  });
+});
+
 describe('computeScorecard', () => {
   it('ranks a clean entry above an overextended momentum name', () => {
     /*
@@ -77,6 +86,7 @@ describe('computeScorecard', () => {
       {
         epsForwardYear1: 9.98737,
         epsForwardYear2: 17.79608,
+        movingAverage50: 600,
         movingAverage200: 275.00195,
         price: 675.39,
         rating: 'B+',
@@ -88,6 +98,7 @@ describe('computeScorecard', () => {
       {
         epsForwardYear1: 14.24199,
         epsForwardYear2: 14.71419,
+        movingAverage50: 320,
         movingAverage200: 312.8154,
         price: 343.71,
         rating: 'B+',
@@ -110,6 +121,7 @@ describe('computeScorecard', () => {
       {
         epsForwardYear1: -1.31671,
         epsForwardYear2: -0.050203,
+        movingAverage50: 26,
         movingAverage200: 25.3797,
         price: 26.98,
         rating: 'C',
@@ -122,7 +134,7 @@ describe('computeScorecard', () => {
 
     expect(row.forwardPE, 'no multiple when EPS is negative').toBeNull();
     expect(row.epsGrowthPct, 'no growth ratio when base EPS is negative').toBeNull();
-    // upside +14% (+1), extension +6% (+2), PE null (-1), growth null (-2), rating C (-1), revision flat (0) = -1
+    // upside +14% (+1), extension +6% (+2), PE null (-1), growth null (-2), rating C (-1), revision flat (0), trend ok (0) = -1
     expect(row.score).toBe(-1);
   });
 
@@ -130,6 +142,7 @@ describe('computeScorecard', () => {
     const base = {
       epsForwardYear1: 10,
       epsForwardYear2: 12,
+      movingAverage50: 100,
       movingAverage200: 100,
       price: 110,
       rating: 'B',
@@ -148,6 +161,7 @@ describe('computeScorecard', () => {
       {
         epsForwardYear1: 10,
         epsForwardYear2: 12,
+        movingAverage50: 100,
         movingAverage200: 100,
         price: 110,
         rating: 'B',
@@ -160,11 +174,35 @@ describe('computeScorecard', () => {
     expect(row.revisionPct, 'no recent target → neutral, not -100%').toBe(0);
   });
 
+  it('demotes a falling knife: below its 50-day despite a stale-target upside', () => {
+    // ON-like: crashed to 91 (target still 110 → looks like +21% upside), but broke its 50-day.
+    const broken = {
+      epsForwardYear1: 4,
+      epsForwardYear2: 5,
+      movingAverage50: 110,
+      movingAverage200: 70,
+      price: 91,
+      rating: 'B',
+      targetConsensus: 110,
+      targetLastMonth: 110,
+      targetLastQuarter: 110,
+      ticker: 'ON',
+    };
+    const [row] = computeScorecard([broken]);
+    expect(row.trendBroken, 'price below its 50-day').toBe(true);
+
+    // The same name still holding its 50-day would score exactly 3 higher (no guard penalty).
+    const [held] = computeScorecard([{...broken, movingAverage50: 85}]);
+    expect(held.trendBroken).toBe(false);
+    expect(held.score - row.score, 'the guard costs 3 points').toBe(3);
+  });
+
   it('is order-independent: shuffled inputs produce the same ranking', () => {
     const inputs = [
       {
         epsForwardYear1: 68,
         epsForwardYear2: 133,
+        movingAverage50: 1000,
         movingAverage200: 415,
         price: 1213,
         rating: 'A-',
@@ -176,6 +214,7 @@ describe('computeScorecard', () => {
       {
         epsForwardYear1: 14,
         epsForwardYear2: 14,
+        movingAverage50: 320,
         movingAverage200: 312,
         price: 343,
         rating: 'B+',
@@ -187,6 +226,7 @@ describe('computeScorecard', () => {
       {
         epsForwardYear1: 1.08,
         epsForwardYear2: 1.57,
+        movingAverage50: 120,
         movingAverage200: 57,
         price: 132,
         rating: 'C-',

--- a/packages/trading-strategies/src/scorecard/computeScorecard.test.ts
+++ b/packages/trading-strategies/src/scorecard/computeScorecard.test.ts
@@ -4,9 +4,9 @@ import {
   scoreExtension,
   scoreForwardPE,
   scoreGrowth,
+  isTrendBroken,
   scoreRating,
   scoreRevisionMomentum,
-  scoreTrendBreak,
   scoreUpside,
   selectForwardEps,
 } from './computeScorecard.js';
@@ -68,11 +68,12 @@ describe('scoreRevisionMomentum', () => {
   });
 });
 
-describe('scoreTrendBreak', () => {
-  it('penalizes a real break but spares an ordinary wobble', () => {
-    expect(scoreTrendBreak(91, 110), '~17% below — broken').toBe(-3);
-    expect(scoreTrendBreak(108, 110), '~2% below — normal dip').toBe(0);
-    expect(scoreTrendBreak(120, 110), 'above the 50-day').toBe(0);
+describe('isTrendBroken', () => {
+  it('flags a real break but spares an ordinary selloff pullback', () => {
+    expect(isTrendBroken(91, 110), '~17% below — broken').toBe(true);
+    expect(isTrendBroken(100, 110), '~9% below — pullback, not a break').toBe(false);
+    expect(isTrendBroken(108, 110), '~2% below — normal dip').toBe(false);
+    expect(isTrendBroken(120, 110), 'above the 50-day').toBe(false);
   });
 });
 
@@ -190,11 +191,13 @@ describe('computeScorecard', () => {
     };
     const [row] = computeScorecard([broken]);
     expect(row.trendBroken, 'price below its 50-day').toBe(true);
+    // Neutralized: upside +2 → 0, extension +1 → 0, plus a -2 penalty. fwdPE +1, growth +1 remain → 0.
+    expect(row.score).toBe(0);
 
-    // The same name still holding its 50-day would score exactly 3 higher (no guard penalty).
+    // The same name holding its 50-day keeps its upside/extension credit and takes no penalty.
     const [held] = computeScorecard([{...broken, movingAverage50: 85}]);
     expect(held.trendBroken).toBe(false);
-    expect(held.score - row.score, 'the guard costs 3 points').toBe(3);
+    expect(held.score - row.score, 'the broken trend costs the +3 of stale bands plus a -2 penalty').toBe(5);
   });
 
   it('is order-independent: shuffled inputs produce the same ranking', () => {

--- a/packages/trading-strategies/src/scorecard/computeScorecard.ts
+++ b/packages/trading-strategies/src/scorecard/computeScorecard.ts
@@ -2,9 +2,9 @@
  * Deterministic "am I too late?" scorecard for momentum names.
  *
  * The rubric exists to answer one question — has a stock already run past the point of a sensible
- * entry? — so every band rewards room left (upside, low extension, reasonable valuation, growth)
- * and punishes a stretched, priced-for-perfection chart. Same inputs always yield the same ranking;
- * a stock's score never depends on the others in the list.
+ * entry? — so every band rewards room left (upside, low extension, reasonable valuation, growth,
+ * and analysts still raising targets) and punishes a stretched, priced-for-perfection chart. Same
+ * inputs always yield the same ranking; a stock's score never depends on the others in the list.
  */
 
 /** Raw, per-ticker inputs the rubric scores. The orchestrator fills these from the data provider. */
@@ -19,6 +19,10 @@ export interface ScorecardInput {
   epsForwardYear2: number;
   /** Aggregate analyst letter grade (e.g. "A-", "B+", "C"). */
   rating: string;
+  /** Average analyst price target as of last month — for estimate-revision momentum. */
+  targetLastMonth: number;
+  /** Average analyst price target as of last quarter — the baseline the last month is compared against. */
+  targetLastQuarter: number;
 }
 
 export interface ScorecardRow {
@@ -33,7 +37,9 @@ export interface ScorecardRow {
   /** Distance above the 200-day moving average, in percent. The primary "too late" gauge. */
   extensionPct: number;
   rating: string;
-  /** Sum of the five rubric bands; higher means more room left (less likely to be too late). */
+  /** Recent change in the average target (last month vs last quarter), in percent. Positive = analysts raising. */
+  revisionPct: number;
+  /** Sum of the six rubric bands; higher means more room left (less likely to be too late). */
   score: number;
 }
 
@@ -106,18 +112,45 @@ export function scoreRating(rating: string) {
   return -1; // C or worse, or unrecognized
 }
 
+/**
+ * Estimate-revision momentum: the recent move in the average analyst target. This is the one band
+ * that re-admits "trend" — rising targets are the fundamental tell that a move will persist rather
+ * than exhaust, and it isn't captured by valuation, growth, or a composite sentiment score.
+ */
+export function scoreRevisionMomentum(revisionPct: number) {
+  if (revisionPct >= 3) {
+    return 2; // analysts raising targets fast
+  }
+  if (revisionPct >= 0.5) {
+    return 1;
+  }
+  if (revisionPct > -0.5) {
+    return 0; // roughly flat
+  }
+  return -2; // targets being cut — momentum fading
+}
+
 function toRow(input: ScorecardInput): ScorecardRow {
   const upsidePct = (input.targetConsensus / input.price - 1) * 100;
   const extensionPct = (input.price / input.movingAverage200 - 1) * 100;
   const forwardPE = input.epsForwardYear1 > 0 ? input.price / input.epsForwardYear1 : null;
   const epsGrowthPct = input.epsForwardYear1 > 0 ? (input.epsForwardYear2 / input.epsForwardYear1 - 1) * 100 : null;
+  /*
+   * Both must be present: a zero last-month target means "no target issued recently" (missing data),
+   * not a 100% cut, so it scores neutral rather than getting hammered.
+   */
+  const revisionPct =
+    input.targetLastMonth > 0 && input.targetLastQuarter > 0
+      ? (input.targetLastMonth / input.targetLastQuarter - 1) * 100
+      : 0;
 
   const score =
     scoreUpside(upsidePct) +
     scoreExtension(extensionPct) +
     scoreForwardPE(forwardPE) +
     scoreGrowth(epsGrowthPct) +
-    scoreRating(input.rating);
+    scoreRating(input.rating) +
+    scoreRevisionMomentum(revisionPct);
 
   return {
     epsGrowthPct,
@@ -125,6 +158,7 @@ function toRow(input: ScorecardInput): ScorecardRow {
     forwardPE,
     price: input.price,
     rating: input.rating,
+    revisionPct,
     score,
     ticker: input.ticker,
     upsidePct,

--- a/packages/trading-strategies/src/scorecard/computeScorecard.ts
+++ b/packages/trading-strategies/src/scorecard/computeScorecard.ts
@@ -1,0 +1,159 @@
+/**
+ * Deterministic "am I too late?" scorecard for momentum names.
+ *
+ * The rubric exists to answer one question — has a stock already run past the point of a sensible
+ * entry? — so every band rewards room left (upside, low extension, reasonable valuation, growth)
+ * and punishes a stretched, priced-for-perfection chart. Same inputs always yield the same ranking;
+ * a stock's score never depends on the others in the list.
+ */
+
+/** Raw, per-ticker inputs the rubric scores. The orchestrator fills these from the data provider. */
+export interface ScorecardInput {
+  ticker: string;
+  price: number;
+  movingAverage200: number;
+  targetConsensus: number;
+  /** Average EPS estimate for the nearest forward fiscal year. */
+  epsForwardYear1: number;
+  /** Average EPS estimate for the fiscal year after that. */
+  epsForwardYear2: number;
+  /** Aggregate analyst letter grade (e.g. "A-", "B+", "C"). */
+  rating: string;
+}
+
+export interface ScorecardRow {
+  ticker: string;
+  price: number;
+  /** Upside to the consensus target, in percent. Negative means price already overshot the target. */
+  upsidePct: number;
+  /** Price over nearest-year EPS. `null` when that EPS is not positive (loss-making). */
+  forwardPE: number | null;
+  /** Year-2 vs year-1 EPS growth, in percent. `null` when year-1 EPS is not positive. */
+  epsGrowthPct: number | null;
+  /** Distance above the 200-day moving average, in percent. The primary "too late" gauge. */
+  extensionPct: number;
+  rating: string;
+  /** Sum of the five rubric bands; higher means more room left (less likely to be too late). */
+  score: number;
+}
+
+export function scoreUpside(upsidePct: number) {
+  if (upsidePct > 15) {
+    return 2;
+  }
+  if (upsidePct >= 0) {
+    return 1;
+  }
+  if (upsidePct >= -10) {
+    return 0;
+  }
+  return -2;
+}
+
+export function scoreExtension(extensionPct: number) {
+  if (extensionPct < 25) {
+    return 2;
+  }
+  if (extensionPct < 60) {
+    return 1;
+  }
+  if (extensionPct <= 100) {
+    return 0;
+  }
+  return -2;
+}
+
+export function scoreForwardPE(forwardPE: number | null) {
+  if (forwardPE === null || forwardPE <= 0) {
+    return -1; // loss-making — no meaningful multiple
+  }
+  if (forwardPE < 20) {
+    return 2;
+  }
+  if (forwardPE < 40) {
+    return 1;
+  }
+  if (forwardPE <= 60) {
+    return 0;
+  }
+  return -1;
+}
+
+export function scoreGrowth(epsGrowthPct: number | null) {
+  if (epsGrowthPct === null) {
+    return -2; // loss-making — growth not meaningful
+  }
+  if (epsGrowthPct > 40) {
+    return 2;
+  }
+  if (epsGrowthPct >= 15) {
+    return 1;
+  }
+  if (epsGrowthPct >= 0) {
+    return 0;
+  }
+  return -2;
+}
+
+export function scoreRating(rating: string) {
+  const grade = rating.trim().charAt(0).toUpperCase();
+  if (grade === 'A') {
+    return 1;
+  }
+  if (grade === 'B') {
+    return 0;
+  }
+  return -1; // C or worse, or unrecognized
+}
+
+function toRow(input: ScorecardInput): ScorecardRow {
+  const upsidePct = (input.targetConsensus / input.price - 1) * 100;
+  const extensionPct = (input.price / input.movingAverage200 - 1) * 100;
+  const forwardPE = input.epsForwardYear1 > 0 ? input.price / input.epsForwardYear1 : null;
+  const epsGrowthPct = input.epsForwardYear1 > 0 ? (input.epsForwardYear2 / input.epsForwardYear1 - 1) * 100 : null;
+
+  const score =
+    scoreUpside(upsidePct) +
+    scoreExtension(extensionPct) +
+    scoreForwardPE(forwardPE) +
+    scoreGrowth(epsGrowthPct) +
+    scoreRating(input.rating);
+
+  return {
+    epsGrowthPct,
+    extensionPct,
+    forwardPE,
+    price: input.price,
+    rating: input.rating,
+    score,
+    ticker: input.ticker,
+    upsidePct,
+  };
+}
+
+/**
+ * Scores each input against the rubric and returns the rows best-first. Ties break by upside, then
+ * ticker, so the ordering is fully determined by the inputs.
+ */
+export function computeScorecard(inputs: ScorecardInput[]): ScorecardRow[] {
+  return inputs
+    .map(toRow)
+    .sort((a, b) => b.score - a.score || b.upsidePct - a.upsidePct || a.ticker.localeCompare(b.ticker));
+}
+
+/**
+ * Picks the two nearest forward fiscal years from a provider's estimate list. Anchored to an
+ * injected `now` rather than the wall clock so the selection is reproducible in tests.
+ */
+export function selectForwardEps(estimates: {date: string; epsAvg: number}[], now: Date) {
+  const future = estimates
+    .filter(estimate => new Date(estimate.date).getTime() > now.getTime())
+    .sort((a, b) => a.date.localeCompare(b.date));
+
+  const [year1, year2] = future;
+  if (!year1 || !year2) {
+    throw new Error(`Need at least two forward estimates after ${now.toISOString()}, found ${future.length}.`);
+  }
+
+  return {epsForwardYear1: year1.epsAvg, epsForwardYear2: year2.epsAvg};
+}

--- a/packages/trading-strategies/src/scorecard/computeScorecard.ts
+++ b/packages/trading-strategies/src/scorecard/computeScorecard.ts
@@ -4,9 +4,9 @@
  * The rubric exists to answer one question — has a stock already run past the point of a sensible
  * entry? — so every band rewards room left (upside, low extension, reasonable valuation, growth,
  * and analysts still raising targets) and punishes a stretched, priced-for-perfection chart. A
- * falling-knife guard demotes names that have broken below their 50-day, where a stale analyst
- * target makes the upside look deceptively good. Same inputs always yield the same ranking; a
- * stock's score never depends on the others in the list.
+ * falling-knife guard stops trusting the upside/extension bands (and adds a penalty) for any name
+ * that has broken well below its 50-day, where a stale analyst target makes a crash look deceptively
+ * cheap. Same inputs always yield the same ranking; a stock's score never depends on the others.
  */
 
 /** Raw, per-ticker inputs the rubric scores. The orchestrator fills these from the data provider. */
@@ -136,19 +136,27 @@ export function scoreRevisionMomentum(revisionPct: number) {
   return -2; // targets being cut — momentum fading
 }
 
-/** How far below its 50-day a name must fall to count as a broken trend rather than a normal wobble. */
-const FALLING_KNIFE_THRESHOLD_PCT = -8;
+/**
+ * How far below its 50-day a name must fall to count as a broken trend rather than a normal pullback.
+ * Set deliberately deep: in a broad selloff healthy names routinely sit ~5–10% under their 50-day,
+ * and only a genuine break (well past that) signals a stale target.
+ */
+const FALLING_KNIFE_THRESHOLD_PCT = -15;
+
+/** Penalty once a trend is broken — a gap-down is real negative information, not a discount. */
+const TREND_BREAK_PENALTY = -2;
 
 /**
- * Falling-knife guard. A momentum name trades above its 50-day by definition; once it drops well
- * through it, the short-term trend has broken and — critically — the analyst target is now stale, so
- * the upside and extension bands read misleadingly bullish (a crash temporarily looks "cheaper and
- * less stretched"). The threshold keeps an ordinary 2–3% dip from tripping the penalty; only a real
- * break (a gap-down through the line) does, parking the name until the dust settles.
+ * Falling-knife test. A momentum name trades above its 50-day by definition; once it drops well
+ * through it (more than {@link FALLING_KNIFE_THRESHOLD_PCT} below), the short-term trend has broken.
+ * The threshold keeps an ordinary 2–3% dip from tripping — only a real break (a gap-down through the
+ * line) counts. {@link computeScorecard} uses it to stop trusting the now-stale upside/extension bands.
  */
-export function scoreTrendBreak(price: number, movingAverage50: number) {
-  const belowFiftyDayPct = movingAverage50 > 0 ? (price / movingAverage50 - 1) * 100 : 0;
-  return belowFiftyDayPct < FALLING_KNIFE_THRESHOLD_PCT ? -3 : 0;
+export function isTrendBroken(price: number, movingAverage50: number) {
+  if (movingAverage50 <= 0) {
+    return false;
+  }
+  return (price / movingAverage50 - 1) * 100 < FALLING_KNIFE_THRESHOLD_PCT;
 }
 
 function toRow(input: ScorecardInput): ScorecardRow {
@@ -165,17 +173,24 @@ function toRow(input: ScorecardInput): ScorecardRow {
       ? (input.targetLastMonth / input.targetLastQuarter - 1) * 100
       : 0;
 
-  const trendBreakPenalty = scoreTrendBreak(input.price, input.movingAverage50);
-  const trendBroken = trendBreakPenalty < 0;
+  const trendBroken = isTrendBroken(input.price, input.movingAverage50);
+
+  /*
+   * A broken trend means the analyst target is stale, so a crash makes the upside and extension bands
+   * look deceptively good ("cheaper, less stretched"). Don't trust them: cap their positive
+   * contribution at zero, then add a penalty for the break itself.
+   */
+  const upsideScore = trendBroken ? Math.min(0, scoreUpside(upsidePct)) : scoreUpside(upsidePct);
+  const extensionScore = trendBroken ? Math.min(0, scoreExtension(extensionPct)) : scoreExtension(extensionPct);
 
   const score =
-    scoreUpside(upsidePct) +
-    scoreExtension(extensionPct) +
+    upsideScore +
+    extensionScore +
     scoreForwardPE(forwardPE) +
     scoreGrowth(epsGrowthPct) +
     scoreRating(input.rating) +
     scoreRevisionMomentum(revisionPct) +
-    trendBreakPenalty;
+    (trendBroken ? TREND_BREAK_PENALTY : 0);
 
   return {
     epsGrowthPct,

--- a/packages/trading-strategies/src/scorecard/computeScorecard.ts
+++ b/packages/trading-strategies/src/scorecard/computeScorecard.ts
@@ -3,14 +3,18 @@
  *
  * The rubric exists to answer one question — has a stock already run past the point of a sensible
  * entry? — so every band rewards room left (upside, low extension, reasonable valuation, growth,
- * and analysts still raising targets) and punishes a stretched, priced-for-perfection chart. Same
- * inputs always yield the same ranking; a stock's score never depends on the others in the list.
+ * and analysts still raising targets) and punishes a stretched, priced-for-perfection chart. A
+ * falling-knife guard demotes names that have broken below their 50-day, where a stale analyst
+ * target makes the upside look deceptively good. Same inputs always yield the same ranking; a
+ * stock's score never depends on the others in the list.
  */
 
 /** Raw, per-ticker inputs the rubric scores. The orchestrator fills these from the data provider. */
 export interface ScorecardInput {
   ticker: string;
   price: number;
+  /** 50-day moving average. A momentum name losing it signals a broken short-term trend. */
+  movingAverage50: number;
   movingAverage200: number;
   targetConsensus: number;
   /** Average EPS estimate for the nearest forward fiscal year. */
@@ -39,7 +43,9 @@ export interface ScorecardRow {
   rating: string;
   /** Recent change in the average target (last month vs last quarter), in percent. Positive = analysts raising. */
   revisionPct: number;
-  /** Sum of the six rubric bands; higher means more room left (less likely to be too late). */
+  /** True when price has dropped well below its 50-day MA — a broken trend that makes the target/upside stale. */
+  trendBroken: boolean;
+  /** Sum of the rubric bands plus the trend-break guard; higher means more room left (less likely too late). */
   score: number;
 }
 
@@ -130,6 +136,21 @@ export function scoreRevisionMomentum(revisionPct: number) {
   return -2; // targets being cut — momentum fading
 }
 
+/** How far below its 50-day a name must fall to count as a broken trend rather than a normal wobble. */
+const FALLING_KNIFE_THRESHOLD_PCT = -8;
+
+/**
+ * Falling-knife guard. A momentum name trades above its 50-day by definition; once it drops well
+ * through it, the short-term trend has broken and — critically — the analyst target is now stale, so
+ * the upside and extension bands read misleadingly bullish (a crash temporarily looks "cheaper and
+ * less stretched"). The threshold keeps an ordinary 2–3% dip from tripping the penalty; only a real
+ * break (a gap-down through the line) does, parking the name until the dust settles.
+ */
+export function scoreTrendBreak(price: number, movingAverage50: number) {
+  const belowFiftyDayPct = movingAverage50 > 0 ? (price / movingAverage50 - 1) * 100 : 0;
+  return belowFiftyDayPct < FALLING_KNIFE_THRESHOLD_PCT ? -3 : 0;
+}
+
 function toRow(input: ScorecardInput): ScorecardRow {
   const upsidePct = (input.targetConsensus / input.price - 1) * 100;
   const extensionPct = (input.price / input.movingAverage200 - 1) * 100;
@@ -144,13 +165,17 @@ function toRow(input: ScorecardInput): ScorecardRow {
       ? (input.targetLastMonth / input.targetLastQuarter - 1) * 100
       : 0;
 
+  const trendBreakPenalty = scoreTrendBreak(input.price, input.movingAverage50);
+  const trendBroken = trendBreakPenalty < 0;
+
   const score =
     scoreUpside(upsidePct) +
     scoreExtension(extensionPct) +
     scoreForwardPE(forwardPE) +
     scoreGrowth(epsGrowthPct) +
     scoreRating(input.rating) +
-    scoreRevisionMomentum(revisionPct);
+    scoreRevisionMomentum(revisionPct) +
+    trendBreakPenalty;
 
   return {
     epsGrowthPct,
@@ -161,6 +186,7 @@ function toRow(input: ScorecardInput): ScorecardRow {
     revisionPct,
     score,
     ticker: input.ticker,
+    trendBroken,
     upsidePct,
   };
 }

--- a/packages/trading-strategies/src/scorecard/computeTipRanksScorecard.test.ts
+++ b/packages/trading-strategies/src/scorecard/computeTipRanksScorecard.test.ts
@@ -1,0 +1,90 @@
+import {describe, expect, it} from 'vitest';
+import {
+  computeTipRanksScorecard,
+  scoreConsensus,
+  scoreSmartScore,
+  scoreTrailingPE,
+} from './computeTipRanksScorecard.js';
+
+describe('scoreSmartScore', () => {
+  it('rewards a high TipRanks Smart Score', () => {
+    expect(scoreSmartScore(9), 'outperform').toBe(2);
+    expect(scoreSmartScore(7), 'leaning positive').toBe(1);
+    expect(scoreSmartScore(5), 'neutral').toBe(0);
+    expect(scoreSmartScore(3), 'underperform').toBe(-2);
+  });
+});
+
+describe('scoreConsensus', () => {
+  it('maps the analyst consensus label, ignoring spacing and case', () => {
+    expect(scoreConsensus('Strong Buy')).toBe(2);
+    expect(scoreConsensus('StrongBuy')).toBe(2);
+    expect(scoreConsensus('Moderate Buy')).toBe(1);
+    expect(scoreConsensus('Hold')).toBe(0);
+    expect(scoreConsensus('Strong Sell')).toBe(-2);
+  });
+});
+
+describe('scoreTrailingPE', () => {
+  it('uses higher bands than the forward version (trailing runs richer)', () => {
+    expect(scoreTrailingPE(20)).toBe(2);
+    expect(scoreTrailingPE(40)).toBe(1);
+    expect(scoreTrailingPE(70)).toBe(0);
+    expect(scoreTrailingPE(120), 'very rich').toBe(-1);
+    expect(scoreTrailingPE(-5), 'loss-making').toBe(-1);
+  });
+});
+
+describe('computeTipRanksScorecard', () => {
+  it('ranks a strong, un-stretched name above an overextended one', () => {
+    const rows = computeTipRanksScorecard([
+      {
+        consensus: 'Strong Buy',
+        movingAverage200: 420.72,
+        price: 1213.56,
+        smartScore: 9,
+        targetConsensus: 1496.52,
+        ticker: 'MU',
+        trailingPE: 52.9,
+      },
+      {
+        consensus: 'Buy',
+        movingAverage200: 275,
+        price: 675.39,
+        smartScore: 9,
+        targetConsensus: 479.29,
+        ticker: 'WDC',
+        trailingPE: 39.7,
+      },
+    ]);
+
+    expect(rows[0].ticker, 'MU keeps upside; WDC overshot and is far above its 200-day').toBe('MU');
+    expect(rows[0].score).toBeGreaterThan(rows[1].score);
+  });
+
+  it('is order-independent', () => {
+    const inputs = [
+      {
+        consensus: 'Strong Buy',
+        movingAverage200: 420,
+        price: 1213,
+        smartScore: 9,
+        targetConsensus: 1496,
+        ticker: 'MU',
+        trailingPE: 52,
+      },
+      {
+        consensus: 'Hold',
+        movingAverage200: 57,
+        price: 132,
+        smartScore: 4,
+        targetConsensus: 91,
+        ticker: 'INTC',
+        trailingPE: 120,
+      },
+    ];
+    expect(computeTipRanksScorecard(inputs).map(r => r.ticker)).toEqual(
+      computeTipRanksScorecard([...inputs].reverse()).map(r => r.ticker)
+    );
+  });
+});

--- a/packages/trading-strategies/src/scorecard/computeTipRanksScorecard.ts
+++ b/packages/trading-strategies/src/scorecard/computeTipRanksScorecard.ts
@@ -1,0 +1,110 @@
+import {scoreExtension, scoreUpside} from './computeScorecard.js';
+
+/**
+ * A TipRanks-only variant of the momentum scorecard. It keeps the two metrics TipRanks supplies
+ * directly (upside to target, extension vs the 200-day MA) and swaps the forward-looking bands the
+ * FMP version uses — forward P/E and EPS growth, which TipRanks does not expose — for TipRanks'
+ * own signals: the Smart Score, the analyst consensus, and the (trailing) P/E. The result answers
+ * "is the overall signal strong and is there room left?" rather than "is it cheap versus *future*
+ * earnings?". Same inputs always yield the same ranking.
+ */
+
+export interface TipRanksScorecardInput {
+  ticker: string;
+  price: number;
+  movingAverage200: number;
+  targetConsensus: number;
+  /** TipRanks Smart Score, 1–10. */
+  smartScore: number;
+  /** Analyst consensus label, e.g. "Strong Buy", "Hold", "Sell". Spacing/case are ignored. */
+  consensus: string;
+  /** Trailing P/E (TipRanks has no forward EPS, so this stands in for the FMP forward multiple). */
+  trailingPE: number;
+}
+
+export interface TipRanksScorecardRow {
+  ticker: string;
+  price: number;
+  upsidePct: number;
+  extensionPct: number;
+  smartScore: number;
+  consensus: string;
+  trailingPE: number;
+  score: number;
+}
+
+export function scoreSmartScore(smartScore: number) {
+  if (smartScore >= 8) {
+    return 2; // TipRanks "Outperform" band
+  }
+  if (smartScore >= 6) {
+    return 1;
+  }
+  if (smartScore >= 4) {
+    return 0;
+  }
+  return -2; // "Underperform"
+}
+
+export function scoreConsensus(consensus: string) {
+  const normalized = consensus.replace(/\s+/g, '').toLowerCase();
+  if (normalized === 'strongbuy') {
+    return 2;
+  }
+  if (normalized.endsWith('buy')) {
+    return 1; // "Buy" / "Moderate Buy"
+  }
+  if (normalized === 'hold' || normalized === 'neutral') {
+    return 0;
+  }
+  return -2; // any flavour of sell
+}
+
+export function scoreTrailingPE(trailingPE: number) {
+  if (trailingPE <= 0) {
+    return -1; // loss-making — no meaningful multiple
+  }
+  if (trailingPE < 25) {
+    return 2;
+  }
+  if (trailingPE < 50) {
+    return 1;
+  }
+  if (trailingPE <= 80) {
+    return 0;
+  }
+  return -1;
+}
+
+function toRow(input: TipRanksScorecardInput): TipRanksScorecardRow {
+  const upsidePct = (input.targetConsensus / input.price - 1) * 100;
+  const extensionPct = (input.price / input.movingAverage200 - 1) * 100;
+
+  const score =
+    scoreUpside(upsidePct) +
+    scoreExtension(extensionPct) +
+    scoreSmartScore(input.smartScore) +
+    scoreConsensus(input.consensus) +
+    scoreTrailingPE(input.trailingPE);
+
+  return {
+    consensus: input.consensus,
+    extensionPct,
+    price: input.price,
+    score,
+    smartScore: input.smartScore,
+    ticker: input.ticker,
+    trailingPE: input.trailingPE,
+    upsidePct,
+  };
+}
+
+/**
+ * Scores each input against the TipRanks rubric, best-first, with the same stable tiebreaks as the
+ * FMP scorecard (score → upside → ticker) so the two rankings are directly comparable.
+ */
+export function computeTipRanksScorecard(inputs: TipRanksScorecardInput[]): TipRanksScorecardRow[] {
+  return inputs
+    .map(toRow)
+    .sort((a, b) => b.score - a.score || b.upsidePct - a.upsidePct || a.ticker.localeCompare(b.ticker));
+}

--- a/packages/trading-strategies/src/scorecard/index.ts
+++ b/packages/trading-strategies/src/scorecard/index.ts
@@ -1,2 +1,3 @@
 export * from './computeScorecard.js';
+export * from './computeTipRanksScorecard.js';
 export * from './MomentumScorecard.js';

--- a/packages/trading-strategies/src/scorecard/index.ts
+++ b/packages/trading-strategies/src/scorecard/index.ts
@@ -1,0 +1,2 @@
+export * from './computeScorecard.js';
+export * from './MomentumScorecard.js';


### PR DESCRIPTION
## What

Turns the ad-hoc "am I too late to buy this momentum name?" analysis into **deterministic, tested code**. Same inputs → same ranking, every run.

### Deterministic scoring core — `trading-strategies/src/scorecard/computeScorecard.ts`
A transparent **points rubric** scored per stock (cohort-independent — a stock's score never depends on the others):

| Signal | Bands |
|---|---|
| Upside to consensus target | >15% +2 · 0–15% +1 · −10–0% 0 · <−10% −2 |
| Extension vs 200-day MA | <25% +2 · 25–60% +1 · 60–100% 0 · >100% −2 |
| Forward P/E | <20 +2 · 20–40 +1 · 40–60 0 · >60 / loss −1 |
| EPS growth (FY2 vs FY1) | >40% +2 · 15–40% +1 · 0–15% 0 · <0 / loss −2 |
| Analyst rating | A +1 · B 0 · C or worse −1 |

`computeScorecard` sorts best-first with stable tiebreaks (score → upside → ticker). `selectForwardEps` picks the two nearest forward fiscal years, anchored to an injected `now` so it's reproducible.

### Orchestrator — `MomentumScorecard.ts`
Thin I/O layer: fetches the raw figures per ticker from FMP, hands them to the pure rubric. All judgement lives in `computeScorecard`.

### New typed FMP client — `exchange/src/data/fmp/FmpAPI.ts`
Read-only Financial Modeling Prep client (`quote`, `price-target-consensus`, `analyst-estimates`, `ratings-snapshot`) with zod `looseObject` schemas, axios + retry, mirroring the existing `AlpacaAPI` conventions.

## Notes
The rubric thresholds are intentionally easy to tune in one place. Verified end-to-end against the live FMP API across the current S&P 500 momentum top 20; unit tests pin every band, loss-making handling, order-independence, and forward-year selection.