### PR TITLE
refactor(trading-signals): migrate remaining object-result indicators to the shared signal base

### DIFF
--- a/packages/trading-signals/src/momentum/STOCH/StochasticOscillator.test.ts
+++ b/packages/trading-signals/src/momentum/STOCH/StochasticOscillator.test.ts
@@ -98,6 +98,19 @@ describe('StochasticOscillator', () => {
       expect(result?.stochK.toFixed(2)).toBe('0.00');
       expect(result?.stochD.toFixed(2)).toBe('0.00');
     });
+
+    it('includes a %K of zero in the %D average', () => {
+      const stoch = new StochasticOscillator(1, 1, 3);
+
+      // A close at the window low produces %K = 0, which must still count toward %D
+      expect(stoch.add({close: 5, high: 10, low: 0})).toBeNull();
+      expect(stoch.add({close: 0, high: 10, low: 0})).toBeNull();
+
+      const result = stoch.add({close: 1, high: 4, low: 0});
+
+      expect(result?.stochK.toFixed(2)).toBe('25.00');
+      expect(result?.stochD.toFixed(2)).toBe('25.00');
+    });
   });
 
   describe('getSignal', () => {

--- a/packages/trading-signals/src/momentum/STOCH/StochasticOscillator.ts
+++ b/packages/trading-signals/src/momentum/STOCH/StochasticOscillator.ts
@@ -1,6 +1,6 @@
 import {SMA} from '../../trend/SMA/SMA.js';
 import type {HighLowClose} from '../../types/HighLowClose.js';
-import {TechnicalIndicator, TradingSignal} from '../../types/Indicator.js';
+import {TradingSignal, TrendTechnicalIndicator} from '../../types/Indicator.js';
 import {pushUpdate} from '../../util/pushUpdate.js';
 
 export interface StochasticResult {
@@ -28,11 +28,10 @@ export interface StochasticResult {
  * @see https://www.investopedia.com/terms/s/stochasticoscillator.asp
  * @see https://tulipindicators.org/stoch
  */
-export class StochasticOscillator extends TechnicalIndicator<StochasticResult, HighLowClose<number>> {
+export class StochasticOscillator extends TrendTechnicalIndicator<StochasticResult, HighLowClose<number>> {
   public readonly candles: HighLowClose<number>[] = [];
   readonly #periodM: SMA;
   readonly #periodP: SMA;
-  #previousResult?: StochasticResult;
 
   /**
    * @param n The %k period
@@ -70,23 +69,20 @@ export class StochasticOscillator extends TechnicalIndicator<StochasticResult, H
       const stochD = stochK && this.#periodP.update(stochK, replace); // (stoch_d, %d)
 
       if (stochK !== null && stochD !== null) {
-        if (replace) {
-          this.result = this.#previousResult;
-        }
-
-        this.#previousResult = this.result;
-
-        return (this.result = {
-          stochD,
-          stochK,
-        });
+        return this.setResult(
+          {
+            stochD,
+            stochK,
+          },
+          replace
+        );
       }
     }
 
     return null;
   }
 
-  protected calculateSignal(result?: StochasticResult | null | undefined) {
+  protected override calculateSignalState(result?: StochasticResult | null | undefined) {
     const hasResult = result !== null && result !== undefined;
     const isOversold = hasResult && result.stochK <= 20;
     const isOverbought = hasResult && result.stochK >= 80;
@@ -101,19 +97,5 @@ export class StochasticOscillator extends TechnicalIndicator<StochasticResult, H
       default:
         return TradingSignal.SIDEWAYS;
     }
-  }
-
-  getSignal(): {
-    state: (typeof TradingSignal)[keyof typeof TradingSignal];
-    hasChanged: boolean;
-  } {
-    const previousState = this.calculateSignal(this.#previousResult);
-    const state = this.calculateSignal(this.getResult());
-    const hasChanged = previousState !== state;
-
-    return {
-      hasChanged,
-      state,
-    };
   }
 }

--- a/packages/trading-signals/src/momentum/STOCH/StochasticOscillator.ts
+++ b/packages/trading-signals/src/momentum/STOCH/StochasticOscillator.ts
@@ -66,7 +66,8 @@ export class StochasticOscillator extends TrendTechnicalIndicator<StochasticResu
       // Prevent division by zero
       fastK = fastK / (divisor === 0 ? 1 : divisor);
       const stochK = this.#periodM.update(fastK, replace); // (stoch_k, %k)
-      const stochD = stochK && this.#periodP.update(stochK, replace); // (stoch_d, %d)
+      // %K of 0 (close at the window low) is a valid reading and must still feed the %D average
+      const stochD = stochK !== null ? this.#periodP.update(stochK, replace) : null; // (stoch_d, %d)
 
       if (stochK !== null && stochD !== null) {
         return this.setResult(

--- a/packages/trading-signals/src/volatility/ABANDS/AccelerationBands.test.ts
+++ b/packages/trading-signals/src/volatility/ABANDS/AccelerationBands.test.ts
@@ -18,7 +18,7 @@ describe('AccelerationBands', () => {
     it('returns upper, middle and lower bands', () => {
       const interval = 20;
       const accBands = new AccelerationBands(interval, 4);
-      expect(accBands.isStable).toBe(false);
+      const offset = accBands.getRequiredInputs() - 1;
 
       // Test data from: https://github.com/QuantConnect/Lean/blob/master/Tests/TestData/spy_acceleration_bands_20_4.txt
       const candles = [
@@ -42,12 +42,13 @@ describe('AccelerationBands', () => {
         {close: 188.12, high: 189.74, low: 186.93, open: 188.24},
         {close: 191.63, high: 191.83, low: 189.44, open: 190.4},
         {close: 192.13, high: 192.49, low: 189.82, open: 192.03},
-      ];
+      ] as const;
 
-      for (const candle of candles) {
-        const {close, high, low} = candle;
+      candles.forEach(({close, high, low}, index) => {
         accBands.add({close, high, low});
-      }
+
+        expect(accBands.isStable).toBe(index >= offset);
+      });
 
       let result = accBands.getResultOrThrow();
 
@@ -75,6 +76,30 @@ describe('AccelerationBands', () => {
       } catch (error) {
         expect(error).toBeInstanceOf(NotEnoughDataError);
       }
+    });
+  });
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const accBands = new AccelerationBands(5, 4);
+
+      for (let i = 0; i < 5; i++) {
+        accBands.add({close: 50 + i, high: 60, low: 40});
+      }
+
+      const originalValue = {close: 55, high: 60, low: 40} as const;
+      const replacedValue = {close: 45, high: 60, low: 40} as const;
+
+      const originalResult = accBands.add(originalValue);
+      const replacedResult = accBands.replace(replacedValue);
+
+      expect(replacedResult?.middle).not.toBe(originalResult?.middle);
+
+      const restoredResult = accBands.replace(originalValue);
+
+      expect(restoredResult?.lower).toBe(originalResult?.lower);
+      expect(restoredResult?.middle).toBe(originalResult?.middle);
+      expect(restoredResult?.upper).toBe(originalResult?.upper);
     });
   });
 
@@ -117,32 +142,38 @@ describe('AccelerationBands', () => {
       expect(signal.state).toBe(TradingSignal.UNKNOWN);
     });
 
-    it('returns BULLISH when close breaks above the previous upper band', () => {
+    it('returns BULLISH when the close breaks above the upper band', () => {
       const accBands = new AccelerationBands(5, 4);
-      // 5 stable candles for first result, then spike: signal compares against previous bands
+
+      // Fill the interval with flat candles so the bands stay narrow around 50
       for (let i = 0; i < 5; i++) {
         accBands.add({close: 50, high: 51, low: 49});
       }
+
       accBands.add({close: 80, high: 81, low: 79});
       const signal = accBands.getSignal();
       expect(signal.state).toBe(TradingSignal.BULLISH);
     });
 
-    it('returns BEARISH when close breaks below the previous lower band', () => {
+    it('returns BEARISH when the close breaks below the lower band', () => {
       const accBands = new AccelerationBands(5, 4);
+
       for (let i = 0; i < 5; i++) {
         accBands.add({close: 50, high: 51, low: 49});
       }
+
       accBands.add({close: 20, high: 21, low: 19});
       const signal = accBands.getSignal();
       expect(signal.state).toBe(TradingSignal.BEARISH);
     });
 
-    it('returns SIDEWAYS when close is between the previous bands', () => {
+    it('returns SIDEWAYS when the close stays between the bands', () => {
       const accBands = new AccelerationBands(5, 4);
+
       for (let i = 0; i < 5; i++) {
         accBands.add({close: 50, high: 51, low: 49});
       }
+
       accBands.add({close: 50, high: 51, low: 49});
       const signal = accBands.getSignal();
       expect(signal.state).toBe(TradingSignal.SIDEWAYS);
@@ -150,13 +181,15 @@ describe('AccelerationBands', () => {
 
     it('tracks signal state changes', () => {
       const accBands = new AccelerationBands(5, 4);
-      // 6 stable candles: need previous result to exist for non-UNKNOWN signal
+
+      // Flat candles keep the bands narrow around 50
       for (let i = 0; i < 6; i++) {
         accBands.add({close: 50, high: 51, low: 49});
       }
+
       expect(accBands.getSignal().state).toBe(TradingSignal.SIDEWAYS);
 
-      // Spike above previous upper band (BULLISH)
+      // Spike up: the close escapes the bands to the upside
       accBands.add({close: 80, high: 81, low: 79});
       const signal = accBands.getSignal();
       expect(signal.state).toBe(TradingSignal.BULLISH);
@@ -165,17 +198,24 @@ describe('AccelerationBands', () => {
 
     it('restores previous signal state on replace', () => {
       const accBands = new AccelerationBands(5, 4);
+
       for (let i = 0; i < 6; i++) {
         accBands.add({close: 50, high: 51, low: 49});
       }
+
       expect(accBands.getSignal().state).toBe(TradingSignal.SIDEWAYS);
 
       // Add a spike, then replace it with a normal value
       accBands.add({close: 80, high: 81, low: 79});
       expect(accBands.getSignal().state).toBe(TradingSignal.BULLISH);
 
+      const signal = accBands.getSignal();
       accBands.replace({close: 50, high: 51, low: 49});
-      expect(accBands.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+      const restoredSignal = accBands.getSignal();
+
+      expect(signal.hasChanged).toBe(true);
+      expect(restoredSignal.state).toBe(TradingSignal.SIDEWAYS);
+      expect(restoredSignal.hasChanged).toBe(false);
     });
   });
 });

--- a/packages/trading-signals/src/volatility/ABANDS/AccelerationBands.ts
+++ b/packages/trading-signals/src/volatility/ABANDS/AccelerationBands.ts
@@ -1,4 +1,4 @@
-import {TechnicalIndicator, TradingSignal} from '../../types/Indicator.js';
+import {TradingSignal, TrendTechnicalIndicator} from '../../types/Indicator.js';
 import type {MovingAverage} from '../../trend/MA/MovingAverage.js';
 import type {MovingAverageTypes} from '../../trend/MA/MovingAverageTypes.js';
 import {SMA} from '../../trend/SMA/SMA.js';
@@ -23,12 +23,10 @@ import type {HighLowClose} from '../../types/HighLowClose.js';
  * @see https://github.com/QuantConnect/Lean/blob/master/Indicators/AccelerationBands.cs
  * @see https://github.com/twopirllc/pandas-ta/blob/master/pandas_ta/volatility/accbands.py
  */
-export class AccelerationBands extends TechnicalIndicator<BandsResult, HighLowClose<number>> {
+export class AccelerationBands extends TrendTechnicalIndicator<BandsResult, HighLowClose<number>> {
   readonly #lowerBand: MovingAverage;
   readonly #middleBand: MovingAverage;
   readonly #upperBand: MovingAverage;
-  #previousResult?: BandsResult;
-  #twoPreviousResult?: BandsResult;
   #lastClose?: number;
   #previousClose?: number;
 
@@ -56,56 +54,51 @@ export class AccelerationBands extends TechnicalIndicator<BandsResult, HighLowCl
     this.#middleBand.update(close, replace);
     this.#upperBand.update(high * (1 + coefficient), replace);
 
+    /*
+     * Rewind the close history so "calculateSignalState" sees the close that belonged to
+     * "previousResult" while "setResult" re-caches the previous signal state
+     */
     if (replace) {
-      this.result = this.#previousResult;
-      this.#previousResult = this.#twoPreviousResult;
       this.#lastClose = this.#previousClose;
     }
 
-    this.#twoPreviousResult = this.#previousResult;
-    this.#previousResult = this.result;
-    this.#previousClose = this.#lastClose;
-    this.#lastClose = close;
+    let result: BandsResult | null = null;
 
-    if (this.isStable) {
-      return (this.result = {
-        lower: this.#lowerBand.getResultOrThrow(),
-        middle: this.#middleBand.getResultOrThrow(),
-        upper: this.#upperBand.getResultOrThrow(),
-      });
+    if (this.#middleBand.isStable) {
+      result = this.setResult(
+        {
+          lower: this.#lowerBand.getResultOrThrow(),
+          middle: this.#middleBand.getResultOrThrow(),
+          upper: this.#upperBand.getResultOrThrow(),
+        },
+        replace
+      );
     }
 
-    return null;
+    if (!replace) {
+      this.#previousClose = this.#lastClose;
+    }
+
+    this.#lastClose = close;
+
+    return result;
   }
 
-  override get isStable() {
-    return this.#middleBand.isStable;
-  }
+  protected override calculateSignalState(result?: BandsResult | null) {
+    const close = this.#lastClose;
 
-  protected calculateSignal(result?: BandsResult | null, close?: number) {
     if (!result || close === undefined) {
       return TradingSignal.UNKNOWN;
     }
+
     if (close > result.upper) {
       return TradingSignal.BULLISH;
     }
+
     if (close < result.lower) {
       return TradingSignal.BEARISH;
     }
+
     return TradingSignal.SIDEWAYS;
-  }
-
-  getSignal(): {
-    state: (typeof TradingSignal)[keyof typeof TradingSignal];
-    hasChanged: boolean;
-  } {
-    const previousState = this.calculateSignal(this.#twoPreviousResult, this.#previousClose);
-    const state = this.calculateSignal(this.#previousResult, this.#lastClose);
-    const hasChanged = previousState !== state;
-
-    return {
-      hasChanged,
-      state,
-    };
   }
 }


### PR DESCRIPTION
> [!IMPORTANT]
> **Stacked on #1182; merge that first, GitHub will retarget this to main.**

## Summary

Finishes the migration that #1182 started: the last two object-result indicators with hand-rolled `#previousResult` caching and `getSignal()` logic now extend the shared `TrendTechnicalIndicator` base and implement only `calculateSignalState()`. Exported names and result shapes are unchanged.

- **`StochasticOscillator`** (`src/momentum/STOCH/StochasticOscillator.ts`): drops `#previousResult` and the hand-rolled `getSignal()`, commits results via `setResult()`. Mechanically identical to the MACD migration in #1182.
- **`AccelerationBands`** (`src/volatility/ABANDS/AccelerationBands.ts`): drops the `#previousResult`/`#twoPreviousResult` bookkeeping, mirrors the BollingerBands migration including the close-history rewind on `replace()` so the re-cached previous signal state pairs the previous bands with the close that belonged to them. Like BBANDS, `getSignal()` now evaluates the latest close against the **current** bands instead of the previous candle's bands (test descriptions updated accordingly). The redundant `isStable` override is gone — the base's `result !== undefined` flips at the same input as the middle band's stability.

### ABANDS warm-up verification (no off-by-one, no fix needed)

Checked whether ABANDS has the same dropOut off-by-one that #1182 fixed in BBANDS. It does not: ABANDS never used the `pushUpdate` dropOut pattern — it keys off its moving averages' `isStable`, which flips at exactly `interval` inputs, so the first result already lands at `getRequiredInputs()`.

Evidence against the QuantConnect reference (`spy_acceleration_bands_20_4.txt`, ABANDS(20, 4)): feeding exactly the first 20 SPY candles yields `lower 187.6891 / middle 194.6195 / upper 201.8016`, matching reference line 21 (the 20th data row) to all four decimals. The existing fixture test asserted this after 20 adds; this PR additionally asserts `isStable === index >= getRequiredInputs() - 1` on every add, pinning first emission to exactly 20 inputs.

### Remaining `getSignal` implementations

`grep -rln "getSignal" src` after this change matches only `src/types/Indicator.ts`. DMI/DX and PSAR were checked explicitly — they don't implement `getSignal` or hand-roll previous-result caching, so there are no skipped stragglers.

## Test plan

- [x] `npm test` in `packages/trading-signals` — 63 files / 456 tests pass, coverage 100% on statements, branches, functions, lines
- [x] `npm run lint` in `packages/trading-signals` — clean
- [x] New ABANDS tests: bidirectional `replace()` restoration, `isStable` offset assertion against the QuantConnect fixture, `hasChanged` restoration on replace (mirroring the BBANDS tests from #1182)
- [x] Downstream: rebuilt `candles`, `messaging`, `exchange`, `trading-signals` dists and ran `npm test` in `packages/trading-strategies` — 22 files / 248 tests pass
