### PR TITLE
feat(trading-strategies): add configurable SMA crossover strategy

### DIFF
--- a/packages/trading-signals-docs/pages/backtest.tsx
+++ b/packages/trading-signals-docs/pages/backtest.tsx
@@ -10,6 +10,8 @@ import {
   MultiIndicatorConfluenceStrategy,
   ScalpStrategy,
   MeanReversionStrategy,
+  SmaCrossoverStrategy,
+  SmaCrossoverSchema,
   ProtectedStrategy,
   TrailingStopStrategy,
   type BacktestResult,
@@ -43,6 +45,8 @@ function createStrategy(strategyId: StrategyId, config: Record<string, unknown>)
       return new ScalpStrategy(config as ScalpConfig);
     case 'mean-reversion':
       return new MeanReversionStrategy({config});
+    case 'sma-crossover':
+      return new SmaCrossoverStrategy(SmaCrossoverSchema.parse(config));
     case 'protection-only':
       return new ProtectedStrategy({config});
     case 'trailing-stop':

--- a/packages/trading-signals-docs/pages/backtest.tsx
+++ b/packages/trading-signals-docs/pages/backtest.tsx
@@ -11,15 +11,9 @@ import {
   ScalpStrategy,
   MeanReversionStrategy,
   SmaCrossoverStrategy,
-  SmaCrossoverSchema,
   ProtectedStrategy,
   TrailingStopStrategy,
   type BacktestResult,
-  BuyOnceConfig,
-  BuyBelowSellAboveConfig,
-  type MultiIndicatorConfluenceConfig,
-  type ScalpConfig,
-  type TrailingStopConfig,
 } from 'trading-strategies';
 import {DatasetSelector} from '../components/DatasetSelector';
 import {StrategyConfigurator} from '../components/StrategyConfigurator';
@@ -27,30 +21,42 @@ import {BacktestResults} from '../components/BacktestResults';
 import {ProtectionModal} from '../components/ProtectionModal';
 import {datasets} from '../utils/datasets';
 import type {CandleDataset} from '../utils/types';
-import {strategyDefinitions, type StrategyId} from '../utils/strategySchemas';
+import {
+  strategyDefinitions,
+  type StrategyId,
+  BuyOnceSchema,
+  BuyBelowSellAboveSchema,
+  CoinFlipSchema,
+  MultiIndicatorConfluenceSchema,
+  ScalpSchema,
+  MeanReversionSchema,
+  SmaCrossoverSchema,
+  ProtectedStrategySchema,
+  TrailingStopSchema,
+} from '../utils/strategySchemas';
 
 function createStrategy(strategyId: StrategyId, config: Record<string, unknown>) {
   switch (strategyId) {
     case 'buy-and-hold':
-      return new BuyOnceStrategy(config as BuyOnceConfig);
+      return new BuyOnceStrategy(BuyOnceSchema.parse(config));
     case 'coin-flip':
-      return new CoinFlipStrategy(config);
+      return new CoinFlipStrategy(CoinFlipSchema.parse(config));
     case 'buy-once':
-      return new BuyOnceStrategy(config as BuyOnceConfig);
+      return new BuyOnceStrategy(BuyOnceSchema.parse(config));
     case 'buy-below-sell-above':
-      return new BuyBelowSellAboveStrategy(config as BuyBelowSellAboveConfig);
+      return new BuyBelowSellAboveStrategy(BuyBelowSellAboveSchema.parse(config));
     case 'multi-indicator-confluence':
-      return new MultiIndicatorConfluenceStrategy(config as MultiIndicatorConfluenceConfig);
+      return new MultiIndicatorConfluenceStrategy(MultiIndicatorConfluenceSchema.parse(config));
     case 'scalp':
-      return new ScalpStrategy(config as ScalpConfig);
+      return new ScalpStrategy(ScalpSchema.parse(config));
     case 'mean-reversion':
-      return new MeanReversionStrategy({config});
+      return new MeanReversionStrategy({config: MeanReversionSchema.parse(config)});
     case 'sma-crossover':
       return new SmaCrossoverStrategy(SmaCrossoverSchema.parse(config));
     case 'protection-only':
-      return new ProtectedStrategy({config});
+      return new ProtectedStrategy({config: ProtectedStrategySchema.parse(config)});
     case 'trailing-stop':
-      return new TrailingStopStrategy(config as TrailingStopConfig);
+      return new TrailingStopStrategy(TrailingStopSchema.parse(config));
   }
 }
 

--- a/packages/trading-signals-docs/utils/strategySchemas.ts
+++ b/packages/trading-signals-docs/utils/strategySchemas.ts
@@ -1,10 +1,10 @@
 import {z} from 'zod';
 import type {Candle} from '@typedtrader/exchange';
-import {BuyOnceSchema, BuyBelowSellAboveSchema, CoinFlipSchema, MultiIndicatorConfluenceSchema, ScalpSchema, MeanReversionSchema, ProtectedStrategySchema, TrailingStopSchema, suggestScalpOffset} from 'trading-strategies';
+import {BuyOnceSchema, BuyBelowSellAboveSchema, CoinFlipSchema, MultiIndicatorConfluenceSchema, ScalpSchema, MeanReversionSchema, SmaCrossoverSchema, ProtectedStrategySchema, TrailingStopSchema, suggestScalpOffset} from 'trading-strategies';
 
-export {BuyOnceSchema, BuyBelowSellAboveSchema, CoinFlipSchema, MultiIndicatorConfluenceSchema, ScalpSchema, MeanReversionSchema, ProtectedStrategySchema, TrailingStopSchema};
+export {BuyOnceSchema, BuyBelowSellAboveSchema, CoinFlipSchema, MultiIndicatorConfluenceSchema, ScalpSchema, MeanReversionSchema, SmaCrossoverSchema, ProtectedStrategySchema, TrailingStopSchema};
 
-export type StrategyId = 'buy-and-hold' | 'buy-once' | 'buy-below-sell-above' | 'coin-flip' | 'multi-indicator-confluence' | 'scalp' | 'mean-reversion' | 'protection-only' | 'trailing-stop';
+export type StrategyId = 'buy-and-hold' | 'buy-once' | 'buy-below-sell-above' | 'coin-flip' | 'multi-indicator-confluence' | 'scalp' | 'mean-reversion' | 'sma-crossover' | 'protection-only' | 'trailing-stop';
 
 export interface StrategyDefinition {
   id: StrategyId;
@@ -121,6 +121,14 @@ export const strategyDefinitions: StrategyDefinition[] = [
       'Batches 1-minute candles into 1-hour bars and applies Bollinger Bands (20, 2.5). Sells when price breaks above the upper band; rebuys when it returns to the middle band.',
     schema: MeanReversionSchema,
     getDefaultConfig: () => ({}),
+  },
+  {
+    id: 'sma-crossover',
+    name: 'SMA Crossover',
+    description:
+      'Crosses a fast SMA against a slow SMA — each with its own period and timeframe (e.g. SMA5 on 1m bars vs SMA10 on 2m bars). Buys when the fast SMA crosses above the slow one and sells when it crosses below (market orders).',
+    schema: SmaCrossoverSchema,
+    getDefaultConfig: () => ({fastPeriod: 5, fastTimeframe: '1m', slowPeriod: 10, slowTimeframe: '2m'}),
   },
   {
     id: 'protection-only',

--- a/packages/trading-strategies/src/index.ts
+++ b/packages/trading-strategies/src/index.ts
@@ -20,6 +20,11 @@ export {
 } from './strategy-multi-indicator-confluence/MultiIndicatorConfluenceStrategy.js';
 export {ScalpStrategy, ScalpSchema, type ScalpConfig} from './strategy-scalp/ScalpStrategy.js';
 export {
+  SmaCrossoverStrategy,
+  SmaCrossoverSchema,
+  type SmaCrossoverConfig,
+} from './strategy-sma-crossover/SmaCrossoverStrategy.js';
+export {
   MeanReversionStrategy,
   MeanReversionSchema,
   type MeanReversionConfig,

--- a/packages/trading-strategies/src/strategy-sma-crossover/SmaCrossoverStrategy.test.ts
+++ b/packages/trading-strategies/src/strategy-sma-crossover/SmaCrossoverStrategy.test.ts
@@ -65,37 +65,53 @@ describe('SmaCrossoverStrategy', () => {
   // Falls first (fast SMA below slow), then rallies (cross up → BUY), then drops (cross down → SELL).
   const crossoverPrices = [10, 9, 8, 7, 6, 7, 9, 12, 15, 12, 9, 6];
 
+  /*
+   * Different timeframes: fast SMA2 on 1m bars vs slow SMA2 on 2m bars.
+   * The 2m batcher emits on candle indices 1, 3, 5, 7, 9, so the slow SMA is stable from
+   * index 3 onward. Fast crosses above slow at index 6 (BUY) and back below at index 9 (SELL).
+   */
+  const dualTimeframePrices = [10, 10, 10, 8, 8, 6, 14, 20, 8, 4];
+
   describe('config', () => {
     it('applies defaults when constructed without a config', () => {
       const strategy = new SmaCrossoverStrategy();
       expect(strategy.isWarmedUp).toBe(false);
     });
 
-    it('rejects a shortPeriod that is not smaller than longPeriod', () => {
-      expect(() => new SmaCrossoverStrategy({longPeriod: 20, shortPeriod: 20})).toThrowError(/must be smaller/);
-      expect(() => new SmaCrossoverStrategy({longPeriod: 20, shortPeriod: 30})).toThrowError(/must be smaller/);
+    it('rejects a fast and slow SMA that are configured identically', () => {
+      expect(
+        () => new SmaCrossoverStrategy({fastPeriod: 10, fastTimeframe: '5m', slowPeriod: 10, slowTimeframe: '5m'})
+      ).toThrowError(/never cross/);
+    });
+
+    it('allows the same timeframe as long as the periods differ', () => {
+      expect(
+        () => new SmaCrossoverStrategy({fastPeriod: 2, fastTimeframe: '1m', slowPeriod: 3, slowTimeframe: '1m'})
+      ).not.toThrow();
     });
 
     it('rejects a timeframe below one minute', () => {
-      expect(() => new SmaCrossoverStrategy({timeframe: '30s'})).toThrowError();
+      expect(() => new SmaCrossoverStrategy({fastTimeframe: '30s'})).toThrowError();
+      expect(() => new SmaCrossoverStrategy({slowTimeframe: '30s'})).toThrowError();
     });
 
     it('accepts ms-syntax timeframes like "5m" and "1d"', () => {
-      expect(() => new SmaCrossoverStrategy({timeframe: '5m'})).not.toThrow();
-      expect(() => new SmaCrossoverStrategy({timeframe: '1d'})).not.toThrow();
+      expect(() => new SmaCrossoverStrategy({fastTimeframe: '5m', slowTimeframe: '1d'})).not.toThrow();
     });
   });
 
-  describe('processCandle', () => {
+  describe('processCandle (shared timeframe)', () => {
+    const config = {fastPeriod: 2, fastTimeframe: '1m', slowPeriod: 3, slowTimeframe: '1m'} as const;
+
     it('stays silent until both SMAs are warmed up', async () => {
-      const strategy = new SmaCrossoverStrategy({longPeriod: 3, shortPeriod: 2, timeframe: '1m'});
-      const advices = await feed(strategy, [10, 11]); // only 2 bars: SMA3 not stable yet
+      const strategy = new SmaCrossoverStrategy(config);
+      const advices = await feed(strategy, [10, 11]); // only 2 bars: slow SMA3 not stable yet
       expect(advices).toHaveLength(0);
       expect(strategy.isWarmedUp).toBe(false);
     });
 
     it('buys when the fast SMA crosses above the slow SMA', async () => {
-      const strategy = new SmaCrossoverStrategy({longPeriod: 3, shortPeriod: 2, timeframe: '1m'});
+      const strategy = new SmaCrossoverStrategy(config);
       const [buy] = await feed(strategy, crossoverPrices);
       assertMarket(buy, OrderSide.BUY);
       expect(buy.amountIn).toBe('counter');
@@ -103,7 +119,7 @@ describe('SmaCrossoverStrategy', () => {
     });
 
     it('sells when the fast SMA crosses back below the slow SMA', async () => {
-      const strategy = new SmaCrossoverStrategy({longPeriod: 3, shortPeriod: 2, timeframe: '1m'});
+      const strategy = new SmaCrossoverStrategy(config);
       const [, sell] = await feed(strategy, crossoverPrices);
       assertMarket(sell, OrderSide.SELL);
       expect(sell.amountIn).toBe('base');
@@ -111,9 +127,30 @@ describe('SmaCrossoverStrategy', () => {
     });
 
     it('fires exactly one BUY then one SELL across a single up-and-down swing', async () => {
-      const strategy = new SmaCrossoverStrategy({longPeriod: 3, shortPeriod: 2, timeframe: '1m'});
+      const strategy = new SmaCrossoverStrategy(config);
       const advices = await feed(strategy, crossoverPrices);
       expect(advices.map(advice => advice.side)).toEqual([OrderSide.BUY, OrderSide.SELL]);
+    });
+  });
+
+  describe('processCandle (different timeframes)', () => {
+    const config = {fastPeriod: 2, fastTimeframe: '1m', slowPeriod: 2, slowTimeframe: '2m'} as const;
+
+    it('crosses a 1m fast SMA against a 2m slow SMA (one BUY then one SELL)', async () => {
+      const strategy = new SmaCrossoverStrategy(config);
+      const advices = await feed(strategy, dualTimeframePrices);
+      expect(advices.map(advice => advice.side)).toEqual([OrderSide.BUY, OrderSide.SELL]);
+      const [buy, sell] = advices;
+      assertMarket(buy, OrderSide.BUY);
+      assertMarket(sell, OrderSide.SELL);
+    });
+
+    it('waits for the slower SMA before it can produce advice', async () => {
+      const strategy = new SmaCrossoverStrategy(config);
+      // Two 1m candles warm up the fast SMA but only complete one 2m bar, so slow SMA2 is not stable.
+      const advices = await feed(strategy, dualTimeframePrices.slice(0, 3));
+      expect(advices).toHaveLength(0);
+      expect(strategy.isWarmedUp).toBe(false);
     });
   });
 });

--- a/packages/trading-strategies/src/strategy-sma-crossover/SmaCrossoverStrategy.test.ts
+++ b/packages/trading-strategies/src/strategy-sma-crossover/SmaCrossoverStrategy.test.ts
@@ -105,8 +105,8 @@ describe('SmaCrossoverStrategy', () => {
 
     it('stays silent until both SMAs are warmed up', async () => {
       const strategy = new SmaCrossoverStrategy(config);
-      const advices = await feed(strategy, [10, 11]); // only 2 bars: slow SMA3 not stable yet
-      expect(advices).toHaveLength(0);
+      const advices = await feed(strategy, [10, 11]);
+      expect(advices, 'only 2 bars fed, so the slow SMA3 is not stable yet').toHaveLength(0);
       expect(strategy.isWarmedUp).toBe(false);
     });
 
@@ -147,9 +147,8 @@ describe('SmaCrossoverStrategy', () => {
 
     it('waits for the slower SMA before it can produce advice', async () => {
       const strategy = new SmaCrossoverStrategy(config);
-      // Two 1m candles warm up the fast SMA but only complete one 2m bar, so slow SMA2 is not stable.
       const advices = await feed(strategy, dualTimeframePrices.slice(0, 3));
-      expect(advices).toHaveLength(0);
+      expect(advices, 'three 1m candles complete only one 2m bar, so the slow SMA2 is not stable yet').toHaveLength(0);
       expect(strategy.isWarmedUp).toBe(false);
     });
   });

--- a/packages/trading-strategies/src/strategy-sma-crossover/SmaCrossoverStrategy.test.ts
+++ b/packages/trading-strategies/src/strategy-sma-crossover/SmaCrossoverStrategy.test.ts
@@ -1,0 +1,119 @@
+import Big from 'big.js';
+import {describe, expect, it} from 'vitest';
+import {CandleBatcher, OrderSide, OrderType, TradingPair} from '@typedtrader/exchange';
+import type {Candle, OneMinuteBatchedCandle} from '@typedtrader/exchange';
+import type {MarketOrderAdvice, OrderAdvice, TradingSessionState} from '../trader/index.js';
+import {AllAvailableAmount} from '../trader/index.js';
+import {SmaCrossoverStrategy} from './SmaCrossoverStrategy.js';
+
+const pair = new TradingPair('AAPL', 'USD');
+
+const mockState: TradingSessionState = {
+  baseBalance: new Big(0),
+  counterBalance: new Big(1000),
+  feeRates: {
+    [OrderType.LIMIT]: new Big('0.001'),
+    [OrderType.MARKET]: new Big('0.002'),
+  },
+  tradingRules: {
+    base_increment: '0.01',
+    base_max_size: '10000',
+    base_min_size: '0.01',
+    counter_increment: '0.01',
+    counter_min_size: '1',
+    pair,
+  },
+};
+
+const ONE_MINUTE_IN_MS = 60_000;
+
+function makeCandle(close: number, index: number): OneMinuteBatchedCandle {
+  const closeStr = String(close);
+  const exchangeCandle: Candle = {
+    base: 'AAPL',
+    close: closeStr,
+    counter: 'USD',
+    high: String(close + 1),
+    low: String(close - 1),
+    open: closeStr,
+    openTimeInISO: new Date(1735689600000 + index * ONE_MINUTE_IN_MS).toISOString(),
+    openTimeInMillis: 1735689600000 + index * ONE_MINUTE_IN_MS,
+    sizeInMillis: ONE_MINUTE_IN_MS,
+    volume: '1000',
+  };
+  return CandleBatcher.createOneMinuteBatchedCandle([exchangeCandle]);
+}
+
+async function feed(strategy: SmaCrossoverStrategy, prices: number[]): Promise<OrderAdvice[]> {
+  const advices: OrderAdvice[] = [];
+  for (const [index, price] of prices.entries()) {
+    const advice = await strategy.onCandle(makeCandle(price, index), mockState);
+    if (advice) {
+      advices.push(advice);
+    }
+  }
+  return advices;
+}
+
+function assertMarket(advice: OrderAdvice, side: OrderSide): asserts advice is MarketOrderAdvice {
+  if (advice.type !== OrderType.MARKET || advice.side !== side) {
+    throw new Error(`Expected a MARKET ${side} advice but received ${JSON.stringify(advice)}`);
+  }
+}
+
+describe('SmaCrossoverStrategy', () => {
+  // Falls first (fast SMA below slow), then rallies (cross up → BUY), then drops (cross down → SELL).
+  const crossoverPrices = [10, 9, 8, 7, 6, 7, 9, 12, 15, 12, 9, 6];
+
+  describe('config', () => {
+    it('applies defaults when constructed without a config', () => {
+      const strategy = new SmaCrossoverStrategy();
+      expect(strategy.isWarmedUp).toBe(false);
+    });
+
+    it('rejects a shortPeriod that is not smaller than longPeriod', () => {
+      expect(() => new SmaCrossoverStrategy({longPeriod: 20, shortPeriod: 20})).toThrowError(/must be smaller/);
+      expect(() => new SmaCrossoverStrategy({longPeriod: 20, shortPeriod: 30})).toThrowError(/must be smaller/);
+    });
+
+    it('rejects a timeframe below one minute', () => {
+      expect(() => new SmaCrossoverStrategy({timeframe: '30s'})).toThrowError();
+    });
+
+    it('accepts ms-syntax timeframes like "5m" and "1d"', () => {
+      expect(() => new SmaCrossoverStrategy({timeframe: '5m'})).not.toThrow();
+      expect(() => new SmaCrossoverStrategy({timeframe: '1d'})).not.toThrow();
+    });
+  });
+
+  describe('processCandle', () => {
+    it('stays silent until both SMAs are warmed up', async () => {
+      const strategy = new SmaCrossoverStrategy({longPeriod: 3, shortPeriod: 2, timeframe: '1m'});
+      const advices = await feed(strategy, [10, 11]); // only 2 bars: SMA3 not stable yet
+      expect(advices).toHaveLength(0);
+      expect(strategy.isWarmedUp).toBe(false);
+    });
+
+    it('buys when the fast SMA crosses above the slow SMA', async () => {
+      const strategy = new SmaCrossoverStrategy({longPeriod: 3, shortPeriod: 2, timeframe: '1m'});
+      const [buy] = await feed(strategy, crossoverPrices);
+      assertMarket(buy, OrderSide.BUY);
+      expect(buy.amountIn).toBe('counter');
+      expect(buy.amount).toBe(AllAvailableAmount);
+    });
+
+    it('sells when the fast SMA crosses back below the slow SMA', async () => {
+      const strategy = new SmaCrossoverStrategy({longPeriod: 3, shortPeriod: 2, timeframe: '1m'});
+      const [, sell] = await feed(strategy, crossoverPrices);
+      assertMarket(sell, OrderSide.SELL);
+      expect(sell.amountIn).toBe('base');
+      expect(sell.amount).toBe(AllAvailableAmount);
+    });
+
+    it('fires exactly one BUY then one SELL across a single up-and-down swing', async () => {
+      const strategy = new SmaCrossoverStrategy({longPeriod: 3, shortPeriod: 2, timeframe: '1m'});
+      const advices = await feed(strategy, crossoverPrices);
+      expect(advices.map(advice => advice.side)).toEqual([OrderSide.BUY, OrderSide.SELL]);
+    });
+  });
+});

--- a/packages/trading-strategies/src/strategy-sma-crossover/SmaCrossoverStrategy.ts
+++ b/packages/trading-strategies/src/strategy-sma-crossover/SmaCrossoverStrategy.ts
@@ -20,96 +20,115 @@ const timeframeString = z.string().refine(value => {
 const barCount = z.number().int().positive();
 
 export const SmaCrossoverSchema = z.object({
-  /** Number of bars in the slow SMA. Must be larger than `shortPeriod`. */
-  longPeriod: barCount.default(20),
-  /** Number of bars in the fast SMA. Must be smaller than `longPeriod`. */
-  shortPeriod: barCount.default(10),
-  /** Bar size both SMAs are computed on, in `ms` syntax (e.g. "1m", "5m", "1d"). */
-  timeframe: timeframeString.default('1m'),
+  /** Number of bars in the fast SMA. */
+  fastPeriod: barCount.default(10),
+  /** Bar size the fast SMA is computed on, in `ms` syntax (e.g. "1m", "5m", "1d"). */
+  fastTimeframe: timeframeString.default('1m'),
+  /** Number of bars in the slow SMA. */
+  slowPeriod: barCount.default(20),
+  /** Bar size the slow SMA is computed on, in `ms` syntax (e.g. "1m", "5m", "1d"). */
+  slowTimeframe: timeframeString.default('5m'),
 });
 
 export type SmaCrossoverConfig = z.input<typeof SmaCrossoverSchema>;
 
 /**
- * Classic dual-SMA crossover: a fast SMA and a slow SMA over the same timeframe.
- * When the fast SMA crosses *above* the slow one the trend has turned up, so buy;
- * when it crosses *below*, the trend has turned down, so sell. Both entries and
- * exits are market orders using the full available balance.
+ * Classic dual-SMA crossover: a fast SMA and a slow SMA. Each has its own bar count
+ * *and* its own timeframe, so you can cross, say, an SMA10 on 1-minute bars against an
+ * SMA20 on 5-minute bars. When the fast SMA crosses *above* the slow one the trend has
+ * turned up, so buy; when it crosses *below*, the trend has turned down, so sell. Both
+ * entries and exits are market orders using the full available balance.
  */
 export class SmaCrossoverStrategy extends Strategy {
   static override NAME = '@typedtrader/strategy-sma-crossover';
   static override marketTypes: readonly MarketType[] = [MarketType.BULLISH, MarketType.BEARISH];
 
-  readonly #shortPeriod: number;
-  readonly #longPeriod: number;
-  readonly #shortSma: SMA;
-  readonly #longSma: SMA;
-  readonly #batcher: CandleBatcher;
+  readonly #fastPeriod: number;
+  readonly #slowPeriod: number;
+  readonly #fastTimeframe: string;
+  readonly #slowTimeframe: string;
+  readonly #fast: SMA;
+  readonly #slow: SMA;
+  readonly #fastBatcher: CandleBatcher;
+  readonly #slowBatcher: CandleBatcher;
 
   /**
-   * Whether the fast SMA sat above the slow SMA on the previous completed bar.
+   * Whether the fast SMA sat above the slow SMA on the previous evaluated bar.
    * A crossover is the bar where this flips, so advice fires *once at the cross*
    * instead of on every bar the fast SMA stays on one side. `undefined` until the
    * first bar where both SMAs are stable.
    */
-  #shortWasAboveLong: boolean | undefined = undefined;
+  #fastWasAboveSlow: boolean | undefined = undefined;
 
   constructor(config?: SmaCrossoverConfig) {
     const parsed = SmaCrossoverSchema.parse(config ?? {});
     super({config: parsed});
 
-    if (parsed.shortPeriod >= parsed.longPeriod) {
+    const fastIntervalInMillis = ms(parsed.fastTimeframe as StringValue);
+    const slowIntervalInMillis = ms(parsed.slowTimeframe as StringValue);
+    if (parsed.fastPeriod === parsed.slowPeriod && fastIntervalInMillis === slowIntervalInMillis) {
       throw new Error(
-        `SmaCrossoverStrategy: shortPeriod (${parsed.shortPeriod}) must be smaller than longPeriod (${parsed.longPeriod})`
+        'SmaCrossoverStrategy: the fast and slow SMA must differ in period or timeframe, otherwise they are identical and never cross'
       );
     }
 
-    this.#shortPeriod = parsed.shortPeriod;
-    this.#longPeriod = parsed.longPeriod;
-    this.#shortSma = new SMA(parsed.shortPeriod);
-    this.#longSma = new SMA(parsed.longPeriod);
-    this.#batcher = new CandleBatcher(ms(parsed.timeframe as StringValue));
+    this.#fastPeriod = parsed.fastPeriod;
+    this.#slowPeriod = parsed.slowPeriod;
+    this.#fastTimeframe = parsed.fastTimeframe;
+    this.#slowTimeframe = parsed.slowTimeframe;
+    this.#fast = new SMA(parsed.fastPeriod);
+    this.#slow = new SMA(parsed.slowPeriod);
+    this.#fastBatcher = new CandleBatcher(fastIntervalInMillis);
+    this.#slowBatcher = new CandleBatcher(slowIntervalInMillis);
   }
 
   /** Whether both SMAs have seen enough bars to produce a value. */
   get isWarmedUp() {
-    return this.#shortSma.isStable && this.#longSma.isStable;
+    return this.#fast.isStable && this.#slow.isStable;
   }
 
   protected override async processCandle(
     candle: OneMinuteBatchedCandle,
     _state: TradingSessionState
   ): Promise<OrderAdvice | void> {
-    // Strategies always receive 1-minute candles; roll them up to the configured timeframe.
-    const bar = this.#batcher.addToBatch(candle);
-    if (!bar) {
-      return;
+    // Strategies always receive 1-minute candles; roll them up to each SMA's own timeframe.
+    const fastBar = this.#fastBatcher.addToBatch(candle);
+    if (fastBar) {
+      this.#fast.add(fastBar.close.toNumber());
+    }
+    const slowBar = this.#slowBatcher.addToBatch(candle);
+    if (slowBar) {
+      this.#slow.add(slowBar.close.toNumber());
     }
 
-    const closePrice = bar.close.toNumber();
-    this.#shortSma.add(closePrice);
-    this.#longSma.add(closePrice);
+    // No SMA advanced on this candle, so the relationship cannot have changed.
+    if (!fastBar && !slowBar) {
+      return;
+    }
 
     if (!this.isWarmedUp) {
       return;
     }
 
-    const shortValue = this.#shortSma.getResultOrThrow();
-    const longValue = this.#longSma.getResultOrThrow();
-    const shortAboveLong = shortValue > longValue;
+    const fastValue = this.#fast.getResultOrThrow();
+    const slowValue = this.#slow.getResultOrThrow();
+    const fastAboveSlow = fastValue > slowValue;
 
-    // Detecting a *crossover* needs the previous bar's relationship, not just this one's.
-    const shortWasAboveLong = this.#shortWasAboveLong;
-    this.#shortWasAboveLong = shortAboveLong;
-    if (shortWasAboveLong === undefined || shortWasAboveLong === shortAboveLong) {
+    // Detecting a *crossover* needs the previous relationship, not just this bar's.
+    const fastWasAboveSlow = this.#fastWasAboveSlow;
+    this.#fastWasAboveSlow = fastAboveSlow;
+    if (fastWasAboveSlow === undefined || fastWasAboveSlow === fastAboveSlow) {
       return;
     }
 
-    if (shortAboveLong) {
+    const fastLabel = `SMA${this.#fastPeriod}@${this.#fastTimeframe} (${fastValue.toFixed(2)})`;
+    const slowLabel = `SMA${this.#slowPeriod}@${this.#slowTimeframe} (${slowValue.toFixed(2)})`;
+
+    if (fastAboveSlow) {
       return {
         amount: AllAvailableAmount,
         amountIn: 'counter',
-        reason: `SMA${this.#shortPeriod} (${shortValue.toFixed(2)}) crossed above SMA${this.#longPeriod} (${longValue.toFixed(2)})`,
+        reason: `${fastLabel} crossed above ${slowLabel}`,
         side: OrderSide.BUY,
         type: OrderType.MARKET,
       };
@@ -118,7 +137,7 @@ export class SmaCrossoverStrategy extends Strategy {
     return {
       amount: AllAvailableAmount,
       amountIn: 'base',
-      reason: `SMA${this.#shortPeriod} (${shortValue.toFixed(2)}) crossed below SMA${this.#longPeriod} (${longValue.toFixed(2)})`,
+      reason: `${fastLabel} crossed below ${slowLabel}`,
       side: OrderSide.SELL,
       type: OrderType.MARKET,
     };

--- a/packages/trading-strategies/src/strategy-sma-crossover/SmaCrossoverStrategy.ts
+++ b/packages/trading-strategies/src/strategy-sma-crossover/SmaCrossoverStrategy.ts
@@ -7,7 +7,7 @@ import {SMA} from 'trading-signals';
 import {AllAvailableAmount} from '../trader/index.js';
 import type {OrderAdvice, TradingSessionState} from '../trader/index.js';
 import {MarketType} from '../strategy/MarketType.js';
-import {ProtectedStrategy, ProtectedStrategySchema} from '../strategy-protected/ProtectedStrategy.js';
+import {Strategy} from '../strategy/Strategy.js';
 
 const ONE_MINUTE_IN_MS = 60_000;
 
@@ -19,7 +19,7 @@ const timeframeString = z.string().refine(value => {
 
 const barCount = z.number().int().positive();
 
-export const SmaCrossoverSchema = ProtectedStrategySchema.extend({
+export const SmaCrossoverSchema = z.object({
   /** Number of bars in the slow SMA. Must be larger than `shortPeriod`. */
   longPeriod: barCount.default(20),
   /** Number of bars in the fast SMA. Must be smaller than `longPeriod`. */
@@ -36,7 +36,7 @@ export type SmaCrossoverConfig = z.input<typeof SmaCrossoverSchema>;
  * when it crosses *below*, the trend has turned down, so sell. Both entries and
  * exits are market orders using the full available balance.
  */
-export class SmaCrossoverStrategy extends ProtectedStrategy {
+export class SmaCrossoverStrategy extends Strategy {
   static override NAME = '@typedtrader/strategy-sma-crossover';
   static override marketTypes: readonly MarketType[] = [MarketType.BULLISH, MarketType.BEARISH];
 
@@ -78,13 +78,8 @@ export class SmaCrossoverStrategy extends ProtectedStrategy {
 
   protected override async processCandle(
     candle: OneMinuteBatchedCandle,
-    state: TradingSessionState
+    _state: TradingSessionState
   ): Promise<OrderAdvice | void> {
-    const guardAdvice = await super.processCandle(candle, state);
-    if (guardAdvice) {
-      return guardAdvice;
-    }
-
     // Strategies always receive 1-minute candles; roll them up to the configured timeframe.
     const bar = this.#batcher.addToBatch(candle);
     if (!bar) {

--- a/packages/trading-strategies/src/strategy-sma-crossover/SmaCrossoverStrategy.ts
+++ b/packages/trading-strategies/src/strategy-sma-crossover/SmaCrossoverStrategy.ts
@@ -1,0 +1,131 @@
+import type {StringValue} from 'ms';
+import {ms} from 'ms';
+import {z} from 'zod';
+import {CandleBatcher, OrderSide, OrderType} from '@typedtrader/exchange';
+import type {OneMinuteBatchedCandle} from '@typedtrader/exchange';
+import {SMA} from 'trading-signals';
+import {AllAvailableAmount} from '../trader/index.js';
+import type {OrderAdvice, TradingSessionState} from '../trader/index.js';
+import {MarketType} from '../strategy/MarketType.js';
+import {ProtectedStrategy, ProtectedStrategySchema} from '../strategy-protected/ProtectedStrategy.js';
+
+const ONE_MINUTE_IN_MS = 60_000;
+
+/** A duration in `ms` syntax (`"1m"`, `"5m"`, `"1d"`), no smaller than one candle (`"1m"`). */
+const timeframeString = z.string().refine(value => {
+  const millis = ms(value as StringValue);
+  return typeof millis === 'number' && Number.isFinite(millis) && millis >= ONE_MINUTE_IN_MS;
+}, 'Must be a duration of at least "1m" in ms syntax, e.g. "1m", "5m", "1d"');
+
+const barCount = z.number().int().positive();
+
+export const SmaCrossoverSchema = ProtectedStrategySchema.extend({
+  /** Number of bars in the slow SMA. Must be larger than `shortPeriod`. */
+  longPeriod: barCount.default(20),
+  /** Number of bars in the fast SMA. Must be smaller than `longPeriod`. */
+  shortPeriod: barCount.default(10),
+  /** Bar size both SMAs are computed on, in `ms` syntax (e.g. "1m", "5m", "1d"). */
+  timeframe: timeframeString.default('1m'),
+});
+
+export type SmaCrossoverConfig = z.input<typeof SmaCrossoverSchema>;
+
+/**
+ * Classic dual-SMA crossover: a fast SMA and a slow SMA over the same timeframe.
+ * When the fast SMA crosses *above* the slow one the trend has turned up, so buy;
+ * when it crosses *below*, the trend has turned down, so sell. Both entries and
+ * exits are market orders using the full available balance.
+ */
+export class SmaCrossoverStrategy extends ProtectedStrategy {
+  static override NAME = '@typedtrader/strategy-sma-crossover';
+  static override marketTypes: readonly MarketType[] = [MarketType.BULLISH, MarketType.BEARISH];
+
+  readonly #shortPeriod: number;
+  readonly #longPeriod: number;
+  readonly #shortSma: SMA;
+  readonly #longSma: SMA;
+  readonly #batcher: CandleBatcher;
+
+  /**
+   * Whether the fast SMA sat above the slow SMA on the previous completed bar.
+   * A crossover is the bar where this flips, so advice fires *once at the cross*
+   * instead of on every bar the fast SMA stays on one side. `undefined` until the
+   * first bar where both SMAs are stable.
+   */
+  #shortWasAboveLong: boolean | undefined = undefined;
+
+  constructor(config?: SmaCrossoverConfig) {
+    const parsed = SmaCrossoverSchema.parse(config ?? {});
+    super({config: parsed});
+
+    if (parsed.shortPeriod >= parsed.longPeriod) {
+      throw new Error(
+        `SmaCrossoverStrategy: shortPeriod (${parsed.shortPeriod}) must be smaller than longPeriod (${parsed.longPeriod})`
+      );
+    }
+
+    this.#shortPeriod = parsed.shortPeriod;
+    this.#longPeriod = parsed.longPeriod;
+    this.#shortSma = new SMA(parsed.shortPeriod);
+    this.#longSma = new SMA(parsed.longPeriod);
+    this.#batcher = new CandleBatcher(ms(parsed.timeframe as StringValue));
+  }
+
+  /** Whether both SMAs have seen enough bars to produce a value. */
+  get isWarmedUp() {
+    return this.#shortSma.isStable && this.#longSma.isStable;
+  }
+
+  protected override async processCandle(
+    candle: OneMinuteBatchedCandle,
+    state: TradingSessionState
+  ): Promise<OrderAdvice | void> {
+    const guardAdvice = await super.processCandle(candle, state);
+    if (guardAdvice) {
+      return guardAdvice;
+    }
+
+    // Strategies always receive 1-minute candles; roll them up to the configured timeframe.
+    const bar = this.#batcher.addToBatch(candle);
+    if (!bar) {
+      return;
+    }
+
+    const closePrice = bar.close.toNumber();
+    this.#shortSma.add(closePrice);
+    this.#longSma.add(closePrice);
+
+    if (!this.isWarmedUp) {
+      return;
+    }
+
+    const shortValue = this.#shortSma.getResultOrThrow();
+    const longValue = this.#longSma.getResultOrThrow();
+    const shortAboveLong = shortValue > longValue;
+
+    // Detecting a *crossover* needs the previous bar's relationship, not just this one's.
+    const shortWasAboveLong = this.#shortWasAboveLong;
+    this.#shortWasAboveLong = shortAboveLong;
+    if (shortWasAboveLong === undefined || shortWasAboveLong === shortAboveLong) {
+      return;
+    }
+
+    if (shortAboveLong) {
+      return {
+        amount: AllAvailableAmount,
+        amountIn: 'counter',
+        reason: `SMA${this.#shortPeriod} (${shortValue.toFixed(2)}) crossed above SMA${this.#longPeriod} (${longValue.toFixed(2)})`,
+        side: OrderSide.BUY,
+        type: OrderType.MARKET,
+      };
+    }
+
+    return {
+      amount: AllAvailableAmount,
+      amountIn: 'base',
+      reason: `SMA${this.#shortPeriod} (${shortValue.toFixed(2)}) crossed below SMA${this.#longPeriod} (${longValue.toFixed(2)})`,
+      side: OrderSide.SELL,
+      type: OrderType.MARKET,
+    };
+  }
+}

--- a/packages/trading-strategies/src/strategy/StrategyRegistry.ts
+++ b/packages/trading-strategies/src/strategy/StrategyRegistry.ts
@@ -12,6 +12,7 @@ import {
 import {MeanReversionStrategy, MeanReversionSchema} from '../strategy-mean-reversion/MeanReversionStrategy.js';
 import {NoopStrategy, NoopSchema} from '../strategy-noop/NoopStrategy.js';
 import {ScalpStrategy, ScalpSchema} from '../strategy-scalp/ScalpStrategy.js';
+import {SmaCrossoverStrategy, SmaCrossoverSchema} from '../strategy-sma-crossover/SmaCrossoverStrategy.js';
 import {ProtectedStrategy, ProtectedStrategySchema} from '../strategy-protected/ProtectedStrategy.js';
 import {TrailingStopStrategy, TrailingStopSchema} from '../strategy-trailing-stop/TrailingStopStrategy.js';
 import type {Strategy} from './Strategy.js';
@@ -53,6 +54,10 @@ const registry: Record<string, StrategyEntry> = {
   [ScalpStrategy.NAME]: {
     create: (config: unknown) => new ScalpStrategy(ScalpSchema.parse(config)),
     schema: ScalpSchema,
+  },
+  [SmaCrossoverStrategy.NAME]: {
+    create: (config: unknown) => new SmaCrossoverStrategy(SmaCrossoverSchema.parse(config ?? {})),
+    schema: SmaCrossoverSchema,
   },
   [TrailingStopStrategy.NAME]: {
     create: (config: unknown) => new TrailingStopStrategy(TrailingStopSchema.parse(config ?? {})),


### PR DESCRIPTION
## What

Adds a classic **dual-SMA crossover** strategy (`SmaCrossoverStrategy`, `@typedtrader/strategy-sma-crossover`) — a compact, configurable trend-follower that's ideal for demos.

## Behaviour

- A **fast SMA** and a **slow SMA** computed over the same timeframe.
- **BUY** (market order, all available counter currency) when the fast SMA crosses **above** the slow SMA.
- **SELL** (market order, all available base) when the fast SMA crosses **below** the slow SMA.
- Fires **once at the crossover** (tracks the previous bar's fast-vs-slow relationship), not on every bar the fast SMA stays on one side.

## Configuration

| Field | Meaning | Default |
| --- | --- | --- |
| `timeframe` | Bar size both SMAs run on, in `ms` syntax (`"1m"`, `"5m"`, `"1d"`), min `"1m"` | `"1m"` |
| `shortPeriod` | Bar count of the fast SMA (must be `< longPeriod`) | `10` |
| `longPeriod` | Bar count of the slow SMA | `20` |
| `protected` | Inherited stop-loss / take-profit guards from `ProtectedStrategy` | — |

## Implementation notes

- Extends `ProtectedStrategy`, so stop-loss/take-profit guards compose for free; `processCandle` calls `super.processCandle` first.
- Rolls the runtime's 1-minute candles up to the configured timeframe with `CandleBatcher` (same pattern as `MeanReversionStrategy`).
- Timeframe is validated with a `ms`-syntax refinement; `shortPeriod < longPeriod` is enforced in the constructor (matching `ProtectedStrategy`'s convention of not turning the schema into `ZodEffects`).
- Wired into `StrategyRegistry` and exported from the package barrel (`SmaCrossoverStrategy`, `SmaCrossoverSchema`, `SmaCrossoverConfig`).

## Tests

`SmaCrossoverStrategy.test.ts` — 8 cases: default construction, `shortPeriod >= longPeriod` rejection, sub-`1m` timeframe rejection, `"5m"`/`"1d"` acceptance, warm-up gating, and a hand-verified up-and-down price swing producing exactly one BUY then one SELL.

Full package suite: **256 passing**; `tsc` and lint clean.