### PR TITLE
fix(trading-signals-docs): preserve strategy config when switching market condition

### DIFF
--- a/packages/trading-signals-docs/pages/backtest.tsx
+++ b/packages/trading-signals-docs/pages/backtest.tsx
@@ -111,12 +111,13 @@ export default function BacktestPage() {
   const currentDataset = selectedDataset === 'custom' ? customDataset : datasets.find(d => d.id === selectedDataset)!;
   const candles = (currentDataset?.candles ?? []) as Candle[];
 
-  // Recompute defaults when dataset or strategy changes (including custom dataset uploads)
+  // Recompute defaults only when the strategy changes — deliberately NOT on Market Condition
+  // (dataset) changes, so manual config edits survive switching between datasets.
   useEffect(() => {
     const def = strategyDefinitions.find(s => s.id === selectedStrategy)!;
     const defaults = def.getDefaultConfig(candles);
     setConfigJson(JSON.stringify(defaults, null, 2));
-  }, [selectedDataset, selectedStrategy, customDataset]);
+  }, [selectedStrategy]);
 
   // Validate JSON on every change
   useEffect(() => {


### PR DESCRIPTION
## Problem

On the backtester page, editing the **Strategy Configuration** and then changing the **Market Condition** silently discarded the edits.

## Cause

The effect that regenerates the config defaults listed `selectedDataset` (and `customDataset`) in its dependency array, so any Market Condition change overwrote `configJson` with freshly-computed defaults — wiping manual edits.

## Fix

Scope that effect to `[selectedStrategy]` only. Config now recomputes when the **strategy** changes (each strategy has a different schema, so old values wouldn't be valid) but is preserved when the **Market Condition** changes.

### Tradeoff

Strategies whose defaults derive from dataset prices (`buy-once` `buyAt`, `buy-below-sell-above` thresholds, `scalp` ATR offset) will keep their values across a market switch instead of refreshing. Re-selecting the strategy regenerates price-appropriate defaults.

## Testing

- `npm run test:types` passes
- No existing test asserted the old reset-on-dataset behavior (the `market-condition-select` e2e test targets the trend indicators page, not the backtester)