### PR TITLE
fix(trading-strategies): auto-remove a trailing stop when its position is gone

### DIFF
--- a/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.test.ts
+++ b/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.test.ts
@@ -1,5 +1,5 @@
 import Big from 'big.js';
-import {describe, expect, it} from 'vitest';
+import {describe, expect, it, vi} from 'vitest';
 import {AlpacaBroker, AlpacaBrokerMock, OrderSide, OrderType, TradingPair} from '@typedtrader/exchange';
 import type {Candle} from '@typedtrader/exchange';
 import {BacktestExecutor} from '../backtest/BacktestExecutor.js';
@@ -68,6 +68,29 @@ describe('TrailingStopStrategy', () => {
     expect(result.trades[0].advice.type).toBe(OrderType.LIMIT);
     expect(strategy.trailingState.exited).toBe(true);
     expect(strategy.trailingState.exitLimitPrice).toBe('108');
+  });
+
+  it('finishes (auto-removes) when an attached position is gone, e.g. closed externally', async () => {
+    /*
+     * Simulate a strategy that attached to a position on a previous run, then the position was
+     * closed outside this strategy (a manual sale, a rebalance). It boots with a zero balance.
+     */
+    const strategy = new TrailingStopStrategy({trailDownPct: '10'});
+    strategy.restoreState({exited: false, exitLimitPrice: null, exitReason: null, peakPrice: '100', stopPrice: '90'});
+    const onFinish = vi.fn();
+    strategy.onFinish = onFinish;
+
+    const config: BacktestConfig = {
+      broker: createMockExchange({baseBalance: '0'}),
+      candles: [createCandle({close: '95', open: '95'})],
+      strategy,
+      tradingPair,
+    };
+
+    await new BacktestExecutor(config).execute();
+
+    expect(strategy.trailingState.exited, 'no position left to trail → marked done').toBe(true);
+    expect(onFinish, 'runtime is told to tear the session down').toHaveBeenCalledTimes(1);
   });
 
   it('does not exit while price stays above the trail target', async () => {

--- a/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.ts
+++ b/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.ts
@@ -137,6 +137,14 @@ export class TrailingStopStrategy extends Strategy {
     return this.getProxiedState<TrailingStopState>();
   }
 
+  /**
+   * `true` once the trail has latched onto a position and begun tracking a peak. `peakPrice` is the
+   * sentinel: it stays `'0'` until the first candle with a sellable position attaches the trail.
+   */
+  get #isAttached() {
+    return this.#state.peakPrice !== '0';
+  }
+
   /** Read-only snapshot of the current trailing-stop state. Useful for tests and diagnostics. */
   get trailingState(): Readonly<TrailingStopState> {
     return {...this.#state};
@@ -150,7 +158,7 @@ export class TrailingStopStrategy extends Strategy {
       return undefined;
     }
 
-    if (this.#state.peakPrice === '0') {
+    if (!this.#isAttached) {
       if (!this.hasSellablePosition(state)) {
         return undefined;
       }

--- a/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.ts
+++ b/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.ts
@@ -48,9 +48,10 @@ export type TrailingStopConfig = z.input<typeof TrailingStopSchema>;
 
 export type TrailingStopState = {
   /**
-   * `true` once the trailing-stop sell has fully filled (position reduced to zero in
-   * `onFill`). Once set, `processCandle` short-circuits and emits no further advice;
-   * `onOrderFilled` invokes `onFinish` so the runtime can tear the session down.
+   * `true` once the position is gone — either the trailing-stop sell fully filled (detected in
+   * `onFill`) or the position was found already closed on a later candle (closed manually or by
+   * another process). Once set, `processCandle` short-circuits and emits no further advice, and
+   * `onFinish` is invoked so the runtime can tear the session down.
    */
   exited: boolean;
   /**
@@ -164,6 +165,15 @@ export class TrailingStopStrategy extends Strategy {
     }
 
     if (!this.hasSellablePosition(state)) {
+      /*
+       * We attached to a position earlier but it is gone now — our own exit filled, or it was
+       * closed manually or by another process (a rebalance, a different strategy). There is
+       * nothing left to trail, so finish and let the runtime tear the session down. This is what
+       * prevents orphaned trailing stops: a position closed outside this strategy still cleans up
+       * (on the next candle once the balance reflects it, e.g. after the position drops to zero).
+       */
+      this.#state.exited = true;
+      await this.onFinish?.();
       return undefined;
     }
 


### PR DESCRIPTION
## Problem
A trailing stop only finished (and got torn down) when **its own** exit sell filled (`onOrderFilled` -> `onFinish`). When a position was closed any other way — a manual sale, a rebalance, another strategy — the trailing stop kept running with nothing to protect and was relaunched on every deploy. That's the cause of the orphaned NVDA/CSCO strategies seen on the live deployment.

## Fix
Once the strategy has **attached** (`peakPrice !== '0'`), a candle that finds **no sellable position** now marks it done and calls `onFinish`, so the runtime removes it. The own-exit path is unchanged (no double-fire: after an own sell, `exited` short-circuits `processCandle` and `onOrderFilled` still fires).

## Known limitation (called out honestly)
The `TradingSession` only refreshes `baseBalance` at `start()` and after its **own** fills (external fills are ignored). So a *live* external close is picked up on the **next restart** (when `start()` re-reads the true balance), not in real time. Real-time detection would require the session to refresh balance per candle — deliberately left out of scope to keep this change small and low-risk.

## Test
Added a test simulating the orphan: a strategy with restored "attached" state boots with a zero balance and finishes (calls `onFinish`) on the first candle. Full package suite green (218 tests).