### PR TITLE
refactor(messaging): type the platform seam and scope the multi-platform claim

### DIFF
--- a/packages/messaging/README.md
+++ b/packages/messaging/README.md
@@ -4,7 +4,7 @@ Messaging interface for controlling personal trading bots remotely via [Telegram
 
 ## Features
 
-- **Multi-Platform:** Flexible `MessagingPlatform` interface for adding new platforms
+- **Platform Seam:** Slash commands and notifications run through the `MessagingPlatform` interface; interactive wizards are Telegram-only (see [Platform Support](#platform-support))
 - **Command Interface:** Execute trading bot commands via messaging
 - **Real-Time Updates:** Get live candle data, time, and bot status
 - **Owner Authentication:** Access control via Telegram user IDs
@@ -62,6 +62,32 @@ For example, to protect an existing AAPL position with a 5% stop-loss and 10% ta
 ```
 /strategyAdd 1 AAPL,USD {"protected":{"stopLossPct":"5","takeProfitPct":"10","seedFromBalance":true}}
 ```
+
+## Platform Support
+
+Telegram is the only implemented platform. The `MessagingPlatform` interface (`src/platform/MessagingPlatform.ts`) is a seam, not a full abstraction — only part of the feature set goes through it.
+
+**Platform-agnostic today:**
+
+- Slash commands registered via `registerCommand` — plain text in, Markdown reply out
+- Notifications (watch alerts, strategy updates, scheduled report output) via `PlatformDispatcher`, routed by platform-prefixed user IDs (e.g. `telegram:123456`)
+
+**Telegram-only (built on grammY):**
+
+- Interactive wizards: `/accountAdd`, `/accountEdit`, `/watchAdd`, `/strategyAdd`, and the trade commands (`/buyMarket`, `/sellMarket`, `/buyLimit`, `/sellLimit`)
+- Inline keyboards and multi-step callback flows such as `/reportAdd`
+
+### Adding a new platform
+
+Implement `MessagingPlatform` and register the instance in `startServer.ts` under a unique platform prefix:
+
+- `start()` / `stop()` — connect and disconnect the bot
+- `sendMessage(userId, text)` — deliver Markdown to a platform-prefixed user ID (strip your own prefix)
+- `registerCommand(name, handler)` — wire slash commands to the shared, platform-agnostic handlers
+- `commandList` / `platformInfo` — power `/help` and `/version`
+- Optional: `setReportScheduler` / `setWatchMonitor` / `setStrategyMonitor` — typed against the port interfaces in `MessagingPlatform.ts`; only needed if your platform offers flows that activate reports, watches, or strategies
+
+Current limits: a new platform gets text commands and notifications only. The wizards and inline-keyboard flows live inside `TelegramPlatform` and would need a platform-specific reimplementation.
 
 ## Motivation
 

--- a/packages/messaging/src/platform/MessagingPlatform.ts
+++ b/packages/messaging/src/platform/MessagingPlatform.ts
@@ -1,3 +1,7 @@
+import type {ReportAttributes} from '../database/models/Report.js';
+import type {StrategyAttributes} from '../database/models/Strategy.js';
+import type {WatchAttributes} from '../database/models/Watch.js';
+
 export interface MessageContext {
   /** Platform-prefixed sender ID, e.g. "telegram:123" */
   senderId: string;
@@ -18,14 +22,42 @@ export interface PlatformInfo {
   sdkVersion: string;
 }
 
+/*
+ * Ports: the narrow, platform-facing slice of a backend service. A platform's
+ * interactive flows may need to activate what they just persisted (schedule a
+ * report, subscribe a watch/strategy, restart sessions after a credentials
+ * edit), but they must not reach into service internals — these interfaces
+ * pin down exactly what a platform is allowed to drive.
+ */
+
+export interface ReportSchedulerPort {
+  scheduleReport(row: ReportAttributes, options?: {runImmediately?: boolean}): void;
+}
+
+export interface WatchMonitorPort {
+  restartForAccount(accountId: number): Promise<void>;
+  subscribeToWatch(watch: WatchAttributes): Promise<void>;
+}
+
+export interface StrategyMonitorPort {
+  restartForAccount(accountId: number): Promise<void>;
+  subscribeToStrategy(row: StrategyAttributes): Promise<void>;
+}
+
 export interface MessagingPlatform {
   start(): Promise<void>;
   stop(): Promise<void>;
   sendMessage(userId: string, text: string): Promise<void>;
   registerCommand(name: string | string[], handler: CommandHandler): void;
-  setReportScheduler?(scheduler: unknown): void;
-  setWatchMonitor?(monitor: unknown): void;
-  setStrategyMonitor?(monitor: unknown): void;
+  /*
+   * Optional setter injection: the monitors are constructed after the
+   * platforms (they need the PlatformDispatcher, which needs the platforms),
+   * so they cannot be constructor arguments. Platforms without interactive
+   * flows that activate services simply omit these.
+   */
+  setReportScheduler?(scheduler: ReportSchedulerPort): void;
+  setWatchMonitor?(monitor: WatchMonitorPort): void;
+  setStrategyMonitor?(monitor: StrategyMonitorPort): void;
   /** List of registered command names (e.g., ["/help", "/price"]) */
   readonly commandList: string[];
   /** Platform-specific metadata for info commands */

--- a/packages/messaging/src/platform/TelegramPlatform.ts
+++ b/packages/messaging/src/platform/TelegramPlatform.ts
@@ -5,14 +5,21 @@ import {type Conversation, type ConversationFlavor, conversations, createConvers
 import {z} from 'zod';
 import {OrderSide, TradingPair} from '@typedtrader/exchange';
 import {getAvailableReportNames, reportRequiresAccount} from 'trading-strategies';
-import type {CommandHandler, MessageContext, MessagingPlatform, PlatformInfo} from './MessagingPlatform.js';
+import type {
+  CommandHandler,
+  MessageContext,
+  MessagingPlatform,
+  PlatformInfo,
+  ReportSchedulerPort,
+  StrategyMonitorPort,
+  WatchMonitorPort,
+} from './MessagingPlatform.js';
 import {markdownToTelegramHtml, splitForTelegram} from './telegramMarkdown.js';
 import {getAccountBrokerClient} from '../broker/getAccountBrokerClient.js';
 import {placeOrder} from '../command/placeOrder.js';
 import {reportAdd} from '../command/report/reportAdd.js';
 import {assertInterval} from '../validation/assertInterval.js';
 import {Account} from '../database/models/Account.js';
-import type {ReportScheduler, StrategyMonitor, WatchMonitor} from '../service/index.js';
 import {logger} from '../logger.js';
 import {
   ACCOUNT_ADD_WIZARD_ID,
@@ -314,9 +321,9 @@ export class TelegramPlatform implements MessagingPlatform {
   readonly #ownerIds: string[];
   readonly #commands: Map<string, CommandHandler> = new Map();
   #platformInfo: PlatformInfo = {botAddress: '', sdkVersion: ''};
-  #reportScheduler?: ReportScheduler;
-  #watchMonitor?: WatchMonitor;
-  #strategyMonitor?: StrategyMonitor;
+  #reportScheduler?: ReportSchedulerPort;
+  #watchMonitor?: WatchMonitorPort;
+  #strategyMonitor?: StrategyMonitorPort;
 
   constructor(botToken: string, ownerIds?: string) {
     this.#bot = new Bot<TradeContext>(botToken);
@@ -430,15 +437,15 @@ export class TelegramPlatform implements MessagingPlatform {
     });
   }
 
-  setReportScheduler(scheduler: ReportScheduler): void {
+  setReportScheduler(scheduler: ReportSchedulerPort): void {
     this.#reportScheduler = scheduler;
   }
 
-  setWatchMonitor(monitor: WatchMonitor): void {
+  setWatchMonitor(monitor: WatchMonitorPort): void {
     this.#watchMonitor = monitor;
   }
 
-  setStrategyMonitor(monitor: StrategyMonitor): void {
+  setStrategyMonitor(monitor: StrategyMonitorPort): void {
     this.#strategyMonitor = monitor;
   }
 

--- a/packages/messaging/src/platform/wizards/accountEditWizard.ts
+++ b/packages/messaging/src/platform/wizards/accountEditWizard.ts
@@ -2,7 +2,8 @@ import {getAuthenticatedBrokerClient} from '@typedtrader/exchange';
 import {buildMarketDataFromAccount} from '../../broker/getAccountBrokerClient.js';
 import {Account} from '../../database/models/Account.js';
 import {logger} from '../../logger.js';
-import {restartAccountSessions, type StrategyMonitor, type WatchMonitor} from '../../service/index.js';
+import {restartAccountSessions} from '../../service/index.js';
+import type {StrategyMonitorPort, WatchMonitorPort} from '../MessagingPlatform.js';
 import {
   deleteSecretMessages,
   inlineKeyboard,
@@ -16,8 +17,8 @@ export interface AccountEditWizardArgs {
 }
 
 export function makeAccountEditWizard(deps: {
-  strategyMonitor: () => StrategyMonitor | undefined;
-  watchMonitor: () => WatchMonitor | undefined;
+  strategyMonitor: () => StrategyMonitorPort | undefined;
+  watchMonitor: () => WatchMonitorPort | undefined;
 }) {
   return async function accountEditWizard(
     conversation: WizardConversation,

--- a/packages/messaging/src/platform/wizards/strategyAddWizard.ts
+++ b/packages/messaging/src/platform/wizards/strategyAddWizard.ts
@@ -3,7 +3,7 @@ import {createStrategy, getStrategyNames} from 'trading-strategies';
 import {Account} from '../../database/models/Account.js';
 import {Strategy} from '../../database/models/Strategy.js';
 import {logger} from '../../logger.js';
-import type {StrategyMonitor} from '../../service/index.js';
+import type {StrategyMonitorPort} from '../MessagingPlatform.js';
 import {
   inlineKeyboard,
   waitForTextOrCancel,
@@ -16,7 +16,7 @@ export interface StrategyAddWizardArgs {
   userId: string;
 }
 
-export function makeStrategyAddWizard(deps: {strategyMonitor: () => StrategyMonitor | undefined}) {
+export function makeStrategyAddWizard(deps: {strategyMonitor: () => StrategyMonitorPort | undefined}) {
   return async function strategyAddWizard(
     conversation: WizardConversation,
     ctx: WizardContext,

--- a/packages/messaging/src/platform/wizards/watchAddWizard.ts
+++ b/packages/messaging/src/platform/wizards/watchAddWizard.ts
@@ -7,7 +7,7 @@ import {Watch} from '../../database/models/Watch.js';
 import {assertInterval} from '../../validation/assertInterval.js';
 import {parseThreshold} from '../../validation/parseThreshold.js';
 import {logger} from '../../logger.js';
-import type {WatchMonitor} from '../../service/index.js';
+import type {WatchMonitorPort} from '../MessagingPlatform.js';
 import {
   inlineKeyboard,
   waitForTextOrCancel,
@@ -22,7 +22,7 @@ export interface WatchAddWizardArgs {
 
 const INTERVALS = ['1m', '5m', '15m', '1h', '6h', '12h', '1d'] as const;
 
-export function makeWatchAddWizard(deps: {watchMonitor: () => WatchMonitor | undefined}) {
+export function makeWatchAddWizard(deps: {watchMonitor: () => WatchMonitorPort | undefined}) {
   return async function watchAddWizard(
     conversation: WizardConversation,
     ctx: WizardContext,

--- a/packages/messaging/src/service/restartAccountSessions.ts
+++ b/packages/messaging/src/service/restartAccountSessions.ts
@@ -1,5 +1,4 @@
-import type {StrategyMonitor} from './StrategyMonitor.js';
-import type {WatchMonitor} from './WatchMonitor.js';
+import type {StrategyMonitorPort, WatchMonitorPort} from '../platform/MessagingPlatform.js';
 
 /**
  * Restart every watch and strategy bound to an account so live sessions reconnect with the
@@ -8,8 +7,8 @@ import type {WatchMonitor} from './WatchMonitor.js';
  */
 export async function restartAccountSessions(
   accountId: number,
-  strategyMonitor: StrategyMonitor | undefined,
-  watchMonitor: WatchMonitor | undefined
+  strategyMonitor: StrategyMonitorPort | undefined,
+  watchMonitor: WatchMonitorPort | undefined
 ): Promise<void> {
   await strategyMonitor?.restartForAccount(accountId);
   await watchMonitor?.restartForAccount(accountId);


### PR DESCRIPTION
## Summary

The `MessagingPlatform` abstraction claimed to be multi-platform, but it leaked its Telegram implementation: `setReportScheduler?(scheduler: unknown)`, `setWatchMonitor?(...)`, and `setStrategyMonitor?(...)` took `unknown` purely so `TelegramPlatform` could down-cast to the concrete service classes. And the README implied a second platform (Discord/Slack) would get the full experience, when in reality every interactive flow (trade confirmation, wizards, inline keyboards, the reportAdd state machine) is grammY-specific.

This PR makes the seam honest without building a conversation framework:

- **Typed ports instead of `unknown`:** `MessagingPlatform.ts` now defines minimal port interfaces describing exactly what a platform may call on the report scheduler and the watch/strategy monitors (derived from what `TelegramPlatform` actually invokes). The down-casts in `TelegramPlatform` are gone; the wizards and `restartAccountSessions` accept the ports as well. All type-only imports — no runtime coupling added.
- **Scoped claim in the README:** documents precisely what is platform-agnostic today (slash commands via `registerCommand`, notifications via `PlatformDispatcher`, platform-prefixed user ids) versus Telegram-only (interactive wizards, inline keyboards, multi-step flows), plus an "Adding a new platform" section describing the real surface to implement and its current limits.

Behavior is unchanged — this is a typing + documentation fix.

## Test plan

- [x] `npm test` in `packages/messaging`: 6 test files pass, typecheck clean, dependency-cruiser reports no violations
- [x] `npm run lint` in `packages/messaging`: eslint + prettier clean