### PR TITLE
refactor(trading-strategies): add explicit setState API for nested strategy state

### DIFF
--- a/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.ts
+++ b/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.ts
@@ -219,14 +219,13 @@ export class ProtectedStrategy extends Strategy {
   }
 
   /**
-   * Reassigns the top-level `protected` key on the proxied state with a merged
-   * snapshot. The top-level write triggers the base `Strategy` Proxy's `set`
-   * trap, which in turn fires `onSave` so `StrategyMonitor` persists to the DB.
-   * Nested property mutations would silently bypass persistence.
+   * `setState` merges top-level keys only, so the nested `protected` object is merged
+   * here before being swapped in wholesale.
    */
   #setProtectedState(patch: Partial<ProtectedStrategyState>): void {
-    const proxied = this.getProxiedState<ProtectedContainerState>();
-    proxied[PROTECTED_STATE_KEY] = {...proxied[PROTECTED_STATE_KEY], ...patch};
+    this.setState<ProtectedContainerState>({
+      [PROTECTED_STATE_KEY]: {...this.#protectedState, ...patch},
+    });
   }
 
   /** Read-only snapshot of the current protected state. Useful for tests and diagnostics. */
@@ -448,9 +447,9 @@ export class ProtectedStrategy extends Strategy {
     });
 
     /*
-     * The base class only updates `#_state`; the proxied state still points at
-     * the original object from the constructor. Reassigning `protected` through
-     * the proxy propagates restored values into the proxied state.
+     * The base class only updates the persisted snapshot; the proxied state still
+     * points at the original object from the constructor. Writing the restored
+     * values via `setState` propagates them into the proxied state as well.
      */
     this.#setProtectedState(restoredProtected);
   }

--- a/packages/trading-strategies/src/strategy/Strategy.test.ts
+++ b/packages/trading-strategies/src/strategy/Strategy.test.ts
@@ -35,7 +35,7 @@ function getPersistedState(strategy: Strategy): Record<string, unknown> {
   return state;
 }
 
-describe(Strategy, () => {
+describe('Strategy', () => {
   describe('setState', () => {
     it('merges the patch into the current state and fires onSave exactly once', () => {
       const {onSave, strategy} = makeStrategy();
@@ -85,6 +85,30 @@ describe(Strategy, () => {
       restored.restoreState(persisted);
 
       expect(restored.state).toEqual({counter: 7, nested: {value: 3}});
+    });
+
+    it('keeps restored keys when setState is called after restoreState', () => {
+      const restored = new TestStrategy({counter: 0, nested: {value: 1}});
+      restored.restoreState({counter: 7, nested: {value: 3}});
+
+      restored.setState<TestState>({nested: {value: 4}});
+
+      expect(restored.state).toEqual({counter: 7, nested: {value: 4}});
+      expect(restored.proxiedState.counter).toBe(7);
+    });
+  });
+
+  describe('without state', () => {
+    class StatelessStrategy extends Strategy {
+      static override NAME = 'stateless-strategy';
+
+      protected override async processCandle(): Promise<void> {}
+    }
+
+    it('throws when setState is called before any state exists', () => {
+      const strategy = new StatelessStrategy();
+
+      expect(() => strategy.setState({counter: 1})).toThrow('No state to update');
     });
   });
 });

--- a/packages/trading-strategies/src/strategy/Strategy.test.ts
+++ b/packages/trading-strategies/src/strategy/Strategy.test.ts
@@ -1,0 +1,90 @@
+import {describe, expect, it, vi} from 'vitest';
+import {Strategy} from './Strategy.js';
+
+type TestState = {
+  counter: number;
+  nested: {value: number};
+};
+
+class TestStrategy extends Strategy {
+  static override NAME = 'test-strategy';
+
+  constructor(state: TestState) {
+    super({state});
+  }
+
+  get proxiedState(): TestState {
+    return this.getProxiedState<TestState>();
+  }
+
+  protected override async processCandle(): Promise<void> {}
+}
+
+function makeStrategy() {
+  const strategy = new TestStrategy({counter: 0, nested: {value: 1}});
+  const onSave = vi.fn();
+  strategy.onSave = onSave;
+  return {onSave, strategy};
+}
+
+function getPersistedState(strategy: Strategy): Record<string, unknown> {
+  const state = strategy.state;
+  if (state === null) {
+    throw new Error('Expected strategy state to be set');
+  }
+  return state;
+}
+
+describe(Strategy, () => {
+  describe('setState', () => {
+    it('merges the patch into the current state and fires onSave exactly once', () => {
+      const {onSave, strategy} = makeStrategy();
+
+      strategy.setState<TestState>({counter: 5, nested: {value: 2}});
+
+      expect(strategy.state).toEqual({counter: 5, nested: {value: 2}});
+      expect(onSave).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps untouched keys and updates the proxied state view', () => {
+      const {strategy} = makeStrategy();
+
+      strategy.setState<TestState>({nested: {value: 42}});
+
+      expect(strategy.state).toEqual({counter: 0, nested: {value: 42}});
+      expect(strategy.proxiedState.nested.value).toBe(42);
+    });
+  });
+
+  describe('nested mutation trap', () => {
+    it('does NOT fire onSave when a nested property is mutated without setState', () => {
+      const {onSave, strategy} = makeStrategy();
+
+      strategy.proxiedState.nested.value = 99;
+
+      expect(onSave).not.toHaveBeenCalled();
+    });
+
+    it('fires onSave for top-level assignments on the proxied state', () => {
+      const {onSave, strategy} = makeStrategy();
+
+      strategy.proxiedState.counter = 1;
+
+      expect(onSave).toHaveBeenCalledTimes(1);
+      expect(strategy.state).toEqual({counter: 1, nested: {value: 1}});
+    });
+  });
+
+  describe('restoreState', () => {
+    it('restores a state that was written via setState', () => {
+      const {strategy} = makeStrategy();
+      strategy.setState<TestState>({counter: 7, nested: {value: 3}});
+      const persisted = structuredClone(getPersistedState(strategy));
+
+      const restored = new TestStrategy({counter: 0, nested: {value: 1}});
+      restored.restoreState(persisted);
+
+      expect(restored.state).toEqual({counter: 7, nested: {value: 3}});
+    });
+  });
+});

--- a/packages/trading-strategies/src/strategy/Strategy.ts
+++ b/packages/trading-strategies/src/strategy/Strategy.ts
@@ -5,10 +5,10 @@ import type {MarketType} from './MarketType.js';
 
 /**
  * State persistence is snapshot-based: the Proxy behind `getProxiedState()` only traps
- * TOP-LEVEL assignments, so mutating a nested object in place (e.g.
- * `this.state.foo.bar = x`) changes memory but is silently lost on restart. Use
- * {@link Strategy.setState} to update nested state — it merges the patch and persists
- * in one step.
+ * TOP-LEVEL assignments, so mutating a nested object reached through it in place (e.g.
+ * `this.getProxiedState().foo.bar = x`) changes memory but is silently lost on restart.
+ * Use {@link Strategy.setState} to update nested state — it merges the patch and
+ * persists in one step.
  */
 export abstract class Strategy implements TradingSessionStrategy {
   static NAME: string;
@@ -97,9 +97,28 @@ export abstract class Strategy implements TradingSessionStrategy {
    * patch persists once, not once per key.
    */
   setState<T extends Record<string, unknown>>(patch: Partial<T>): void {
-    const target = this.#stateTarget ?? {...this.state};
-    Object.assign(target, patch);
-    this.state = {...target};
+    const snapshot = this.state;
+    if (!snapshot) {
+      throw new Error('No state to update. Pass {state} to the Strategy constructor or call restoreState() first.');
+    }
+
+    if (this.#stateTarget) {
+      /*
+       * Sync the Proxy's target to the persisted snapshot before patching: restoreState()
+       * replaces the snapshot but not the target, so merging from the target alone would
+       * resurrect stale pre-restore values and clobber restored keys.
+       */
+      for (const key of Object.keys(this.#stateTarget)) {
+        if (!(key in snapshot)) {
+          delete this.#stateTarget[key];
+        }
+      }
+      Object.assign(this.#stateTarget, snapshot, patch);
+      this.state = {...this.#stateTarget};
+      return;
+    }
+
+    this.state = {...snapshot, ...patch};
   }
 
   /**

--- a/packages/trading-strategies/src/strategy/Strategy.ts
+++ b/packages/trading-strategies/src/strategy/Strategy.ts
@@ -3,6 +3,13 @@ import type {OneMinuteBatchedCandle} from '@typedtrader/exchange';
 import type {OrderAdvice, TradingSessionState, TradingSessionStrategy} from '../trader/index.js';
 import type {MarketType} from './MarketType.js';
 
+/**
+ * State persistence is snapshot-based: the Proxy behind `getProxiedState()` only traps
+ * TOP-LEVEL assignments, so mutating a nested object in place (e.g.
+ * `this.state.foo.bar = x`) changes memory but is silently lost on restart. Use
+ * {@link Strategy.setState} to update nested state — it merges the patch and persists
+ * in one step.
+ */
 export abstract class Strategy implements TradingSessionStrategy {
   static NAME: string;
 
@@ -55,9 +62,11 @@ export abstract class Strategy implements TradingSessionStrategy {
 
   readonly #proxiedState: Record<string, unknown> | null = null;
   readonly #proxiedConfig: Record<string, unknown> | null = null;
+  readonly #stateTarget: Record<string, unknown> | null = null;
 
   constructor(options?: {state?: Record<string, unknown>; config?: Record<string, unknown>}) {
     if (options?.state) {
+      this.#stateTarget = options.state;
       this.#proxiedState = this.#createProxy(options.state, snapshot => {
         this.state = snapshot;
       });
@@ -80,6 +89,17 @@ export abstract class Strategy implements TradingSessionStrategy {
 
   restoreState(persisted: Record<string, unknown>): void {
     this.#_state = persisted;
+  }
+
+  /**
+   * The supported way to update nested state (see the class doc for the Proxy trap this
+   * avoids). Writes go to the raw target instead of through the Proxy so a multi-key
+   * patch persists once, not once per key.
+   */
+  setState<T extends Record<string, unknown>>(patch: Partial<T>): void {
+    const target = this.#stateTarget ?? {...this.state};
+    Object.assign(target, patch);
+    this.state = {...target};
   }
 
   /**


### PR DESCRIPTION
## Summary

`Strategy` persists state via an ES `Proxy` whose `set` trap only fires on **top-level** property assignments. Nested mutations (e.g. `this.state.protected.foo = x`) change memory but never trigger `onSave()` — the change is silently lost on restart. `ProtectedStrategy` worked around this by manually reassigning the whole nested `protected` key through the proxy.

This PR makes the supported path explicit:

- **New `Strategy.setState(patch)`**: shallow-merges a partial state patch into the current state and fires `onSave()` exactly once. Writes go to the raw proxy target instead of through the Proxy, so a multi-key patch persists once rather than once per key. Typed per-call as `setState<T extends Record<string, unknown>>(patch: Partial<T>)`, matching the existing `getProxiedState<T>()` pattern.
- **`ProtectedStrategy` refactored** to route `#setProtectedState` through `setState`, removing the fragile manual proxy-reassignment pattern. Behavior is identical (including the `restoreState` propagation into the proxied state).
- **Class-level JSDoc** on `Strategy` documenting the nested-mutation trap and pointing to `setState` as the supported path.

Top-level proxy behavior is unchanged; no public API is broken.

## Test plan

- New colocated `Strategy.test.ts`:
  - `setState` merges the patch, the result is visible via the `state` getter and the proxied view, and `onSave` fires exactly once (also for multi-key patches)
  - a nested mutation without `setState` does **not** fire `onSave` (documents the trap)
  - top-level assignments on the proxied state still fire `onSave` (existing behavior preserved)
  - `restoreState` round-trips a state written via `setState`
- `npm test` in `packages/trading-strategies`: 23 files / 253 tests pass (includes the full `ProtectedStrategy` suite, unchanged)
- `npm run lint` in `packages/trading-strategies`: clean