### PR TITLE
feat: fee-aware round-trip profit helper + SMA crossover that won't sell at a loss

### DIFF
--- a/packages/exchange/src/util/index.ts
+++ b/packages/exchange/src/util/index.ts
@@ -1,1 +1,2 @@
 export * from './isEarningsDay.js';
+export * from './roundTripProfit.js';

--- a/packages/exchange/src/util/roundTripProfit.test.ts
+++ b/packages/exchange/src/util/roundTripProfit.test.ts
@@ -1,0 +1,114 @@
+import Big from 'big.js';
+import {describe, expect, it} from 'vitest';
+import {calculateRoundTripProfit, isProfitableAfterFees} from './roundTripProfit.js';
+
+describe('calculateRoundTripProfit', () => {
+  // 0.1% maker on the buy, 0.2% taker on the sell — typical exchange fees.
+  const fees = {entryFeeRate: 0.001, exitFeeRate: 0.002};
+
+  it('reports a profit when the sale clears both fees', () => {
+    const result = calculateRoundTripProfit({entryPrice: 100, exitPrice: 101, quantity: 1, ...fees});
+    expect(result.isProfitable).toBe(true);
+    // entryCost = 100 * 1.001 = 100.1; exitProceeds = 101 * 0.998 = 100.798.
+    expect(result.entryCost.toNumber()).toBeCloseTo(100.1, 10);
+    expect(result.exitProceeds.toNumber()).toBeCloseTo(100.798, 10);
+    expect(result.netProfit.toNumber()).toBeCloseTo(0.698, 10);
+  });
+
+  it('reports a loss even when the sell price is ABOVE the buy price, because fees eat the gain', () => {
+    // Sold higher (100 -> 100.2) yet still loses money once both fees are paid.
+    const result = calculateRoundTripProfit({entryPrice: 100, exitPrice: 100.2, quantity: 1, ...fees});
+    expect(result.isProfitable).toBe(false);
+    expect(result.netProfit.lt(0)).toBe(true);
+    // exitProceeds = 100.2 * 0.998 = 99.9996; entryCost = 100.1 -> net = -0.1004.
+    expect(result.netProfit.toNumber()).toBeCloseTo(-0.1004, 10);
+  });
+
+  it('computes the break-even sell price that clears both fees', () => {
+    const result = calculateRoundTripProfit({entryPrice: 100, exitPrice: 100.2, quantity: 1, ...fees});
+    // 100 * 1.001 / 0.998 = 100.300601...
+    expect(result.breakEvenPrice.toNumber()).toBeCloseTo(100.300601, 6);
+
+    // Selling at the break-even price nets ~0.
+    const atBreakEven = calculateRoundTripProfit({
+      entryPrice: 100,
+      exitPrice: result.breakEvenPrice,
+      quantity: 1,
+      ...fees,
+    });
+    expect(atBreakEven.netProfit.toNumber()).toBeCloseTo(0, 6);
+
+    // A hair below break-even loses; a hair above profits.
+    const below = calculateRoundTripProfit({
+      entryPrice: 100,
+      exitPrice: result.breakEvenPrice.minus('0.01'),
+      quantity: 1,
+      ...fees,
+    });
+    const above = calculateRoundTripProfit({
+      entryPrice: 100,
+      exitPrice: result.breakEvenPrice.plus('0.01'),
+      quantity: 1,
+      ...fees,
+    });
+    expect(below.isProfitable).toBe(false);
+    expect(above.isProfitable).toBe(true);
+  });
+
+  it('scales net profit with quantity', () => {
+    const one = calculateRoundTripProfit({entryPrice: 50, exitPrice: 55, quantity: 1, ...fees});
+    const ten = calculateRoundTripProfit({entryPrice: 50, exitPrice: 55, quantity: 10, ...fees});
+    expect(ten.netProfit.toNumber()).toBeCloseTo(one.netProfit.mul(10).toNumber(), 10);
+    // Profitability does not depend on quantity.
+    expect(ten.isProfitable).toBe(one.isProfitable);
+  });
+
+  it('reports net profit as a percentage of the amount invested', () => {
+    const result = calculateRoundTripProfit({entryPrice: 100, exitPrice: 101, quantity: 3, ...fees});
+    const expected = result.netProfit.div(result.entryCost).mul(100);
+    expect(result.netProfitPercent.toNumber()).toBeCloseTo(expected.toNumber(), 10);
+  });
+
+  it('treats a sale below the entry price as a loss', () => {
+    const result = calculateRoundTripProfit({entryPrice: 100, exitPrice: 99, quantity: 1, ...fees});
+    expect(result.isProfitable).toBe(false);
+  });
+
+  it('with zero fees, is profitable whenever the exit price exceeds the entry price', () => {
+    const result = calculateRoundTripProfit({
+      entryFeeRate: 0,
+      entryPrice: 100,
+      exitFeeRate: 0,
+      exitPrice: 100.01,
+      quantity: 1,
+    });
+    expect(result.isProfitable).toBe(true);
+    expect(result.breakEvenPrice.toNumber()).toBeCloseTo(100, 10);
+  });
+
+  it('accepts Big and string inputs', () => {
+    const result = calculateRoundTripProfit({
+      entryFeeRate: '0.001',
+      entryPrice: new Big('100'),
+      exitFeeRate: '0.002',
+      exitPrice: '101',
+      quantity: new Big('2'),
+    });
+    expect(result.isProfitable).toBe(true);
+  });
+
+  it('throws when the exit fee rate is 100% or more (break-even is unreachable)', () => {
+    expect(() =>
+      calculateRoundTripProfit({entryFeeRate: 0, entryPrice: 100, exitFeeRate: 1, exitPrice: 101, quantity: 1})
+    ).toThrowError(/below 1/);
+  });
+});
+
+describe('isProfitableAfterFees', () => {
+  it('mirrors the verdict from calculateRoundTripProfit', () => {
+    const input = {entryFeeRate: 0.001, entryPrice: 100, exitFeeRate: 0.002, exitPrice: 100.2, quantity: 1};
+    expect(isProfitableAfterFees(input)).toBe(calculateRoundTripProfit(input).isProfitable);
+    expect(isProfitableAfterFees(input)).toBe(false);
+    expect(isProfitableAfterFees({...input, exitPrice: 105})).toBe(true);
+  });
+});

--- a/packages/exchange/src/util/roundTripProfit.ts
+++ b/packages/exchange/src/util/roundTripProfit.ts
@@ -1,0 +1,90 @@
+import Big from 'big.js';
+import type {BigSource} from 'big.js';
+
+/**
+ * One buy-then-sell round trip. Fee rates are fractions of the traded notional
+ * (price × quantity): `0.001` is 0.1%. Use the maker rate (`FeeRate.LIMIT`) or taker
+ * rate (`FeeRate.MARKET`) for each leg depending on the order type you would place.
+ */
+export interface RoundTripInput {
+  /** Average price the position was bought at (its cost basis per unit). */
+  entryPrice: BigSource;
+  /** Price the position would be sold at. */
+  exitPrice: BigSource;
+  /** Base quantity being sold. */
+  quantity: BigSource;
+  /** Fee rate paid on the buy, as a fraction of notional. */
+  entryFeeRate: BigSource;
+  /** Fee rate paid on the sell, as a fraction of notional. */
+  exitFeeRate: BigSource;
+}
+
+export interface RoundTripProfit {
+  /** Fee paid on the buy (entryPrice × quantity × entryFeeRate). */
+  entryFee: Big;
+  /** Fee paid on the sell (exitPrice × quantity × exitFeeRate). */
+  exitFee: Big;
+  /** Total spent to acquire the position, including the buy fee. */
+  entryCost: Big;
+  /** Amount received from the sale, after the sell fee. */
+  exitProceeds: Big;
+  /** `exitProceeds − entryCost`. Positive means the round trip nets a profit. */
+  netProfit: Big;
+  /** {@link netProfit} as a percentage of {@link entryCost}. */
+  netProfitPercent: Big;
+  /** Lowest sell price at which the round trip breaks even after both fees. */
+  breakEvenPrice: Big;
+  /** Whether selling nets a profit after both fees. */
+  isProfitable: boolean;
+}
+
+/**
+ * Answers the question a trader actually cares about before selling: *after paying the
+ * fee on both the buy and the sell, does this sale come out ahead of what I paid?* A
+ * naive "exit price > entry price" check says yes on trades that a round trip of fees
+ * quietly turns into a loss, which is how a high-churn strategy bleeds money while
+ * looking like it wins more often than it loses.
+ *
+ * The verdict is fee-inclusive on both legs and also reports the {@link RoundTripProfit.breakEvenPrice}
+ * — the minimum sell price that clears both fees — so a caller can hold out for it.
+ */
+export function calculateRoundTripProfit(input: RoundTripInput): RoundTripProfit {
+  const entryPrice = new Big(input.entryPrice);
+  const exitPrice = new Big(input.exitPrice);
+  const quantity = new Big(input.quantity);
+  const entryFeeRate = new Big(input.entryFeeRate);
+  const exitFeeRate = new Big(input.exitFeeRate);
+
+  const entryNotional = entryPrice.mul(quantity);
+  const exitNotional = exitPrice.mul(quantity);
+  const entryFee = entryNotional.mul(entryFeeRate);
+  const exitFee = exitNotional.mul(exitFeeRate);
+
+  const entryCost = entryNotional.plus(entryFee);
+  const exitProceeds = exitNotional.minus(exitFee);
+  const netProfit = exitProceeds.minus(entryCost);
+  const netProfitPercent = entryCost.eq(0) ? new Big(0) : netProfit.div(entryCost).mul(100);
+
+  // Solve exitPrice·(1 − exitFeeRate) = entryPrice·(1 + entryFeeRate) for exitPrice.
+  const proceedsFactor = new Big(1).minus(exitFeeRate);
+  if (proceedsFactor.lte(0)) {
+    throw new Error(`exitFeeRate must be below 1 (100%), got ${exitFeeRate.toString()}`);
+  }
+  const breakEvenPrice = entryPrice.mul(new Big(1).plus(entryFeeRate)).div(proceedsFactor);
+
+  return {
+    breakEvenPrice,
+    entryCost,
+    entryFee,
+    exitFee,
+    exitProceeds,
+    isProfitable: netProfit.gt(0),
+    netProfit,
+    netProfitPercent,
+  };
+}
+
+/** Convenience wrapper over {@link calculateRoundTripProfit} returning just the profit verdict. */
+export function isProfitableAfterFees(input: RoundTripInput) {
+  return calculateRoundTripProfit(input).isProfitable;
+}

--- a/packages/trading-signals-docs/pages/backtest.tsx
+++ b/packages/trading-signals-docs/pages/backtest.tsx
@@ -11,6 +11,7 @@ import {
   ScalpStrategy,
   MeanReversionStrategy,
   SmaCrossoverStrategy,
+  FeeAwareSmaCrossoverStrategy,
   ProtectedStrategy,
   TrailingStopStrategy,
   type BacktestResult,
@@ -31,6 +32,7 @@ import {
   ScalpSchema,
   MeanReversionSchema,
   SmaCrossoverSchema,
+  FeeAwareSmaCrossoverSchema,
   ProtectedStrategySchema,
   TrailingStopSchema,
 } from '../utils/strategySchemas';
@@ -53,6 +55,8 @@ function createStrategy(strategyId: StrategyId, config: Record<string, unknown>)
       return new MeanReversionStrategy({config: MeanReversionSchema.parse(config)});
     case 'sma-crossover':
       return new SmaCrossoverStrategy(SmaCrossoverSchema.parse(config));
+    case 'fee-aware-sma-crossover':
+      return new FeeAwareSmaCrossoverStrategy(FeeAwareSmaCrossoverSchema.parse(config));
     case 'protection-only':
       return new ProtectedStrategy({config: ProtectedStrategySchema.parse(config)});
     case 'trailing-stop':

--- a/packages/trading-signals-docs/utils/strategySchemas.ts
+++ b/packages/trading-signals-docs/utils/strategySchemas.ts
@@ -1,10 +1,10 @@
 import {z} from 'zod';
 import type {Candle} from '@typedtrader/exchange';
-import {BuyOnceSchema, BuyBelowSellAboveSchema, CoinFlipSchema, MultiIndicatorConfluenceSchema, ScalpSchema, MeanReversionSchema, SmaCrossoverSchema, ProtectedStrategySchema, TrailingStopSchema, suggestScalpOffset} from 'trading-strategies';
+import {BuyOnceSchema, BuyBelowSellAboveSchema, CoinFlipSchema, MultiIndicatorConfluenceSchema, ScalpSchema, MeanReversionSchema, SmaCrossoverSchema, FeeAwareSmaCrossoverSchema, ProtectedStrategySchema, TrailingStopSchema, suggestScalpOffset} from 'trading-strategies';
 
-export {BuyOnceSchema, BuyBelowSellAboveSchema, CoinFlipSchema, MultiIndicatorConfluenceSchema, ScalpSchema, MeanReversionSchema, SmaCrossoverSchema, ProtectedStrategySchema, TrailingStopSchema};
+export {BuyOnceSchema, BuyBelowSellAboveSchema, CoinFlipSchema, MultiIndicatorConfluenceSchema, ScalpSchema, MeanReversionSchema, SmaCrossoverSchema, FeeAwareSmaCrossoverSchema, ProtectedStrategySchema, TrailingStopSchema};
 
-export type StrategyId = 'buy-and-hold' | 'buy-once' | 'buy-below-sell-above' | 'coin-flip' | 'multi-indicator-confluence' | 'scalp' | 'mean-reversion' | 'sma-crossover' | 'protection-only' | 'trailing-stop';
+export type StrategyId = 'buy-and-hold' | 'buy-once' | 'buy-below-sell-above' | 'coin-flip' | 'multi-indicator-confluence' | 'scalp' | 'mean-reversion' | 'sma-crossover' | 'fee-aware-sma-crossover' | 'protection-only' | 'trailing-stop';
 
 export interface StrategyDefinition {
   id: StrategyId;
@@ -128,6 +128,14 @@ export const strategyDefinitions: StrategyDefinition[] = [
     description:
       'Crosses a fast SMA against a slow SMA — each with its own period and timeframe (e.g. SMA5 on 1m bars vs SMA10 on 2m bars). Buys when the fast SMA crosses above the slow one and sells when it crosses below (market orders).',
     schema: SmaCrossoverSchema,
+    getDefaultConfig: () => ({fastPeriod: 5, fastTimeframe: '1m', slowPeriod: 10, slowTimeframe: '2m'}),
+  },
+  {
+    id: 'fee-aware-sma-crossover',
+    name: 'SMA Crossover (Fee-Aware)',
+    description:
+      'Same as SMA Crossover, but it never sells at a loss: on a bearish cross it only sells when the round trip — last buy price vs current price, with the taker fee on both legs — nets a profit. Otherwise it holds. Cuts the fee bleed from whipsaw exits (trade-off: it can hold through a downtrend, so add a stop-loss for a hard floor).',
+    schema: FeeAwareSmaCrossoverSchema,
     getDefaultConfig: () => ({fastPeriod: 5, fastTimeframe: '1m', slowPeriod: 10, slowTimeframe: '2m'}),
   },
   {

--- a/packages/trading-strategies/src/index.ts
+++ b/packages/trading-strategies/src/index.ts
@@ -25,6 +25,11 @@ export {
   type SmaCrossoverConfig,
 } from './strategy-sma-crossover/SmaCrossoverStrategy.js';
 export {
+  FeeAwareSmaCrossoverStrategy,
+  FeeAwareSmaCrossoverSchema,
+  type FeeAwareSmaCrossoverConfig,
+} from './strategy-fee-aware-sma-crossover/FeeAwareSmaCrossoverStrategy.js';
+export {
   MeanReversionStrategy,
   MeanReversionSchema,
   type MeanReversionConfig,

--- a/packages/trading-strategies/src/strategy-buy-and-hold/BuyAndHoldStrategy.test.ts
+++ b/packages/trading-strategies/src/strategy-buy-and-hold/BuyAndHoldStrategy.test.ts
@@ -38,6 +38,11 @@ const mockState: TradingSessionState = {
 
 const ONE_MINUTE_IN_MS = 60_000;
 
+/** A state holding `base` units — guards read the live balance to know there's a position to protect. */
+function held(base: number): TradingSessionState {
+  return {...mockState, baseBalance: new Big(base)};
+}
+
 function makeCandle(close: number, index = 0): OneMinuteBatchedCandle {
   const closeStr = String(close);
   const exchangeCandle: Candle = {
@@ -95,10 +100,10 @@ describe('BuyOnceStrategy (buy-and-hold mode, no buyAt)', () => {
 
       await strategy.onFill(makeFill('100', '10', OrderSide.BUY), mockState);
 
-      const hold = await strategy.onCandle(makeCandle(97, 1), mockState);
+      const hold = await strategy.onCandle(makeCandle(97, 1), held(10));
       expect(hold).toBeUndefined();
 
-      const exit = await strategy.onCandle(makeCandle(95, 2), mockState);
+      const exit = await strategy.onCandle(makeCandle(95, 2), held(10));
       assertLimitSell(exit);
       expect(new Big(exit.price).toFixed(2)).toBe('95.00');
       expect(exit.reason).toContain('[KILL SWITCH]');
@@ -114,10 +119,10 @@ describe('BuyOnceStrategy (buy-and-hold mode, no buyAt)', () => {
       assertMarketBuy(buy);
       await strategy.onFill(makeFill('100', '10', OrderSide.BUY), mockState);
 
-      const hold = await strategy.onCandle(makeCandle(105, 1), mockState);
+      const hold = await strategy.onCandle(makeCandle(105, 1), held(10));
       expect(hold).toBeUndefined();
 
-      const exit = await strategy.onCandle(makeCandle(110, 2), mockState);
+      const exit = await strategy.onCandle(makeCandle(110, 2), held(10));
       assertLimitSell(exit);
       expect(new Big(exit.price).toFixed(2)).toBe('110.00');
       expect(exit.reason).toContain('Take-profit');
@@ -131,7 +136,7 @@ describe('BuyOnceStrategy (buy-and-hold mode, no buyAt)', () => {
       await strategy.onCandle(makeCandle(100), mockState);
       await strategy.onFill(makeFill('100', '10', OrderSide.BUY), mockState);
 
-      const exit = await strategy.onCandle(makeCandle(95, 1), mockState);
+      const exit = await strategy.onCandle(makeCandle(95, 1), held(10));
       assertLimitSell(exit);
 
       await strategy.onFill(makeFill('95', '10', OrderSide.SELL), mockState);
@@ -153,10 +158,10 @@ describe('BuyOnceStrategy (buy-and-hold mode, no buyAt)', () => {
       const restored = new BuyOnceStrategy({protected: {stopLossPct: '5'}});
       restored.restoreState(snapshot!);
 
-      const shouldHold = await restored.onCandle(makeCandle(98, 1), mockState);
+      const shouldHold = await restored.onCandle(makeCandle(98, 1), held(10));
       expect(shouldHold).toBeUndefined();
 
-      const exit = await restored.onCandle(makeCandle(95, 2), mockState);
+      const exit = await restored.onCandle(makeCandle(95, 2), held(10));
       assertLimitSell(exit);
       expect(new Big(exit.price).toFixed(2)).toBe('95.00');
     });

--- a/packages/trading-strategies/src/strategy-buy-once/BuyOnceStrategy.ts
+++ b/packages/trading-strategies/src/strategy-buy-once/BuyOnceStrategy.ts
@@ -97,8 +97,8 @@ export class BuyOnceStrategy extends ProtectedStrategy {
     };
   }
 
-  override restoreState(persisted: Record<string, unknown>): void {
-    super.restoreState(persisted);
+  protected override hydrateState(persisted: Record<string, unknown>): void {
+    super.hydrateState(persisted);
     if (typeof persisted.bought === 'boolean') {
       this.#state.bought = persisted.bought;
     }

--- a/packages/trading-strategies/src/strategy-fee-aware-sma-crossover/FeeAwareSmaCrossoverStrategy.test.ts
+++ b/packages/trading-strategies/src/strategy-fee-aware-sma-crossover/FeeAwareSmaCrossoverStrategy.test.ts
@@ -1,0 +1,135 @@
+import Big from 'big.js';
+import {describe, expect, it} from 'vitest';
+import {CandleBatcher, OrderPosition, OrderSide, OrderType, TradingPair} from '@typedtrader/exchange';
+import type {Candle, Fill, OneMinuteBatchedCandle} from '@typedtrader/exchange';
+import type {OrderAdvice, TradingSessionState, TradingSessionStrategy} from '../trader/index.js';
+import {SmaCrossoverStrategy} from '../strategy-sma-crossover/SmaCrossoverStrategy.js';
+import {FeeAwareSmaCrossoverStrategy} from './FeeAwareSmaCrossoverStrategy.js';
+
+const pair = new TradingPair('AAPL', 'USD');
+const ONE_MINUTE_IN_MS = 60_000;
+const FEE_RATE = '0.002'; // 0.2% taker on both legs
+
+function makeState(baseBalance: Big, counterBalance: Big): TradingSessionState {
+  return {
+    baseBalance,
+    counterBalance,
+    feeRates: {[OrderType.LIMIT]: new Big(FEE_RATE), [OrderType.MARKET]: new Big(FEE_RATE)},
+    tradingRules: {
+      base_increment: '0.0001',
+      base_max_size: '100000',
+      base_min_size: '0.0001',
+      counter_increment: '0.01',
+      counter_min_size: '1',
+      pair,
+    },
+  };
+}
+
+function makeCandle(close: number, index: number): OneMinuteBatchedCandle {
+  const closeStr = String(close);
+  const exchangeCandle: Candle = {
+    base: 'AAPL',
+    close: closeStr,
+    counter: 'USD',
+    high: String(close + 1),
+    low: String(close - 1),
+    open: closeStr,
+    openTimeInISO: new Date(1735689600000 + index * ONE_MINUTE_IN_MS).toISOString(),
+    openTimeInMillis: 1735689600000 + index * ONE_MINUTE_IN_MS,
+    sizeInMillis: ONE_MINUTE_IN_MS,
+    volume: '1000',
+  };
+  return CandleBatcher.createOneMinuteBatchedCandle([exchangeCandle]);
+}
+
+function makeFill(price: number, size: Big, side: OrderSide): Fill {
+  return {
+    created_at: '2025-01-01T00:00:00.000Z',
+    fee: '0',
+    feeAsset: 'USD',
+    order_id: 'order-1',
+    pair,
+    position: OrderPosition.LONG,
+    price: String(price),
+    side,
+    size: size.toFixed(8),
+  };
+}
+
+/**
+ * Drives a strategy through a price series, simulating an all-in / all-out fill at each
+ * candle's close whenever advice comes back — mirroring how the runtime would fill a
+ * market order and then notify the strategy via `onFill`. Returns the order sides emitted.
+ */
+async function feedWithFills(strategy: TradingSessionStrategy, prices: number[]): Promise<OrderSide[]> {
+  const sides: OrderSide[] = [];
+  let base = new Big(0);
+  let counter = new Big(1000);
+  const feeRate = new Big(FEE_RATE);
+
+  for (const [index, price] of prices.entries()) {
+    const state = makeState(base, counter);
+    const advice: OrderAdvice | void = await strategy.onCandle(makeCandle(price, index), state);
+    if (!advice) {
+      continue;
+    }
+    sides.push(advice.side);
+
+    const p = new Big(price);
+    if (advice.side === OrderSide.BUY) {
+      const qty = counter.div(p.mul(new Big(1).plus(feeRate)));
+      base = base.plus(qty);
+      counter = new Big(0);
+      await strategy.onFill?.(makeFill(price, qty, OrderSide.BUY), makeState(base, counter));
+    } else {
+      const qty = base;
+      counter = counter.plus(qty.mul(p).mul(new Big(1).minus(feeRate)));
+      base = new Big(0);
+      await strategy.onFill?.(makeFill(price, qty, OrderSide.SELL), makeState(base, counter));
+    }
+  }
+
+  return sides;
+}
+
+describe('FeeAwareSmaCrossoverStrategy', () => {
+  const config = {fastPeriod: 2, fastTimeframe: '1m', slowPeriod: 3, slowTimeframe: '1m'} as const;
+
+  /*
+   * Baseline SMA crossover buys at ~9 and its bearish cross also lands at ~9: a wash on
+   * price, a net loss after fees.
+   */
+  const losingRoundTrip = [10, 9, 8, 7, 6, 7, 9, 12, 15, 12, 9, 6];
+
+  // Buys at ~9, then the bearish cross lands at ~22 — comfortably profitable after fees.
+  const winningRoundTrip = [10, 9, 8, 7, 6, 9, 13, 18, 24, 30, 26, 22];
+
+  it('the plain SMA crossover sells even when the round trip loses money', async () => {
+    const sides = await feedWithFills(new SmaCrossoverStrategy(config), losingRoundTrip);
+    expect(sides).toEqual([OrderSide.BUY, OrderSide.SELL]);
+  });
+
+  it('the fee-aware variant holds instead of selling that losing round trip', async () => {
+    const sides = await feedWithFills(new FeeAwareSmaCrossoverStrategy(config), losingRoundTrip);
+    expect(sides).toEqual([OrderSide.BUY]); // the loss-making SELL is suppressed
+  });
+
+  it('still sells when the round trip is profitable after fees', async () => {
+    const sides = await feedWithFills(new FeeAwareSmaCrossoverStrategy(config), winningRoundTrip);
+    expect(sides).toEqual([OrderSide.BUY, OrderSide.SELL]);
+  });
+
+  it('does not gate the buy — entries behave exactly like the base strategy', async () => {
+    const plain = await feedWithFills(new SmaCrossoverStrategy(config), winningRoundTrip);
+    const feeAware = await feedWithFills(new FeeAwareSmaCrossoverStrategy(config), winningRoundTrip);
+    expect(feeAware[0]).toBe(OrderSide.BUY);
+    expect(feeAware).toEqual(plain);
+  });
+
+  it('inherits the base config validation', () => {
+    expect(
+      () => new FeeAwareSmaCrossoverStrategy({fastPeriod: 5, fastTimeframe: '1m', slowPeriod: 5, slowTimeframe: '1m'})
+    ).toThrowError(/never cross/);
+  });
+});

--- a/packages/trading-strategies/src/strategy-fee-aware-sma-crossover/FeeAwareSmaCrossoverStrategy.ts
+++ b/packages/trading-strategies/src/strategy-fee-aware-sma-crossover/FeeAwareSmaCrossoverStrategy.ts
@@ -1,0 +1,68 @@
+import Big from 'big.js';
+import {OrderSide, OrderType, calculateRoundTripProfit} from '@typedtrader/exchange';
+import type {Fill, OneMinuteBatchedCandle} from '@typedtrader/exchange';
+import type {OrderAdvice, TradingSessionState} from '../trader/index.js';
+import {
+  SmaCrossoverSchema,
+  SmaCrossoverStrategy,
+  type SmaCrossoverConfig,
+} from '../strategy-sma-crossover/SmaCrossoverStrategy.js';
+
+export const FeeAwareSmaCrossoverSchema = SmaCrossoverSchema;
+export type FeeAwareSmaCrossoverConfig = SmaCrossoverConfig;
+
+/**
+ * An {@link SmaCrossoverStrategy} that refuses to sell at a loss. It trades all-in /
+ * all-out — buying and selling the entire balance in one shot — so a single entry price
+ * is enough: it remembers the last buy and, when the crossover signals a bearish exit,
+ * only forwards the SELL when selling at the current price nets a profit after the taker
+ * fee on both legs (see `calculateRoundTripProfit`). Otherwise it holds.
+ *
+ * Trade-off: skipping unprofitable exits means holding through a downtrend rather than
+ * taking a small loss, so pair it with a stop-loss if you need a hard floor.
+ */
+export class FeeAwareSmaCrossoverStrategy extends SmaCrossoverStrategy {
+  static override NAME = '@typedtrader/strategy-fee-aware-sma-crossover';
+
+  /** Price of the most recent BUY fill — the entry the next SELL is measured against. `undefined` while flat. */
+  #lastBuyPrice: Big | undefined = undefined;
+
+  async onFill(fill: Fill, _state: TradingSessionState): Promise<void> {
+    this.#lastBuyPrice = fill.side === OrderSide.BUY ? new Big(fill.price) : undefined;
+  }
+
+  protected override async processCandle(
+    candle: OneMinuteBatchedCandle,
+    state: TradingSessionState
+  ): Promise<OrderAdvice | void> {
+    const advice = await super.processCandle(candle, state);
+
+    // Only gate SELLs; buys and "do nothing" pass straight through.
+    if (!advice || advice.side !== OrderSide.SELL) {
+      return advice;
+    }
+
+    // No known entry to measure against — don't block the exit.
+    if (!this.#lastBuyPrice) {
+      return advice;
+    }
+
+    const profit = calculateRoundTripProfit({
+      entryFeeRate: state.feeRates[OrderType.MARKET],
+      entryPrice: this.#lastBuyPrice,
+      exitFeeRate: state.feeRates[OrderType.MARKET],
+      exitPrice: candle.close,
+      quantity: state.baseBalance,
+    });
+
+    if (!profit.isProfitable) {
+      // Selling here would lock in a loss after fees — hold instead.
+      return;
+    }
+
+    return {
+      ...advice,
+      reason: `${advice.reason ?? 'SMA bearish cross'}; nets +${profit.netProfitPercent.toFixed(2)}% after fees`,
+    };
+  }
+}

--- a/packages/trading-strategies/src/strategy-fee-aware-sma-crossover/FeeAwareSmaCrossoverStrategy.ts
+++ b/packages/trading-strategies/src/strategy-fee-aware-sma-crossover/FeeAwareSmaCrossoverStrategy.ts
@@ -1,6 +1,5 @@
-import Big from 'big.js';
 import {OrderSide, OrderType, calculateRoundTripProfit} from '@typedtrader/exchange';
-import type {Fill, OneMinuteBatchedCandle} from '@typedtrader/exchange';
+import type {OneMinuteBatchedCandle} from '@typedtrader/exchange';
 import type {OrderAdvice, TradingSessionState} from '../trader/index.js';
 import {
   SmaCrossoverSchema,
@@ -12,24 +11,18 @@ export const FeeAwareSmaCrossoverSchema = SmaCrossoverSchema;
 export type FeeAwareSmaCrossoverConfig = SmaCrossoverConfig;
 
 /**
- * An {@link SmaCrossoverStrategy} that refuses to sell at a loss. It trades all-in /
- * all-out — buying and selling the entire balance in one shot — so a single entry price
- * is enough: it remembers the last buy and, when the crossover signals a bearish exit,
- * only forwards the SELL when selling at the current price nets a profit after the taker
- * fee on both legs (see `calculateRoundTripProfit`). Otherwise it holds.
+ * An {@link SmaCrossoverStrategy} that refuses to sell at a loss. When the crossover signals
+ * a bearish exit, it only forwards the SELL when selling at the current price nets a profit
+ * after the taker fee on both legs (see `calculateRoundTripProfit`). Otherwise it holds.
+ *
+ * The entry it measures against is the base `Strategy`'s fill-tracked last buy price — which,
+ * for this all-in / all-out strategy, is the price of the position it currently holds.
  *
  * Trade-off: skipping unprofitable exits means holding through a downtrend rather than
  * taking a small loss, so pair it with a stop-loss if you need a hard floor.
  */
 export class FeeAwareSmaCrossoverStrategy extends SmaCrossoverStrategy {
   static override NAME = '@typedtrader/strategy-fee-aware-sma-crossover';
-
-  /** Price of the most recent BUY fill — the entry the next SELL is measured against. `undefined` while flat. */
-  #lastBuyPrice: Big | undefined = undefined;
-
-  async onFill(fill: Fill, _state: TradingSessionState): Promise<void> {
-    this.#lastBuyPrice = fill.side === OrderSide.BUY ? new Big(fill.price) : undefined;
-  }
 
   protected override async processCandle(
     candle: OneMinuteBatchedCandle,
@@ -42,14 +35,15 @@ export class FeeAwareSmaCrossoverStrategy extends SmaCrossoverStrategy {
       return advice;
     }
 
-    // No known entry to measure against — don't block the exit.
-    if (!this.#lastBuyPrice) {
+    // No tracked entry to measure against — don't block the exit.
+    const entryPrice = this.lastBuyPrice;
+    if (!entryPrice) {
       return advice;
     }
 
     const profit = calculateRoundTripProfit({
       entryFeeRate: state.feeRates[OrderType.MARKET],
-      entryPrice: this.#lastBuyPrice,
+      entryPrice,
       exitFeeRate: state.feeRates[OrderType.MARKET],
       exitPrice: candle.close,
       quantity: state.baseBalance,

--- a/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.test.ts
+++ b/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.test.ts
@@ -39,6 +39,14 @@ const mockState: TradingSessionState = {
   },
 };
 
+/**
+ * A state holding `base` units. Guards read the live base balance for quantity and to decide
+ * whether there is a position at all, so tests pass the balance they are simulating.
+ */
+function held(base: number): TradingSessionState {
+  return {...mockState, baseBalance: new Big(base)};
+}
+
 const ONE_MINUTE_IN_MS = ms('1m');
 
 function makeCandle(close: number, index = 0): OneMinuteBatchedCandle {
@@ -153,12 +161,12 @@ describe('ProtectedStrategySchema', () => {
 
 describe('ProtectedStrategy', () => {
   describe('stop-loss', () => {
-    it('fires a LIMIT sell at the nominal target price when unrealized loss reaches the threshold', async () => {
+    it('fires a LIMIT sell at the nominal target price when the loss reaches the threshold', async () => {
       const strategy = new TestProtectedStrategy({protected: {stopLossPct: '5'}});
       await strategy.onFill(makeFill('100', '10', OrderSide.BUY), mockState);
 
       // Price drops 5% — stop-loss should fire
-      const advice = await strategy.onCandle(makeCandle(95), mockState);
+      const advice = await strategy.onCandle(makeCandle(95), held(10));
 
       assertLimitSell(advice);
       expect(advice.amount).toBe(AllAvailableAmount);
@@ -174,7 +182,7 @@ describe('ProtectedStrategy', () => {
       await strategy.onFill(makeFill('100', '10', OrderSide.BUY), mockState);
 
       // Market gaps to 90 (-10%), far past the -5% threshold — limit still sits at 95
-      const advice = await strategy.onCandle(makeCandle(90), mockState);
+      const advice = await strategy.onCandle(makeCandle(90), held(10));
 
       assertLimitSell(advice);
       expect(new Big(advice.price).toFixed(2)).toBe('95.00');
@@ -185,7 +193,7 @@ describe('ProtectedStrategy', () => {
       await strategy.onFill(makeFill('100', '10', OrderSide.BUY), mockState);
 
       // Price drops only 3% — guard should pass, subclass runs
-      const advice = await strategy.onCandle(makeCandle(97), mockState);
+      const advice = await strategy.onCandle(makeCandle(97), held(10));
 
       expect(advice).toBeUndefined();
       expect(strategy.ownLogicCallCount).toBe(1);
@@ -193,16 +201,16 @@ describe('ProtectedStrategy', () => {
 
     it('fires a LIMIT sell at the nominal USD loss target when stopLossNominal is reached', async () => {
       /*
-       * 10 shares @ 100 = $1000 invested. stopLossNominal=10 → exit when unrealized loss
-       * is $10, i.e. price of 99 (each share only needs to drop $1).
+       * 10 shares @ 100. stopLossNominal=10 → exit when the unrealized loss is $10, i.e. a
+       * price of 99 (each of the 10 shares only needs to drop $1).
        */
       const strategy = new TestProtectedStrategy({protected: {stopLossNominal: '10'}});
       await strategy.onFill(makeFill('100', '10', OrderSide.BUY), mockState);
 
-      const notYet = await strategy.onCandle(makeCandle(99.5), mockState);
+      const notYet = await strategy.onCandle(makeCandle(99.5), held(10));
       expect(notYet).toBeUndefined();
 
-      const advice = await strategy.onCandle(makeCandle(99), mockState);
+      const advice = await strategy.onCandle(makeCandle(99), held(10));
       assertLimitSell(advice);
       expect(new Big(advice.price).toFixed(2)).toBe('99.00');
       expect(advice.reason).toContain('Stop-loss');
@@ -214,37 +222,37 @@ describe('ProtectedStrategy', () => {
       const strategy = new TestProtectedStrategy({protected: {stopLossPrice: '92'}});
       await strategy.onFill(makeFill('100', '10', OrderSide.BUY), mockState);
 
-      const notYet = await strategy.onCandle(makeCandle(93), mockState);
+      const notYet = await strategy.onCandle(makeCandle(93), held(10));
       expect(notYet).toBeUndefined();
 
-      const advice = await strategy.onCandle(makeCandle(92), mockState);
+      const advice = await strategy.onCandle(makeCandle(92), held(10));
       assertLimitSell(advice);
       expect(new Big(advice.price).toFixed(2)).toBe('92.00');
       expect(advice.reason).toContain('Stop-loss');
       expect(advice.reason).toContain('target 92');
     });
 
-    it('fires at the configured price regardless of avg entry', async () => {
+    it('fires at the configured price regardless of the entry', async () => {
       // Buy at 50 — far below the 92 stopLossPrice. Guard still arms and fires at 92.
       const strategy = new TestProtectedStrategy({protected: {stopLossPrice: '92'}});
       await strategy.onFill(makeFill('50', '10', OrderSide.BUY), mockState);
 
       // Price above the stop target — no fire even though we're above entry
-      const notYet = await strategy.onCandle(makeCandle(100), mockState);
+      const notYet = await strategy.onCandle(makeCandle(100), held(10));
       expect(notYet).toBeUndefined();
 
-      const advice = await strategy.onCandle(makeCandle(92), mockState);
+      const advice = await strategy.onCandle(makeCandle(92), held(10));
       assertLimitSell(advice);
       expect(new Big(advice.price).toFixed(2)).toBe('92.00');
     });
   });
 
   describe('take-profit', () => {
-    it('fires a LIMIT sell at the nominal target price when unrealized gain reaches the threshold', async () => {
+    it('fires a LIMIT sell at the nominal target price when the gain reaches the threshold', async () => {
       const strategy = new TestProtectedStrategy({protected: {takeProfitPct: '10'}});
       await strategy.onFill(makeFill('100', '10', OrderSide.BUY), mockState);
 
-      const advice = await strategy.onCandle(makeCandle(110), mockState);
+      const advice = await strategy.onCandle(makeCandle(110), held(10));
 
       assertLimitSell(advice);
       expect(new Big(advice.price).toFixed(2)).toBe('110.00');
@@ -255,16 +263,16 @@ describe('ProtectedStrategy', () => {
 
     it('fires a LIMIT sell at the nominal USD target when takeProfitNominal is reached', async () => {
       /*
-       * 10 shares @ 100 = $1000 invested. takeProfitNominal=10 → exit when portfolio hits $1010,
-       * i.e. price of 101 (each share only needs to gain $1).
+       * 10 shares @ 100. takeProfitNominal=10 → exit when the unrealized gain is $10, i.e. a
+       * price of 101 (each of the 10 shares only needs to gain $1).
        */
       const strategy = new TestProtectedStrategy({protected: {takeProfitNominal: '10'}});
       await strategy.onFill(makeFill('100', '10', OrderSide.BUY), mockState);
 
-      const notYet = await strategy.onCandle(makeCandle(100.5), mockState);
+      const notYet = await strategy.onCandle(makeCandle(100.5), held(10));
       expect(notYet).toBeUndefined();
 
-      const advice = await strategy.onCandle(makeCandle(101), mockState);
+      const advice = await strategy.onCandle(makeCandle(101), held(10));
       assertLimitSell(advice);
       expect(new Big(advice.price).toFixed(2)).toBe('101.00');
       expect(advice.reason).toContain('Take-profit');
@@ -276,10 +284,10 @@ describe('ProtectedStrategy', () => {
       const strategy = new TestProtectedStrategy({protected: {takeProfitPrice: '108'}});
       await strategy.onFill(makeFill('100', '10', OrderSide.BUY), mockState);
 
-      const notYet = await strategy.onCandle(makeCandle(107), mockState);
+      const notYet = await strategy.onCandle(makeCandle(107), held(10));
       expect(notYet).toBeUndefined();
 
-      const advice = await strategy.onCandle(makeCandle(108), mockState);
+      const advice = await strategy.onCandle(makeCandle(108), held(10));
       assertLimitSell(advice);
       expect(new Big(advice.price).toFixed(2)).toBe('108.00');
       expect(advice.reason).toContain('Take-profit');
@@ -290,7 +298,7 @@ describe('ProtectedStrategy', () => {
       const strategy = new TestProtectedStrategy({protected: {takeProfitPct: '10'}});
       await strategy.onFill(makeFill('100', '10', OrderSide.BUY), mockState);
 
-      const advice = await strategy.onCandle(makeCandle(105), mockState);
+      const advice = await strategy.onCandle(makeCandle(105), held(10));
 
       expect(advice).toBeUndefined();
       expect(strategy.ownLogicCallCount).toBe(1);
@@ -313,19 +321,15 @@ describe('ProtectedStrategy', () => {
   });
 
   describe('seedFromBalance', () => {
-    const stateWithPosition: TradingSessionState = {
-      ...mockState,
-      baseBalance: new Big(10),
-    };
+    const stateWithPosition = held(10);
 
-    it('seeds position from account balance and first candle close', async () => {
+    it('seeds the entry price from the first candle close', async () => {
       const strategy = new TestProtectedStrategy({protected: {seedFromBalance: true, stopLossPct: '5'}});
 
-      // First candle at 100 with 10 shares in account → seeds avgEntry=100, size=10
+      // First candle at 100 with 10 shares in the account → seeds the entry at 100
       await strategy.onCandle(makeCandle(100), stateWithPosition);
 
-      expect(strategy.protectedState.totalPositionSize).toBe('10');
-      expect(strategy.protectedState.totalCostBasis).toBe('1000');
+      expect(strategy.protectedState.seedEntryPrice).toBe('100');
     });
 
     it('fires stop-loss relative to the seeded baseline price', async () => {
@@ -360,7 +364,7 @@ describe('ProtectedStrategy', () => {
 
       const advice = await strategy.onCandle(makeCandle(100), mockState);
 
-      expect(strategy.protectedState.totalPositionSize).toBe('0');
+      expect(strategy.protectedState.seedEntryPrice).toBeNull();
       expect(advice).toBeDefined();
       expect(advice?.side).toBe(OrderSide.BUY);
     });
@@ -370,25 +374,25 @@ describe('ProtectedStrategy', () => {
 
       const advice = await strategy.onCandle(makeCandle(100), stateWithPosition);
 
-      expect(strategy.protectedState.totalPositionSize).toBe('0');
+      expect(strategy.protectedState.seedEntryPrice).toBeNull();
       expect(advice).toBeDefined();
       expect(advice?.side).toBe(OrderSide.BUY);
     });
 
-    it('does not re-seed after position was already tracked via onFill', async () => {
+    it('does not seed when a buy fill already set the entry', async () => {
       const strategy = new TestProtectedStrategy({protected: {seedFromBalance: true, stopLossPct: '5'}});
 
-      // Position tracked via fill at 80
+      // Entry established by a real buy at 80
       await strategy.onFill(makeFill('80', '10', OrderSide.BUY), mockState);
 
-      // Candle at 100 should NOT overwrite the fill-based tracking
+      // Candle at 100 should NOT seed — the last buy price is the entry
       await strategy.onCandle(makeCandle(100), stateWithPosition);
 
-      expect(strategy.protectedState.totalCostBasis).toBe('800');
-      expect(strategy.protectedState.totalPositionSize).toBe('10');
+      expect(strategy.protectedState.seedEntryPrice).toBeNull();
+      expect(strategy.lastBuyPrice?.toFixed()).toBe('80');
     });
 
-    it('persists seeded state through restoreState', async () => {
+    it('persists the seeded entry through restoreState', async () => {
       const strategy = new TestProtectedStrategy({protected: {seedFromBalance: true, stopLossPct: '5'}});
       await strategy.onCandle(makeCandle(100), stateWithPosition);
 
@@ -397,10 +401,9 @@ describe('ProtectedStrategy', () => {
       const restored = new TestProtectedStrategy({protected: {seedFromBalance: true, stopLossPct: '5'}});
       restored.restoreState(snapshot!);
 
-      expect(restored.protectedState.totalPositionSize).toBe('10');
-      expect(restored.protectedState.totalCostBasis).toBe('1000');
+      expect(restored.protectedState.seedEntryPrice).toBe('100');
 
-      // Guard should fire on restored instance
+      // Guard should fire on the restored instance relative to the seeded entry
       const advice = await restored.onCandle(makeCandle(95), stateWithPosition);
       assertLimitSell(advice);
     });
@@ -411,17 +414,17 @@ describe('ProtectedStrategy', () => {
       const strategy = new TestProtectedStrategy({protected: {stopLossPct: '5'}, signalAdvice: true});
       await strategy.onFill(makeFill('100', '10', OrderSide.BUY), mockState);
 
-      // Trigger stop-loss — position is still 10 because no sell fill has arrived yet
-      const killAdvice = await strategy.onCandle(makeCandle(94), mockState);
+      // Trigger stop-loss — the position is still held, so the exit re-emits
+      const killAdvice = await strategy.onCandle(makeCandle(94), held(10));
       assertLimitSell(killAdvice);
       expect(new Big(killAdvice.price).toFixed(2)).toBe('95.00');
       expect(strategy.protectedState.killed).toBe(true);
 
       /*
-       * Simulate exchange rejecting/delaying the fill: next candle must retry with
+       * Simulate the exchange rejecting/delaying the fill: the next candle must retry with
        * the same nominal limit price, regardless of where the market is now.
        */
-      const retryAdvice = await strategy.onCandle(makeCandle(120), mockState);
+      const retryAdvice = await strategy.onCandle(makeCandle(120), held(10));
       assertLimitSell(retryAdvice);
       expect(new Big(retryAdvice.price).toFixed(2)).toBe('95.00');
       expect(retryAdvice.reason).toContain('[KILL SWITCH]');
@@ -430,18 +433,14 @@ describe('ProtectedStrategy', () => {
       expect(strategy.ownLogicCallCount).toBe(0);
     });
 
-    it('goes silent once the position is fully exited via onFill', async () => {
+    it('goes silent once the position has been fully exited', async () => {
       const strategy = new TestProtectedStrategy({protected: {stopLossPct: '5'}, signalAdvice: true});
       await strategy.onFill(makeFill('100', '10', OrderSide.BUY), mockState);
 
-      await strategy.onCandle(makeCandle(94), mockState);
+      await strategy.onCandle(makeCandle(94), held(10));
       expect(strategy.protectedState.killed).toBe(true);
 
-      // The sell advice finally fills — position goes to zero
-      await strategy.onFill(makeFill('94', '10', OrderSide.SELL), mockState);
-      expect(strategy.protectedState.totalPositionSize).toBe('0');
-
-      // Now subsequent candles return undefined — truly terminal
+      // The sell fills and the balance drains — subsequent candles return undefined (terminal)
       const advice = await strategy.onCandle(makeCandle(120), mockState);
       expect(advice).toBeUndefined();
       expect(strategy.ownLogicCallCount).toBe(0);
@@ -453,12 +452,11 @@ describe('ProtectedStrategy', () => {
       strategy.onFinish = onFinish;
 
       await strategy.onFill(makeFill('100', '10', OrderSide.BUY), mockState);
-      await strategy.onCandle(makeCandle(94), mockState);
+      await strategy.onCandle(makeCandle(94), held(10));
       expect(strategy.protectedState.killed).toBe(true);
       expect(onFinish).not.toHaveBeenCalled();
 
       // Kill-switch sell actually fills → session reports order done
-      await strategy.onFill(makeFill('94', '10', OrderSide.SELL), mockState);
       await strategy.onOrderFilled(makeOrder(OrderSide.SELL), mockState);
       expect(onFinish).toHaveBeenCalledTimes(1);
     });
@@ -469,7 +467,6 @@ describe('ProtectedStrategy', () => {
       strategy.onFinish = onFinish;
 
       await strategy.onFill(makeFill('100', '10', OrderSide.BUY), mockState);
-      await strategy.onFill(makeFill('110', '10', OrderSide.SELL), mockState);
       await strategy.onOrderFilled(makeOrder(OrderSide.SELL), mockState);
 
       expect(strategy.protectedState.killed).toBe(false);
@@ -482,7 +479,7 @@ describe('ProtectedStrategy', () => {
       strategy.onFinish = onFinish;
 
       await strategy.onFill(makeFill('100', '10', OrderSide.BUY), mockState);
-      await strategy.onCandle(makeCandle(94), mockState);
+      await strategy.onCandle(makeCandle(94), held(10));
       expect(strategy.protectedState.killed).toBe(true);
 
       // A BUY order completing (shouldn't happen in practice once killed, but guard anyway)
@@ -491,47 +488,43 @@ describe('ProtectedStrategy', () => {
     });
   });
 
-  describe('position tracking', () => {
-    it('uses cost-basis averaging across multiple buys to compute the limit price', async () => {
+  describe('entry price', () => {
+    it('measures guards from the last buy price, not an average across buys', async () => {
       const strategy = new TestProtectedStrategy({protected: {stopLossPct: '5'}});
 
-      // Buy 10 @ 100, then 10 @ 120 → avg = 110
+      // Buy 10 @ 100, then 10 @ 120 → entry is the last buy of 120 (no averaging)
       await strategy.onFill(makeFill('100', '10', OrderSide.BUY), mockState);
       await strategy.onFill(makeFill('120', '10', OrderSide.BUY), mockState);
 
-      // -5% of 110 = 104.5. At 105, no fire. At 104, fires.
-      const notYet = await strategy.onCandle(makeCandle(105), mockState);
+      // -5% of 120 = 114. At 115, no fire. At 114, fires.
+      const notYet = await strategy.onCandle(makeCandle(115), held(20));
       expect(notYet).toBeUndefined();
 
-      const fires = await strategy.onCandle(makeCandle(104), mockState);
+      const fires = await strategy.onCandle(makeCandle(114), held(20));
       assertLimitSell(fires);
-      // Nominal limit price is 110 * 0.95 = 104.5 (NOT the candle close of 104)
-      expect(new Big(fires.price).toFixed(2)).toBe('104.50');
+      expect(new Big(fires.price).toFixed(2)).toBe('114.00');
     });
 
-    it('uses the current average entry price after a partial sell', async () => {
+    it('still measures from the last buy after a partial sell', async () => {
       const strategy = new TestProtectedStrategy({protected: {stopLossPct: '5'}});
 
-      // Buy 20 @ 100, then sell 10 (partial exit). Avg entry stays at 100.
+      // Buy 20 @ 100, then sell 10. The last buy price (100) stays the entry.
       await strategy.onFill(makeFill('100', '20', OrderSide.BUY), mockState);
       await strategy.onFill(makeFill('110', '10', OrderSide.SELL), mockState);
 
-      const fires = await strategy.onCandle(makeCandle(95), mockState);
+      // 10 shares remain; -5% of 100 → 95
+      const fires = await strategy.onCandle(makeCandle(95), held(10));
       assertLimitSell(fires);
-      // Limit is nominal 5% below the preserved avg entry of 100 → 95
       expect(new Big(fires.price).toFixed(2)).toBe('95.00');
     });
 
-    it('resets position tracking to zero on a full exit', async () => {
+    it('does not fire once the position is fully sold (no live balance)', async () => {
       const strategy = new TestProtectedStrategy({protected: {stopLossPct: '5'}});
 
       await strategy.onFill(makeFill('100', '10', OrderSide.BUY), mockState);
       await strategy.onFill(makeFill('110', '10', OrderSide.SELL), mockState);
 
-      expect(strategy.protectedState.totalPositionSize).toBe('0');
-      expect(strategy.protectedState.totalCostBasis).toBe('0');
-
-      // After a full exit, the guard should not fire on any price move — no position
+      // No live balance → no position to protect, guard stays silent
       const advice = await strategy.onCandle(makeCandle(1), mockState);
       expect(advice).toBeUndefined();
     });
@@ -543,7 +536,7 @@ describe('ProtectedStrategy', () => {
       await strategy.onFill(makeFill('100', '10', OrderSide.BUY), mockState);
 
       // Price crashes 99% — guard still does nothing because no thresholds set
-      const advice = await strategy.onCandle(makeCandle(1), mockState);
+      const advice = await strategy.onCandle(makeCandle(1), held(10));
 
       expect(advice).toBeDefined();
       expect(advice?.side).toBe(OrderSide.BUY);
@@ -604,7 +597,7 @@ describe('ProtectedStrategy', () => {
       await strategy.onFill(makeFill('100', '10', OrderSide.BUY), mockState);
 
       // Hits take-profit first at 101
-      const advice = await strategy.onCandle(makeCandle(101), mockState);
+      const advice = await strategy.onCandle(makeCandle(101), held(10));
       assertLimitSell(advice);
       expect(new Big(advice.price).toFixed(2)).toBe('101.00');
       expect(advice.reason).toContain('Take-profit');
@@ -615,28 +608,28 @@ describe('ProtectedStrategy', () => {
       await strategy.onFill(makeFill('100', '10', OrderSide.BUY), mockState);
 
       // -$10 at 10 shares → price 99
-      const advice = await strategy.onCandle(makeCandle(99), mockState);
+      const advice = await strategy.onCandle(makeCandle(99), held(10));
       assertLimitSell(advice);
       expect(new Big(advice.price).toFixed(2)).toBe('99.00');
       expect(advice.reason).toContain('Stop-loss');
     });
   });
 
-  describe('nominal across multiple buys', () => {
-    it('uses the current cost-basis / positionSize when computing the nominal target', async () => {
+  describe('nominal guard sizing', () => {
+    it('divides the nominal target by the live position size', async () => {
       const strategy = new TestProtectedStrategy({protected: {takeProfitNominal: '20'}});
 
-      // Buy 10 @ 100, then 10 @ 120 → positionSize 20, costBasis 2200, avgEntry 110
+      // Buy 10 @ 100, then 10 @ 120 → entry is the last buy of 120, live size 20
       await strategy.onFill(makeFill('100', '10', OrderSide.BUY), mockState);
       await strategy.onFill(makeFill('120', '10', OrderSide.BUY), mockState);
 
-      // +$20 target at 20 shares → each share needs to gain $1 from avg → target 111
-      const notYet = await strategy.onCandle(makeCandle(110.5), mockState);
+      // +$20 target at 20 shares → each share needs to gain $1 from entry → target 121
+      const notYet = await strategy.onCandle(makeCandle(120.5), held(20));
       expect(notYet).toBeUndefined();
 
-      const advice = await strategy.onCandle(makeCandle(111), mockState);
+      const advice = await strategy.onCandle(makeCandle(121), held(20));
       assertLimitSell(advice);
-      expect(new Big(advice.price).toFixed(2)).toBe('111.00');
+      expect(new Big(advice.price).toFixed(2)).toBe('121.00');
     });
   });
 
@@ -652,8 +645,8 @@ describe('ProtectedStrategy', () => {
       const restored = new TestProtectedStrategy({protected: {stopLossPct: '5'}});
       restored.restoreState(snapshot!);
 
-      // The restored strategy should know about the position and fire at -5%
-      const advice = await restored.onCandle(makeCandle(95), mockState);
+      // The restored strategy knows the last buy price and fires at -5%
+      const advice = await restored.onCandle(makeCandle(95), held(10));
       assertLimitSell(advice);
       expect(new Big(advice.price).toFixed(2)).toBe('95.00');
     });
@@ -661,7 +654,7 @@ describe('ProtectedStrategy', () => {
     it('restores the killedLimitPrice after a guard has already fired', async () => {
       const strategy = new TestProtectedStrategy({protected: {stopLossPct: '5'}});
       await strategy.onFill(makeFill('100', '10', OrderSide.BUY), mockState);
-      await strategy.onCandle(makeCandle(95), mockState); // fire the guard
+      await strategy.onCandle(makeCandle(95), held(10)); // fire the guard
       expect(strategy.protectedState.killed).toBe(true);
 
       const snapshot = strategy.state;
@@ -672,7 +665,7 @@ describe('ProtectedStrategy', () => {
       expect(restored.protectedState.killedLimitPrice).toBe('95');
 
       // Retry on the restored instance should re-emit the same limit advice
-      const advice = await restored.onCandle(makeCandle(50), mockState);
+      const advice = await restored.onCandle(makeCandle(50), held(10));
       assertLimitSell(advice);
       expect(new Big(advice.price).toFixed(2)).toBe('95.00');
     });
@@ -684,8 +677,7 @@ describe('ProtectedStrategy', () => {
       strategy.restoreState({ownField: 42});
 
       expect(strategy.protectedState.killed).toBe(false);
-      expect(strategy.protectedState.totalPositionSize).toBe('0');
-      expect(strategy.protectedState.totalCostBasis).toBe('0');
+      expect(strategy.protectedState.seedEntryPrice).toBeNull();
     });
 
     it('falls back to defaults when restored state has killed=true but no killedOrderType', async () => {
@@ -701,13 +693,11 @@ describe('ProtectedStrategy', () => {
           killedLimitPrice: null,
           killedOrderType: null,
           killedReason: 'stale',
-          totalCostBasis: '1000',
-          totalPositionSize: '10',
+          seedEntryPrice: null,
         },
       });
 
       expect(strategy.protectedState.killed).toBe(false);
-      expect(strategy.protectedState.totalPositionSize).toBe('0');
     });
 
     it('falls back to defaults when killedOrderType="limit" but killedLimitPrice is null', async () => {
@@ -719,8 +709,7 @@ describe('ProtectedStrategy', () => {
           killedLimitPrice: null,
           killedOrderType: 'limit',
           killedReason: 'stale',
-          totalCostBasis: '1000',
-          totalPositionSize: '10',
+          seedEntryPrice: null,
         },
       });
 
@@ -736,17 +725,15 @@ describe('ProtectedStrategy', () => {
           killedLimitPrice: null,
           killedOrderType: 'market',
           killedReason: 'Stop-loss fired',
-          totalCostBasis: '1000',
-          totalPositionSize: '10',
+          seedEntryPrice: null,
         },
       });
 
       expect(strategy.protectedState.killed).toBe(true);
       expect(strategy.protectedState.killedOrderType).toBe('market');
-      expect(strategy.protectedState.totalPositionSize).toBe('10');
     });
 
-    it('falls back to defaults when totalCostBasis is not a valid numeric string', async () => {
+    it('falls back to defaults when seedEntryPrice is not a valid numeric string', async () => {
       const strategy = new TestProtectedStrategy({protected: {stopLossPct: '5'}});
 
       strategy.restoreState({
@@ -755,13 +742,12 @@ describe('ProtectedStrategy', () => {
           killedLimitPrice: null,
           killedOrderType: null,
           killedReason: null,
-          totalCostBasis: 'not-a-number',
-          totalPositionSize: '10',
+          seedEntryPrice: 'not-a-number',
         },
       });
 
-      expect(strategy.protectedState.totalCostBasis).toBe('0');
-      expect(strategy.protectedState.totalPositionSize).toBe('0');
+      expect(strategy.protectedState.seedEntryPrice).toBeNull();
+      expect(strategy.protectedState.killed).toBe(false);
     });
 
     it('falls back to defaults when killedLimitPrice is not a valid numeric string', async () => {
@@ -773,8 +759,7 @@ describe('ProtectedStrategy', () => {
           killedLimitPrice: 'garbage',
           killedOrderType: 'limit',
           killedReason: null,
-          totalCostBasis: '1000',
-          totalPositionSize: '10',
+          seedEntryPrice: null,
         },
       });
 
@@ -783,7 +768,7 @@ describe('ProtectedStrategy', () => {
   });
 
   describe('persistence (onSave)', () => {
-    it('fires onSave when onFill accumulates a BUY', async () => {
+    it('fires onSave when onFill records a buy', async () => {
       const strategy = new TestProtectedStrategy({protected: {stopLossPct: '5'}});
       const onSave = vi.fn();
       strategy.onSave = onSave;
@@ -793,7 +778,7 @@ describe('ProtectedStrategy', () => {
       expect(onSave).toHaveBeenCalled();
     });
 
-    it('fires onSave when onFill reduces the position on a SELL', async () => {
+    it('fires onSave when onFill records a sell', async () => {
       const strategy = new TestProtectedStrategy({protected: {stopLossPct: '5'}});
       await strategy.onFill(makeFill('100', '10', OrderSide.BUY), mockState);
 
@@ -812,7 +797,7 @@ describe('ProtectedStrategy', () => {
       const onSave = vi.fn();
       strategy.onSave = onSave;
 
-      await strategy.onCandle(makeCandle(94), mockState);
+      await strategy.onCandle(makeCandle(94), held(10));
 
       expect(onSave).toHaveBeenCalled();
     });
@@ -823,7 +808,7 @@ describe('ProtectedStrategy', () => {
       const strategy = new TestProtectedStrategy({protected: {stopLossPct: '5'}, signalAdvice: true});
       await strategy.onFill(makeFill('100', '10', OrderSide.BUY), mockState);
 
-      const advice = await strategy.onCandle(makeCandle(90), mockState);
+      const advice = await strategy.onCandle(makeCandle(90), held(10));
 
       assertLimitSell(advice);
       expect(advice.reason).toContain('Stop-loss');
@@ -834,7 +819,7 @@ describe('ProtectedStrategy', () => {
       const strategy = new TestProtectedStrategy({protected: {stopLossPct: '5', takeProfitPct: '10'}});
       await strategy.onFill(makeFill('100', '10', OrderSide.BUY), mockState);
 
-      const advice = await strategy.onCandle(makeCandle(94), mockState);
+      const advice = await strategy.onCandle(makeCandle(94), held(10));
       assertLimitSell(advice);
       expect(advice.reason).toContain('Stop-loss');
     });
@@ -845,7 +830,7 @@ describe('ProtectedStrategy', () => {
       const strategy = new TestProtectedStrategy({protected: {stopLossPct: '5'}});
       await strategy.onFill(makeFill('100', '10', OrderSide.BUY), mockState);
 
-      const advice = await strategy.onCandle(makeCandle(95), mockState);
+      const advice = await strategy.onCandle(makeCandle(95), held(10));
       assertLimitSell(advice);
       expect(strategy.protectedState.killedOrderType).toBe('limit');
     });
@@ -854,7 +839,7 @@ describe('ProtectedStrategy', () => {
       const strategy = new TestProtectedStrategy({protected: {takeProfitPct: '10'}});
       await strategy.onFill(makeFill('100', '10', OrderSide.BUY), mockState);
 
-      const advice = await strategy.onCandle(makeCandle(110), mockState);
+      const advice = await strategy.onCandle(makeCandle(110), held(10));
       assertLimitSell(advice);
       expect(strategy.protectedState.killedOrderType).toBe('limit');
     });
@@ -863,7 +848,7 @@ describe('ProtectedStrategy', () => {
       const strategy = new TestProtectedStrategy({protected: {stopLossOrder: 'market', stopLossPct: '5'}});
       await strategy.onFill(makeFill('100', '10', OrderSide.BUY), mockState);
 
-      const advice = await strategy.onCandle(makeCandle(95), mockState);
+      const advice = await strategy.onCandle(makeCandle(95), held(10));
       assertMarketSell(advice);
       expect(advice.amount).toBe(AllAvailableAmount);
       expect(advice.amountIn).toBe('base');
@@ -879,7 +864,7 @@ describe('ProtectedStrategy', () => {
       const strategy = new TestProtectedStrategy({protected: {takeProfitOrder: 'market', takeProfitPct: '10'}});
       await strategy.onFill(makeFill('100', '10', OrderSide.BUY), mockState);
 
-      const advice = await strategy.onCandle(makeCandle(110), mockState);
+      const advice = await strategy.onCandle(makeCandle(110), held(10));
       assertMarketSell(advice);
       expect(advice.reason).toContain('Take-profit');
       expect(advice.reason).toContain('(market)');
@@ -898,7 +883,7 @@ describe('ProtectedStrategy', () => {
       });
       await strategy.onFill(makeFill('100', '10', OrderSide.BUY), mockState);
 
-      const stopAdvice = await strategy.onCandle(makeCandle(95), mockState);
+      const stopAdvice = await strategy.onCandle(makeCandle(95), held(10));
       assertMarketSell(stopAdvice);
     });
 
@@ -912,7 +897,7 @@ describe('ProtectedStrategy', () => {
       });
       await strategy.onFill(makeFill('100', '10', OrderSide.BUY), mockState);
 
-      const profitAdvice = await strategy.onCandle(makeCandle(110), mockState);
+      const profitAdvice = await strategy.onCandle(makeCandle(110), held(10));
       assertMarketSell(profitAdvice);
     });
 
@@ -924,11 +909,11 @@ describe('ProtectedStrategy', () => {
       await strategy.onFill(makeFill('100', '10', OrderSide.BUY), mockState);
 
       // Fire
-      const first = await strategy.onCandle(makeCandle(95), mockState);
+      const first = await strategy.onCandle(makeCandle(95), held(10));
       assertMarketSell(first);
 
-      // Retry on next candle — position still 10, should re-emit market sell
-      const second = await strategy.onCandle(makeCandle(150), mockState);
+      // Retry on next candle — position still held, should re-emit market sell
+      const second = await strategy.onCandle(makeCandle(150), held(10));
       assertMarketSell(second);
       expect(strategy.ownLogicCallCount).toBe(0);
     });
@@ -936,7 +921,7 @@ describe('ProtectedStrategy', () => {
     it('persists killedOrderType across restoreState', async () => {
       const strategy = new TestProtectedStrategy({protected: {stopLossOrder: 'market', stopLossPct: '5'}});
       await strategy.onFill(makeFill('100', '10', OrderSide.BUY), mockState);
-      await strategy.onCandle(makeCandle(95), mockState); // fire
+      await strategy.onCandle(makeCandle(95), held(10)); // fire
 
       const snapshot = strategy.state;
 
@@ -946,7 +931,7 @@ describe('ProtectedStrategy', () => {
       expect(restored.protectedState.killedLimitPrice).toBeNull();
 
       // Retry on restored instance should still be MARKET, not LIMIT
-      const advice = await restored.onCandle(makeCandle(50), mockState);
+      const advice = await restored.onCandle(makeCandle(50), held(10));
       assertMarketSell(advice);
     });
   });

--- a/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.ts
+++ b/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.ts
@@ -2,7 +2,7 @@ import Big from 'big.js';
 import {z} from 'zod';
 import {OrderSide, OrderType} from '@typedtrader/exchange';
 import {AllAvailableAmount} from '../trader/index.js';
-import type {Fill, PendingOrder, OneMinuteBatchedCandle} from '@typedtrader/exchange';
+import type {PendingOrder, OneMinuteBatchedCandle} from '@typedtrader/exchange';
 import type {LimitOrderAdvice, OrderAdvice, TradingSessionState} from '../trader/index.js';
 import {MarketType} from '../strategy/MarketType.js';
 import {Strategy} from '../strategy/Strategy.js';
@@ -14,10 +14,9 @@ import {positiveNumberString} from '../util/validators.js';
  */
 export const ProtectedConfigSchema = z.object({
   /**
-   * When `true`, the strategy seeds its position tracking from the account's existing
-   * base balance and the first candle's close price. This allows attaching guard
-   * protection to a position that was opened externally (manual trade, another strategy).
-   * Percentage and nominal guards will be relative to the price at attach time.
+   * When `true`, the strategy seeds its guard entry price from the first candle's close
+   * so it can attach to a position opened externally (manual trade, another strategy),
+   * where there is no buy of its own to measure from.
    */
   seedFromBalance: z.boolean().default(false),
   /**
@@ -34,7 +33,7 @@ export const ProtectedConfigSchema = z.object({
    */
   stopLossOrder: z.enum(['limit', 'market']).default('limit'),
   /**
-   * Stop-loss as a percentage of avg entry. "5" = sell everything at avgEntry * 0.95.
+   * Stop-loss as a percentage of the entry price. "5" = sell everything at entry * 0.95.
    * Mutually exclusive with `stopLossNominal` and `stopLossPrice`. Omit all three to
    * disable the stop-loss guard.
    */
@@ -57,7 +56,7 @@ export const ProtectedConfigSchema = z.object({
    */
   takeProfitOrder: z.enum(['limit', 'market']).default('limit'),
   /**
-   * Take-profit as a percentage of avg entry. "10" = sell everything at avgEntry * 1.10.
+   * Take-profit as a percentage of the entry price. "10" = sell everything at entry * 1.10.
    * Mutually exclusive with `takeProfitNominal` and `takeProfitPrice`. Omit all three to
    * disable the take-profit guard.
    */
@@ -89,10 +88,12 @@ export type ProtectedStrategyState = {
   killedOrderType: GuardOrderType | null;
   /** Limit price of the kill-switch sell order, as a Big string. `null` for market orders or until a guard fires. */
   killedLimitPrice: string | null;
-  /** Cumulative cost basis across all BUY fills: sum of (price * size). Stored as a Big string. */
-  totalCostBasis: string;
-  /** Net base quantity held (BUYs minus SELLs). Stored as a Big string. */
-  totalPositionSize: string;
+  /**
+   * Entry price captured when `seedFromBalance` attaches guards to a position opened outside
+   * the strategy (no buy fill of its own), as a Big string. `null` when there is no seeded
+   * position — a real buy uses the base strategy's last buy price instead.
+   */
+  seedEntryPrice: string | null;
 };
 
 const PROTECTED_STATE_KEY = 'protected';
@@ -102,8 +103,7 @@ const defaultProtectedState = (): ProtectedStrategyState => ({
   killedLimitPrice: null,
   killedOrderType: null,
   killedReason: null,
-  totalCostBasis: '0',
-  totalPositionSize: '0',
+  seedEntryPrice: null,
 });
 
 type ProtectedContainerState = {[PROTECTED_STATE_KEY]: ProtectedStrategyState};
@@ -117,7 +117,7 @@ type ProtectedContainerState = {[PROTECTED_STATE_KEY]: ProtectedStrategyState};
  *
  * Kill-switch orders can be configured as either `limit` (default) or `market` per
  * direction via `stopLossOrder` / `takeProfitOrder`. For `limit` orders, the advice
- * uses the nominal threshold price (for example, `avgEntry * (1 ± threshold/100)`
+ * uses the nominal threshold price (for example, `entry * (1 ± threshold/100)`
  * for percentage-based guards) rather than the current market price — the kill
  * switch exits at exactly the configured percentage regardless of how far the
  * market has already moved, at the cost of possibly not filling in a gap scenario.
@@ -125,12 +125,11 @@ type ProtectedContainerState = {[PROTECTED_STATE_KEY]: ProtectedStrategyState};
  * whatever the prevailing market offers at the firing candle — guaranteed fill,
  * unpredictable price.
  *
- * Position tracking uses cost-basis averaging from `onFill` events, so it handles
- * multiple buys and partial sells correctly. Once a guard fires, the subclass is
- * never called again for this session; the strategy keeps emitting the same
- * sell-all advice (limit with the stored target price, or market) on every candle
- * until `onFill` confirms the position is fully exited — so a rejected or delayed
- * placement is automatically retried.
+ * Guards measure from the strategy's last buy price (tracked by the base `Strategy`) and
+ * the live base balance, so there is no position bookkeeping of its own. Once a guard fires,
+ * the subclass is never called again for this session; the strategy keeps emitting the same
+ * sell-all advice (limit with the stored target price, or market) on every candle until the
+ * position is fully sold — so a rejected or delayed placement is automatically retried.
  *
  * Usage:
  *
@@ -235,11 +234,10 @@ export class ProtectedStrategy extends Strategy {
   }
 
   /**
-   * Once a guard has fired, the subclass is never called again. If the position
-   * is still non-zero (the sell order was rejected or hasn't filled yet), this
-   * keeps re-emitting the kill-switch advice (limit at the stored target price
-   * or a market sell, depending on the configured order type) until `onFill`
-   * brings the position to zero. Only then does `onCandle` return `void`.
+   * Once a guard has fired, the subclass is never called again. While a sellable position
+   * remains (the sell order was rejected or hasn't filled yet), this keeps re-emitting the
+   * kill-switch advice (limit at the stored target price or a market sell, depending on the
+   * configured order type). Only once the position is gone does it return `void`.
    */
   protected override async decideAdvice(
     candle: OneMinuteBatchedCandle,
@@ -248,8 +246,7 @@ export class ProtectedStrategy extends Strategy {
     const protectedState = this.#protectedState;
     if (protectedState.killed) {
       // Kill switch active: re-emit the exit until the position is gone, then stay silent.
-      const positionSize = new Big(protectedState.totalPositionSize);
-      if (positionSize.gt(0) && protectedState.killedOrderType) {
+      if (this.hasSellablePosition(state) && protectedState.killedOrderType) {
         const limitPrice = protectedState.killedLimitPrice ? new Big(protectedState.killedLimitPrice) : null;
         return this.#killSwitchAdvice(
           protectedState.killedReason ?? 'kill switch',
@@ -271,30 +268,29 @@ export class ProtectedStrategy extends Strategy {
       return;
     }
 
-    let positionSize = new Big(this.#protectedState.totalPositionSize);
-
-    if (positionSize.lte(0) && this.#seedFromBalance && state.baseBalance.gt(0)) {
-      const seedSize = state.baseBalance;
-      const seedCost = candle.close.mul(seedSize);
-      this.#setProtectedState({
-        totalCostBasis: seedCost.toFixed(),
-        totalPositionSize: seedSize.toFixed(),
-      });
-      positionSize = seedSize;
+    // Attach guards to an externally-opened position (no buy of our own) once, if configured.
+    if (
+      this.#seedFromBalance &&
+      !this.lastBuyPrice &&
+      this.#protectedState.seedEntryPrice === null &&
+      state.baseBalance.gt(0)
+    ) {
+      this.#setProtectedState({seedEntryPrice: candle.close.toFixed()});
     }
 
-    if (positionSize.lte(0)) {
+    const entryPrice = this.#entryPrice;
+    if (!entryPrice || !this.hasSellablePosition(state)) {
       return;
     }
 
-    const avgEntry = new Big(this.#protectedState.totalCostBasis).div(positionSize);
+    const positionSize = state.baseBalance;
     const currentPrice = candle.close;
 
     if (this.#stopLoss) {
-      const targetPrice = this.#resolveStopLossLimit(avgEntry, positionSize);
+      const targetPrice = this.#resolveStopLossLimit(entryPrice, positionSize);
       if (currentPrice.lte(targetPrice)) {
         const orderType = this.#stopLossOrder;
-        const reason = this.#stopLossReason(avgEntry, currentPrice, positionSize, targetPrice, orderType);
+        const reason = this.#stopLossReason(entryPrice, currentPrice, positionSize, targetPrice, orderType);
         this.#setProtectedState({
           killed: true,
           killedLimitPrice: orderType === 'limit' ? targetPrice.toFixed() : null,
@@ -306,10 +302,10 @@ export class ProtectedStrategy extends Strategy {
     }
 
     if (this.#takeProfit) {
-      const targetPrice = this.#resolveTakeProfitLimit(avgEntry, positionSize);
+      const targetPrice = this.#resolveTakeProfitLimit(entryPrice, positionSize);
       if (currentPrice.gte(targetPrice)) {
         const orderType = this.#takeProfitOrder;
-        const reason = this.#takeProfitReason(avgEntry, currentPrice, positionSize, targetPrice, orderType);
+        const reason = this.#takeProfitReason(entryPrice, currentPrice, positionSize, targetPrice, orderType);
         this.#setProtectedState({
           killed: true,
           killedLimitPrice: orderType === 'limit' ? targetPrice.toFixed() : null,
@@ -321,46 +317,56 @@ export class ProtectedStrategy extends Strategy {
     }
   }
 
-  #resolveStopLossLimit(avgEntry: Big, positionSize: Big): Big {
+  /** Entry the guards measure against: the base strategy's last buy, or a seeded price for an external position. */
+  get #entryPrice(): Big | undefined {
+    const lastBuy = this.lastBuyPrice;
+    if (lastBuy) {
+      return lastBuy;
+    }
+    const seeded = this.#protectedState.seedEntryPrice;
+    return seeded === null ? undefined : new Big(seeded);
+  }
+
+  #resolveStopLossLimit(entryPrice: Big, positionSize: Big): Big {
     if (!this.#stopLoss) {
       throw new Error('unreachable: stop-loss is not configured');
     }
     switch (this.#stopLoss.kind) {
       case 'pct':
-        return avgEntry.mul(new Big(1).minus(this.#stopLoss.pct.div(100)));
+        return entryPrice.mul(new Big(1).minus(this.#stopLoss.pct.div(100)));
       case 'nominal':
-        return avgEntry.minus(this.#stopLoss.nominal.div(positionSize));
+        return entryPrice.minus(this.#stopLoss.nominal.div(positionSize));
       case 'price':
         return this.#stopLoss.price;
     }
   }
 
-  #resolveTakeProfitLimit(avgEntry: Big, positionSize: Big): Big {
+  #resolveTakeProfitLimit(entryPrice: Big, positionSize: Big): Big {
     if (!this.#takeProfit) {
       throw new Error('unreachable: take-profit is not configured');
     }
     switch (this.#takeProfit.kind) {
       case 'pct':
-        return avgEntry.mul(new Big(1).plus(this.#takeProfit.pct.div(100)));
+        return entryPrice.mul(new Big(1).plus(this.#takeProfit.pct.div(100)));
       case 'nominal':
-        return avgEntry.plus(this.#takeProfit.nominal.div(positionSize));
+        return entryPrice.plus(this.#takeProfit.nominal.div(positionSize));
       case 'price':
         return this.#takeProfit.price;
     }
   }
 
-  #stopLossReason(avgEntry: Big, currentPrice: Big, positionSize: Big, targetPrice: Big, orderType: GuardOrderType) {
+  #stopLossReason(entryPrice: Big, currentPrice: Big, positionSize: Big, targetPrice: Big, orderType: GuardOrderType) {
     if (!this.#stopLoss) {
       return '';
     }
     const orderSuffix = orderType === 'limit' ? `(limit ${targetPrice.toFixed()})` : '(market)';
     switch (this.#stopLoss.kind) {
       case 'pct': {
-        const pctChange = currentPrice.minus(avgEntry).div(avgEntry).mul(100);
+        const pctChange = currentPrice.minus(entryPrice).div(entryPrice).mul(100);
         return `Stop-loss: ${pctChange.toFixed(2)}% <= -${this.#stopLoss.pct.toFixed(2)}% ${orderSuffix}`;
       }
       case 'nominal': {
-        const unrealized = currentPrice.minus(avgEntry).mul(positionSize);
+        const unrealized = currentPrice.minus(entryPrice).mul(positionSize);
         return `Stop-loss: unrealized ${unrealized.toFixed(2)} <= -${this.#stopLoss.nominal.toFixed(2)} ${orderSuffix}`;
       }
       case 'price':
@@ -368,58 +374,29 @@ export class ProtectedStrategy extends Strategy {
     }
   }
 
-  #takeProfitReason(avgEntry: Big, currentPrice: Big, positionSize: Big, targetPrice: Big, orderType: GuardOrderType) {
+  #takeProfitReason(
+    entryPrice: Big,
+    currentPrice: Big,
+    positionSize: Big,
+    targetPrice: Big,
+    orderType: GuardOrderType
+  ) {
     if (!this.#takeProfit) {
       return '';
     }
     const orderSuffix = orderType === 'limit' ? `(limit ${targetPrice.toFixed()})` : '(market)';
     switch (this.#takeProfit.kind) {
       case 'pct': {
-        const pctChange = currentPrice.minus(avgEntry).div(avgEntry).mul(100);
+        const pctChange = currentPrice.minus(entryPrice).div(entryPrice).mul(100);
         return `Take-profit: +${pctChange.toFixed(2)}% >= +${this.#takeProfit.pct.toFixed(2)}% ${orderSuffix}`;
       }
       case 'nominal': {
-        const unrealized = currentPrice.minus(avgEntry).mul(positionSize);
+        const unrealized = currentPrice.minus(entryPrice).mul(positionSize);
         return `Take-profit: unrealized +${unrealized.toFixed(2)} >= +${this.#takeProfit.nominal.toFixed(2)} ${orderSuffix}`;
       }
       case 'price':
         return `Take-profit: price ${currentPrice.toFixed()} >= target ${this.#takeProfit.price.toFixed()} ${orderSuffix}`;
     }
-  }
-
-  protected override async processFill(fill: Fill, _state: TradingSessionState): Promise<void> {
-    const protectedState = this.#protectedState;
-    const fillPrice = new Big(fill.price);
-    const fillSize = new Big(fill.size);
-
-    if (fill.side === OrderSide.BUY) {
-      const newCostBasis = new Big(protectedState.totalCostBasis).plus(fillPrice.mul(fillSize));
-      const newPositionSize = new Big(protectedState.totalPositionSize).plus(fillSize);
-      this.#setProtectedState({
-        totalCostBasis: newCostBasis.toFixed(),
-        totalPositionSize: newPositionSize.toFixed(),
-      });
-      return;
-    }
-
-    // SELL: reduce position proportionally using the current average entry price.
-    const currentPositionSize = new Big(protectedState.totalPositionSize);
-    if (currentPositionSize.lte(0)) {
-      return;
-    }
-
-    const avgEntry = new Big(protectedState.totalCostBasis).div(currentPositionSize);
-    const newPositionSize = currentPositionSize.minus(fillSize);
-
-    if (newPositionSize.lte(0)) {
-      this.#setProtectedState({totalCostBasis: '0', totalPositionSize: '0'});
-      return;
-    }
-
-    this.#setProtectedState({
-      totalCostBasis: avgEntry.mul(newPositionSize).toFixed(),
-      totalPositionSize: newPositionSize.toFixed(),
-    });
   }
 
   /**
@@ -470,18 +447,17 @@ export class ProtectedStrategy extends Strategy {
  * Validates that a persisted object is a well-formed `ProtectedStrategyState`.
  *
  * Beyond shape checks, this also enforces cross-field invariants that
- * `restoreState` relies on to produce a safe runtime state:
+ * `hydrateState` relies on to produce a safe runtime state:
  *
- * - If `killed === true`, `killedOrderType` must be set so the retry path in
- *   `onCandle` can re-emit the correct advice kind. A `killed=true` state with
+ * - If `killed === true`, `killedOrderType` must be set so the retry path can
+ *   re-emit the correct advice kind. A `killed=true` state with
  *   `killedOrderType=null` would leave an open position with no further exit.
  * - If `killedOrderType === 'limit'`, `killedLimitPrice` must be set so the
  *   retry can re-build the limit advice.
- * - Numeric string fields (`totalCostBasis`, `totalPositionSize`,
- *   `killedLimitPrice`) must be parseable by `Big` — otherwise the next
- *   `onCandle` would throw inside `new Big(...)`.
+ * - Numeric string fields (`killedLimitPrice`, `seedEntryPrice`) must be
+ *   parseable by `Big` — otherwise the next candle would throw inside `new Big(...)`.
  *
- * Returning `false` from here causes `restoreState` to fall back to the
+ * Returning `false` from here causes `hydrateState` to fall back to the
  * default state, re-arming the guards on the next candle.
  */
 function isProtectedStrategyState(value: unknown): value is ProtectedStrategyState {
@@ -506,19 +482,19 @@ function isProtectedStrategyState(value: unknown): value is ProtectedStrategySta
   if (candidate.killedLimitPrice !== null && typeof candidate.killedLimitPrice !== 'string') {
     return false;
   }
-  if (typeof candidate.totalCostBasis !== 'string' || !isValidBigString(candidate.totalCostBasis)) {
-    return false;
-  }
-  if (typeof candidate.totalPositionSize !== 'string' || !isValidBigString(candidate.totalPositionSize)) {
-    return false;
-  }
   if (typeof candidate.killedLimitPrice === 'string' && !isValidBigString(candidate.killedLimitPrice)) {
+    return false;
+  }
+  if (
+    candidate.seedEntryPrice !== null &&
+    (typeof candidate.seedEntryPrice !== 'string' || !isValidBigString(candidate.seedEntryPrice))
+  ) {
     return false;
   }
 
   /*
    * Cross-field invariants: a killed state must be fully specified so that
-   * the retry path in onCandle has everything it needs to build fresh advice.
+   * the retry path has everything it needs to build fresh advice.
    */
   if (candidate.killed === true) {
     if (candidate.killedOrderType === null) {

--- a/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.ts
+++ b/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.ts
@@ -390,8 +390,7 @@ export class ProtectedStrategy extends Strategy {
     }
   }
 
-  override async onFill(fill: Fill, state: TradingSessionState): Promise<void> {
-    await super.onFill(fill, state);
+  protected override async processFill(fill: Fill, _state: TradingSessionState): Promise<void> {
     const protectedState = this.#protectedState;
     const fillPrice = new Big(fill.price);
     const fillSize = new Big(fill.size);

--- a/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.ts
+++ b/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.ts
@@ -390,7 +390,8 @@ export class ProtectedStrategy extends Strategy {
     }
   }
 
-  async onFill(fill: Fill, _state: TradingSessionState): Promise<void> {
+  override async onFill(fill: Fill, state: TradingSessionState): Promise<void> {
+    await super.onFill(fill, state);
     const protectedState = this.#protectedState;
     const fillPrice = new Big(fill.price);
     const fillSize = new Big(fill.size);

--- a/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.ts
+++ b/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.ts
@@ -241,29 +241,26 @@ export class ProtectedStrategy extends Strategy {
    * or a market sell, depending on the configured order type) until `onFill`
    * brings the position to zero. Only then does `onCandle` return `void`.
    */
-  override async onCandle(candle: OneMinuteBatchedCandle, state: TradingSessionState): Promise<OrderAdvice | void> {
-    this.lastBatchedCandle = candle;
-
+  protected override async decideAdvice(
+    candle: OneMinuteBatchedCandle,
+    state: TradingSessionState
+  ): Promise<OrderAdvice | void> {
     const protectedState = this.#protectedState;
     if (protectedState.killed) {
+      // Kill switch active: re-emit the exit until the position is gone, then stay silent.
       const positionSize = new Big(protectedState.totalPositionSize);
       if (positionSize.gt(0) && protectedState.killedOrderType) {
         const limitPrice = protectedState.killedLimitPrice ? new Big(protectedState.killedLimitPrice) : null;
-        const advice = this.#killSwitchAdvice(
+        return this.#killSwitchAdvice(
           protectedState.killedReason ?? 'kill switch',
           protectedState.killedOrderType,
           limitPrice
         );
-        this.latestAdvice = advice;
-        return advice;
       }
-      this.latestAdvice = undefined;
       return;
     }
 
-    const advice = await this.processCandle(candle, state);
-    this.latestAdvice = advice ? advice : undefined;
-    return advice;
+    return super.decideAdvice(candle, state);
   }
 
   protected override async processCandle(
@@ -436,22 +433,11 @@ export class ProtectedStrategy extends Strategy {
     }
   }
 
-  override restoreState(persisted: Record<string, unknown>): void {
+  protected override hydrateState(persisted: Record<string, unknown>): void {
     const existing = persisted[PROTECTED_STATE_KEY];
     const restoredProtected: ProtectedStrategyState = isProtectedStrategyState(existing)
       ? existing
       : defaultProtectedState();
-
-    super.restoreState({
-      ...persisted,
-      [PROTECTED_STATE_KEY]: restoredProtected,
-    });
-
-    /*
-     * The base class only updates `#_state`; the proxied state still points at
-     * the original object from the constructor. Reassigning `protected` through
-     * the proxy propagates restored values into the proxied state.
-     */
     this.#setProtectedState(restoredProtected);
   }
 

--- a/packages/trading-strategies/src/strategy-protected/README.md
+++ b/packages/trading-strategies/src/strategy-protected/README.md
@@ -8,7 +8,7 @@ An abstract base class that adds composable **kill-switch** behaviour (stop-loss
 
 | Phase | Action |
 | --- | --- |
-| **active** | Tracks position cost basis via `onFill`. On each candle, checks whether any configured guard has tripped. |
+| **active** | Tracks position cost basis via `processFill`. On each candle, checks whether any configured guard has tripped. |
 | **tripped** | A guard has fired. Emits a `SELL` advice — `LIMIT` at the nominal target price or `MARKET`, depending on `stopLossOrder` / `takeProfitOrder`. The subclass is not called. |
 | **retrying** | Still tripped, position not yet fully exited. Keeps re-emitting the same advice on every candle until `onFill` clears it. |
 | **closed** | Position fully exited via `onFill`. `onCandle` returns `void` for the rest of the session. Truly terminal. |
@@ -80,9 +80,7 @@ export class MyStrategy extends ProtectedStrategy {
   constructor(config: MyStrategyConfig) {
     super({
       config,
-      state: {
-        /* subclass-specific fields */
-      },
+      state: {/* subclass-specific fields */},
     });
   }
 
@@ -97,7 +95,7 @@ export class MyStrategy extends ProtectedStrategy {
 }
 ```
 
-`onFill` is inherited and handles position tracking automatically. If a subclass overrides `onFill` for its own state machine (e.g. `ScalpStrategy`), it must call `super.onFill(fill, state)` first so cost-basis tracking stays in sync.
+Cost-basis tracking runs in `processFill`, the hook the base `Strategy` calls on every fill (after it records the last buy/sell price). A subclass that needs its own fill handling (e.g. `ScalpStrategy`) overrides `processFill` and calls `super.processFill(fill, state)` first so cost-basis tracking stays in sync.
 
 ## Position tracking
 

--- a/packages/trading-strategies/src/strategy-scalp/ScalpStrategy.ts
+++ b/packages/trading-strategies/src/strategy-scalp/ScalpStrategy.ts
@@ -144,9 +144,8 @@ export class ScalpStrategy extends ProtectedStrategy {
     this.#state.phase = 'pendingAdvice';
   }
 
-  override restoreState(persisted: Record<string, unknown>): void {
-    super.restoreState(persisted);
-
+  protected override hydrateState(persisted: Record<string, unknown>): void {
+    super.hydrateState(persisted);
     if (typeof persisted.lastFillPrice === 'string') {
       this.#state.lastFillPrice = persisted.lastFillPrice;
     }

--- a/packages/trading-strategies/src/strategy-scalp/ScalpStrategy.ts
+++ b/packages/trading-strategies/src/strategy-scalp/ScalpStrategy.ts
@@ -137,8 +137,8 @@ export class ScalpStrategy extends ProtectedStrategy {
     return er.getResultOrThrow() < ScalpStrategy.ER_THRESHOLD;
   }
 
-  override async onFill(fill: Fill, state: TradingSessionState): Promise<void> {
-    await super.onFill(fill, state);
+  protected override async processFill(fill: Fill, state: TradingSessionState): Promise<void> {
+    await super.processFill(fill, state);
     this.#state.lastFillPrice = fill.price;
     this.#state.lastFillSide = fill.side;
     this.#state.phase = 'pendingAdvice';

--- a/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.ts
+++ b/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.ts
@@ -249,7 +249,8 @@ export class TrailingStopStrategy extends Strategy {
     return advice;
   }
 
-  async onFill(fill: Fill, state: TradingSessionState): Promise<void> {
+  override async onFill(fill: Fill, state: TradingSessionState): Promise<void> {
+    await super.onFill(fill, state);
     if (fill.side !== OrderSide.SELL) {
       return;
     }

--- a/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.ts
+++ b/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.ts
@@ -270,9 +270,8 @@ export class TrailingStopStrategy extends Strategy {
     }
   }
 
-  override restoreState(persisted: Record<string, unknown>): void {
+  protected override hydrateState(persisted: Record<string, unknown>): void {
     const validated: TrailingStopState = isTrailingStopState(persisted) ? persisted : defaultState();
-    super.restoreState(validated);
     const restored = this.#state;
     restored.exited = validated.exited;
     restored.peakPrice = validated.peakPrice;

--- a/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.ts
+++ b/packages/trading-strategies/src/strategy-trailing-stop/TrailingStopStrategy.ts
@@ -249,8 +249,7 @@ export class TrailingStopStrategy extends Strategy {
     return advice;
   }
 
-  override async onFill(fill: Fill, state: TradingSessionState): Promise<void> {
-    await super.onFill(fill, state);
+  protected override async processFill(fill: Fill, state: TradingSessionState): Promise<void> {
     if (fill.side !== OrderSide.SELL) {
       return;
     }

--- a/packages/trading-strategies/src/strategy/Strategy.test.ts
+++ b/packages/trading-strategies/src/strategy/Strategy.test.ts
@@ -1,0 +1,78 @@
+import Big from 'big.js';
+import {describe, expect, it} from 'vitest';
+import {OrderPosition, OrderSide, OrderType, TradingPair} from '@typedtrader/exchange';
+import type {Fill, OneMinuteBatchedCandle} from '@typedtrader/exchange';
+import type {OrderAdvice, TradingSessionState} from '../trader/index.js';
+import {Strategy} from './Strategy.js';
+
+const pair = new TradingPair('AAPL', 'USD');
+
+const mockState: TradingSessionState = {
+  baseBalance: new Big(0),
+  counterBalance: new Big(1000),
+  feeRates: {[OrderType.LIMIT]: new Big('0.001'), [OrderType.MARKET]: new Big('0.002')},
+  tradingRules: {
+    base_increment: '0.0001',
+    base_max_size: '100000',
+    base_min_size: '0.0001',
+    counter_increment: '0.01',
+    counter_min_size: '1',
+    pair,
+  },
+};
+
+function makeFill(price: string, size: string, side: OrderSide): Fill {
+  return {
+    created_at: '2025-01-01T00:00:00.000Z',
+    fee: '0',
+    feeAsset: 'USD',
+    order_id: 'order-1',
+    pair,
+    position: OrderPosition.LONG,
+    price,
+    side,
+    size,
+  };
+}
+
+/** Minimal concrete strategy that never trades — exercises only the base position tracking. */
+class TestStrategy extends Strategy {
+  static override NAME = 'test-strategy';
+
+  protected override async processCandle(
+    _candle: OneMinuteBatchedCandle,
+    _state: TradingSessionState
+  ): Promise<OrderAdvice | void> {
+    // Never trades; only the inherited position tracking is under test.
+  }
+}
+
+describe('Strategy fill tracking', () => {
+  it('starts with no recorded fills', () => {
+    const strategy = new TestStrategy();
+    expect(strategy.lastBuyPrice).toBeUndefined();
+    expect(strategy.lastSellPrice).toBeUndefined();
+  });
+
+  it('records the most recent buy price', async () => {
+    const strategy = new TestStrategy();
+    await strategy.onFill(makeFill('100', '1', OrderSide.BUY), mockState);
+    await strategy.onFill(makeFill('120', '1', OrderSide.BUY), mockState);
+    expect(strategy.lastBuyPrice?.toNumber()).toBe(120); // latest buy wins
+    expect(strategy.lastSellPrice).toBeUndefined();
+  });
+
+  it('records the most recent sell price without clearing the last buy', async () => {
+    const strategy = new TestStrategy();
+    await strategy.onFill(makeFill('100', '1', OrderSide.BUY), mockState);
+    await strategy.onFill(makeFill('130', '1', OrderSide.SELL), mockState);
+    expect(strategy.lastBuyPrice?.toNumber()).toBe(100);
+    expect(strategy.lastSellPrice?.toNumber()).toBe(130);
+  });
+
+  it('persists the last fills under the strategy state so the runtime can save it', async () => {
+    const strategy = new TestStrategy();
+    await strategy.onFill(makeFill('100', '1', OrderSide.BUY), mockState);
+    expect(strategy.state).toMatchObject({__lastFills__: {lastBuyPrice: '100', lastSellPrice: null}});
+  });
+});

--- a/packages/trading-strategies/src/strategy/Strategy.test.ts
+++ b/packages/trading-strategies/src/strategy/Strategy.test.ts
@@ -43,7 +43,16 @@ class TestStrategy extends Strategy {
     _candle: OneMinuteBatchedCandle,
     _state: TradingSessionState
   ): Promise<OrderAdvice | void> {
-    // Never trades; only the inherited position tracking is under test.
+    // Never trades; only the inherited fill tracking is under test.
+  }
+}
+
+/** Overrides the fill hook to prove the base still tracks prices without any `super` call. */
+class FillHookStrategy extends TestStrategy {
+  fillCount = 0;
+
+  protected override async processFill(): Promise<void> {
+    this.fillCount++;
   }
 }
 
@@ -73,6 +82,13 @@ describe('Strategy fill tracking', () => {
   it('persists the last fills under the strategy state so the runtime can save it', async () => {
     const strategy = new TestStrategy();
     await strategy.onFill(makeFill('100', '1', OrderSide.BUY), mockState);
-    expect(strategy.state).toMatchObject({__lastFills__: {lastBuyPrice: '100', lastSellPrice: null}});
+    expect(strategy.state).toMatchObject({strategyLastFills: {lastBuyPrice: '100', lastSellPrice: null}});
+  });
+
+  it('still tracks prices when a subclass overrides the fill hook (no super call needed)', async () => {
+    const strategy = new FillHookStrategy();
+    await strategy.onFill(makeFill('100', '1', OrderSide.BUY), mockState);
+    expect(strategy.fillCount).toBe(1); // the subclass hook ran
+    expect(strategy.lastBuyPrice?.toNumber()).toBe(100); // and the base tracked the price on its own
   });
 });

--- a/packages/trading-strategies/src/strategy/Strategy.test.ts
+++ b/packages/trading-strategies/src/strategy/Strategy.test.ts
@@ -56,6 +56,15 @@ class FillHookStrategy extends TestStrategy {
   }
 }
 
+/** Overrides the restore hook to prove the base stores state without a `super.restoreState()` call. */
+class RestoreHookStrategy extends TestStrategy {
+  hydrated: Record<string, unknown> | undefined = undefined;
+
+  protected override hydrateState(persisted: Record<string, unknown>): void {
+    this.hydrated = persisted;
+  }
+}
+
 describe('Strategy fill tracking', () => {
   it('starts with no recorded fills', () => {
     const strategy = new TestStrategy();
@@ -90,5 +99,12 @@ describe('Strategy fill tracking', () => {
     await strategy.onFill(makeFill('100', '1', OrderSide.BUY), mockState);
     expect(strategy.fillCount).toBe(1); // the subclass hook ran
     expect(strategy.lastBuyPrice?.toNumber()).toBe(100); // and the base tracked the price on its own
+  });
+
+  it('stores state and calls the hydrateState hook on restore (no super call needed)', () => {
+    const strategy = new RestoreHookStrategy();
+    strategy.restoreState({foo: 'bar'});
+    expect(strategy.state).toMatchObject({foo: 'bar'}); // the base stored the snapshot
+    expect(strategy.hydrated).toEqual({foo: 'bar'}); // the subclass hook ran without chaining super
   });
 });

--- a/packages/trading-strategies/src/strategy/Strategy.ts
+++ b/packages/trading-strategies/src/strategy/Strategy.ts
@@ -93,14 +93,30 @@ export abstract class Strategy implements TradingSessionStrategy {
 
   async onCandle(candle: OneMinuteBatchedCandle, state: TradingSessionState): Promise<OrderAdvice | void> {
     this.lastBatchedCandle = candle;
-    const advice = await this.processCandle(candle, state);
+    const advice = await this.decideAdvice(candle, state);
     this.latestAdvice = advice ? advice : undefined;
     return advice;
   }
 
+  /**
+   * Turns a candle into advice. Defaults to `processCandle`. A base that needs to gate candle
+   * handling (like ProtectedStrategy while a kill switch is active) overrides this instead of
+   * `onCandle`, so the candle and advice bookkeeping above is never duplicated or forgotten.
+   */
+  protected async decideAdvice(
+    candle: OneMinuteBatchedCandle,
+    state: TradingSessionState
+  ): Promise<OrderAdvice | void> {
+    return this.processCandle(candle, state);
+  }
+
   restoreState(persisted: Record<string, unknown>): void {
     this.#_state = persisted;
+    this.hydrateState(persisted);
   }
+
+  /** Override to copy persisted fields into the live state on restore. The base has already stored the snapshot. */
+  protected hydrateState(_persisted: Record<string, unknown>): void {}
 
   /**
    * Remembers the last buy and sell price, then lets subclasses react by overriding

--- a/packages/trading-strategies/src/strategy/Strategy.ts
+++ b/packages/trading-strategies/src/strategy/Strategy.ts
@@ -4,13 +4,10 @@ import type {Fill, OneMinuteBatchedCandle} from '@typedtrader/exchange';
 import type {OrderAdvice, TradingSessionState, TradingSessionStrategy} from '../trader/index.js';
 import type {MarketType} from './MarketType.js';
 
-const LAST_FILLS_STATE_KEY = '__lastFills__';
+const LAST_FILLS_STATE_KEY = 'strategyLastFills';
 
-/** Most recent fill price per side, persisted alongside the strategy's own state under a reserved key. */
 type LastFills = {
-  /** Price of the most recent BUY fill, as a Big string. `null` until the first buy. */
   lastBuyPrice: string | null;
-  /** Price of the most recent SELL fill, as a Big string. `null` until the first sell. */
   lastSellPrice: string | null;
 };
 
@@ -73,9 +70,8 @@ export abstract class Strategy implements TradingSessionStrategy {
 
   constructor(options?: {state?: Record<string, unknown>; config?: Record<string, unknown>}) {
     /*
-     * The base always keeps a state object so it can track the open position from fills,
-     * even for strategies that don't declare any state of their own. A restored position
-     * (present in the provided state) is preserved rather than reset.
+     * The base always keeps a state object so it can remember the last buy and sell price,
+     * even for strategies that declare no state of their own. A restored value is kept as-is.
      */
     const providedState = options?.state ?? {};
     const initialState: Record<string, unknown> = {
@@ -107,24 +103,25 @@ export abstract class Strategy implements TradingSessionStrategy {
   }
 
   /**
-   * Records the most recent BUY / SELL fill price, exposed as {@link lastBuyPrice} /
-   * {@link lastSellPrice}, so a strategy can measure an exit against its entry without
-   * bookkeeping of its own. Subclasses that override `onFill` MUST call
-   * `super.onFill(fill, state)` to keep this accurate.
+   * Remembers the last buy and sell price, then lets subclasses react by overriding
+   * `processFill`. Because the tracking lives here and `processFill` is the extension point,
+   * a subclass can never forget to keep the last prices up to date.
    */
-  async onFill(fill: Fill, _state: TradingSessionState): Promise<void> {
+  async onFill(fill: Fill, state: TradingSessionState): Promise<void> {
     const patch: Partial<LastFills> =
       fill.side === OrderSide.BUY ? {lastBuyPrice: fill.price} : {lastSellPrice: fill.price};
     this.#setLastFills(patch);
+    await this.processFill(fill, state);
   }
 
-  /** Price of the most recent BUY fill, or `undefined` if there hasn't been one. */
+  /** Override to react to a fill. The last buy and sell price are already recorded by the time this runs. */
+  protected async processFill(_fill: Fill, _state: TradingSessionState): Promise<void> {}
+
   get lastBuyPrice(): Big | undefined {
     const price = this.#lastFills.lastBuyPrice;
     return price === null ? undefined : new Big(price);
   }
 
-  /** Price of the most recent SELL fill, or `undefined` if there hasn't been one. */
   get lastSellPrice(): Big | undefined {
     const price = this.#lastFills.lastSellPrice;
     return price === null ? undefined : new Big(price);
@@ -135,10 +132,7 @@ export abstract class Strategy implements TradingSessionStrategy {
   }
 
   #setLastFills(patch: Partial<LastFills>): void {
-    /*
-     * Reassigning the reserved top-level key trips the state Proxy's set trap, which fires
-     * `onSave` so the runtime persists it (nested mutations would bypass persistence).
-     */
+    // Replace the whole key so the state Proxy notices the change and saves it.
     const proxied = this.getProxiedState<LastFillsContainer>();
     proxied[LAST_FILLS_STATE_KEY] = {...proxied[LAST_FILLS_STATE_KEY], ...patch};
   }

--- a/packages/trading-strategies/src/strategy/Strategy.ts
+++ b/packages/trading-strategies/src/strategy/Strategy.ts
@@ -1,7 +1,22 @@
 import Big from 'big.js';
-import type {OneMinuteBatchedCandle} from '@typedtrader/exchange';
+import {OrderSide} from '@typedtrader/exchange';
+import type {Fill, OneMinuteBatchedCandle} from '@typedtrader/exchange';
 import type {OrderAdvice, TradingSessionState, TradingSessionStrategy} from '../trader/index.js';
 import type {MarketType} from './MarketType.js';
+
+const LAST_FILLS_STATE_KEY = '__lastFills__';
+
+/** Most recent fill price per side, persisted alongside the strategy's own state under a reserved key. */
+type LastFills = {
+  /** Price of the most recent BUY fill, as a Big string. `null` until the first buy. */
+  lastBuyPrice: string | null;
+  /** Price of the most recent SELL fill, as a Big string. `null` until the first sell. */
+  lastSellPrice: string | null;
+};
+
+type LastFillsContainer = {[LAST_FILLS_STATE_KEY]: LastFills};
+
+const defaultLastFills = (): LastFills => ({lastBuyPrice: null, lastSellPrice: null});
 
 export abstract class Strategy implements TradingSessionStrategy {
   static NAME: string;
@@ -57,12 +72,21 @@ export abstract class Strategy implements TradingSessionStrategy {
   readonly #proxiedConfig: Record<string, unknown> | null = null;
 
   constructor(options?: {state?: Record<string, unknown>; config?: Record<string, unknown>}) {
-    if (options?.state) {
-      this.#proxiedState = this.#createProxy(options.state, snapshot => {
-        this.state = snapshot;
-      });
-      this.state = {...options.state};
-    }
+    /*
+     * The base always keeps a state object so it can track the open position from fills,
+     * even for strategies that don't declare any state of their own. A restored position
+     * (present in the provided state) is preserved rather than reset.
+     */
+    const providedState = options?.state ?? {};
+    const initialState: Record<string, unknown> = {
+      ...providedState,
+      [LAST_FILLS_STATE_KEY]: providedState[LAST_FILLS_STATE_KEY] ?? defaultLastFills(),
+    };
+    this.#proxiedState = this.#createProxy(initialState, snapshot => {
+      this.state = snapshot;
+    });
+    this.state = {...initialState};
+
     if (options?.config) {
       this.#proxiedConfig = this.#createProxy(options.config, snapshot => {
         this.config = snapshot;
@@ -80,6 +104,43 @@ export abstract class Strategy implements TradingSessionStrategy {
 
   restoreState(persisted: Record<string, unknown>): void {
     this.#_state = persisted;
+  }
+
+  /**
+   * Records the most recent BUY / SELL fill price, exposed as {@link lastBuyPrice} /
+   * {@link lastSellPrice}, so a strategy can measure an exit against its entry without
+   * bookkeeping of its own. Subclasses that override `onFill` MUST call
+   * `super.onFill(fill, state)` to keep this accurate.
+   */
+  async onFill(fill: Fill, _state: TradingSessionState): Promise<void> {
+    const patch: Partial<LastFills> =
+      fill.side === OrderSide.BUY ? {lastBuyPrice: fill.price} : {lastSellPrice: fill.price};
+    this.#setLastFills(patch);
+  }
+
+  /** Price of the most recent BUY fill, or `undefined` if there hasn't been one. */
+  get lastBuyPrice(): Big | undefined {
+    const price = this.#lastFills.lastBuyPrice;
+    return price === null ? undefined : new Big(price);
+  }
+
+  /** Price of the most recent SELL fill, or `undefined` if there hasn't been one. */
+  get lastSellPrice(): Big | undefined {
+    const price = this.#lastFills.lastSellPrice;
+    return price === null ? undefined : new Big(price);
+  }
+
+  get #lastFills(): LastFills {
+    return this.getProxiedState<LastFillsContainer>()[LAST_FILLS_STATE_KEY];
+  }
+
+  #setLastFills(patch: Partial<LastFills>): void {
+    /*
+     * Reassigning the reserved top-level key trips the state Proxy's set trap, which fires
+     * `onSave` so the runtime persists it (nested mutations would bypass persistence).
+     */
+    const proxied = this.getProxiedState<LastFillsContainer>();
+    proxied[LAST_FILLS_STATE_KEY] = {...proxied[LAST_FILLS_STATE_KEY], ...patch};
   }
 
   /**

--- a/packages/trading-strategies/src/strategy/Strategy.ts
+++ b/packages/trading-strategies/src/strategy/Strategy.ts
@@ -112,6 +112,7 @@ export abstract class Strategy implements TradingSessionStrategy {
 
   restoreState(persisted: Record<string, unknown>): void {
     this.#_state = persisted;
+    this.#restoreLastFills(persisted);
     this.hydrateState(persisted);
   }
 
@@ -151,6 +152,18 @@ export abstract class Strategy implements TradingSessionStrategy {
     // Replace the whole key so the state Proxy notices the change and saves it.
     const proxied = this.getProxiedState<LastFillsContainer>();
     proxied[LAST_FILLS_STATE_KEY] = {...proxied[LAST_FILLS_STATE_KEY], ...patch};
+  }
+
+  #restoreLastFills(persisted: Record<string, unknown>): void {
+    const fills = persisted[LAST_FILLS_STATE_KEY];
+    if (!fills || typeof fills !== 'object') {
+      return;
+    }
+    const record = fills as Record<string, unknown>;
+    this.#setLastFills({
+      lastBuyPrice: typeof record.lastBuyPrice === 'string' ? record.lastBuyPrice : null,
+      lastSellPrice: typeof record.lastSellPrice === 'string' ? record.lastSellPrice : null,
+    });
   }
 
   /**

--- a/packages/trading-strategies/src/strategy/StrategyRegistry.ts
+++ b/packages/trading-strategies/src/strategy/StrategyRegistry.ts
@@ -6,6 +6,10 @@ import {
 } from '../strategy-buy-below-sell-above/BuyBelowSellAboveStrategy.js';
 import {CoinFlipStrategy, CoinFlipSchema} from '../strategy-coin-flip/CoinFlipStrategy.js';
 import {
+  FeeAwareSmaCrossoverStrategy,
+  FeeAwareSmaCrossoverSchema,
+} from '../strategy-fee-aware-sma-crossover/FeeAwareSmaCrossoverStrategy.js';
+import {
   MultiIndicatorConfluenceStrategy,
   MultiIndicatorConfluenceSchema,
 } from '../strategy-multi-indicator-confluence/MultiIndicatorConfluenceStrategy.js';
@@ -34,6 +38,10 @@ const registry: Record<string, StrategyEntry> = {
   [CoinFlipStrategy.NAME]: {
     create: (config: unknown) => new CoinFlipStrategy(CoinFlipSchema.parse(config ?? {})),
     schema: CoinFlipSchema,
+  },
+  [FeeAwareSmaCrossoverStrategy.NAME]: {
+    create: (config: unknown) => new FeeAwareSmaCrossoverStrategy(FeeAwareSmaCrossoverSchema.parse(config ?? {})),
+    schema: FeeAwareSmaCrossoverSchema,
   },
   [MeanReversionStrategy.NAME]: {
     create: (config: unknown) => new MeanReversionStrategy({config: MeanReversionSchema.parse(config ?? {})}),


### PR DESCRIPTION
## Why

The SMA crossover bleeds money on trading fees: it sells on every bearish cross, including round trips where the sell price barely differs from the buy price — a "win" on raw price that a maker+taker fee round trip quietly turns into a loss. There was no helper anywhere to check whether a sale actually nets a profit after fees.

## What

Four commits, bottom-up:

### 1. `feat(exchange)` — round-trip profit helper
`calculateRoundTripProfit({entryPrice, exitPrice, quantity, entryFeeRate, exitFeeRate})` → `{ netProfit, netProfitPercent, entryCost, exitProceeds, entryFee, exitFee, breakEvenPrice, isProfitable }`, plus `isProfitableAfterFees(...)`. Fee-inclusive on **both** legs; also reports the **break-even sell price**. Pure util in `@typedtrader/exchange`, 10 tests.

### 2. `feat(trading-strategies)` — `FeeAwareSmaCrossoverStrategy`
Extends `SmaCrossoverStrategy` and gates only the SELL: on a bearish cross it forwards the SELL only when the round trip nets a profit after the taker fee on both legs — otherwise it **holds**. Buys pass through unchanged. Registered + exported.

### 3. `feat(trading-signals-docs)` — backtest page
Adds **"SMA Crossover (Fee-Aware)"** to the backtest UI to compare head-to-head with the plain crossover.

### 4. `refactor(trading-strategies)` — position tracking on the base `Strategy`
Moves fill-driven position tracking into the root `Strategy`: a base `onFill` maintains `positionSize` and a cost-basis-averaged `averageEntryPrice`, persisted under a reserved state key. Any strategy can now measure an exit against its entry without its own bookkeeping.
- `FeeAwareSmaCrossoverStrategy` drops its own last-buy tracking and reads `averageEntryPrice` from the base (correct under partial fills, not just all-in/out).
- `ProtectedStrategy` and `TrailingStopStrategy` now `override onFill` with a `super.onFill()` call so base tracking stays accurate (they keep their own state too, for now — a later cleanup could collapse the duplication).
- Adds `Strategy.test.ts` covering buys, partial sells, full exit, and persistence.

## Trade-off (documented in the class)

Skipping unprofitable exits means it can **hold through a downtrend** rather than take a small loss. Pair with a stop-loss for a hard floor. This is a fee-bleed fix, not a risk-management change.

## Verification

`exchange`: 10 helper tests. `trading-strategies`: full suite **269** green (incl. new base tracking). Docs `tsc` clean. Lint clean across all packages.