### PR TITLE
refactor(trading-strategies): move TradingSession next to BacktestExecutor and unify advice execution

### DIFF
--- a/packages/exchange/README.md
+++ b/packages/exchange/README.md
@@ -15,7 +15,7 @@ Utilities for handling trading exchange data with proper type safety and aggrega
 The `Broker` interface is intentionally kept generic so that any broker can implement it. This means:
 
 - **Bring your own broker.** Alpaca and Trading212 are first-class, but the package is built to be extended.
-- **Extend the abstract `Broker` class** and your integration plugs straight into `TradingSession` for live strategies and `BacktestExecutor` for backtesting — both for free, with no extra wiring. See [`BROKER_TEMPLATE.md`](./BROKER_TEMPLATE.md) for the conventions every integration follows.
+- **Extend the abstract `Broker` class** and your integration plugs straight into the `trading-strategies` package's `TradingSession` for live strategies and `BacktestExecutor` for backtesting — both for free, with no extra wiring. See [`BROKER_TEMPLATE.md`](./BROKER_TEMPLATE.md) for the conventions every integration follows.
 - **Extend `MarketDataSource`** to add live-streaming candles for your strategies. If your broker has no market-data API, plug in an existing source (e.g. Alpaca) instead — execution and market data are deliberately separated so they can be mixed and matched.
 
 ## Alpaca

--- a/packages/exchange/src/broker/Broker.ts
+++ b/packages/exchange/src/broker/Broker.ts
@@ -132,6 +132,8 @@ export interface PendingLimitOrder extends ExchangePendingOrderBase {
 export interface PendingMarketOrder extends ExchangePendingOrderBase {
   /** Market orders don't have a price. */
   type: 'MARKET';
+  /** When `true`, `size` is a counter-currency (notional) amount, not a base quantity. */
+  sizeInCounter?: boolean;
 }
 
 /**

--- a/packages/exchange/src/broker/BrokerMock.test.ts
+++ b/packages/exchange/src/broker/BrokerMock.test.ts
@@ -113,6 +113,57 @@ describe('BrokerMock', () => {
       expect(fills[0].price).toBe('98');
       expect(fills[0].side).toBe(OrderSide.SELL);
     });
+
+    it('converts a counter-sized (notional) market buy at the fill price with the fee inside the spend', async () => {
+      const exchange = createExchange('0', '10000');
+
+      exchange.processCandle(createCandle({close: '100', open: '100'}));
+
+      await exchange.placeMarketOrder(pair, {
+        side: OrderSide.BUY,
+        size: '1000',
+        sizeInCounter: true,
+      });
+
+      // Converts at the NEXT candle's open (105), not at the stale price seen at placement time (100)
+      const fills = exchange.processCandle(
+        createCandle({close: '110', open: '105', openTimeInISO: '2025-01-01T00:01:00.000Z'})
+      );
+
+      expect(fills).toHaveLength(1);
+      const fill = fills[0];
+      expect(fill.price).toBe('105');
+
+      // The 0.25% taker fee comes out of the 1000 USD spend, so net = 1000 / 1.0025
+      const net = new Big('1000').div('1.0025');
+      expect(new Big(fill.fee).toFixed(8)).toBe(new Big('1000').minus(net).toFixed(8));
+      expect(new Big(fill.size).toFixed(8)).toBe(net.div('105').toFixed(8));
+
+      // Exactly the notional amount left the counter balance — no more, no less
+      const balances = await exchange.getAvailableBalances(pair);
+      expect(balances.counter.toFixed(2)).toBe('9000.00');
+      expect(balances.base.eq(fill.size)).toBe(true);
+    });
+
+    it('releases the full hold when a counter-sized market buy is canceled', async () => {
+      const exchange = createExchange('0', '10000');
+
+      exchange.processCandle(createCandle({close: '100', open: '100'}));
+
+      await exchange.placeMarketOrder(pair, {
+        side: OrderSide.BUY,
+        size: '1000',
+        sizeInCounter: true,
+      });
+      await exchange.cancelOpenOrders(pair);
+
+      const balances = await exchange.getAvailableBalances(pair);
+      expect(balances.counter.toFixed(2)).toBe('10000.00');
+
+      const [btc, usd] = await exchange.listBalances();
+      expect(btc.hold).toBe('0');
+      expect(usd.hold).toBe('0');
+    });
   });
 
   describe('limit orders', () => {

--- a/packages/exchange/src/broker/BrokerMock.ts
+++ b/packages/exchange/src/broker/BrokerMock.ts
@@ -404,11 +404,11 @@ export abstract class BrokerMock extends Broker {
 
     // Give back exactly what was held for this order (works for limit AND market buys)
     const hold = this.#orderHolds.get(orderId);
-    if (hold) {
-      this.#releaseHold(hold.currency, hold.amount);
-      this.#addAvailable(hold.currency, hold.amount);
-      this.#orderHolds.delete(orderId);
-    }
+    assert.ok(hold, `No hold recorded for order "${orderId}"`);
+
+    this.#releaseHold(hold.currency, hold.amount);
+    this.#addAvailable(hold.currency, hold.amount);
+    this.#orderHolds.delete(orderId);
   }
 
   async cancelOpenOrders(pair: TradingPair) {

--- a/packages/exchange/src/broker/BrokerMock.ts
+++ b/packages/exchange/src/broker/BrokerMock.ts
@@ -28,6 +28,11 @@ export interface ExchangeMockBalance {
 export abstract class BrokerMock extends Broker {
   readonly #balances: Map<string, ExchangeMockBalance>;
   readonly #pendingOrders: PendingOrder[] = [];
+  /**
+   * Exact amount put on hold per order, so cancels and fills release precisely what was
+   * held — reconstructing the hold from order fields drifts once prices improve on fill.
+   */
+  readonly #orderHolds = new Map<string, {amount: Big; currency: string}>();
   readonly #fills: Fill[] = [];
   #currentCandle: Candle | undefined;
   #historicalCandles: Candle[] = [];
@@ -97,6 +102,31 @@ export abstract class BrokerMock extends Broker {
     if (order.type === OrderType.MARKET) {
       // Market orders fill at candle open price
       fillPrice = candleOpen;
+
+      if (order.sizeInCounter) {
+        /*
+         * Notional order: `size` is the total counter spend. The fee comes out of that
+         * spend, and the base quantity is whatever the remainder buys at the fill price —
+         * conversion happens here, at fill time, never at placement time with a stale price.
+         */
+        const feeRate = this.#getFeeRateSync(OrderType.MARKET);
+        const grossCounter = new Big(order.size);
+        const netCounter = grossCounter.div(new Big(1).plus(feeRate));
+        const fee = grossCounter.minus(netCounter);
+
+        const fill: Fill = {
+          created_at: candle.openTimeInISO,
+          fee: fee.toFixed(),
+          feeAsset: pair.counter,
+          order_id: order.id,
+          pair,
+          position: OrderPosition.LONG,
+          price: fillPrice.toFixed(),
+          side: order.side,
+          size: netCounter.div(fillPrice).toFixed(),
+        };
+        return fill;
+      }
     } else {
       // Limit order
       const limitPrice = new Big(order.price);
@@ -140,19 +170,30 @@ export abstract class BrokerMock extends Broker {
     const size = new Big(fill.size);
     const price = new Big(fill.price);
     const fee = new Big(fill.fee);
+    const hold = this.#orderHolds.get(order.id);
+    assert.ok(hold, `No hold recorded for order "${order.id}"`);
 
     if (order.side === OrderSide.BUY) {
-      // Release counter hold, add base
       const counterCost = size.mul(price).plus(fee);
-      this.#releaseHold(order.pair.counter, counterCost);
+      this.#releaseHold(order.pair.counter, hold.amount);
+      /*
+       * The hold was an estimate (limit price, or a pre-fill price for market orders).
+       * Settle the difference: refund unspent counter on price improvement, or charge
+       * the shortfall when the fill came in above the estimate.
+       */
+      const refund = hold.amount.minus(counterCost);
+      if (!refund.eq(0)) {
+        this.#addAvailable(order.pair.counter, refund);
+      }
       this.#addAvailable(order.pair.base, size);
     } else {
       // Release base hold, add counter revenue
-      this.#releaseHold(order.pair.base, size);
+      this.#releaseHold(order.pair.base, hold.amount);
       const netRevenue = size.mul(price).minus(fee);
       this.#addAvailable(order.pair.counter, netRevenue);
     }
 
+    this.#orderHolds.delete(order.id);
     this.#fills.push(fill);
   }
 
@@ -160,8 +201,20 @@ export abstract class BrokerMock extends Broker {
   protected override async placeOrder(pair: TradingPair, options: MarketOrderOptions): Promise<PendingMarketOrder>;
   protected override async placeOrder(pair: TradingPair, options: OrderOptions) {
     const rules = await this.getTradingRules(pair);
-    const size = this.#applyTradingRules(new Big(options.size), options, rules);
-    assert.ok(size);
+    const isCounterSized = options.type === OrderType.MARKET && options.sizeInCounter;
+
+    let size: Big;
+
+    if (isCounterSized) {
+      assert.ok(options.side === OrderSide.BUY, 'BrokerMock only supports counter-sized (notional) MARKET BUY orders');
+      size = this.#applyNotionalTradingRules(new Big(options.size), rules);
+    } else {
+      const validated = this.#applyTradingRules(new Big(options.size), options, rules);
+      assert.ok(validated, `Order size "${options.size}" violates the trading rules`);
+      size = validated;
+    }
+
+    const orderId = String(this.#nextOrderId++);
 
     // Validate balance and put amount on hold
     if (options.side === OrderSide.BUY) {
@@ -173,8 +226,8 @@ export abstract class BrokerMock extends Broker {
         const feeRate = this.#getFeeRateSync(options.type);
         counterNeeded = counterNeeded.plus(counterNeeded.mul(feeRate));
       } else if (options.sizeInCounter) {
-        // Market order: we don't know the exact price yet, so hold the full counter amount.
-        counterNeeded = new Big(options.size);
+        // Notional market order: the size IS the full counter spend, fee included.
+        counterNeeded = size;
       } else {
         // Market order, best-effort: hold based on current candle price if available.
         const estimatedPrice = this.#currentCandle ? new Big(this.#currentCandle.close) : new Big(0);
@@ -184,11 +237,11 @@ export abstract class BrokerMock extends Broker {
       }
 
       this.#holdBalance(pair.counter, counterNeeded);
+      this.#orderHolds.set(orderId, {amount: counterNeeded, currency: pair.counter});
     } else {
       this.#holdBalance(pair.base, size);
+      this.#orderHolds.set(orderId, {amount: size, currency: pair.base});
     }
-
-    const orderId = String(this.#nextOrderId++);
 
     if (options.type === OrderType.LIMIT) {
       const price = this.#roundDownToIncrement(new Big(options.price), new Big(rules.counter_increment));
@@ -209,10 +262,38 @@ export abstract class BrokerMock extends Broker {
       pair,
       side: options.side,
       size: size.toFixed(),
+      sizeInCounter: options.sizeInCounter,
       type: OrderType.MARKET,
     };
     this.#pendingOrders.push(pending);
     return pending;
+  }
+
+  /**
+   * Rule enforcement for counter-sized (notional) orders. The base quantity is only known
+   * at fill time, so the base minimum is checked against an estimate from the current
+   * candle — mirroring a real broker rejecting an order that is too small to execute.
+   */
+  #applyNotionalTradingRules(counterAmount: Big, rules: TradingRules) {
+    const size = this.#roundDownToIncrement(counterAmount, new Big(rules.counter_increment));
+    assert.ok(
+      size.gte(rules.counter_min_size),
+      `Notional size "${size.toFixed()}" is below the minimum of "${rules.counter_min_size}"`
+    );
+
+    if (this.#currentCandle) {
+      const estimatedPrice = new Big(this.#currentCandle.close);
+      if (estimatedPrice.gt(0)) {
+        const feeRate = this.#getFeeRateSync(OrderType.MARKET);
+        const estimatedBase = size.div(new Big(1).plus(feeRate)).div(estimatedPrice);
+        assert.ok(
+          estimatedBase.gte(rules.base_min_size),
+          `Notional size "${size.toFixed()}" buys an estimated "${estimatedBase.toFixed()}" base units, below the minimum of "${rules.base_min_size}"`
+        );
+      }
+    }
+
+    return size;
   }
 
   #applyTradingRules(size: Big, options: OrderOptions, rules: TradingRules) {
@@ -313,28 +394,20 @@ export abstract class BrokerMock extends Broker {
     return this.#fills.find(f => f.order_id === orderId);
   }
 
-  async cancelOrderById(pair: TradingPair, orderId: string) {
+  async cancelOrderById(_pair: TradingPair, orderId: string) {
     const index = this.#pendingOrders.findIndex(o => o.id === orderId);
     if (index === -1) {
       throw new Error(`Order ${orderId} not found`);
     }
 
-    const order = this.#pendingOrders[index];
     this.#pendingOrders.splice(index, 1);
 
-    // Release hold
-    if (order.side === OrderSide.BUY) {
-      if (order.type === OrderType.LIMIT) {
-        const price = new Big(order.price);
-        const counterAmount = new Big(order.size).mul(price);
-        const feeRate = this.#getFeeRateSync(order.type);
-        const totalHeld = counterAmount.plus(counterAmount.mul(feeRate));
-        this.#releaseHold(pair.counter, totalHeld);
-        this.#addAvailable(pair.counter, totalHeld);
-      }
-    } else {
-      this.#releaseHold(pair.base, new Big(order.size));
-      this.#addAvailable(pair.base, new Big(order.size));
+    // Give back exactly what was held for this order (works for limit AND market buys)
+    const hold = this.#orderHolds.get(orderId);
+    if (hold) {
+      this.#releaseHold(hold.currency, hold.amount);
+      this.#addAvailable(hold.currency, hold.amount);
+      this.#orderHolds.delete(orderId);
     }
   }
 

--- a/packages/exchange/src/broker/trading212/Trading212Broker.ts
+++ b/packages/exchange/src/broker/trading212/Trading212Broker.ts
@@ -335,7 +335,7 @@ export class Trading212Broker extends Broker implements MarketDataSource {
     /*
      * Trading212's `minTradeQuantity` is the floor *and* the increment for fractional shares.
      * Use the same non-zero fallback for both — falling back to '0' on `base_min_size` would
-     * let computed sizes of zero pass `TradingSession`'s min-size guard.
+     * let computed sizes of zero pass the trading session's min-size guard.
      */
     const minQuantity = `${instrument.minTradeQuantity ?? '0.000000001'}`;
     return {

--- a/packages/exchange/src/index.ts
+++ b/packages/exchange/src/index.ts
@@ -2,5 +2,4 @@ export * from './candle/index.js';
 export * from './broker/index.js';
 export * from './broker/alpaca/index.js';
 export * from './broker/trading212/index.js';
-export * from './trader/index.js';
 export * from './util/index.js';

--- a/packages/messaging/src/service/StrategyMonitor.test.ts
+++ b/packages/messaging/src/service/StrategyMonitor.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import {describe, it, expect, vi, beforeEach} from 'vitest';
-import {OrderSide, OrderSizeBelowMinimumError} from '@typedtrader/exchange';
+import {OrderSide} from '@typedtrader/exchange';
+import {OrderSizeBelowMinimumError} from 'trading-strategies';
 import {logger} from '../logger.js';
 import type {MessagingPlatform} from '../platform/MessagingPlatform.js';
 import type {StrategyAttributes} from '../database/models/Strategy.js';
@@ -42,13 +43,17 @@ vi.mock('@typedtrader/exchange', async importActual => {
     ...actual,
     getBrokerClient: vi.fn(() => ({})),
     TradingPair: {fromString: vi.fn(() => ({base: 'BTC', counter: 'USD'}))},
-    TradingSession: TradingSessionMock,
   };
 });
 
-vi.mock('trading-strategies', () => ({
-  createStrategy: vi.fn(() => mockStrategy),
-}));
+vi.mock('trading-strategies', async importActual => {
+  const actual = await importActual<Record<string, unknown>>();
+  return {
+    ...actual,
+    createStrategy: vi.fn(() => mockStrategy),
+    TradingSession: TradingSessionMock,
+  };
+});
 
 vi.mock('../logger.js', () => ({
   logger: {debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn()},

--- a/packages/messaging/src/service/StrategyMonitor.ts
+++ b/packages/messaging/src/service/StrategyMonitor.ts
@@ -1,6 +1,6 @@
-import {TradingPair, TradingSession} from '@typedtrader/exchange';
+import {TradingPair} from '@typedtrader/exchange';
 import type {Fill} from '@typedtrader/exchange';
-import {createStrategy} from 'trading-strategies';
+import {createStrategy, TradingSession} from 'trading-strategies';
 import type {Strategy as TradingStrategy} from 'trading-strategies';
 import {getAccountBrokerClient} from '../broker/getAccountBrokerClient.js';
 import {Account} from '../database/models/Account.js';

--- a/packages/trading-strategies/src/backtest/BacktestConfig.ts
+++ b/packages/trading-strategies/src/backtest/BacktestConfig.ts
@@ -1,4 +1,5 @@
-import type {Candle, BrokerMock, TradingPair, TradingSessionStrategy} from '@typedtrader/exchange';
+import type {Candle, BrokerMock, TradingPair} from '@typedtrader/exchange';
+import type {TradingSessionStrategy} from '../trader/index.js';
 
 export interface BacktestConfig {
   /** The candle data to run through the strategy (in chronological order). */

--- a/packages/trading-strategies/src/backtest/BacktestExecutor.test.ts
+++ b/packages/trading-strategies/src/backtest/BacktestExecutor.test.ts
@@ -1,7 +1,9 @@
 import Big from 'big.js';
 import {describe, expect, it} from 'vitest';
-import {AllAvailableAmount, AlpacaBrokerMock, OrderSide, OrderType} from '@typedtrader/exchange';
-import type {Candle, TradingRules, OrderAdvice, TradingSessionState} from '@typedtrader/exchange';
+import {AlpacaBrokerMock, OrderSide, OrderType} from '@typedtrader/exchange';
+import {AllAvailableAmount} from '../trader/index.js';
+import type {Candle, TradingRules} from '@typedtrader/exchange';
+import type {OrderAdvice, TradingSessionState} from '../trader/index.js';
 import {TradingPair} from '@typedtrader/exchange';
 import {BacktestExecutor} from './BacktestExecutor.js';
 import {BuyBelowSellAboveStrategy} from '../strategy-buy-below-sell-above/BuyBelowSellAboveStrategy.js';
@@ -284,6 +286,58 @@ describe('BacktestExecutor', () => {
       // Strategy advises sell, but base balance is 0
       expect(result.trades).toHaveLength(0);
       expect(result.finalBaseBalance.toFixed(2)).toBe('0.00');
+      expect(result.finalCounterBalance.toFixed(2)).toBe('1000.00');
+
+      // Dropped advice is reported, not silently swallowed — one skip per advising candle
+      expect(result.skippedAdvices).toHaveLength(2);
+      expect(result.skippedAdvices[0].reason).toContain('below minimum');
+      expect(result.skippedAdvices[0].advice.side).toBe(OrderSide.SELL);
+    });
+
+    it('cancels an outstanding order when newer advice arrives, mirroring a live session', async () => {
+      class RepriceBuy extends Strategy {
+        static override NAME = 'RepriceBuy';
+        #candleCount = 0;
+
+        protected override async processCandle(
+          _candle: OneMinuteBatchedCandle,
+          _state: TradingSessionState
+        ): Promise<OrderAdvice | void> {
+          this.#candleCount += 1;
+
+          if (this.#candleCount === 1) {
+            // Would fill on candle 3 (low=88) if it survived
+            return {amount: '1', amountIn: 'base', price: '90', side: OrderSide.BUY, type: OrderType.LIMIT};
+          }
+
+          if (this.#candleCount === 2) {
+            // Replaces the first order with one that can never fill
+            return {amount: '1', amountIn: 'base', price: '50', side: OrderSide.BUY, type: OrderType.LIMIT};
+          }
+        }
+      }
+
+      const candles = [
+        createCandle({close: '100', high: '100', low: '100', open: '100', openTimeInISO: '2025-01-01T00:00:00.000Z'}),
+        createCandle({close: '100', high: '100', low: '100', open: '100', openTimeInISO: '2025-01-01T00:01:00.000Z'}),
+        createCandle({close: '95', high: '100', low: '88', open: '100', openTimeInISO: '2025-01-01T00:02:00.000Z'}),
+      ];
+
+      const config: BacktestConfig = {
+        broker: createMockExchange(),
+        candles,
+        strategy: new RepriceBuy(),
+        tradingPair,
+      };
+
+      const result = await new BacktestExecutor(config).execute();
+
+      /*
+       * A live TradingSession cancels outstanding orders before acting on new advice. Without
+       * that, the buy@90 from candle 1 would survive and fill on candle 3 (low=88) — a trade
+       * a live session would never make.
+       */
+      expect(result.trades).toHaveLength(0);
       expect(result.finalCounterBalance.toFixed(2)).toBe('1000.00');
     });
 
@@ -683,6 +737,8 @@ describe('BacktestExecutor', () => {
       const result = await new BacktestExecutor(config).execute();
 
       expect(result.trades).toHaveLength(0);
+      expect(result.skippedAdvices).toHaveLength(2);
+      expect(result.skippedAdvices[0].reason).toContain('below the minimum');
     });
 
     it('skips sell trades when the base balance is below base_min_size', async () => {

--- a/packages/trading-strategies/src/backtest/BacktestExecutor.ts
+++ b/packages/trading-strategies/src/backtest/BacktestExecutor.ts
@@ -1,8 +1,15 @@
 import Big from 'big.js';
-import {AllAvailableAmount, CandleBatcher, OrderSide, OrderType} from '@typedtrader/exchange';
-import type {Candle, FeeRate, TradingRules, OrderAdvice, TradingPair, TradingSessionState} from '@typedtrader/exchange';
+import {CandleBatcher} from '@typedtrader/exchange';
+import type {Candle, FeeRate, TradingRules, TradingPair} from '@typedtrader/exchange';
+import {AdviceExecutor} from '../trader/AdviceExecutor.js';
+import type {OrderAdvice, TradingSessionState} from '../trader/TradingSessionTypes.js';
 import type {BacktestConfig} from './BacktestConfig.js';
-import type {BacktestPerformanceSummary, BacktestResult, BacktestTrade} from './BacktestResult.js';
+import type {
+  BacktestPerformanceSummary,
+  BacktestResult,
+  BacktestSkippedAdvice,
+  BacktestTrade,
+} from './BacktestResult.js';
 import {PerformanceCalculator} from './PerformanceCalculator.js';
 
 export class BacktestExecutor {
@@ -25,7 +32,11 @@ export class BacktestExecutor {
       exchange.getFeeRates(tradingPair),
     ]);
 
+    // The exact same advice→order translation a live TradingSession uses
+    const adviceExecutor = new AdviceExecutor({broker: exchange, feeRates, pair: tradingPair, tradingRules});
+
     const trades: BacktestTrade[] = [];
+    const skippedAdvices: BacktestSkippedAdvice[] = [];
     let totalFees = new Big(0);
 
     for (const candle of candles) {
@@ -35,7 +46,7 @@ export class BacktestExecutor {
       if (fills.length > 0) {
         for (const fill of fills) {
           trades.push({
-            advice: this.#findAdviceForFill(fill.order_id, trades),
+            advice: this.#findAdviceForFill(fill.order_id),
             fee: new Big(fill.fee),
             openTimeInISO: fill.created_at,
             price: new Big(fill.price),
@@ -61,8 +72,23 @@ export class BacktestExecutor {
         continue;
       }
 
-      // Step 3: Translate advice into exchange orders
-      await this.#placeOrderFromAdvice(advice, tradingPair, tradingRules, feeRates);
+      // Step 3: Replace outstanding orders with the newest advice, mirroring TradingSession
+      const openOrders = await exchange.getOpenOrders(tradingPair);
+      if (openOrders.length > 0) {
+        await exchange.cancelOpenOrders(tradingPair);
+      }
+
+      const outcome = await adviceExecutor.execute(advice);
+
+      if (outcome.status === 'PLACED') {
+        this.#orderAdviceMap.set(outcome.order.id, advice);
+      } else {
+        skippedAdvices.push({
+          advice,
+          openTimeInISO: candle.openTimeInISO,
+          reason: outcome.error.message,
+        });
+      }
     }
 
     /*
@@ -89,6 +115,7 @@ export class BacktestExecutor {
       initialCounterBalance,
       performance,
       profitOrLoss,
+      skippedAdvices,
       totalCandles: candles.length,
       totalFees,
       trades,
@@ -98,16 +125,11 @@ export class BacktestExecutor {
   /** Map to track which order_id corresponds to which advice */
   readonly #orderAdviceMap = new Map<string, OrderAdvice>();
 
-  #findAdviceForFill(orderId: string, _trades: BacktestTrade[]): OrderAdvice {
+  #findAdviceForFill(orderId: string): OrderAdvice {
     const advice = this.#orderAdviceMap.get(orderId);
     if (!advice) {
-      // Fallback: shouldn't happen in normal flow
-      return {
-        amount: AllAvailableAmount,
-        amountIn: 'counter',
-        side: OrderSide.BUY,
-        type: OrderType.MARKET,
-      };
+      // Fabricating a fallback advice here would silently corrupt the cycle/win-rate stats
+      throw new Error(`No advice recorded for filled order "${orderId}"`);
     }
     return advice;
   }
@@ -124,124 +146,6 @@ export class BacktestExecutor {
       lastOrderSide,
       tradingRules,
     };
-  }
-
-  async #placeOrderFromAdvice(
-    advice: OrderAdvice,
-    pair: TradingPair,
-    tradingRules: TradingRules,
-    feeRates: FeeRate
-  ): Promise<void> {
-    const {broker: exchange} = this.#config;
-
-    try {
-      if (advice.type === OrderType.LIMIT) {
-        const rawPrice = new Big(advice.price);
-        const price = this.#roundLimitPrice(rawPrice, tradingRules);
-
-        if (price.lte(0)) {
-          return;
-        }
-
-        const balances = await exchange.getAvailableBalances(pair);
-
-        let size: Big;
-        if (advice.side === OrderSide.BUY) {
-          if (advice.amount !== AllAvailableAmount) {
-            size = new Big(advice.amount);
-          } else {
-            const feeRate = feeRates[OrderType.LIMIT];
-            const netSpend = balances.counter.div(new Big(1).plus(feeRate));
-            size = netSpend.div(price);
-          }
-        } else {
-          // SELL
-          const amount = advice.amount !== AllAvailableAmount ? new Big(advice.amount) : balances.base;
-          if (amount.lte(0) || balances.base.lte(0)) {
-            return;
-          }
-          size = amount.gt(balances.base) ? balances.base : amount;
-        }
-
-        if (size.lte(0)) {
-          return;
-        }
-
-        const order = await exchange.placeLimitOrder(pair, {
-          price: price.toFixed(),
-          side: advice.side,
-          size: size.toFixed(),
-        });
-        this.#orderAdviceMap.set(order.id, advice);
-      } else {
-        // MARKET order
-        const balances = await exchange.getAvailableBalances(pair);
-
-        if (advice.side === OrderSide.BUY) {
-          if (advice.amountIn === 'counter') {
-            const spendAmount = advice.amount !== AllAvailableAmount ? new Big(advice.amount) : balances.counter;
-            if (spendAmount.lte(0) || balances.counter.lte(0)) {
-              return;
-            }
-            const actualSpend = spendAmount.gt(balances.counter) ? balances.counter : spendAmount;
-            const latestCandle = await exchange.getLatestCandle(pair, 0);
-            const estimatedPrice = new Big(latestCandle.close);
-            if (estimatedPrice.eq(0)) {
-              return;
-            }
-            const feeRate = feeRates[OrderType.MARKET];
-            const netSpend = actualSpend.div(new Big(1).plus(feeRate));
-            const size = netSpend.div(estimatedPrice);
-
-            if (size.lte(0)) {
-              return;
-            }
-
-            const order = await exchange.placeMarketOrder(pair, {
-              side: OrderSide.BUY,
-              size: size.toFixed(),
-              sizeInCounter: false,
-            });
-            this.#orderAdviceMap.set(order.id, advice);
-          } else {
-            // amountIn: 'base' — amount is always explicit (enforced by MarketBuyBaseAdvice)
-            const size = new Big(advice.amount);
-            if (size.lte(0)) {
-              return;
-            }
-
-            const order = await exchange.placeMarketOrder(pair, {
-              side: OrderSide.BUY,
-              size: size.toFixed(),
-              sizeInCounter: false,
-            });
-            this.#orderAdviceMap.set(order.id, advice);
-          }
-        } else {
-          // SELL MARKET
-          const amount = advice.amount !== AllAvailableAmount ? new Big(advice.amount) : balances.base;
-          if (amount.lte(0) || balances.base.lte(0)) {
-            return;
-          }
-          const actualSize = amount.gt(balances.base) ? balances.base : amount;
-
-          const order = await exchange.placeMarketOrder(pair, {
-            side: OrderSide.SELL,
-            size: actualSize.toFixed(),
-            sizeInCounter: false,
-          });
-          this.#orderAdviceMap.set(order.id, advice);
-        }
-      }
-    } catch {
-      // Order rejected (insufficient balance, trading rules, etc.) - skip
-    }
-  }
-
-  /** Rounds a limit-order price down to the exchange's counter_increment. */
-  #roundLimitPrice(rawPrice: Big, tradingRules: TradingRules): Big {
-    const counterIncrement = new Big(tradingRules.counter_increment);
-    return rawPrice.div(counterIncrement).round(0, Big.roundDown).mul(counterIncrement);
   }
 
   #buildPerformanceSummary(

--- a/packages/trading-strategies/src/backtest/BacktestResult.ts
+++ b/packages/trading-strategies/src/backtest/BacktestResult.ts
@@ -1,5 +1,6 @@
-import type {OrderSide, OrderAdvice} from '@typedtrader/exchange';
+import type {OrderSide} from '@typedtrader/exchange';
 import type Big from 'big.js';
+import type {OrderAdvice} from '../trader/TradingSessionTypes.js';
 
 export interface BacktestTrade {
   /** The advice that triggered this trade. */
@@ -54,4 +55,19 @@ export interface BacktestResult {
   totalCandles: number;
   /** All trades executed during the backtest. */
   trades: BacktestTrade[];
+  /**
+   * Advice the executor could not turn into an order (below minimum size, insufficient
+   * balance, rule violations). A live session surfaces these as `error` events; a backtest
+   * that hid them would report results a live run could never reproduce.
+   */
+  skippedAdvices: BacktestSkippedAdvice[];
+}
+
+export interface BacktestSkippedAdvice {
+  /** The advice that could not be executed. */
+  advice: OrderAdvice;
+  /** The ISO timestamp of the candle on which the advice was skipped. */
+  openTimeInISO: string;
+  /** Why the order was not placed. */
+  reason: string;
 }

--- a/packages/trading-strategies/src/index.ts
+++ b/packages/trading-strategies/src/index.ts
@@ -1,5 +1,6 @@
 export * from './backtest/index.js';
 export * from './strategy/index.js';
+export * from './trader/index.js';
 export {BuyOnceStrategy, BuyOnceSchema, type BuyOnceConfig} from './strategy-buy-once/BuyOnceStrategy.js';
 /** @deprecated Use {@link BuyOnceStrategy} without `buyAt` instead. */
 export {

--- a/packages/trading-strategies/src/start/runStrategy.ts
+++ b/packages/trading-strategies/src/start/runStrategy.ts
@@ -1,5 +1,6 @@
 import {config} from 'dotenv-defaults';
-import {AlpacaMarketData, getTrading212Client, OrderSide, TradingPair, TradingSession} from '@typedtrader/exchange';
+import {AlpacaMarketData, getTrading212Client, OrderSide, TradingPair} from '@typedtrader/exchange';
+import {TradingSession} from '../trader/index.js';
 import {BuyOnceStrategy} from '../strategy-buy-once/BuyOnceStrategy.js';
 
 /*

--- a/packages/trading-strategies/src/strategy-buy-and-hold/BuyAndHoldStrategy.test.ts
+++ b/packages/trading-strategies/src/strategy-buy-and-hold/BuyAndHoldStrategy.test.ts
@@ -1,15 +1,8 @@
 import Big from 'big.js';
 import {describe, expect, it} from 'vitest';
 import {CandleBatcher, OrderPosition, OrderSide, OrderType, TradingPair} from '@typedtrader/exchange';
-import type {
-  Candle,
-  Fill,
-  LimitOrderAdvice,
-  MarketOrderAdvice,
-  OneMinuteBatchedCandle,
-  OrderAdvice,
-  TradingSessionState,
-} from '@typedtrader/exchange';
+import type {Candle, Fill, OneMinuteBatchedCandle} from '@typedtrader/exchange';
+import type {LimitOrderAdvice, MarketOrderAdvice, OrderAdvice, TradingSessionState} from '../trader/index.js';
 import {BuyOnceStrategy} from '../strategy-buy-once/BuyOnceStrategy.js';
 
 function assertMarketBuy(advice: OrderAdvice | void): asserts advice is MarketOrderAdvice {

--- a/packages/trading-strategies/src/strategy-buy-below-sell-above/BuyBelowSellAboveStrategy.ts
+++ b/packages/trading-strategies/src/strategy-buy-below-sell-above/BuyBelowSellAboveStrategy.ts
@@ -1,6 +1,8 @@
 import type {z} from 'zod';
-import {AllAvailableAmount, OrderSide, OrderType} from '@typedtrader/exchange';
-import type {OneMinuteBatchedCandle, OrderAdvice, TradingSessionState} from '@typedtrader/exchange';
+import {OrderSide, OrderType} from '@typedtrader/exchange';
+import {AllAvailableAmount} from '../trader/index.js';
+import type {OneMinuteBatchedCandle} from '@typedtrader/exchange';
+import type {OrderAdvice, TradingSessionState} from '../trader/index.js';
 import Big from 'big.js';
 import {MarketType} from '../strategy/MarketType.js';
 import {ProtectedStrategy, ProtectedStrategySchema} from '../strategy-protected/ProtectedStrategy.js';

--- a/packages/trading-strategies/src/strategy-buy-once/BuyOnceStrategy.test.ts
+++ b/packages/trading-strategies/src/strategy-buy-once/BuyOnceStrategy.test.ts
@@ -1,7 +1,8 @@
 import Big from 'big.js';
 import {describe, expect, it} from 'vitest';
 import {AlpacaBrokerMock, CandleBatcher, OrderSide, OrderType} from '@typedtrader/exchange';
-import type {Candle, TradingSessionState} from '@typedtrader/exchange';
+import type {Candle} from '@typedtrader/exchange';
+import type {TradingSessionState} from '../trader/index.js';
 import {TradingPair} from '@typedtrader/exchange';
 import {BacktestExecutor} from '../backtest/BacktestExecutor.js';
 import {BuyOnceStrategy} from './BuyOnceStrategy.js';

--- a/packages/trading-strategies/src/strategy-buy-once/BuyOnceStrategy.ts
+++ b/packages/trading-strategies/src/strategy-buy-once/BuyOnceStrategy.ts
@@ -1,6 +1,8 @@
 import type {z} from 'zod';
-import {AllAvailableAmount, OrderSide, OrderType} from '@typedtrader/exchange';
-import type {OneMinuteBatchedCandle, OrderAdvice, TradingSessionState} from '@typedtrader/exchange';
+import {OrderSide, OrderType} from '@typedtrader/exchange';
+import {AllAvailableAmount} from '../trader/index.js';
+import type {OneMinuteBatchedCandle} from '@typedtrader/exchange';
+import type {OrderAdvice, TradingSessionState} from '../trader/index.js';
 import Big from 'big.js';
 import {MarketType} from '../strategy/MarketType.js';
 import {ProtectedStrategy, ProtectedStrategySchema} from '../strategy-protected/ProtectedStrategy.js';

--- a/packages/trading-strategies/src/strategy-coin-flip/CoinFlipStrategy.ts
+++ b/packages/trading-strategies/src/strategy-coin-flip/CoinFlipStrategy.ts
@@ -1,6 +1,8 @@
 import type {z} from 'zod';
-import {AllAvailableAmount, OrderSide, OrderType} from '@typedtrader/exchange';
-import type {OneMinuteBatchedCandle, OrderAdvice, TradingSessionState} from '@typedtrader/exchange';
+import {OrderSide, OrderType} from '@typedtrader/exchange';
+import {AllAvailableAmount} from '../trader/index.js';
+import type {OneMinuteBatchedCandle} from '@typedtrader/exchange';
+import type {OrderAdvice, TradingSessionState} from '../trader/index.js';
 import {MarketType} from '../strategy/MarketType.js';
 import {ProtectedStrategy, ProtectedStrategySchema} from '../strategy-protected/ProtectedStrategy.js';
 

--- a/packages/trading-strategies/src/strategy-mean-reversion/MeanReversionStrategy.ts
+++ b/packages/trading-strategies/src/strategy-mean-reversion/MeanReversionStrategy.ts
@@ -1,6 +1,8 @@
 import type {z} from 'zod';
-import {AllAvailableAmount, CandleBatcher, OrderSide, OrderType} from '@typedtrader/exchange';
-import type {Candle, OneMinuteBatchedCandle, OrderAdvice, TradingSessionState} from '@typedtrader/exchange';
+import {CandleBatcher, OrderSide, OrderType} from '@typedtrader/exchange';
+import {AllAvailableAmount} from '../trader/index.js';
+import type {Candle, OneMinuteBatchedCandle} from '@typedtrader/exchange';
+import type {OrderAdvice, TradingSessionState} from '../trader/index.js';
 import {BollingerBands} from 'trading-signals';
 import {MarketType} from '../strategy/MarketType.js';
 import {ProtectedStrategy, ProtectedStrategySchema} from '../strategy-protected/ProtectedStrategy.js';

--- a/packages/trading-strategies/src/strategy-multi-indicator-confluence/MultiIndicatorConfluenceStrategy.test.ts
+++ b/packages/trading-strategies/src/strategy-multi-indicator-confluence/MultiIndicatorConfluenceStrategy.test.ts
@@ -1,7 +1,8 @@
 import Big from 'big.js';
 import {describe, expect, it} from 'vitest';
 import {CandleBatcher, OrderSide, OrderType} from '@typedtrader/exchange';
-import type {Candle, TradingSessionState} from '@typedtrader/exchange';
+import type {Candle} from '@typedtrader/exchange';
+import type {TradingSessionState} from '../trader/index.js';
 import {MultiIndicatorConfluenceSchema, MultiIndicatorConfluenceStrategy} from './MultiIndicatorConfluenceStrategy.js';
 import type {MultiIndicatorConfluenceConfig} from './MultiIndicatorConfluenceStrategy.js';
 

--- a/packages/trading-strategies/src/strategy-multi-indicator-confluence/MultiIndicatorConfluenceStrategy.ts
+++ b/packages/trading-strategies/src/strategy-multi-indicator-confluence/MultiIndicatorConfluenceStrategy.ts
@@ -1,5 +1,7 @@
-import {AllAvailableAmount, OrderSide, OrderType} from '@typedtrader/exchange';
-import type {OneMinuteBatchedCandle, OrderAdvice, TradingSessionState} from '@typedtrader/exchange';
+import {OrderSide, OrderType} from '@typedtrader/exchange';
+import {AllAvailableAmount} from '../trader/index.js';
+import type {OneMinuteBatchedCandle} from '@typedtrader/exchange';
+import type {OrderAdvice, TradingSessionState} from '../trader/index.js';
 import {BollingerBands, EMA, MACD, RSI} from 'trading-signals';
 import {MarketType} from '../strategy/MarketType.js';
 import {ProtectedStrategy} from '../strategy-protected/ProtectedStrategy.js';

--- a/packages/trading-strategies/src/strategy-noop/NoopStrategy.test.ts
+++ b/packages/trading-strategies/src/strategy-noop/NoopStrategy.test.ts
@@ -1,7 +1,8 @@
 import Big from 'big.js';
 import {describe, expect, it} from 'vitest';
 import {CandleBatcher, OrderType, TradingPair} from '@typedtrader/exchange';
-import type {Candle, TradingSessionState} from '@typedtrader/exchange';
+import type {Candle} from '@typedtrader/exchange';
+import type {TradingSessionState} from '../trader/index.js';
 import {NoopStrategy} from './NoopStrategy.js';
 
 function createCandle(): Candle {

--- a/packages/trading-strategies/src/strategy-noop/NoopStrategy.ts
+++ b/packages/trading-strategies/src/strategy-noop/NoopStrategy.ts
@@ -1,5 +1,6 @@
 import {z} from 'zod';
-import type {OneMinuteBatchedCandle, OrderAdvice, TradingSessionState} from '@typedtrader/exchange';
+import type {OneMinuteBatchedCandle} from '@typedtrader/exchange';
+import type {OrderAdvice, TradingSessionState} from '../trader/index.js';
 import {MarketType} from '../strategy/MarketType.js';
 import {Strategy} from '../strategy/Strategy.js';
 

--- a/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.test.ts
+++ b/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.test.ts
@@ -2,24 +2,10 @@ import Big from 'big.js';
 import {ms} from 'ms';
 import {describe, expect, it, vi} from 'vitest';
 import {z} from 'zod';
-import {
-  AllAvailableAmount,
-  CandleBatcher,
-  OrderPosition,
-  OrderSide,
-  OrderType,
-  TradingPair,
-} from '@typedtrader/exchange';
-import type {
-  Candle,
-  Fill,
-  PendingOrder,
-  LimitOrderAdvice,
-  MarketOrderAdvice,
-  OneMinuteBatchedCandle,
-  OrderAdvice,
-  TradingSessionState,
-} from '@typedtrader/exchange';
+import {CandleBatcher, OrderPosition, OrderSide, OrderType, TradingPair} from '@typedtrader/exchange';
+import {AllAvailableAmount} from '../trader/index.js';
+import type {Candle, Fill, PendingOrder, OneMinuteBatchedCandle} from '@typedtrader/exchange';
+import type {LimitOrderAdvice, MarketOrderAdvice, OrderAdvice, TradingSessionState} from '../trader/index.js';
 import {ProtectedStrategy, ProtectedStrategySchema} from './ProtectedStrategy.js';
 
 function assertLimitSell(advice: OrderAdvice | void): asserts advice is LimitOrderAdvice {

--- a/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.ts
+++ b/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.ts
@@ -1,14 +1,9 @@
 import Big from 'big.js';
 import {z} from 'zod';
-import {AllAvailableAmount, OrderSide, OrderType} from '@typedtrader/exchange';
-import type {
-  Fill,
-  PendingOrder,
-  LimitOrderAdvice,
-  OneMinuteBatchedCandle,
-  OrderAdvice,
-  TradingSessionState,
-} from '@typedtrader/exchange';
+import {OrderSide, OrderType} from '@typedtrader/exchange';
+import {AllAvailableAmount} from '../trader/index.js';
+import type {Fill, PendingOrder, OneMinuteBatchedCandle} from '@typedtrader/exchange';
+import type {LimitOrderAdvice, OrderAdvice, TradingSessionState} from '../trader/index.js';
 import {MarketType} from '../strategy/MarketType.js';
 import {Strategy} from '../strategy/Strategy.js';
 import {positiveNumberString} from '../util/validators.js';

--- a/packages/trading-strategies/src/strategy-scalp/ScalpStrategy.test.ts
+++ b/packages/trading-strategies/src/strategy-scalp/ScalpStrategy.test.ts
@@ -1,7 +1,8 @@
 import Big from 'big.js';
 import {describe, expect, it} from 'vitest';
 import {CandleBatcher, OrderSide, OrderType} from '@typedtrader/exchange';
-import type {Candle, Fill, LimitOrderAdvice, TradingSessionState} from '@typedtrader/exchange';
+import type {Candle, Fill} from '@typedtrader/exchange';
+import type {LimitOrderAdvice, TradingSessionState} from '../trader/index.js';
 import {TradingPair} from '@typedtrader/exchange';
 import {ScalpStrategy, ScalpSchema} from './ScalpStrategy.js';
 

--- a/packages/trading-strategies/src/strategy-scalp/ScalpStrategy.ts
+++ b/packages/trading-strategies/src/strategy-scalp/ScalpStrategy.ts
@@ -1,7 +1,9 @@
 import {z} from 'zod';
 import Big from 'big.js';
-import {AllAvailableAmount, CandleBatcher, OrderSide, OrderType} from '@typedtrader/exchange';
-import type {Candle, Fill, OneMinuteBatchedCandle, OrderAdvice, TradingSessionState} from '@typedtrader/exchange';
+import {CandleBatcher, OrderSide, OrderType} from '@typedtrader/exchange';
+import {AllAvailableAmount} from '../trader/index.js';
+import type {Candle, Fill, OneMinuteBatchedCandle} from '@typedtrader/exchange';
+import type {OrderAdvice, TradingSessionState} from '../trader/index.js';
 import {EMA, ER} from 'trading-signals';
 import {MarketType} from '../strategy/MarketType.js';
 import {ProtectedStrategy, ProtectedStrategySchema} from '../strategy-protected/ProtectedStrategy.js';

--- a/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.ts
+++ b/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.ts
@@ -1,14 +1,9 @@
 import Big from 'big.js';
 import {z} from 'zod';
-import {AllAvailableAmount, OrderSide, OrderType} from '@typedtrader/exchange';
-import type {
-  Fill,
-  PendingOrder,
-  LimitOrderAdvice,
-  OneMinuteBatchedCandle,
-  OrderAdvice,
-  TradingSessionState,
-} from '@typedtrader/exchange';
+import {OrderSide, OrderType} from '@typedtrader/exchange';
+import {AllAvailableAmount} from '../trader/index.js';
+import type {Fill, PendingOrder, OneMinuteBatchedCandle} from '@typedtrader/exchange';
+import type {LimitOrderAdvice, OrderAdvice, TradingSessionState} from '../trader/index.js';
 import {MarketType} from '../strategy/MarketType.js';
 import {Strategy} from '../strategy/Strategy.js';
 import {positiveNumberString} from '../util/validators.js';

--- a/packages/trading-strategies/src/strategy/Strategy.ts
+++ b/packages/trading-strategies/src/strategy/Strategy.ts
@@ -1,10 +1,6 @@
 import Big from 'big.js';
-import type {
-  OneMinuteBatchedCandle,
-  OrderAdvice,
-  TradingSessionState,
-  TradingSessionStrategy,
-} from '@typedtrader/exchange';
+import type {OneMinuteBatchedCandle} from '@typedtrader/exchange';
+import type {OrderAdvice, TradingSessionState, TradingSessionStrategy} from '../trader/index.js';
 import type {MarketType} from './MarketType.js';
 
 export abstract class Strategy implements TradingSessionStrategy {

--- a/packages/trading-strategies/src/trader/AdviceExecutor.test.ts
+++ b/packages/trading-strategies/src/trader/AdviceExecutor.test.ts
@@ -1,0 +1,148 @@
+import Big from 'big.js';
+import {describe, expect, it, vi} from 'vitest';
+import {OrderSide, OrderType, TradingPair} from '@typedtrader/exchange';
+import type {FeeRate, TradingRules} from '@typedtrader/exchange';
+import {AdviceExecutor} from './AdviceExecutor.js';
+import type {AdviceExecution} from './AdviceExecutor.js';
+import {OrderSizeBelowMinimumError} from './OrderSizeBelowMinimumError.js';
+import {AllAvailableAmount} from './TradingSessionTypes.js';
+import type {OrderAdvice} from './TradingSessionTypes.js';
+
+const pair = new TradingPair('BTC', 'USD');
+
+const tradingRules: TradingRules = {
+  base_increment: '0.0001',
+  base_max_size: String(Number.MAX_SAFE_INTEGER),
+  base_min_size: '0.0001',
+  counter_increment: '0.01',
+  counter_min_size: '1',
+  pair,
+};
+
+const feeRates: FeeRate = {
+  [OrderType.LIMIT]: new Big(0.0015),
+  [OrderType.MARKET]: new Big(0.0025),
+};
+
+function createExecutor(options: {baseBalance?: string; counterBalance?: string} = {}) {
+  const broker = {
+    getAvailableBalances: vi.fn().mockResolvedValue({
+      base: new Big(options.baseBalance ?? '10'),
+      counter: new Big(options.counterBalance ?? '5000'),
+    }),
+    placeLimitOrder: vi.fn().mockResolvedValue({
+      id: 'limit-1',
+      pair,
+      price: '100',
+      side: OrderSide.BUY,
+      size: '1',
+      type: OrderType.LIMIT,
+    }),
+    placeMarketOrder: vi.fn().mockResolvedValue({
+      id: 'market-1',
+      pair,
+      side: OrderSide.BUY,
+      size: '1',
+      type: OrderType.MARKET,
+    }),
+  };
+  return {broker, executor: new AdviceExecutor({broker, feeRates, pair, tradingRules})};
+}
+
+describe('AdviceExecutor', () => {
+  it('sells the full base holding when a counter-denominated sell requests all available', async () => {
+    const {broker, executor} = createExecutor({baseBalance: '10'});
+    const advice: OrderAdvice = {
+      amount: AllAvailableAmount,
+      amountIn: 'counter',
+      side: OrderSide.SELL,
+      type: OrderType.MARKET,
+    };
+
+    const outcome = await executor.execute(advice);
+
+    expect(outcome.status).toBe('PLACED');
+    expect(broker.placeMarketOrder).toHaveBeenCalledWith(pair, {
+      side: OrderSide.SELL,
+      size: '10',
+      sizeInCounter: false,
+    });
+  });
+
+  it('clamps a notional market buy to the available counter balance', async () => {
+    const {broker, executor} = createExecutor({counterBalance: '5000'});
+    const advice: OrderAdvice = {
+      amount: '6000',
+      amountIn: 'counter',
+      side: OrderSide.BUY,
+      type: OrderType.MARKET,
+    };
+
+    const outcome = await executor.execute(advice);
+
+    expect(outcome.status).toBe('PLACED');
+    expect(broker.placeMarketOrder).toHaveBeenCalledWith(pair, {
+      side: OrderSide.BUY,
+      size: '5000',
+      sizeInCounter: true,
+    });
+  });
+
+  it('clamps a limit sell to the available base balance', async () => {
+    const {broker, executor} = createExecutor({baseBalance: '3'});
+    const advice: OrderAdvice = {
+      amount: '100',
+      amountIn: 'base',
+      price: '250',
+      side: OrderSide.SELL,
+      type: OrderType.LIMIT,
+    };
+
+    const outcome = await executor.execute(advice);
+
+    expect(outcome.status).toBe('PLACED');
+    expect(broker.placeLimitOrder).toHaveBeenCalledWith(pair, {
+      price: '250',
+      side: OrderSide.SELL,
+      size: '3',
+    });
+  });
+
+  it('skips with an OrderSizeBelowMinimumError instead of placing a zero-size order', async () => {
+    const {broker, executor} = createExecutor({baseBalance: '0'});
+    const advice: OrderAdvice = {
+      amount: AllAvailableAmount,
+      amountIn: 'base',
+      side: OrderSide.SELL,
+      type: OrderType.MARKET,
+    };
+
+    const outcome = await executor.execute(advice);
+
+    assertSkipped(outcome);
+    expect(outcome.error).toBeInstanceOf(OrderSizeBelowMinimumError);
+    expect(broker.placeMarketOrder).not.toHaveBeenCalled();
+    expect(broker.placeLimitOrder).not.toHaveBeenCalled();
+  });
+
+  it('reports broker rejections as skips instead of throwing', async () => {
+    const {broker, executor} = createExecutor();
+    broker.placeMarketOrder.mockRejectedValue(new Error('Insufficient funds'));
+    const advice: OrderAdvice = {
+      amount: AllAvailableAmount,
+      amountIn: 'counter',
+      side: OrderSide.BUY,
+      type: OrderType.MARKET,
+    };
+
+    const outcome = await executor.execute(advice);
+
+    assertSkipped(outcome);
+    expect(outcome.error.message).toBe('Insufficient funds');
+    expect(outcome.balances.counter.eq('5000')).toBe(true);
+  });
+});
+
+function assertSkipped(outcome: AdviceExecution): asserts outcome is Extract<AdviceExecution, {status: 'SKIPPED'}> {
+  expect(outcome.status).toBe('SKIPPED');
+}

--- a/packages/trading-strategies/src/trader/AdviceExecutor.ts
+++ b/packages/trading-strategies/src/trader/AdviceExecutor.ts
@@ -1,0 +1,215 @@
+import Big from 'big.js';
+import {OrderSide, OrderType} from '@typedtrader/exchange';
+import type {ExchangeAvailableBalance, FeeRate, PendingOrder, TradingPair, TradingRules} from '@typedtrader/exchange';
+import {OrderSizeBelowMinimumError} from './OrderSizeBelowMinimumError.js';
+import {AllAvailableAmount} from './TradingSessionTypes.js';
+import type {OrderAdvice, TradingSessionBroker} from './TradingSessionTypes.js';
+
+export type AdviceExecutorBroker = Pick<
+  TradingSessionBroker,
+  'getAvailableBalances' | 'placeLimitOrder' | 'placeMarketOrder'
+>;
+
+export type AdviceExecution =
+  | {status: 'PLACED'; order: PendingOrder; balances: ExchangeAvailableBalance}
+  | {status: 'SKIPPED'; error: Error; balances: ExchangeAvailableBalance};
+
+interface ResolvedOrderSize {
+  size: Big;
+  sizeInCounter: boolean;
+  minimumSize: string;
+}
+
+/**
+ * The single translation from a strategy's {@link OrderAdvice} to a broker order.
+ * `TradingSession` (live) and `BacktestExecutor` (historical) both delegate here, so a
+ * backtest sizes, clamps, and validates orders exactly like a live session would —
+ * keeping the two paths from silently diverging is this class's entire reason to exist.
+ */
+export class AdviceExecutor {
+  readonly #broker: AdviceExecutorBroker;
+  readonly #pair: TradingPair;
+  readonly #tradingRules: TradingRules;
+  readonly #feeRates: FeeRate;
+
+  constructor(options: {
+    broker: AdviceExecutorBroker;
+    pair: TradingPair;
+    tradingRules: TradingRules;
+    feeRates: FeeRate;
+  }) {
+    this.#broker = options.broker;
+    this.#pair = options.pair;
+    this.#tradingRules = options.tradingRules;
+    this.#feeRates = options.feeRates;
+  }
+
+  /**
+   * Balances are re-fetched on every call because fills may have changed them since the
+   * advice was produced. Placement failures are returned as a `SKIPPED` outcome instead of
+   * thrown, so callers always learn about dropped advice — a backtest that silently eats a
+   * rejected order reports results a live session would never achieve.
+   */
+  async execute(advice: OrderAdvice): Promise<AdviceExecution> {
+    const balances = await this.#broker.getAvailableBalances(this.#pair);
+
+    if (advice.type === OrderType.LIMIT) {
+      const price = this.#applyPrecision(new Big(advice.price), this.#tradingRules.counter_increment);
+
+      if (price.lte(0)) {
+        return {
+          balances,
+          error: new Error(`Limit price "${new Big(advice.price).toFixed()}" rounds to zero and cannot be placed`),
+          status: 'SKIPPED',
+        };
+      }
+
+      const resolved = this.#resolveLimitOrderSize(advice, balances, price);
+      const belowMinimum = this.#checkMinimumSize(advice, resolved);
+
+      if (belowMinimum) {
+        return {balances, error: belowMinimum, status: 'SKIPPED'};
+      }
+
+      try {
+        const order = await this.#broker.placeLimitOrder(this.#pair, {
+          price: price.toFixed(),
+          side: advice.side,
+          size: resolved.size.toFixed(),
+        });
+        return {balances, order, status: 'PLACED'};
+      } catch (error) {
+        return {balances, error: toError(error), status: 'SKIPPED'};
+      }
+    }
+
+    const resolved = this.#resolveMarketOrderSize(advice, balances);
+    const belowMinimum = this.#checkMinimumSize(advice, resolved);
+
+    if (belowMinimum) {
+      return {balances, error: belowMinimum, status: 'SKIPPED'};
+    }
+
+    try {
+      const order = await this.#broker.placeMarketOrder(this.#pair, {
+        side: advice.side,
+        size: resolved.size.toFixed(),
+        sizeInCounter: resolved.sizeInCounter,
+      });
+      return {balances, order, status: 'PLACED'};
+    } catch (error) {
+      return {balances, error: toError(error), status: 'SKIPPED'};
+    }
+  }
+
+  /** Limit advice is always sized in base currency (enforced by {@link LimitOrderAdvice}). */
+  #resolveLimitOrderSize(
+    advice: Extract<OrderAdvice, {type: 'LIMIT'}>,
+    balances: ExchangeAvailableBalance,
+    price: Big
+  ): ResolvedOrderSize {
+    const {base_increment, base_min_size} = this.#tradingRules;
+
+    let amount: Big;
+
+    if (advice.amount === AllAvailableAmount) {
+      if (advice.side === OrderSide.BUY) {
+        /*
+         * Fees are charged on top of the notional, so spending the full counter balance on
+         * the order itself would leave nothing for the fee and get the order rejected.
+         */
+        const netSpend = balances.counter.div(new Big(1).plus(this.#feeRates[OrderType.LIMIT]));
+        amount = netSpend.div(price);
+      } else {
+        amount = balances.base;
+      }
+    } else if (advice.side === OrderSide.SELL) {
+      // Never offer more than we hold: a sell above the balance is a guaranteed rejection.
+      const requested = new Big(advice.amount);
+      amount = requested.gt(balances.base) ? balances.base : requested;
+    } else {
+      amount = new Big(advice.amount);
+    }
+
+    return {
+      minimumSize: base_min_size,
+      size: this.#applyPrecision(amount, base_increment),
+      sizeInCounter: false,
+    };
+  }
+
+  #resolveMarketOrderSize(
+    advice: Extract<OrderAdvice, {type: 'MARKET'}>,
+    balances: ExchangeAvailableBalance
+  ): ResolvedOrderSize {
+    const {base_increment, base_min_size, counter_increment, counter_min_size} = this.#tradingRules;
+
+    if (advice.side === OrderSide.BUY && advice.amountIn === 'counter') {
+      // Notional buy: the broker converts at the actual fill price, so no price estimate is needed here.
+      const requested = advice.amount === AllAvailableAmount ? balances.counter : new Big(advice.amount);
+      const amount = requested.gt(balances.counter) ? balances.counter : requested;
+      return {
+        minimumSize: counter_min_size,
+        size: this.#applyPrecision(amount, counter_increment),
+        sizeInCounter: true,
+      };
+    }
+
+    if (advice.side === OrderSide.BUY) {
+      // BUY in base: the amount is always explicit (enforced by MarketBuyBaseAdvice).
+      return {
+        minimumSize: base_min_size,
+        size: this.#applyPrecision(new Big(advice.amount), base_increment),
+        sizeInCounter: false,
+      };
+    }
+
+    // SELL
+    if (advice.amount === AllAvailableAmount) {
+      // "Sell everything" always means the full base holding, even when the advice is denominated in counter.
+      return {
+        minimumSize: base_min_size,
+        size: this.#applyPrecision(balances.base, base_increment),
+        sizeInCounter: false,
+      };
+    }
+
+    if (advice.amountIn === 'counter') {
+      // Notional sell: the broker sells however much base is needed to receive this counter amount.
+      return {
+        minimumSize: counter_min_size,
+        size: this.#applyPrecision(new Big(advice.amount), counter_increment),
+        sizeInCounter: true,
+      };
+    }
+
+    const requested = new Big(advice.amount);
+    const amount = requested.gt(balances.base) ? balances.base : requested;
+    return {
+      minimumSize: base_min_size,
+      size: this.#applyPrecision(amount, base_increment),
+      sizeInCounter: false,
+    };
+  }
+
+  #checkMinimumSize(advice: OrderAdvice, resolved: ResolvedOrderSize): OrderSizeBelowMinimumError | null {
+    if (resolved.size.lt(resolved.minimumSize)) {
+      return new OrderSizeBelowMinimumError({
+        amountIn: advice.amountIn,
+        minimumSize: resolved.minimumSize,
+        side: advice.side,
+        size: resolved.size.toFixed(),
+      });
+    }
+    return null;
+  }
+
+  #applyPrecision(value: Big, increment: string): Big {
+    const inc = new Big(increment);
+    return value.div(inc).round(0, Big.roundDown).mul(inc);
+  }
+}
+
+function toError(value: unknown): Error {
+  return value instanceof Error ? value : new Error(String(value));
+}

--- a/packages/trading-strategies/src/trader/OrderSizeBelowMinimumError.ts
+++ b/packages/trading-strategies/src/trader/OrderSizeBelowMinimumError.ts
@@ -1,4 +1,4 @@
-import type {OrderSide} from '../broker/Broker.js';
+import type {OrderSide} from '@typedtrader/exchange';
 import type {OrderAdvice} from './TradingSessionTypes.js';
 
 export class OrderSizeBelowMinimumError extends Error {

--- a/packages/trading-strategies/src/trader/TradingSession.test.ts
+++ b/packages/trading-strategies/src/trader/TradingSession.test.ts
@@ -1,20 +1,11 @@
 import Big from 'big.js';
 import {EventEmitter} from 'node:events';
+import {AlpacaBroker, OrderPosition, OrderSide, OrderType, TradingPair} from '@typedtrader/exchange';
+import type {Candle, Fill, PendingLimitOrder, PendingMarketOrder} from '@typedtrader/exchange';
 import {TradingSession} from './TradingSession.js';
-import {TradingPair} from '../broker/TradingPair.js';
-import {
-  OrderPosition,
-  OrderSide,
-  OrderType,
-  type Candle,
-  type Fill,
-  type PendingLimitOrder,
-  type PendingMarketOrder,
-} from '../broker/Broker.js';
 import {OrderSizeBelowMinimumError} from './OrderSizeBelowMinimumError.js';
 import {AllAvailableAmount} from './TradingSessionTypes.js';
 import type {OrderAdvice, TradingSessionStrategy} from './TradingSessionTypes.js';
-import {AlpacaBroker} from '../broker/alpaca/AlpacaBroker.js';
 
 const pair = new TradingPair('TSLA', 'USD');
 
@@ -286,11 +277,15 @@ describe('TradingSession', {concurrent: false}, () => {
       exchange.emit('candle-topic-1', sampleCandle);
       await vi.waitFor(() => expect(exchange.placeLimitOrder).toHaveBeenCalledTimes(1));
 
-      // counter=5000, price=250 → 5000/250 = 20, base_increment=0.001 → 20
+      /*
+       * The full counter balance is reduced by the limit fee (0.15%) before sizing, because
+       * fees are charged on top of the notional and would otherwise exceed the balance:
+       * counter=5000 → 5000/1.0015 = 4992.51… → /250 = 19.9700449326…, base_increment=0.000000001
+       */
       expect(exchange.placeLimitOrder).toHaveBeenCalledWith(pair, {
         price: '250',
         side: OrderSide.BUY,
-        size: '20',
+        size: '19.970044932',
       });
     });
 

--- a/packages/trading-strategies/src/trader/TradingSession.ts
+++ b/packages/trading-strategies/src/trader/TradingSession.ts
@@ -1,12 +1,7 @@
-import Big from 'big.js';
 import {EventEmitter} from 'node:events';
-import {CandleBatcher} from '../candle/CandleBatcher.js';
-import type {BatchedCandle} from '../candle/BatchedCandle.js';
-import {ONE_MINUTE_IN_MS} from '../candle/BatchedCandle.js';
-import type {Candle, Fill, PendingOrder} from '../broker/Broker.js';
-import {OrderSide, OrderType} from '../broker/Broker.js';
-import {OrderSizeBelowMinimumError} from './OrderSizeBelowMinimumError.js';
-import {AllAvailableAmount} from './TradingSessionTypes.js';
+import {CandleBatcher, ONE_MINUTE_IN_MS} from '@typedtrader/exchange';
+import type {BatchedCandle, Candle, Fill, PendingOrder} from '@typedtrader/exchange';
+import {AdviceExecutor} from './AdviceExecutor.js';
 import type {
   OrderAdvice,
   TradingSessionEventMap,
@@ -20,6 +15,7 @@ export class TradingSession extends EventEmitter<TradingSessionEventMap> {
   readonly #strategy;
 
   #state: TradingSessionState | null = null;
+  #adviceExecutor: AdviceExecutor | null = null;
   readonly #pendingOrders = new Map<string, PendingOrder>();
   #candleTopicId: string | null = null;
   #orderTopicId: string | null = null;
@@ -69,6 +65,8 @@ export class TradingSession extends EventEmitter<TradingSessionEventMap> {
       tradingRules,
     };
 
+    this.#adviceExecutor = new AdviceExecutor({broker: this.#broker, feeRates, pair: this.#pair, tradingRules});
+
     await this.#strategy.init?.(this.#broker, this.#pair);
 
     // Subscribe to candles only after state is ready
@@ -101,6 +99,7 @@ export class TradingSession extends EventEmitter<TradingSessionEventMap> {
     this.#running = false;
     this.#pendingOrders.clear();
     this.#state = null;
+    this.#adviceExecutor = null;
     this.emit('stopped');
   }
 
@@ -169,87 +168,20 @@ export class TradingSession extends EventEmitter<TradingSessionEventMap> {
       }
     }
 
-    const balances = await this.#broker.getAvailableBalances(this.#pair);
+    const outcome = await this.#adviceExecutor!.execute(advice);
+
     this.#state = {
       ...this.#state!,
-      baseBalance: balances.base,
-      counterBalance: balances.counter,
+      baseBalance: outcome.balances.base,
+      counterBalance: outcome.balances.counter,
     };
 
-    const size = this.#resolveOrderSize(advice);
-    if (!size) {
+    if (outcome.status === 'SKIPPED') {
+      this.emit('error', outcome.error);
       return;
     }
 
-    const {base_min_size, counter_min_size} = this.#state.tradingRules;
-    const minimumSize = advice.amountIn === 'counter' ? counter_min_size : base_min_size;
-
-    if (size.lt(minimumSize)) {
-      this.emit(
-        'error',
-        new OrderSizeBelowMinimumError({
-          amountIn: advice.amountIn,
-          minimumSize,
-          side: advice.side,
-          size: size.toFixed(),
-        })
-      );
-      return;
-    }
-
-    let order: PendingOrder;
-
-    if (advice.type === OrderType.LIMIT) {
-      const price = this.#applyPrecision(new Big(advice.price), this.#state.tradingRules.counter_increment);
-      order = await this.#broker.placeLimitOrder(this.#pair, {
-        price: price.toFixed(),
-        side: advice.side,
-        size: size.toFixed(),
-      });
-    } else {
-      order = await this.#broker.placeMarketOrder(this.#pair, {
-        side: advice.side,
-        size: size.toFixed(),
-        sizeInCounter: advice.amountIn === 'counter',
-      });
-    }
-
-    this.#pendingOrders.set(order.id, order);
-    this.emit('order', order);
-  }
-
-  #resolveOrderSize(advice: OrderAdvice): Big | null {
-    const {tradingRules} = this.#state!;
-
-    if (advice.amount !== AllAvailableAmount) {
-      const amount = new Big(advice.amount);
-      if (advice.amountIn === 'counter') {
-        return this.#applyPrecision(amount, tradingRules.counter_increment);
-      }
-      return this.#applyPrecision(amount, tradingRules.base_increment);
-    }
-
-    if (advice.side === OrderSide.SELL) {
-      return this.#applyPrecision(this.#state!.baseBalance, tradingRules.base_increment);
-    }
-
-    // BUY
-    if (advice.amountIn === 'counter') {
-      return this.#applyPrecision(this.#state!.counterBalance, tradingRules.counter_increment);
-    }
-
-    // BUY + base amount + LIMIT → derive from counter balance / price
-    if (advice.type === OrderType.LIMIT) {
-      const baseAmount = this.#state!.counterBalance.div(new Big(advice.price));
-      return this.#applyPrecision(baseAmount, tradingRules.base_increment);
-    }
-
-    // Unreachable: MarketBuyBaseAdvice requires a non-null amount, handled above
-    return null;
-  }
-
-  #applyPrecision(value: Big, increment: string): Big {
-    const inc = new Big(increment);
-    return value.div(inc).round(0, Big.roundDown).mul(inc);
+    this.#pendingOrders.set(outcome.order.id, outcome.order);
+    this.emit('order', outcome.order);
   }
 }

--- a/packages/trading-strategies/src/trader/TradingSessionTypes.ts
+++ b/packages/trading-strategies/src/trader/TradingSessionTypes.ts
@@ -1,22 +1,23 @@
 import type Big from 'big.js';
 import type {BigSource} from 'big.js';
 import type {EventEmitter} from 'node:events';
-import type {BatchedCandle, OneMinuteBatchedCandle} from '../candle/BatchedCandle.js';
-import type {OrderSide} from '../broker/Broker.js';
 import type {
+  BatchedCandle,
   Candle,
   ExchangeAvailableBalance,
   FeeRate,
   Fill,
   LimitOrderOptions,
+  MarketDataSource,
   MarketOrderOptions,
+  OneMinuteBatchedCandle,
+  OrderSide,
   PendingLimitOrder,
   PendingMarketOrder,
   PendingOrder,
+  TradingPair,
   TradingRules,
-} from '../broker/Broker.js';
-import type {MarketDataSource} from '../broker/MarketDataSource.js';
-import type {TradingPair} from '../broker/TradingPair.js';
+} from '@typedtrader/exchange';
 
 export interface TradingSessionStrategy {
   init?(market: Pick<MarketDataSource, 'getRecentCandles'>, pair: TradingPair): Promise<void>;

--- a/packages/trading-strategies/src/trader/index.ts
+++ b/packages/trading-strategies/src/trader/index.ts
@@ -1,3 +1,4 @@
-export * from './TradingSession.js';
+export * from './AdviceExecutor.js';
 export * from './OrderSizeBelowMinimumError.js';
+export * from './TradingSession.js';
 export * from './TradingSessionTypes.js';


### PR DESCRIPTION
## Summary

Fixes the architectural asymmetry where the **live** execution loop (`TradingSession`) lived in `@typedtrader/exchange` while the **offline** loop (`BacktestExecutor`) lived in `trading-strategies`. That split was the root cause of the duplicated advice→order translation flagged in the architecture review: each loop reimplemented sizing, clamping, precision, and minimum checks — and they had already diverged (the backtest swallowed rejected orders in a bare `catch {}`, sized market buys off a stale price, and never canceled outstanding orders on new advice).

### The move

`src/trader/` (`TradingSession`, `TradingSessionTypes`, `OrderSizeBelowMinimumError`) moves from `packages/exchange` to `packages/trading-strategies`, next to the backtest. `@typedtrader/exchange` is now purely a broker/market-data layer; `trading-strategies` owns both execution loops and re-exports the trader module.

### The unification

Both loops now delegate to a single new **`AdviceExecutor`** (`src/trader/AdviceExecutor.ts`), so a backtest sizes and validates orders exactly like a live session:

- **ALL limit buys are fee-adjusted** (`counter / (1 + fee)`) — previously backtest-only; live sessions could over-place and get rejected for insufficient funds.
- **Sells are clamped to the available base balance** — previously backtest-only.
- **Sizes and limit prices are rounded to exchange increments** — previously live-only.
- **Below-minimum orders produce `OrderSizeBelowMinimumError`** — previously live-only; the backtest silently skipped them.
- **Counter-denominated market buys are placed as notional orders** and converted **at the actual fill price**. This removes the backtest's stale-price sizing (it used the *current* candle's close for an order that fills at the *next* candle's open).
- **Bug fix:** "sell ALL denominated in counter" used to send a base quantity flagged as `sizeInCounter: true` in live sessions; it now sells the full base holding.

### Backtest fidelity improvements

- Mirrors the live loop's **cancel-before-place** policy: new advice replaces outstanding orders.
- **`BacktestResult.skippedAdvices`** (new field): every dropped advice is reported with its reason instead of vanishing into a silent catch — a backtest that hides skipped trades reports results a live run can't reproduce.
- A fill without a recorded advice now **throws** instead of fabricating a fake BUY advice that corrupted win-rate stats.

### BrokerMock

- Supports counter-sized (notional) market buys: conversion happens at fill time, fee inside the spend.
- Tracks the **exact hold per order**, fixing two balance leaks: canceled market buys never released their hold, and limit buys filled with price improvement left the unspent difference stuck on hold (understating final backtest balances).

### Breaking changes

- `@typedtrader/exchange` no longer exports `TradingSession`, the trading-session types, or `OrderSizeBelowMinimumError` — import them from `trading-strategies` (which already depended on exchange; the dependency direction stays clean and acyclic: messaging → trading-strategies → exchange).
- `PendingMarketOrder` gains an optional `sizeInCounter` flag.
- Backtest numbers shift where the old and new semantics differ (that's the point — the new numbers reflect what a live session would do).

## Test plan

- [x] New `AdviceExecutor` unit suite: notional clamping, sell-ALL-in-counter fix, below-minimum skips, broker rejections surfaced as skips
- [x] New `BrokerMock` tests: notional fill math (fee inside spend, conversion at next open), full hold release on cancel
- [x] New backtest parity test: outstanding order canceled when newer advice arrives (would wrongly fill without the new policy)
- [x] Extended backtest tests assert `skippedAdvices` is populated with reasons
- [x] Moved `TradingSession` suite passes with one derived expectation change (fee-adjusted ALL limit buy: `5000/1.0015/250 = 19.970044932`)
- [x] Full monorepo `npm test` green: all 5 test-bearing packages (exchange 85, trading-strategies 22 files/247 tests, messaging 84, trading-signals 63 files), dependency-cruiser clean, docs build clean
- [x] `eslint` clean on exchange, trading-strategies, messaging