### PR TITLE
docs(exchange): highlight Alpaca and Trading212 features in the README

### DIFF
--- a/packages/exchange/README.md
+++ b/packages/exchange/README.md
@@ -32,14 +32,34 @@ const exchange = getAlpacaClient({
 });
 ```
 
+**Why Alpaca:**
+
+- **Commission-free** US stocks and ETFs, with fractional shares.
+- **Add funds commission-free** with [Revolut](https://www.revolut.com/), avoiding the transfer fees most banks charge.
+- **Free paper trading** that mirrors the live API, so strategies can be validated without risking capital.
+- **Free market data** via the IEX feed, including WebSocket-streamed minute bars (the source this package pairs with other brokers).
+- **Crypto** trades 24/7 alongside equities.
+- **[24/5 trading](https://docs.alpaca.markets/us/docs/245-trading)** of US stocks via an overnight session, so positions can be opened or closed from Sunday evening through Friday evening.
+
 **Resources:**
 
 - [Alpaca API Reference](https://docs.alpaca.markets/reference/)
 - [Alpaca OpenAPI Files](https://docs.alpaca.markets/openapi)
+- [24/5 Trading](https://docs.alpaca.markets/us/docs/245-trading)
 
 ## Trading212
 
-[Trading212](https://www.trading212.com/) is supported as a broker. Its API has **no historical bars and no WebSocket**, so `Trading212Broker` requires an external `MarketDataSource` for candle methods.
+[Trading212](https://www.trading212.com/) is supported as a broker.
+
+**Why Trading212:**
+
+- **Commission-free** investing in 13,000+ stocks and ETFs, with fractional shares from £1/€1.
+- **Broad UK, European, and US coverage.**
+- **Multi-currency accounts** for depositing and investing in 13 currencies.
+- **Tax-advantaged Stocks & Shares ISA** (and Cash ISA) for UK residents, with no account fees.
+- **Daily [interest](https://www.trading212.com/interest-on-cash)** paid on uninvested cash.
+
+Its API has **no historical bars and no WebSocket**, so `Trading212Broker` requires an external `MarketDataSource` for candle methods.
 
 The package separates **execution** (`Broker`) from **market data** (`MarketDataSource`) so any data provider can be paired with any broker. For US equities, Alpaca's market-data feed is the natural pairing as it is free, works with a paper account, and supports WebSocket-streamed minute bars:
 


### PR DESCRIPTION
Adds a short, scannable summary of what each broker brings, so the README sells the integrations rather than only documenting their wiring.

## Why Alpaca
- Commission-free US stocks and ETFs with fractional shares
- Commission-free funding via Revolut
- Free paper trading that mirrors the live API
- Free IEX market data with WebSocket-streamed minute bars
- Crypto 24/7
- [24/5 overnight trading](https://docs.alpaca.markets/us/docs/245-trading)

## Why Trading212
- Commission-free investing in 13,000+ stocks and ETFs, fractional from £1/€1
- Broad UK, European, and US coverage
- Multi-currency accounts (13 currencies)
- Stocks & Shares ISA (and Cash ISA) for UK residents
- [Daily interest on uninvested cash](https://www.trading212.com/interest-on-cash)

Figures and the 24/5 details come from the providers' own docs (linked), not from memory. No code changes.