### PR TITLE
refactor(trading-strategies): dispatch trailing-stop phases with switch(true)

### DIFF
--- a/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.ts
+++ b/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.ts
@@ -154,37 +154,56 @@ export class TrailingStopStrategy extends Strategy {
     candle: OneMinuteBatchedCandle,
     state: TradingSessionState
   ): Promise<OrderAdvice | void> {
-    if (this.#state.exited) {
-      return undefined;
-    }
+    const attached = this.#isAttached;
+    const holding = this.hasSellablePosition(state);
 
-    if (!this.#isAttached) {
-      if (!this.hasSellablePosition(state)) {
+    /*
+     * Each case spells out the exact state it handles rather than relying on an invariant left
+     * behind by an earlier early-return. `attached` and `holding` are read once up front so the
+     * conditions compare cached booleans instead of re-running hasSellablePosition per case.
+     */
+    switch (true) {
+      case this.#state.exited:
         return undefined;
-      }
-      const peak = this.#pivotPrice ?? candle.high;
-      const stopTarget = peak.mul(new Big(1).minus(this.#trailDownPct.div(100)));
-      this.#state.peakPrice = peak.toFixed();
-      this.#state.stopPrice = stopTarget.toFixed();
-      this.onMessage?.(
-        `Trail attached. Peak: ${peak.toFixed()}, stop: ${stopTarget.toFixed()} (-${this.#trailDownPct.toFixed()}%)`
-      );
-      return undefined;
+      case !attached && !holding:
+        return undefined; // No position yet, keep waiting to attach.
+      case !attached && holding:
+        this.#attach(candle);
+        return undefined;
+      case attached && !holding:
+        await this.#finishPositionGone();
+        return undefined;
+      case attached && holding:
+        return this.#trail(candle);
+      default:
+        return undefined;
     }
+  }
 
-    if (!this.hasSellablePosition(state)) {
-      /*
-       * We attached to a position earlier but it is gone now — our own exit filled, or it was
-       * closed manually or by another process (a rebalance, a different strategy). There is
-       * nothing left to trail, so finish and let the runtime tear the session down. This is what
-       * prevents orphaned trailing stops: a position closed outside this strategy still cleans up
-       * (on the next candle once the balance reflects it, e.g. after the position drops to zero).
-       */
-      this.#state.exited = true;
-      await this.onFinish?.();
-      return undefined;
-    }
+  /** Latches the trail onto the current position: records the starting peak and its stop target. */
+  #attach(candle: OneMinuteBatchedCandle) {
+    const peak = this.#pivotPrice ?? candle.high;
+    const stopTarget = peak.mul(new Big(1).minus(this.#trailDownPct.div(100)));
+    this.#state.peakPrice = peak.toFixed();
+    this.#state.stopPrice = stopTarget.toFixed();
+    this.onMessage?.(
+      `Trail attached. Peak: ${peak.toFixed()}, stop: ${stopTarget.toFixed()} (-${this.#trailDownPct.toFixed()}%)`
+    );
+  }
 
+  async #finishPositionGone() {
+    /*
+     * We were attached but the position is gone now — our own exit filled, or it was closed
+     * manually or by another process (a rebalance, a different strategy). There is nothing left
+     * to trail, so finish and let the runtime tear the session down. This is what prevents
+     * orphaned trailing stops: a position closed outside this strategy still cleans up.
+     */
+    this.#state.exited = true;
+    await this.onFinish?.();
+  }
+
+  /** Ratchets the peak upward, refreshes the stop, and emits a SELL once price breaches the trail. */
+  #trail(candle: OneMinuteBatchedCandle): OrderAdvice | void {
     const previousPeak = new Big(this.#state.peakPrice);
     const ratchetThreshold = this.#trailUpPct
       ? previousPeak.mul(new Big(1).plus(this.#trailUpPct.div(100)))


### PR DESCRIPTION
Follow-up to #1139.

## What
Rewrites `TrailingStopStrategy.processCandle` from a stack of early-return guard clauses into a `switch(true)` dispatch over the four lifecycle states, extracting each phase into its own method (`#attach`, `#finishPositionGone`, `#trail`).

```ts
const attached = this.#isAttached;
const holding = this.hasSellablePosition(state);

switch (true) {
  case this.#state.exited:    return undefined;
  case !attached && !holding: return undefined;                  // waiting to attach
  case !attached && holding:  this.#attach(candle); return undefined;
  case attached && !holding:  await this.#finishPositionGone(); return undefined;
  case attached && holding:   return this.#trail(candle);        // happy path
  default:                    return undefined;
}
```

## Why
The guard-clause version encoded an implicit invariant: the trailing logic at the bottom was only correct because an earlier branch happened to `return`. Delete that buried `return` and it still compiles but trails on the attach candle. Each `switch(true)` case now states its exact state, so the invariant is visible on the branch instead of inferred from position.

## Notes
- `attached` / `holding` are read once so `hasSellablePosition` runs a single time, not per case.
- No behavior change: the same 17 tests pass; tsc and lint clean.
- `switch(true)` over a boolean isn't exhaustiveness-checked, so the `default` is the backstop.