### PR TITLE
refactor(trading-signals): share signal machinery via object-result base and fix BBANDS warm-up

### DIFF
--- a/packages/trading-signals/src/momentum/MACD/MACD.ts
+++ b/packages/trading-signals/src/momentum/MACD/MACD.ts
@@ -1,6 +1,6 @@
 import type {DEMA} from '../../trend/DEMA/DEMA.js';
 import type {EMA} from '../../trend/EMA/EMA.js';
-import {TechnicalIndicator, TradingSignal} from '../../types/Indicator.js';
+import {TradingSignal, TrendTechnicalIndicator} from '../../types/Indicator.js';
 import {pushUpdate} from '../../util/pushUpdate.js';
 
 export type MACDResult = {
@@ -18,9 +18,8 @@ export type MACDResult = {
  *
  * @see https://www.investopedia.com/terms/m/macd.asp
  */
-export class MACD extends TechnicalIndicator<MACDResult, number> {
+export class MACD extends TrendTechnicalIndicator<MACDResult> {
   public readonly prices: number[] = [];
-  #previousResult?: MACDResult;
 
   public readonly short: EMA | DEMA;
   public readonly long: EMA | DEMA;
@@ -47,22 +46,20 @@ export class MACD extends TechnicalIndicator<MACDResult, number> {
       const macd = short - long;
       const signal = this.signal.update(macd, replace);
 
-      if (replace) {
-        this.result = this.#previousResult;
-      }
-
-      this.#previousResult = this.result;
-
-      return (this.result = {
-        histogram: macd - signal,
-        macd,
-        signal,
-      });
+      return this.setResult(
+        {
+          histogram: macd - signal,
+          macd,
+          signal,
+        },
+        replace
+      );
     }
+
     return null;
   }
 
-  protected calculateSignal(result?: MACDResult | null | undefined) {
+  protected override calculateSignalState(result?: MACDResult | null | undefined) {
     const hasResult = result !== null && result !== undefined;
     const isBullish = hasResult && result.histogram > 0; // MACD above signal line
     const isBearish = hasResult && result.histogram < 0; // MACD below signal line
@@ -76,19 +73,5 @@ export class MACD extends TechnicalIndicator<MACDResult, number> {
       default:
         return TradingSignal.BEARISH;
     }
-  }
-
-  getSignal(): {
-    state: (typeof TradingSignal)[keyof typeof TradingSignal];
-    hasChanged: boolean;
-  } {
-    const previousState = this.calculateSignal(this.#previousResult);
-    const state = this.calculateSignal(this.getResult());
-    const hasChanged = previousState !== state;
-
-    return {
-      hasChanged,
-      state,
-    };
   }
 }

--- a/packages/trading-signals/src/types/Indicator.ts
+++ b/packages/trading-signals/src/types/Indicator.ts
@@ -130,3 +130,52 @@ export abstract class TrendIndicatorSeries<
     };
   }
 }
+
+/**
+ * Counterpart to {@link TrendIndicatorSeries} for indicators whose result is a composite object
+ * (e.g. multiple bands or lines) instead of a single number. Subclasses inherit previous-result
+ * caching and signal-change detection so they don't have to hand-roll it per indicator.
+ */
+export abstract class TrendTechnicalIndicator<
+  Result,
+  Input = number,
+  SignalState = TradingSignals,
+> extends TechnicalIndicator<Result, Input> {
+  protected abstract calculateSignalState(result?: Result | null | undefined): SignalState;
+  protected previousResult?: Result;
+  #previousSignalState?: SignalState;
+
+  protected setResult(value: Result, replace: boolean) {
+    // When replacing, restore the previous signal state
+    if (replace && this.previousResult !== undefined) {
+      this.#previousSignalState = this.calculateSignalState(this.previousResult);
+    } else if (!replace) {
+      // Cache the previous signal state before updating
+      this.#previousSignalState = this.calculateSignalState(this.result);
+    }
+
+    // When replacing the latest value, restore previous result first
+    if (replace) {
+      this.result = this.previousResult;
+    }
+
+    // Cache previous result
+    this.previousResult = this.result;
+
+    // Set new result
+    return (this.result = value);
+  }
+
+  getSignal(): {
+    state: SignalState;
+    hasChanged: boolean;
+  } {
+    const currentState = this.calculateSignalState(this.getResult());
+    const hasChanged = this.#previousSignalState !== undefined && this.#previousSignalState !== currentState;
+
+    return {
+      hasChanged,
+      state: currentState,
+    };
+  }
+}

--- a/packages/trading-signals/src/volatility/BBANDS/BollingerBands.test.ts
+++ b/packages/trading-signals/src/volatility/BBANDS/BollingerBands.test.ts
@@ -1,6 +1,7 @@
 import {BollingerBands} from './BollingerBands.js';
 import data from '../../fixtures/BB/data.json' with {type: 'json'};
 import {NotEnoughDataError} from '../../error/index.js';
+import {SMA} from '../../trend/SMA/SMA.js';
 import {TradingSignal} from '../../types/Indicator.js';
 
 describe('BollingerBands', () => {
@@ -20,12 +21,56 @@ describe('BollingerBands', () => {
     });
   });
 
+  describe('update', () => {
+    it('stabilizes at the same input count as the SMA that defines its middle band', () => {
+      const prices = [81.59, 81.06, 82.87, 83.0, 83.61, 83.15] as const;
+      const interval = 5;
+      const bb = new BollingerBands(interval);
+      const sma = new SMA(interval);
+
+      prices.forEach(price => {
+        const bbResult = bb.add(price);
+        const smaResult = sma.add(price);
+
+        expect(bbResult?.middle ?? null).toBe(smaResult);
+      });
+    });
+  });
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const bb = new BollingerBands(5, 2);
+      const prices = [81.59, 81.06, 82.87, 83.0] as const;
+
+      for (const price of prices) {
+        bb.add(price);
+      }
+
+      const originalValue = 83.61;
+      const replacedValue = 90;
+
+      const originalResult = bb.add(originalValue);
+      const replacedResult = bb.replace(replacedValue);
+
+      expect(replacedResult?.middle).not.toBe(originalResult?.middle);
+
+      const restoredResult = bb.replace(originalValue);
+
+      expect(restoredResult?.middle).toBe(originalResult?.middle);
+      expect(restoredResult?.lower).toBe(originalResult?.lower);
+      expect(restoredResult?.upper).toBe(originalResult?.upper);
+    });
+  });
+
   describe('getResultOrThrow', () => {
     it('calculates Bollinger Bands with interval 20', () => {
       const bb = new BollingerBands(20);
+      const offset = bb.getRequiredInputs() - 1;
 
       data.prices.forEach((price, index) => {
         bb.add(price);
+
+        expect(bb.isStable).toBe(index >= offset);
 
         if (!bb.isStable) {
           return;
@@ -128,19 +173,19 @@ describe('BollingerBands', () => {
       const bb = new BollingerBands(interval, 2);
       expect(bb.getRequiredInputs()).toBe(interval);
 
-      for (let i = 0; i < inputs.length; i++) {
-        const price = inputs[i];
-        bb.add(price);
-        if (bb.isStable) {
-          const {lower, middle, upper} = bb.getResultOrThrow();
-          const expectedLow = expectedLows[i];
-          const expectedMid = expectedMids[i];
-          const expectedUp = expectedUps[i];
-          expect(lower.toFixed(2)).toBe(`${expectedLow}`);
-          expect(middle.toFixed(2)).toBe(`${expectedMid}`);
-          expect(upper.toFixed(2)).toBe(`${expectedUp}`);
+      inputs.forEach((price, i) => {
+        const result = bb.add(price);
+
+        if (result) {
+          expect(result.lower.toFixed(2)).toBe(`${expectedLows[i]}`);
+          expect(result.middle.toFixed(2)).toBe(`${expectedMids[i]}`);
+          expect(result.upper.toFixed(2)).toBe(`${expectedUps[i]}`);
+        } else {
+          expect(expectedLows[i]).toBeUndefined();
         }
-      }
+      });
+
+      expect(bb.isStable).toBe(true);
     });
   });
 
@@ -151,33 +196,38 @@ describe('BollingerBands', () => {
       expect(signal.state).toBe(TradingSignal.UNKNOWN);
     });
 
-    it('returns BULLISH when price breaks above the previous upper band', () => {
+    it('returns BULLISH when the price breaks above the upper band', () => {
       const bb = new BollingerBands(10, 2);
-      // Need 12 adds: 11 for first result, 12th to have a previous result to compare against
-      for (let i = 0; i < 11; i++) {
+
+      // Fill the interval with flat prices so the bands stay narrow around 50
+      for (let i = 0; i < 10; i++) {
         bb.add(50);
       }
-      // Now spike: signal compares 100 against the previous bands (all 50s → narrow bands)
+
       bb.add(100);
       const signal = bb.getSignal();
       expect(signal.state).toBe(TradingSignal.BULLISH);
     });
 
-    it('returns BEARISH when price breaks below the previous lower band', () => {
+    it('returns BEARISH when the price breaks below the lower band', () => {
       const bb = new BollingerBands(10, 2);
-      for (let i = 0; i < 11; i++) {
+
+      for (let i = 0; i < 10; i++) {
         bb.add(50);
       }
+
       bb.add(0);
       const signal = bb.getSignal();
       expect(signal.state).toBe(TradingSignal.BEARISH);
     });
 
-    it('returns SIDEWAYS when price is between the previous bands', () => {
+    it('returns SIDEWAYS when the price stays between the bands', () => {
       const bb = new BollingerBands(10, 2);
+
       for (let i = 0; i < 11; i++) {
         bb.add(50 + (i % 2));
       }
+
       bb.add(50);
       const signal = bb.getSignal();
       expect(signal.state).toBe(TradingSignal.SIDEWAYS);
@@ -185,13 +235,15 @@ describe('BollingerBands', () => {
 
     it('tracks signal state changes', () => {
       const bb = new BollingerBands(10, 2);
-      // Build up stable data: 12 adds to get a previous result for comparison
+
+      // Flat prices keep the bands narrow around 50
       for (let i = 0; i < 12; i++) {
         bb.add(50);
       }
+
       expect(bb.getSignal().state).toBe(TradingSignal.SIDEWAYS);
 
-      // Spike up: compared against previous narrow bands → BULLISH
+      // Spike up: the price escapes the bands to the upside
       bb.add(100);
       const signal = bb.getSignal();
       expect(signal.state).toBe(TradingSignal.BULLISH);
@@ -200,17 +252,24 @@ describe('BollingerBands', () => {
 
     it('restores previous signal state on replace', () => {
       const bb = new BollingerBands(10, 2);
+
       for (let i = 0; i < 12; i++) {
         bb.add(50);
       }
+
       expect(bb.getSignal().state).toBe(TradingSignal.SIDEWAYS);
 
       // Add a spike, then replace it with a normal value
       bb.add(100);
       expect(bb.getSignal().state).toBe(TradingSignal.BULLISH);
 
+      const signal = bb.getSignal();
       bb.replace(50);
-      expect(bb.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+      const restoredSignal = bb.getSignal();
+
+      expect(signal.hasChanged).toBe(true);
+      expect(restoredSignal.state).toBe(TradingSignal.SIDEWAYS);
+      expect(restoredSignal.hasChanged).toBe(false);
     });
   });
 });

--- a/packages/trading-signals/src/volatility/BBANDS/BollingerBands.ts
+++ b/packages/trading-signals/src/volatility/BBANDS/BollingerBands.ts
@@ -1,4 +1,4 @@
-import {TechnicalIndicator, TradingSignal} from '../../types/Indicator.js';
+import {TradingSignal, TrendTechnicalIndicator} from '../../types/Indicator.js';
 import type {BandsResult} from '../../types/BandsResult.js';
 import {getAverage, getStandardDeviation, pushUpdate} from '../../util/index.js';
 
@@ -12,10 +12,8 @@ import {getAverage, getStandardDeviation, pushUpdate} from '../../util/index.js'
  *
  * @see https://www.investopedia.com/terms/b/bollingerbands.asp
  */
-export class BollingerBands extends TechnicalIndicator<BandsResult, number> {
+export class BollingerBands extends TrendTechnicalIndicator<BandsResult> {
   public readonly prices: number[] = [];
-  #previousResult?: BandsResult;
-  #twoPreviousResult?: BandsResult;
   #lastPrice?: number;
   #previousPrice?: number;
 
@@ -33,57 +31,56 @@ export class BollingerBands extends TechnicalIndicator<BandsResult, number> {
   }
 
   update(price: number, replace: boolean) {
-    const dropOut = pushUpdate(this.prices, replace, price, this.interval);
+    pushUpdate(this.prices, replace, price, this.interval);
 
+    /*
+     * Rewind the price history so "calculateSignalState" sees the price that belonged to
+     * "previousResult" while "setResult" re-caches the previous signal state
+     */
     if (replace) {
-      this.result = this.#previousResult;
-      this.#previousResult = this.#twoPreviousResult;
       this.#lastPrice = this.#previousPrice;
     }
 
-    this.#twoPreviousResult = this.#previousResult;
-    this.#previousResult = this.result;
-    this.#previousPrice = this.#lastPrice;
-    this.#lastPrice = price;
+    let result: BandsResult | null = null;
 
-    if (dropOut) {
+    if (this.prices.length === this.interval) {
       const middle = getAverage(this.prices);
       const standardDeviation = getStandardDeviation(this.prices, middle);
 
-      return (this.result = {
-        lower: middle - standardDeviation * this.deviationMultiplier,
-        middle,
-        upper: middle + standardDeviation * this.deviationMultiplier,
-      });
+      result = this.setResult(
+        {
+          lower: middle - standardDeviation * this.deviationMultiplier,
+          middle,
+          upper: middle + standardDeviation * this.deviationMultiplier,
+        },
+        replace
+      );
     }
 
-    return null;
+    if (!replace) {
+      this.#previousPrice = this.#lastPrice;
+    }
+
+    this.#lastPrice = price;
+
+    return result;
   }
 
-  protected calculateSignal(result?: BandsResult | null, price?: number) {
+  protected override calculateSignalState(result?: BandsResult | null) {
+    const price = this.#lastPrice;
+
     if (!result || price === undefined) {
       return TradingSignal.UNKNOWN;
     }
+
     if (price > result.upper) {
       return TradingSignal.BULLISH;
     }
+
     if (price < result.lower) {
       return TradingSignal.BEARISH;
     }
+
     return TradingSignal.SIDEWAYS;
-  }
-
-  getSignal(): {
-    state: (typeof TradingSignal)[keyof typeof TradingSignal];
-    hasChanged: boolean;
-  } {
-    const previousState = this.calculateSignal(this.#twoPreviousResult, this.#previousPrice);
-    const state = this.calculateSignal(this.#previousResult, this.#lastPrice);
-    const hasChanged = previousState !== state;
-
-    return {
-      hasChanged,
-      state,
-    };
   }
 }

--- a/packages/trading-signals/src/volatility/BBW/BollingerBandsWidth.test.ts
+++ b/packages/trading-signals/src/volatility/BBW/BollingerBandsWidth.test.ts
@@ -45,6 +45,7 @@ describe('BollingerBandsWidth', () => {
        */
       const expectations = [
         '0.19',
+        '0.19',
         '0.21',
         '0.21',
         '0.21',
@@ -59,7 +60,7 @@ describe('BollingerBandsWidth', () => {
 
       const interval = 20;
       const bbw = new BollingerBandsWidth(new BollingerBands(interval, 2));
-      const offset = bbw.getRequiredInputs();
+      const offset = bbw.getRequiredInputs() - 1;
 
       expect(bbw.getRequiredInputs()).toBe(interval);
 


### PR DESCRIPTION
## Summary

### BBANDS warm-up off-by-one: confirmed and fixed

`BollingerBands` only computed a result when `pushUpdate` returned a `dropOut`, which first happens at the *(interval+1)*-th input — while `getRequiredInputs()` returns `interval` and the SMA that defines the middle band stabilizes at exactly `interval` inputs. Verification against reference data:

- **JSON fixture** (`src/fixtures/BB/data.json`, interval 20): the first non-null reference value sits at index 19 (the 20th input) — `middle[19] = 74.3`, which equals the mean of `prices[0..19]`. The old implementation emitted its first result at index 20.
- **Tulip Indicators fixture** (`BollingerBands.test.ts`, interval 5): reference values start at index 4 — lower `80.53` / middle `82.43` / upper `84.32`, which match the bands computed from the first five inputs (`81.59, 81.06, 82.87, 83.0, 83.61`; mean `82.426`).
- Both tests masked the missing first value by gating assertions on `if (bb.isStable)`, so the reference values at the first index were silently skipped.

`BollingerBands` now computes from the full window once `prices.length === interval`, making `getRequiredInputs()` accurate. The tests assert the exact warm-up offset (`getRequiredInputs() - 1`), and a new test proves the middle band stabilizes in lockstep with an `SMA` of the same interval. `BollingerBandsWidth` (built on BBANDS) gains one earlier result accordingly; its new first value at index 19 (`0.19`, window `closes[0..19]`) is consistent with the TradingView-verified series.

### Generic object-result indicator base

New `TrendTechnicalIndicator<Result, Input, SignalState>` in `src/types/Indicator.ts` mirrors `TrendIndicatorSeries` but is generic over the result type: `previousResult` caching via `setResult()`, abstract `calculateSignalState()`, and `getSignal()` returning `{state, hasChanged}`. It is exported through the existing `types` barrel.

- `MACD` and `BollingerBands` now extend it; their hand-rolled `#previousResult` / `#twoPreviousResult` bookkeeping and duplicated `calculateSignal` / `getSignal` methods are deleted.
- Public API unchanged: class names, `MACDResult` / `BandsResult` shapes, and the `getSignal()` return shape `{state, hasChanged}` are all stable.
- Bidirectional `replace()` behavior is preserved; `BollingerBands` keeps a two-level price history so signal states are re-derived from the correct (result, price) pairing on replace. A strict bidirectional replace test for BBANDS results was added.

### Behavior note: BBANDS signal semantics

`BollingerBands.getSignal()` previously compared the latest price against the bands from *before* that price entered the window. It now compares the latest price against the current bands (standard %B semantics, and the same comparison downstream code like `MultiIndicatorConfluenceStrategy` performs manually). All existing signal test scenarios produce identical states.

### Follow-ups (out of scope)

`StochasticOscillator` and `AccelerationBands` still hand-roll the same signal machinery (`calculateSignal` + `getSignal`); ABANDS also computes only on `dropOut` and likely has the same warm-up off-by-one. Both are candidates for a follow-up migration onto `TrendTechnicalIndicator`.

## Test plan

- [x] `npm test` in `packages/trading-signals`: 63 files / 455 tests pass, coverage 100% on all metrics (statements 1259/1259, branches 690/690, functions 232/232, lines 1235/1235)
- [x] `npm run lint` in `packages/trading-signals` passes
- [x] `npx lerna run dist --scope trading-strategies --include-dependencies` succeeds; additionally rebuilt all workspace packages via npm workspaces and ran the `trading-strategies` suite: 22 files / 248 tests pass