### PR TITLE
feat(trading-strategies): fingerprint the momentum report result

### DIFF
--- a/packages/trading-strategies/src/index.ts
+++ b/packages/trading-strategies/src/index.ts
@@ -56,6 +56,7 @@ export {
   type SP500HeatmapConfig,
 } from './report-sp500-heatmap/SP500HeatmapReport.js';
 export {
+  hashMomentumRanking,
   SP500MomentumReport,
   SP500MomentumSchema,
   type SP500MomentumConfig,

--- a/packages/trading-strategies/src/report-sp500-momentum/SP500MomentumReport.test.ts
+++ b/packages/trading-strategies/src/report-sp500-momentum/SP500MomentumReport.test.ts
@@ -4,6 +4,7 @@ import {SP500_TIMEZONE} from '../util/sp500Tickers.js';
 import {
   getExchangeYearMonth,
   getMomentumWindow,
+  hashMomentumRanking,
   rankDeltaIcon,
   SP500MomentumReport,
   SP500MomentumSchema,
@@ -120,5 +121,31 @@ describe('rankDeltaIcon', () => {
     expect(rankDeltaIcon(3, true), 'recovered → falls in the losers list').toBe('▼');
     expect(rankDeltaIcon(0, true), 'held').toBe('');
     expect(rankDeltaIcon(null, true), 'new entry').toBe('★');
+  });
+});
+
+describe('hashMomentumRanking', () => {
+  it('is identical for the same ranking, so an unchanged hash means the ranking did not move', () => {
+    expect(hashMomentumRanking(ranking('A', 'B', 'C'))).toBe(hashMomentumRanking(ranking('A', 'B', 'C')));
+  });
+
+  it('changes when the order changes', () => {
+    expect(hashMomentumRanking(ranking('A', 'B', 'C'))).not.toBe(hashMomentumRanking(ranking('B', 'A', 'C')));
+  });
+
+  it('changes when a price changes', () => {
+    const base = [{price12MonthsAgo: 100, priceNow: 150, returnPct: 50, ticker: 'A'}];
+    const moved = [{price12MonthsAgo: 100, priceNow: 160, returnPct: 60, ticker: 'A'}];
+    expect(hashMomentumRanking(base)).not.toBe(hashMomentumRanking(moved));
+  });
+
+  it('is unaffected by display-only fields, so footer and formatting edits never change it', () => {
+    const raw = {price12MonthsAgo: 100, priceNow: 150, returnPct: 50, ticker: 'A'};
+    const newcomer = {...raw, rank: 1, rankDelta: null};
+    const climber = {...raw, rank: 9, rankDelta: 7};
+    expect(
+      hashMomentumRanking([newcomer]),
+      'rank and rankDelta are presentation, not part of the raw fingerprint'
+    ).toBe(hashMomentumRanking([climber]));
   });
 });

--- a/packages/trading-strategies/src/report-sp500-momentum/SP500MomentumReport.ts
+++ b/packages/trading-strategies/src/report-sp500-momentum/SP500MomentumReport.ts
@@ -1,3 +1,4 @@
+import {createHash} from 'node:crypto';
 import {z} from 'zod';
 import type {AlpacaAPI} from '@typedtrader/exchange';
 import {MESSAGE_BREAK, Report} from '../report/Report.js';
@@ -93,6 +94,17 @@ function rankByMomentum(endPrices: Map<string, number>, startPrices: Map<string,
   }
   results.sort((a, b) => b.returnPct - a.returnPct);
   return results;
+}
+
+/**
+ * Stable fingerprint of a ranking, built from the raw ranked data — the ordered tickers and the
+ * prices that produced them — never from the rendered message. Two runs over the same formation
+ * window hash identically, so an unchanged fingerprint from one day to the next means the ranking
+ * did not move; editing the footer, the disclaimer, or any formatting leaves it untouched.
+ */
+export function hashMomentumRanking(ranked: MomentumResult[]) {
+  const canonical = ranked.map(result => `${result.ticker}:${result.priceNow}:${result.price12MonthsAgo}`).join('|');
+  return createHash('sha256').update(canonical).digest('hex').slice(0, 12);
 }
 
 /** Annotates the current ranking with each ticker's rank movement against the previous month's ranking. */
@@ -252,6 +264,7 @@ export class SP500MomentumReport extends Report<SP500MomentumConfig> {
     );
     lines.push('Next to the rank: ▲/▼ = moved up/down in this list vs last month, ★ = new entry.');
     lines.push(`Stocks ranked: ${results.length} / ${SP500_TICKERS.length}`);
+    lines.push(`Result hash: ${hashMomentumRanking(results)} (same as a prior run = ranking unchanged)`);
 
     lines.push('');
     lines.push(


### PR DESCRIPTION
## What
Adds `hashMomentumRanking()` — a stable fingerprint of the momentum ranking — and renders it as a footer line in the S&P 500 Momentum report:

```
Result hash: 809c8f61391a (same as a prior run = ranking unchanged)
```

## Why
The 12-1 window only rolls at month boundaries (it uses historical formation-window closes), so a daily schedule repeats the identical report for ~a month. The hash lets you tell at a glance whether anything actually moved:

- next day, same window → `809c8f61391a` (identical — nothing moved)
- after the window rolls → `ff33473ef0f8` (differs — ranking changed)

## Design
- Computed from the **raw ranked data** (ordered `ticker:priceNow:price12MonthsAgo`), **not** the rendered string — so editing the footer, the disclaimer, or any formatting never changes the hash.
- Independent of display-only fields (`rank`, `rankDelta` arrows).
- SHA-256, truncated to 12 hex chars (48 bits — ample for a "did it change" check).
- Always sends the report (no skipping); the hash rides along in the message.

## Test
4 new unit tests: stable for identical rankings, changes on reorder, changes on price move, and unaffected by display-only fields. Full package suite green (221 tests).

## Follow-up (not in this PR)
If you later want the scheduler to compare automatically (e.g. persist the hash on the `reports` row and flag/skip duplicates), that's a small change in `ReportScheduler` + a DB column — happy to do it separately.