### PR TITLE
fix(exchange): verify Trading212 credentials against an authenticated endpoint

### DIFF
--- a/packages/exchange/src/broker/Broker.ts
+++ b/packages/exchange/src/broker/Broker.ts
@@ -381,6 +381,16 @@ export abstract class Broker extends EventEmitter {
   abstract getTime(): Promise<string>;
 
   /**
+   * Proves the configured credentials are authorized by issuing an authenticated network request,
+   * so bad keys surface immediately instead of at the first real trade. The default probe is
+   * {@link getTime}. Subclasses whose `getTime()` never leaves the process (brokers without a
+   * server-time endpoint, e.g. Trading212) MUST override this with a genuinely authenticated call.
+   */
+  async verifyCredentials(): Promise<void> {
+    await this.getTime();
+  }
+
+  /**
    * Generic function to place an order.
    * @protected Please use `placeLimitOrder` or `placeMarketOrder`.
    */

--- a/packages/exchange/src/broker/getAuthenticatedBrokerClient.test.ts
+++ b/packages/exchange/src/broker/getAuthenticatedBrokerClient.test.ts
@@ -1,0 +1,55 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+
+const {getBrokerClientMock, verifyCredentialsMock} = vi.hoisted(() => {
+  const verifyCredentials = vi.fn();
+  return {
+    getBrokerClientMock: vi.fn(() => ({verifyCredentials})),
+    verifyCredentialsMock: verifyCredentials,
+  };
+});
+
+vi.mock('./getBrokerClient.js', () => ({
+  getBrokerClient: getBrokerClientMock,
+}));
+
+const {getAuthenticatedBrokerClient} = await import('./getAuthenticatedBrokerClient.js');
+const {SimplifiedHttpError} = await import('../util/SimplifiedHttpError.js');
+
+const account = {
+  apiKey: 'key',
+  apiSecret: 'secret',
+  exchangeId: 'Alpaca',
+  isPaper: true,
+};
+
+describe('getAuthenticatedBrokerClient', {concurrent: false}, () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the client once its credentials are verified', async () => {
+    verifyCredentialsMock.mockResolvedValue(undefined);
+
+    const client = await getAuthenticatedBrokerClient(account);
+
+    expect(getBrokerClientMock).toHaveBeenCalledWith(account);
+    expect(verifyCredentialsMock).toHaveBeenCalledTimes(1);
+    expect(client).toBe(getBrokerClientMock.mock.results[0]?.value);
+  });
+
+  it('propagates the failure when credential verification is rejected', async () => {
+    verifyCredentialsMock.mockRejectedValue(
+      new SimplifiedHttpError({
+        data: 'Unauthorized',
+        status: 401,
+        statusText: 'Unauthorized',
+        url: '/api/v0/equity/account/cash',
+      })
+    );
+
+    const failure = getAuthenticatedBrokerClient(account);
+
+    await expect(failure).rejects.toBeInstanceOf(SimplifiedHttpError);
+    await expect(failure).rejects.toMatchObject({status: 401});
+  });
+});

--- a/packages/exchange/src/broker/getAuthenticatedBrokerClient.ts
+++ b/packages/exchange/src/broker/getAuthenticatedBrokerClient.ts
@@ -9,6 +9,6 @@ export async function getAuthenticatedBrokerClient(
   ...args: Parameters<typeof getBrokerClient>
 ): Promise<Broker & MarketDataSource> {
   const client = getBrokerClient(...args);
-  await client.getTime();
+  await client.verifyCredentials();
   return client;
 }

--- a/packages/exchange/src/broker/trading212/Trading212Broker.test.ts
+++ b/packages/exchange/src/broker/trading212/Trading212Broker.test.ts
@@ -1,0 +1,84 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest';
+import type {Candle} from '../Broker.js';
+import {MarketDataSource} from '../MarketDataSource.js';
+
+// Shared mock references
+const mockMethods = {
+  getAccountCash: vi.fn(),
+};
+
+vi.mock('./api/Trading212API.js', () => ({
+  Trading212API: class {
+    getAccountCash = mockMethods.getAccountCash;
+  },
+}));
+
+// Import after mocking
+const {Trading212Broker} = await import('./Trading212Broker.js');
+const {SimplifiedHttpError} = await import('../../util/SimplifiedHttpError.js');
+
+/** `verifyCredentials` never touches market data, so every member can stay unimplemented. */
+class MarketDataSourceStub extends MarketDataSource {
+  async getCandles(): Promise<Candle[]> {
+    throw new Error('Not implemented');
+  }
+
+  async getLatestCandle(): Promise<Candle> {
+    throw new Error('Not implemented');
+  }
+
+  async watchCandles() {
+    throw new Error('Not implemented');
+  }
+
+  unwatchCandles(): void {}
+
+  disconnect(): void {}
+}
+
+describe('Trading212Broker', {concurrent: false}, () => {
+  let broker: InstanceType<typeof Trading212Broker>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    broker = new Trading212Broker({
+      apiKey: 'test',
+      apiSecret: 'test',
+      marketData: new MarketDataSourceStub(),
+      usePaperTrading: true,
+    });
+  });
+
+  describe('verifyCredentials', () => {
+    it('resolves when the authenticated account-cash probe succeeds', async () => {
+      mockMethods.getAccountCash.mockResolvedValue({
+        blocked: null,
+        free: 500.5,
+        invested: 0,
+        pieCash: 0,
+        ppl: 0,
+        result: 0,
+        total: 500.5,
+      });
+
+      await expect(broker.verifyCredentials()).resolves.toBeUndefined();
+      expect(mockMethods.getAccountCash).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects when Trading212 denies the credentials', async () => {
+      mockMethods.getAccountCash.mockRejectedValue(
+        new SimplifiedHttpError({
+          data: 'Unauthorized',
+          status: 401,
+          statusText: 'Unauthorized',
+          url: '/api/v0/equity/account/cash',
+        })
+      );
+
+      const failure = broker.verifyCredentials();
+
+      await expect(failure).rejects.toBeInstanceOf(SimplifiedHttpError);
+      await expect(failure).rejects.toMatchObject({status: 401});
+    });
+  });
+});

--- a/packages/exchange/src/broker/trading212/Trading212Broker.test.ts
+++ b/packages/exchange/src/broker/trading212/Trading212Broker.test.ts
@@ -27,8 +27,8 @@ class MarketDataSourceStub extends MarketDataSource {
     throw new Error('Not implemented');
   }
 
-  async watchCandles() {
-    throw new Error('Not implemented');
+  watchCandles() {
+    return Promise.reject<string>(new Error('Not implemented'));
   }
 
   unwatchCandles(): void {}

--- a/packages/exchange/src/broker/trading212/Trading212Broker.ts
+++ b/packages/exchange/src/broker/trading212/Trading212Broker.ts
@@ -110,6 +110,16 @@ export class Trading212Broker extends Broker implements MarketDataSource {
     return new Date().toISOString();
   }
 
+  /**
+   * The default probe uses `getTime()`, but Trading212's `getTime()` never leaves the process,
+   * so it would accept any credentials. Probe `/equity/account/cash` instead: it is authenticated
+   * and has the most generous rate limit of Trading212's account endpoints (1 request per 2s,
+   * vs. 30s for account info — see `getRetryDelay` in `Trading212API`).
+   */
+  override async verifyCredentials(): Promise<void> {
+    await this.#api.getAccountCash();
+  }
+
   async getCandles(pair: TradingPair, request: CandleImportRequest): Promise<Candle[]> {
     return this.#marketData.getCandles(Trading212Broker.toMarketDataPair(pair), request);
   }


### PR DESCRIPTION
## Summary

`getAuthenticatedBrokerClient` claimed to prove credentials by calling `broker.getTime()`. That works for Alpaca (`/v2/clock` is authenticated), but `Trading212Broker.getTime()` returns the **local** clock without any network call (Trading212 has no server-time endpoint) — so Trading212 credentials were never actually validated and bad keys only surfaced at first real use.

- **`Broker`**: new `verifyCredentials(): Promise<void>` with a default implementation that probes via `getTime()`; documented that subclasses whose `getTime()` never leaves the process MUST override. Public API is additive — no removals.
- **`Trading212Broker`**: overrides `verifyCredentials()` to hit `GET /api/v0/equity/account/cash` — the cheapest authenticated Trading212 endpoint (1 req / 2s rate limit, vs. 30s for account info per `getRetryDelay`). A 401 is not retried by axios-retry (`isRetryableError` excludes 4xx), so bad keys reject immediately with a `SimplifiedHttpError`.
- **`getAuthenticatedBrokerClient`**: calls `verifyCredentials()` instead of `getTime()`; error semantics for callers are unchanged (auth failures still reject with the underlying `SimplifiedHttpError`).
- **`AlpacaBroker`**: unchanged — its `getTime()` already performs an authenticated `/v2/clock` request, so the default probe is correct.

## Test plan

- [x] New `Trading212Broker.test.ts`: `verifyCredentials` resolves on a mocked account-cash response and rejects with a `SimplifiedHttpError` (status 401) when the API denies the credentials.
- [x] New `getAuthenticatedBrokerClient.test.ts`: returns the client after successful verification and propagates verification failures (mocked `getBrokerClient` factory).
- [x] `packages/exchange`: `npm test` — 10 files, 89 tests passed; `npm run lint` — 0 errors (6 pre-existing unused-directive warnings).
- [x] `packages/messaging` (consumes this via `getAccountBrokerClient`): built dependencies, `npm test` — 6 files, 84 tests passed, no fallout.