### PR TITLE
fix(exchange): harden Trading212 order watcher and fee mapping

### DIFF
--- a/packages/exchange/src/broker/trading212/Trading212Broker.test.ts
+++ b/packages/exchange/src/broker/trading212/Trading212Broker.test.ts
@@ -273,6 +273,54 @@ describe('Trading212Broker', {concurrent: false}, () => {
       expect(mockMethods.cancelOrder).toHaveBeenCalledWith(201);
       expect(mockMethods.cancelOrder).toHaveBeenCalledWith(202);
     });
+
+    it('spares manually placed STOP/STOP_LIMIT/VALUE orders that getOpenOrders does not expose', async () => {
+      mockMethods.getOrders.mockResolvedValue([
+        {
+          id: 301,
+          limitPrice: 90,
+          quantity: 1,
+          status: Trading212OrderStatus.NEW,
+          strategy: 'QUANTITY',
+          ticker: 'AAPL_US_EQ',
+          type: 'LIMIT',
+        },
+        {
+          id: 302,
+          quantity: -1,
+          status: Trading212OrderStatus.NEW,
+          stopPrice: 140,
+          strategy: 'QUANTITY',
+          ticker: 'AAPL_US_EQ',
+          type: 'STOP',
+        },
+        {
+          id: 303,
+          limitPrice: 139,
+          quantity: -1,
+          status: Trading212OrderStatus.NEW,
+          stopPrice: 140,
+          strategy: 'QUANTITY',
+          ticker: 'AAPL_US_EQ',
+          type: 'STOP_LIMIT',
+        },
+        {
+          id: 304,
+          status: Trading212OrderStatus.NEW,
+          strategy: 'VALUE',
+          ticker: 'AAPL_US_EQ',
+          type: 'MARKET',
+          value: 100,
+        },
+      ]);
+      mockMethods.cancelOrder.mockResolvedValue(undefined);
+
+      const canceledIds = await broker.cancelOpenOrders(pair);
+
+      expect(canceledIds).toEqual(['301']);
+      expect(mockMethods.cancelOrder).toHaveBeenCalledTimes(1);
+      expect(mockMethods.cancelOrder).toHaveBeenCalledWith(301);
+    });
   });
 
   describe('getFills', () => {
@@ -407,6 +455,58 @@ describe('Trading212Broker', {concurrent: false}, () => {
       broker.unwatchOrders(topicId);
     });
 
+    it('seeds the baseline cursor from orders of any status so a fill-free history does not trigger full paging', async () => {
+      const cancelledOrder = {
+        fill: null,
+        order: {id: 10, quantity: 1, status: Trading212OrderStatus.CANCELLED, ticker: 'AAPL_US_EQ'},
+      };
+      mockMethods.getHistoryOrdersPage
+        .mockResolvedValueOnce({items: [cancelledOrder], nextPagePath: null})
+        .mockResolvedValueOnce({items: [cancelledOrder], nextPagePath: '/api/v0/equity/history/orders?cursor=abc'})
+        .mockResolvedValueOnce({items: [createFilledHistoryOrder(11), cancelledOrder], nextPagePath: null});
+
+      const topicId = await broker.watchOrders(1_000);
+      const fillHandler = vi.fn<(fill: Fill) => void>();
+      broker.on(topicId, fillHandler);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Baseline + one poll: the tick stopped at the already-seen id instead of following nextPagePath.
+      expect(mockMethods.getHistoryOrdersPage).toHaveBeenCalledTimes(2);
+      expect(fillHandler).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(fillHandler).toHaveBeenCalledTimes(1);
+      expect(fillHandler).toHaveBeenCalledWith(expect.objectContaining({order_id: '11'}));
+      broker.unwatchOrders(topicId);
+    });
+
+    it('advances the cursor past non-FILLED orders seen while polling so they are not re-paged forever', async () => {
+      const cancelledOrder = {
+        fill: null,
+        order: {id: 12, quantity: 1, status: Trading212OrderStatus.CANCELLED, ticker: 'AAPL_US_EQ'},
+      };
+      mockMethods.getHistoryOrdersPage
+        .mockResolvedValueOnce({items: [createFilledHistoryOrder(10)], nextPagePath: null})
+        .mockResolvedValueOnce({items: [cancelledOrder, createFilledHistoryOrder(10)], nextPagePath: null})
+        .mockResolvedValueOnce({items: [cancelledOrder], nextPagePath: '/api/v0/equity/history/orders?cursor=abc'});
+
+      const topicId = await broker.watchOrders(1_000);
+      const fillHandler = vi.fn<(fill: Fill) => void>();
+      broker.on(topicId, fillHandler);
+
+      await vi.advanceTimersByTimeAsync(2_000);
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Tick 2 stopped at the cancelled order's id instead of following nextPagePath.
+      expect(mockMethods.getHistoryOrdersPage).toHaveBeenCalledTimes(3);
+      expect(fillHandler).not.toHaveBeenCalled();
+      broker.unwatchOrders(topicId);
+    });
+
     it('pages through history until the last seen id so a burst of fills is not truncated', async () => {
       mockMethods.getHistoryOrdersPage
         .mockResolvedValueOnce({items: [createFilledHistoryOrder(10)], nextPagePath: null})
@@ -467,6 +567,29 @@ describe('Trading212Broker', {concurrent: false}, () => {
       await vi.advanceTimersByTimeAsync(0);
       expect(fillHandler).toHaveBeenCalledWith(expect.objectContaining({order_id: '21'}));
       broker.unwatchOrders(topicId);
+    });
+
+    it('survives a poll failure without any "error" listener (Node throws on unhandled "error" emissions)', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      mockMethods.getHistoryOrdersPage
+        .mockResolvedValueOnce({items: [], nextPagePath: null})
+        .mockRejectedValueOnce(new Error('Trading212 is down'))
+        .mockResolvedValueOnce({items: [createFilledHistoryOrder(21)], nextPagePath: null});
+
+      const topicId = await broker.watchOrders(1_000);
+      const fillHandler = vi.fn<(fill: Fill) => void>();
+      broker.on(topicId, fillHandler);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(warn).toHaveBeenCalledWith('[Trading212] watchOrders poll failed:', new Error('Trading212 is down'));
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(fillHandler).toHaveBeenCalledWith(expect.objectContaining({order_id: '21'}));
+
+      broker.unwatchOrders(topicId);
+      warn.mockRestore();
     });
   });
 });

--- a/packages/exchange/src/broker/trading212/Trading212Broker.ts
+++ b/packages/exchange/src/broker/trading212/Trading212Broker.ts
@@ -22,7 +22,7 @@ import {
 import {TradingPair} from '../TradingPair.js';
 import type {MarketDataSource} from '../MarketDataSource.js';
 import {Trading212API} from './api/Trading212API.js';
-import {Trading212OrderStatus, Trading212TimeValidity} from './api/schema/OrderSchema.js';
+import {Trading212OrderStatus, Trading212TimeValidity, type Order} from './api/schema/OrderSchema.js';
 import {Trading212BrokerMapper} from './Trading212BrokerMapper.js';
 
 export class Trading212Broker extends Broker implements MarketDataSource {
@@ -161,9 +161,14 @@ export class Trading212Broker extends Broker implements MarketDataSource {
     ]);
 
     const tickerToCurrency = new Map(instruments.map(instrument => [instrument.ticker, instrument.currencyCode]));
-    let lastSeenId = baseline.items
-      .filter(item => item.order.id != null && item.order.status === Trading212OrderStatus.FILLED)
-      .reduce((max, item) => Math.max(max, item.order.id ?? 0), 0);
+    /*
+     * The cursor exists to bound paging, not to mark fills, so seed it from the newest
+     * order of ANY status. Seeding from FILLED entries only would leave it at 0 on an
+     * account whose history holds no fill yet, making every tick page the entire order
+     * history against Trading212's 1 req/60s budget. Replay safety is unaffected:
+     * everything in this snapshot predates watchOrders and must never be emitted anyway.
+     */
+    let lastSeenId = baseline.items.reduce((max, item) => Math.max(max, item.order.id ?? 0), 0);
     let stopped = false;
 
     const tick = async () => {
@@ -174,6 +179,7 @@ export class Trading212Broker extends Broker implements MarketDataSource {
          * ones off the first page.
          */
         const newFills: typeof baseline.items = [];
+        let maxScannedId = lastSeenId;
         let nextPath: string | null = null;
         do {
           const page = await this.#api.getHistoryOrdersPage(nextPath ? {nextPath} : undefined);
@@ -184,6 +190,7 @@ export class Trading212Broker extends Broker implements MarketDataSource {
               reachedSeen = true;
               break;
             }
+            maxScannedId = Math.max(maxScannedId, orderId ?? 0);
             if (item.order.status === Trading212OrderStatus.FILLED && orderId != null && item.fill) {
               newFills.push(item);
             }
@@ -200,8 +207,25 @@ export class Trading212Broker extends Broker implements MarketDataSource {
           this.emit(topicId, Trading212BrokerMapper.toFilledOrder(item, pair, accountInfo.currencyCode));
           lastSeenId = Math.max(lastSeenId, item.order.id ?? 0);
         }
+
+        /*
+         * Non-FILLED entries (cancellations, rejections) never emit, but leaving them ahead
+         * of the cursor would make every subsequent tick re-scan — and eventually re-page —
+         * the same finalized orders.
+         */
+        lastSeenId = Math.max(lastSeenId, maxScannedId);
       } catch (error) {
-        this.emit('error', error);
+        /*
+         * 'error' is Node's reserved event: emitting it with zero listeners throws
+         * synchronously, and inside a timer callback that would take down the whole
+         * process over a transient poll failure. Broadcast only when someone is
+         * listening; otherwise warn, so polling always survives to the next tick.
+         */
+        if (this.listenerCount('error') > 0) {
+          this.emit('error', error);
+        } else {
+          console.warn(`[${this.loggerName}] watchOrders poll failed:`, error);
+        }
       } finally {
         if (!stopped) {
           this.#orderWatchers.set(topicId, setTimeout(tick, intervalInMillis));
@@ -276,21 +300,27 @@ export class Trading212Broker extends Broker implements MarketDataSource {
     return balances;
   }
 
+  /**
+   * Shared visibility filter for {@link getOpenOrders} and {@link cancelOpenOrders}.
+   *
+   * The neutral model can only represent QUANTITY-strategy MARKET/LIMIT orders:
+   * - STOP / STOP_LIMIT (e.g. protective stops placed manually in the Trading212 app):
+   *   neutral `OrderType` only models MARKET and LIMIT; coercing would silently lose `stopPrice`.
+   * - VALUE-strategy orders (notional amount in `value` instead of `quantity`): neutral
+   *   `PendingOrder.size` is base-asset units, not notional.
+   *
+   * Both call sites apply this filter on purpose — a session must never cancel an order it
+   * cannot list, or its cancel-before-place would silently wipe a protective stop the user
+   * placed manually.
+   */
+  static #fitsNeutralOrderModel(order: Order) {
+    return (order.type === 'MARKET' || order.type === 'LIMIT') && order.quantity != null;
+  }
+
   async getOpenOrders(pair: TradingPair): Promise<PendingOrder[]> {
     const orders = await this.#api.getOrders();
-    /*
-     * Drop orders that don't fit the neutral model:
-     * - STOP / STOP_LIMIT (e.g. placed manually in the Trading212 app): neutral `OrderType`
-     *   only models MARKET and LIMIT; coercing would silently lose `stopPrice`.
-     * - VALUE-strategy orders (notional amount in `value` instead of `quantity`): neutral
-     *   `PendingOrder.size` is base-asset units, not notional. Filter to QUANTITY-strategy
-     *   orders only.
-     */
     return orders
-      .filter(
-        order =>
-          order.ticker === pair.base && (order.type === 'MARKET' || order.type === 'LIMIT') && order.quantity != null
-      )
+      .filter(order => order.ticker === pair.base && Trading212Broker.#fitsNeutralOrderModel(order))
       .map(order => Trading212BrokerMapper.toOpenOrder(order, pair));
   }
 
@@ -300,7 +330,10 @@ export class Trading212Broker extends Broker implements MarketDataSource {
 
   async cancelOpenOrders(pair: TradingPair): Promise<string[]> {
     const orders = await this.#api.getOrders();
-    const matching = orders.filter(order => order.ticker === pair.base);
+    // Cancel only what getOpenOrders exposes — see #fitsNeutralOrderModel for the invariant.
+    const matching = orders.filter(
+      order => order.ticker === pair.base && Trading212Broker.#fitsNeutralOrderModel(order)
+    );
     await Promise.all(matching.map(order => this.#api.cancelOrder(order.id)));
     return matching.map(order => `${order.id}`);
   }

--- a/packages/exchange/src/broker/trading212/Trading212BrokerMapper.test.ts
+++ b/packages/exchange/src/broker/trading212/Trading212BrokerMapper.test.ts
@@ -155,7 +155,7 @@ describe('Trading212BrokerMapper', () => {
   });
 
   describe('toFilledOrder', () => {
-    it('maps a filled BUY order and sums the tax lines into a fee in the account currency', () => {
+    it('maps a filled BUY order and nets the debit tax lines into a fee in the account currency', () => {
       const item: HistoryOrder = {
         fill: {
           filledAt: '2025-06-02T14:30:01.000Z',
@@ -190,6 +190,43 @@ describe('Trading212BrokerMapper', () => {
         side: OrderSide.BUY,
         size: '2',
       });
+    });
+
+    it('subtracts credit/rebate tax lines from the fee instead of inflating it', () => {
+      const item: HistoryOrder = {
+        fill: {
+          filledAt: '2025-06-02T14:30:01.000Z',
+          price: 100.5,
+          quantity: 2,
+          walletImpact: {
+            taxes: [
+              {name: 'CURRENCY_CONVERSION_FEE', quantity: -0.5},
+              {name: 'CURRENCY_CONVERSION_FEE_REBATE', quantity: 0.2},
+            ],
+          },
+        },
+        order: {id: 12, quantity: 2, status: Trading212OrderStatus.FILLED, ticker: 'AAPL_US_EQ'},
+      };
+
+      const fill = Trading212BrokerMapper.toFilledOrder(item, pair, 'EUR');
+
+      expect(fill.fee).toBe('0.3');
+    });
+
+    it('clamps a net tax credit to a zero fee because neutral Fill.fee is an additive cost', () => {
+      const item: HistoryOrder = {
+        fill: {
+          filledAt: '2025-06-02T14:30:01.000Z',
+          price: 100.5,
+          quantity: 2,
+          walletImpact: {taxes: [{name: 'CURRENCY_CONVERSION_FEE_REBATE', quantity: 0.4}]},
+        },
+        order: {id: 13, quantity: 2, status: Trading212OrderStatus.FILLED, ticker: 'AAPL_US_EQ'},
+      };
+
+      const fill = Trading212BrokerMapper.toFilledOrder(item, pair, 'EUR');
+
+      expect(fill.fee).toBe('0');
     });
 
     it('maps a filled SELL order from a negative fill quantity', () => {

--- a/packages/exchange/src/broker/trading212/Trading212BrokerMapper.ts
+++ b/packages/exchange/src/broker/trading212/Trading212BrokerMapper.ts
@@ -1,3 +1,4 @@
+import Big from 'big.js';
 import type {TradingPair} from '../TradingPair.js';
 import {
   OrderPosition,
@@ -120,11 +121,19 @@ export class Trading212BrokerMapper {
 
     const signedQty = fill.quantity ?? order.quantity ?? order.filledQuantity ?? 0;
     const side = signedQty < 0 ? OrderSide.SELL : OrderSide.BUY;
-    const fee = (fill.walletImpact?.taxes ?? []).reduce((sum, tax) => sum + Math.abs(tax.quantity ?? 0), 0);
+    /*
+     * Tax lines are signed from the account's perspective: debits (FX conversion, stamp
+     * duty) are negative, credits/rebates positive. Net them instead of summing magnitudes
+     * so a rebate reduces the fee rather than inflating it. Neutral `Fill.fee` is a cost
+     * that downstream P&L accumulates additively, so the rare net credit (rebates exceeding
+     * charges) is clamped to zero instead of reported as a negative fee.
+     */
+    const netCost = (fill.walletImpact?.taxes ?? []).reduce((sum, tax) => sum.minus(tax.quantity ?? 0), new Big(0));
+    const fee = netCost.lt(0) ? new Big(0) : netCost;
 
     return {
       created_at: fill.filledAt ?? order.createdAt ?? '',
-      fee: `${fee}`,
+      fee: fee.toFixed(),
       feeAsset: accountCurrency,
       order_id: `${order.id}`,
       pair,


### PR DESCRIPTION
> **Stacked on #1181; merge that first, GitHub will retarget this to main.**

## Summary

Fixes four latent Trading212 bugs documented during the #1181 test-suite work (`packages/exchange/src/broker/trading212/`).

### 1. Unhandled `'error'` emission can crash the process

**Scenario:** `watchOrders`' polling tick emits `'error'` on the broker EventEmitter when a poll fails. `'error'` is Node's reserved event — emitting it with zero listeners throws synchronously, so the first transient API failure inside the timer callback kills the whole process (which also hosts other sessions and the Telegram bot).

**Fix:** The tick emits `'error'` only when `listenerCount('error') > 0` and falls back to a `console.warn` otherwise. Polling always survives to the next tick. Listener-attached behavior is unchanged (backward compatible).

### 2. Empty-baseline full-history paging

**Scenario:** The baseline cursor (`lastSeenId`) was seeded from FILLED orders only. On an account whose history holds no fill yet, it stayed at 0, so every poll tick paged the ENTIRE order history — compounded by Trading212's 1 req/60s rate limit on `/equity/history/orders`.

**Fix:** The cursor is seeded from the newest order of ANY status — it exists to bound paging, not to mark fills. Ticks also advance it past non-FILLED entries (cancellations/rejections) so they aren't re-scanned forever. No-replay guarantee preserved: everything in the baseline snapshot predates `watchOrders` and is never emitted.

### 3. cancel/list asymmetry wipes manual protective stops

**Scenario:** `getOpenOrders` deliberately filters out STOP/STOP_LIMIT/VALUE orders (they don't fit the neutral LIMIT/MARKET model), but `cancelOpenOrders` cancelled them anyway — a session's cancel-before-place silently wiped a user's manually placed stop-loss it never showed.

**Fix:** Both methods now share one predicate (`#fitsNeutralOrderModel`) with the invariant documented at its definition and referenced at the cancel site: a session must never cancel an order it cannot list.

### 4. Fee summation uses `Math.abs` on tax lines

**Scenario:** The fill mapper summed `Math.abs` of all `walletImpact.taxes[].quantity` lines. Tax lines are signed (debits negative, credits/rebates positive), so a rebate line would inflate the reported fee instead of reducing it.

**Fix:** Lines are netted with big.js (matching the surrounding arithmetic). Since neutral `Fill.fee` is a cost that downstream P&L accumulates additively (`totalFees.plus(fill.fee)` in `BacktestExecutor`), the rare net credit is clamped to zero rather than reported as a negative fee — documented at the site.

## Test plan

- Updated the #1181 suites that pinned old behavior and added regression tests (fake-timer pattern for the watcher):
  - watcher survives a poll failure with no `'error'` listener attached and keeps polling (`console.warn` fallback asserted)
  - fill-free baseline (CANCELLED-only history) stops after the first page instead of following `nextPagePath`; later fills still emitted
  - cursor advances past non-FILLED orders seen while polling
  - `cancelOpenOrders` spares STOP/STOP_LIMIT/VALUE orders and still cancels neutral-model orders of the requested ticker
  - mapper nets debit tax lines, subtracts rebates, clamps a net credit to `'0'`
- `npm test` in `packages/exchange`: 12 files, 153 tests passed
- `npm run lint` in `packages/exchange`: 0 errors
- `npm run dist` (tsc) passes