### PR TITLE
feat(trading-signals-docs): add visual strategy builder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4360,6 +4360,55 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -4440,7 +4489,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -4873,6 +4922,48 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@xyflow/react": {
+      "version": "12.11.2",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.11.2.tgz",
+      "integrity": "sha512-eLAlDWJfWnQEhJwGMjlWdAXO9eYllKpliUmPQlAmOLxz6mExXuzMVDUKLMquixgkrtmMFFtug3jGKmYYld12cA==",
+      "license": "MIT",
+      "dependencies": {
+        "@xyflow/system": "0.0.79",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=17",
+        "@types/react-dom": ">=17",
+        "react": ">=17",
+        "react-dom": ">=17"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.79",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.79.tgz",
+      "integrity": "sha512-czLyOh91NF0hIzbNzwi8I6GlqG23BHh2435OddfI6uiaLH3xdrdygO93gqgH1Bv9mhy8XPFQJOBn1FTq4LvEWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
       }
     },
     "node_modules/@yarnpkg/lockfile": {
@@ -5667,6 +5758,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
+    },
     "node_modules/clean-stack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -6124,6 +6221,111 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/dargs": {
       "version": "7.0.0",
@@ -13732,6 +13934,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -14260,6 +14471,34 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
     "packages/candles": {
       "name": "@typedtrader/candles",
       "version": "0.1.0",
@@ -14342,6 +14581,7 @@
         "@testing-library/dom": "^10.4.1",
         "@typedtrader/candles": "0.1.0",
         "@typedtrader/exchange": "0.2.5",
+        "@xyflow/react": "^12.11.2",
         "highcharts": "^13.0.0",
         "next": "^16.2.10",
         "react": "^19.2.7",

--- a/packages/trading-signals-docs/components/graph/BuilderNodeView.tsx
+++ b/packages/trading-signals-docs/components/graph/BuilderNodeView.tsx
@@ -125,13 +125,16 @@ export function createBuilderNodeView({onConfigChange, onDelete}: BuilderNodeCal
                       type={field.widget === 'number' ? 'number' : 'text'}
                       placeholder={field.placeholder}
                       value={value === undefined ? '' : String(value)}
-                      onChange={event =>
-                        onConfigChange(
-                          id,
-                          field.key,
-                          field.widget === 'number' ? Number(event.target.value) : event.target.value
-                        )
-                      }
+                      onChange={event => {
+                        // A cleared number field falls back to the schema default instead of forcing 0.
+                        const next =
+                          field.widget === 'number'
+                            ? event.target.value === ''
+                              ? undefined
+                              : Number(event.target.value)
+                            : event.target.value;
+                        onConfigChange(id, field.key, next);
+                      }}
                     />
                   )}
                 </label>

--- a/packages/trading-signals-docs/components/graph/BuilderNodeView.tsx
+++ b/packages/trading-signals-docs/components/graph/BuilderNodeView.tsx
@@ -1,9 +1,20 @@
 import {Handle, Position} from '@xyflow/react';
 import type {NodeProps} from '@xyflow/react';
 import {getNodeTypeDefinition} from 'trading-strategies';
-import type {NodePortDefinition, PortValueKind} from 'trading-strategies';
+import type {NodePortDefinition, NodeTypeDefinition, PortValueKind} from 'trading-strategies';
 import type {BuilderNode} from '../../utils/graphIO';
 import {NODE_FIELDS} from './nodeFields';
+
+/**
+ * The engine's own Zod defaults, not a UI guess. Parsing `{}` runs every `.default(...)` in
+ * the schema, so an unset config key resolves to exactly the value `GraphStrategy` would use.
+ */
+function getConfigDefaults(definition: NodeTypeDefinition): Record<string, unknown> {
+  const result = definition.configSchema.safeParse({});
+  return result.success && typeof result.data === 'object' && result.data !== null
+    ? (result.data as Record<string, unknown>)
+    : {};
+}
 
 /** Ports snap only to matching colors — the visual grammar for "these blocks fit together". */
 export const PORT_COLORS: Record<PortValueKind, string> = {
@@ -71,6 +82,7 @@ export function createBuilderNodeView({onConfigChange, onDelete}: BuilderNodeCal
     }
     const fields = NODE_FIELDS[data.nodeType] ?? [];
     const accent = CATEGORY_ACCENTS[definition.category] ?? 'border-t-slate-500';
+    const defaults = getConfigDefaults(definition);
 
     return (
       <div
@@ -101,6 +113,7 @@ export function createBuilderNodeView({onConfigChange, onDelete}: BuilderNodeCal
           <div className="px-3 pb-2.5 pt-1 space-y-1.5">
             {fields.map(field => {
               const value = data.config[field.key];
+              const defaultValue = defaults[field.key];
               const common =
                 'nodrag w-full bg-slate-900 border border-slate-600 rounded px-1.5 py-1 text-xs text-white focus:outline-none focus:border-purple-500';
               return (
@@ -110,7 +123,7 @@ export function createBuilderNodeView({onConfigChange, onDelete}: BuilderNodeCal
                     <select
                       data-testid={`node-${id}-${field.key}`}
                       className={common}
-                      value={String(value ?? field.options?.[0]?.value ?? '')}
+                      value={String(value ?? defaultValue ?? field.options?.[0]?.value ?? '')}
                       onChange={event => onConfigChange(id, field.key, event.target.value)}>
                       {field.options?.map(option => (
                         <option key={option.value} value={option.value}>
@@ -123,7 +136,11 @@ export function createBuilderNodeView({onConfigChange, onDelete}: BuilderNodeCal
                       data-testid={`node-${id}-${field.key}`}
                       className={common}
                       type={field.widget === 'number' ? 'number' : 'text'}
-                      placeholder={field.placeholder}
+                      /*
+                       * Shows the engine's real schema default (not just a static hint) so an
+                       * unset field never looks blank when a value will actually be used.
+                       */
+                      placeholder={defaultValue !== undefined ? String(defaultValue) : field.placeholder}
                       value={value === undefined ? '' : String(value)}
                       onChange={event => {
                         // A cleared number field falls back to the schema default instead of forcing 0.

--- a/packages/trading-signals-docs/components/graph/BuilderNodeView.tsx
+++ b/packages/trading-signals-docs/components/graph/BuilderNodeView.tsx
@@ -1,0 +1,146 @@
+import {Handle, Position} from '@xyflow/react';
+import type {NodeProps} from '@xyflow/react';
+import {getNodeTypeDefinition} from 'trading-strategies';
+import type {NodePortDefinition, PortValueKind} from 'trading-strategies';
+import type {BuilderNode} from '../../utils/graphIO';
+import {NODE_FIELDS} from './nodeFields';
+
+/** Ports snap only to matching colors — the visual grammar for "these blocks fit together". */
+export const PORT_COLORS: Record<PortValueKind, string> = {
+  candle: '#f59e0b',
+  number: '#38bdf8',
+  trigger: '#a78bfa',
+};
+
+const CATEGORY_ACCENTS: Record<string, string> = {
+  indicator: 'border-t-sky-500',
+  logic: 'border-t-violet-500',
+  sink: 'border-t-emerald-500',
+  source: 'border-t-amber-500',
+  transform: 'border-t-orange-400',
+};
+
+const HANDLE_TOP_OFFSET = 46;
+const HANDLE_SPACING = 26;
+
+function portHandles(ports: readonly NodePortDefinition[], type: 'source' | 'target') {
+  const position = type === 'target' ? Position.Left : Position.Right;
+  return ports.map((port, index) => (
+    <Handle
+      key={port.name}
+      id={port.name}
+      type={type}
+      position={position}
+      style={{
+        background: PORT_COLORS[port.kind],
+        height: 10,
+        top: HANDLE_TOP_OFFSET + index * HANDLE_SPACING,
+        width: 10,
+      }}
+    />
+  ));
+}
+
+function portLabels(inputs: readonly NodePortDefinition[], outputs: readonly NodePortDefinition[]) {
+  const rows = Math.max(inputs.length, outputs.length);
+  if (rows === 0) {
+    return null;
+  }
+  return (
+    <div className="px-3 pt-1.5 space-y-1.5">
+      {Array.from({length: rows}, (_, index) => (
+        <div key={index} className="flex justify-between text-[10px] leading-4 text-slate-400 h-4">
+          <span>{inputs[index]?.label ?? ''}</span>
+          <span>{outputs[index]?.label ?? ''}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export interface BuilderNodeCallbacks {
+  onConfigChange: (nodeId: string, key: string, value: unknown) => void;
+  onDelete: (nodeId: string) => void;
+}
+
+export function createBuilderNodeView({onConfigChange, onDelete}: BuilderNodeCallbacks) {
+  return function BuilderNodeView({data, id, selected}: NodeProps<BuilderNode>) {
+    const definition = getNodeTypeDefinition(data.nodeType);
+    if (!definition) {
+      return <div className="bg-red-900 text-red-200 text-xs rounded p-2">Unknown node: {data.nodeType}</div>;
+    }
+    const fields = NODE_FIELDS[data.nodeType] ?? [];
+    const accent = CATEGORY_ACCENTS[definition.category] ?? 'border-t-slate-500';
+
+    return (
+      <div
+        data-testid={`node-${id}`}
+        className={`bg-slate-800 border border-t-4 rounded-lg shadow-lg w-52 ${accent} ${
+          selected ? 'border-x-purple-400 border-b-purple-400' : 'border-x-slate-600 border-b-slate-600'
+        }`}>
+        {portHandles(definition.inputs, 'target')}
+        {portHandles(definition.outputs, 'source')}
+        <div className="px-3 pt-2 flex items-start justify-between gap-2">
+          <div className="min-w-0">
+            <div className="text-sm font-semibold text-white">{definition.label}</div>
+            <div className="text-[10px] text-slate-500 truncate" title={id}>
+              {id}
+            </div>
+          </div>
+          <button
+            data-testid={`node-${id}-delete`}
+            aria-label={`Delete ${definition.label} node`}
+            title="Delete node"
+            onClick={() => onDelete(id)}
+            className="nodrag shrink-0 -mr-1 h-5 w-5 rounded flex items-center justify-center text-slate-500 hover:text-white hover:bg-red-500/70 transition-colors cursor-pointer text-xs leading-none">
+            ✕
+          </button>
+        </div>
+        {portLabels(definition.inputs, definition.outputs)}
+        {fields.length > 0 && (
+          <div className="px-3 pb-2.5 pt-1 space-y-1.5">
+            {fields.map(field => {
+              const value = data.config[field.key];
+              const common =
+                'nodrag w-full bg-slate-900 border border-slate-600 rounded px-1.5 py-1 text-xs text-white focus:outline-none focus:border-purple-500';
+              return (
+                <label key={field.key} className="block">
+                  <span className="block text-[10px] text-slate-400 mb-0.5">{field.label}</span>
+                  {field.widget === 'select' ? (
+                    <select
+                      data-testid={`node-${id}-${field.key}`}
+                      className={common}
+                      value={String(value ?? field.options?.[0]?.value ?? '')}
+                      onChange={event => onConfigChange(id, field.key, event.target.value)}>
+                      {field.options?.map(option => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
+                  ) : (
+                    <input
+                      data-testid={`node-${id}-${field.key}`}
+                      className={common}
+                      type={field.widget === 'number' ? 'number' : 'text'}
+                      placeholder={field.placeholder}
+                      value={value === undefined ? '' : String(value)}
+                      onChange={event =>
+                        onConfigChange(
+                          id,
+                          field.key,
+                          field.widget === 'number' ? Number(event.target.value) : event.target.value
+                        )
+                      }
+                    />
+                  )}
+                </label>
+              );
+            })}
+          </div>
+        )}
+        {fields.length === 0 && <div className="pb-2.5" />}
+      </div>
+    );
+  };
+}

--- a/packages/trading-signals-docs/components/graph/GraphEditor.tsx
+++ b/packages/trading-signals-docs/components/graph/GraphEditor.tsx
@@ -1,15 +1,30 @@
-import {useCallback, useEffect, useMemo, useRef} from 'react';
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {Background, Controls, ReactFlow, addEdge, useEdgesState, useNodesState} from '@xyflow/react';
 import type {Connection, Edge, IsValidConnection} from '@xyflow/react';
 import {getNodeTypeDefinition, getNodeTypes} from 'trading-strategies';
 import type {StrategyGraphInput} from 'trading-strategies';
 import type {BuilderNode} from '../../utils/graphIO';
 import {fromStrategyGraph, toStrategyGraph} from '../../utils/graphIO';
+import {NODE_FIELDS} from './nodeFields';
 import {PORT_COLORS, createBuilderNodeView} from './BuilderNodeView';
+
+/** A new object (even with an identical graph) is what tells the editor to apply a reset. */
+export interface GraphResetSignal {
+  graph: StrategyGraphInput;
+  token: number;
+}
 
 interface GraphEditorProps {
   initialGraph: StrategyGraphInput;
   onGraphChange: (graph: StrategyGraphInput) => void;
+  /**
+   * Set by the page to replace the whole canvas (Clear/Template/JSON import) — a bumped
+   * `token` applies `graph` without unmounting React Flow. `next/dynamic` doesn't forward
+   * refs to the loaded component's own imperative handle (it hijacks the ref for its own
+   * `{retry}` API), so a plain prop is the reliable way to command a reset across that
+   * dynamic-import boundary.
+   */
+  resetSignal: GraphResetSignal | null;
 }
 
 const CATEGORY_DOTS: Record<string, string> = {
@@ -19,6 +34,42 @@ const CATEGORY_DOTS: Record<string, string> = {
   source: 'bg-amber-500',
   transform: 'bg-orange-400',
 };
+
+const GRID_COLUMNS = 4;
+const COLUMN_WIDTH = 240;
+const GRID_ORIGIN_X = 240;
+const GRID_ORIGIN_Y = 40;
+const NODE_GAP_Y = 24;
+const NODE_HEADER_HEIGHT = 56;
+const PORT_LABEL_ROW_HEIGHT = 20;
+const FIELD_ROW_HEIGHT = 34;
+const NODE_BOTTOM_PADDING = 12;
+
+/**
+ * Nodes vary in height (an `advice` node with 4 config fields is much taller than a bare
+ * `source:candle` node). A fixed row height would let tall nodes overlap the row below, so
+ * placement uses this estimate to pack nodes shelf-style instead of a uniform grid.
+ */
+function estimateNodeHeight(nodeType: string) {
+  const definition = getNodeTypeDefinition(nodeType);
+  const portRows = definition ? Math.max(definition.inputs.length, definition.outputs.length) : 0;
+  const fieldRows = NODE_FIELDS[nodeType]?.length ?? 0;
+  return NODE_HEADER_HEIGHT + portRows * PORT_LABEL_ROW_HEIGHT + fieldRows * FIELD_ROW_HEIGHT + NODE_BOTTOM_PADDING;
+}
+
+/** Buckets already-placed nodes (template load, JSON import, manual drags) into their nearest column. */
+function columnHeightsFor(nodes: readonly BuilderNode[]): number[] {
+  const heights = Array<number>(GRID_COLUMNS).fill(GRID_ORIGIN_Y);
+  for (const node of nodes) {
+    const column = Math.min(
+      GRID_COLUMNS - 1,
+      Math.max(0, Math.round((node.position.x - GRID_ORIGIN_X) / COLUMN_WIDTH))
+    );
+    const bottom = node.position.y + estimateNodeHeight(node.data.nodeType) + NODE_GAP_Y;
+    heights[column] = Math.max(heights[column], bottom);
+  }
+  return heights;
+}
 
 function styleEdge(edge: Edge, nodes: BuilderNode[]): Edge {
   const source = nodes.find(node => node.id === edge.source);
@@ -31,13 +82,29 @@ function styleEdge(edge: Edge, nodes: BuilderNode[]): Edge {
   };
 }
 
-export function GraphEditor({initialGraph, onGraphChange}: GraphEditorProps) {
-  const initial = useMemo(() => fromStrategyGraph(initialGraph), [initialGraph]);
+export function GraphEditor({initialGraph, onGraphChange, resetSignal}: GraphEditorProps) {
+  /*
+   * `initialGraph` seeds the very first render only; later resets arrive via `resetSignal`
+   * below so the canvas (viewport, React Flow internals) never has to unmount.
+   */
+  const [initial] = useState(() => fromStrategyGraph(initialGraph));
   const [nodes, setNodes, onNodesChange] = useNodesState<BuilderNode>(initial.nodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>(
     initial.edges.map(edge => styleEdge(edge, initial.nodes))
   );
-  const nextNodeNumber = useRef(1);
+  const columnHeights = useRef<number[]>(columnHeightsFor(initial.nodes));
+  const lastAppliedToken = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!resetSignal || resetSignal.token === lastAppliedToken.current) {
+      return;
+    }
+    lastAppliedToken.current = resetSignal.token;
+    const converted = fromStrategyGraph(resetSignal.graph);
+    columnHeights.current = columnHeightsFor(converted.nodes);
+    setNodes(converted.nodes);
+    setEdges(converted.edges.map(edge => styleEdge(edge, converted.nodes)));
+  }, [resetSignal, setNodes, setEdges]);
 
   const onConfigChange = useCallback(
     (nodeId: string, key: string, value: unknown) => {
@@ -109,26 +176,22 @@ export function GraphEditor({initialGraph, onGraphChange}: GraphEditorProps) {
   const addNode = useCallback(
     (nodeType: string) => {
       const shortName = nodeType.replace('source:', '');
-      setNodes(current => {
-        let id = `${shortName}-${nextNodeNumber.current}`;
-        while (current.some(node => node.id === id)) {
-          nextNodeNumber.current += 1;
-          id = `${shortName}-${nextNodeNumber.current}`;
-        }
-        nextNodeNumber.current += 1;
-        // Grid placement right of the palette so fresh nodes never hide behind it or each other.
-        const column = current.length % 4;
-        const row = Math.floor(current.length / 4);
-        const newNode: BuilderNode = {
-          data: {config: {}, nodeType},
-          id,
-          position: {x: 240 + column * 240, y: 40 + row * 300},
-          type: 'builder',
-        };
-        return [...current, newNode];
-      });
+      let suffix = nodes.length + 1;
+      let id = `${shortName}-${suffix}`;
+      while (nodes.some(node => node.id === id)) {
+        suffix += 1;
+        id = `${shortName}-${suffix}`;
+      }
+      // Shelf-pack into the shortest column so a tall node never overlaps the one placed after it.
+      const heights = columnHeights.current;
+      const column = heights.indexOf(Math.min(...heights));
+      const position = {x: GRID_ORIGIN_X + column * COLUMN_WIDTH, y: heights[column]};
+      heights[column] += estimateNodeHeight(nodeType) + NODE_GAP_Y;
+
+      const newNode: BuilderNode = {data: {config: {}, nodeType}, id, position, type: 'builder'};
+      setNodes(current => [...current, newNode]);
     },
-    [setNodes]
+    [nodes, setNodes]
   );
 
   useEffect(() => {

--- a/packages/trading-signals-docs/components/graph/GraphEditor.tsx
+++ b/packages/trading-signals-docs/components/graph/GraphEditor.tsx
@@ -42,9 +42,19 @@ export function GraphEditor({initialGraph, onGraphChange}: GraphEditorProps) {
   const onConfigChange = useCallback(
     (nodeId: string, key: string, value: unknown) => {
       setNodes(current =>
-        current.map(node =>
-          node.id === nodeId ? {...node, data: {...node.data, config: {...node.data.config, [key]: value}}} : node
-        )
+        current.map(node => {
+          if (node.id !== nodeId) {
+            return node;
+          }
+          const config = {...node.data.config};
+          // `undefined` means "unset" — remove the key so the node's schema default applies.
+          if (value === undefined) {
+            delete config[key];
+          } else {
+            config[key] = value;
+          }
+          return {...node, data: {...node.data, config}};
+        })
       );
     },
     [setNodes]

--- a/packages/trading-signals-docs/components/graph/GraphEditor.tsx
+++ b/packages/trading-signals-docs/components/graph/GraphEditor.tsx
@@ -1,0 +1,170 @@
+import {useCallback, useEffect, useMemo, useRef} from 'react';
+import {Background, Controls, ReactFlow, addEdge, useEdgesState, useNodesState} from '@xyflow/react';
+import type {Connection, Edge, IsValidConnection} from '@xyflow/react';
+import {getNodeTypeDefinition, getNodeTypes} from 'trading-strategies';
+import type {StrategyGraphInput} from 'trading-strategies';
+import type {BuilderNode} from '../../utils/graphIO';
+import {fromStrategyGraph, toStrategyGraph} from '../../utils/graphIO';
+import {PORT_COLORS, createBuilderNodeView} from './BuilderNodeView';
+
+interface GraphEditorProps {
+  initialGraph: StrategyGraphInput;
+  onGraphChange: (graph: StrategyGraphInput) => void;
+}
+
+const CATEGORY_DOTS: Record<string, string> = {
+  indicator: 'bg-sky-500',
+  logic: 'bg-violet-500',
+  sink: 'bg-emerald-500',
+  source: 'bg-amber-500',
+  transform: 'bg-orange-400',
+};
+
+function styleEdge(edge: Edge, nodes: BuilderNode[]): Edge {
+  const source = nodes.find(node => node.id === edge.source);
+  const definition = source ? getNodeTypeDefinition(source.data.nodeType) : undefined;
+  const kind = definition?.outputs.find(port => port.name === (edge.sourceHandle ?? 'out'))?.kind;
+  return {
+    ...edge,
+    animated: kind === 'trigger',
+    style: {stroke: kind ? PORT_COLORS[kind] : '#64748b', strokeWidth: 2},
+  };
+}
+
+export function GraphEditor({initialGraph, onGraphChange}: GraphEditorProps) {
+  const initial = useMemo(() => fromStrategyGraph(initialGraph), [initialGraph]);
+  const [nodes, setNodes, onNodesChange] = useNodesState<BuilderNode>(initial.nodes);
+  const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>(
+    initial.edges.map(edge => styleEdge(edge, initial.nodes))
+  );
+  const nextNodeNumber = useRef(1);
+
+  const onConfigChange = useCallback(
+    (nodeId: string, key: string, value: unknown) => {
+      setNodes(current =>
+        current.map(node =>
+          node.id === nodeId ? {...node, data: {...node.data, config: {...node.data.config, [key]: value}}} : node
+        )
+      );
+    },
+    [setNodes]
+  );
+
+  const onDelete = useCallback(
+    (nodeId: string) => {
+      setNodes(current => current.filter(node => node.id !== nodeId));
+      setEdges(current => current.filter(edge => edge.source !== nodeId && edge.target !== nodeId));
+    },
+    [setNodes, setEdges]
+  );
+
+  const nodeTypes = useMemo(
+    () => ({builder: createBuilderNodeView({onConfigChange, onDelete})}),
+    [onConfigChange, onDelete]
+  );
+
+  /**
+   * The Scratch guarantee: a connection between mismatched port kinds (or into an
+   * already-occupied input) simply refuses to snap.
+   */
+  const isValidConnection: IsValidConnection = useCallback(
+    connection => {
+      const source = nodes.find(node => node.id === connection.source);
+      const target = nodes.find(node => node.id === connection.target);
+      if (!source || !target || connection.source === connection.target) {
+        return false;
+      }
+      const sourceDefinition = getNodeTypeDefinition(source.data.nodeType);
+      const targetDefinition = getNodeTypeDefinition(target.data.nodeType);
+      const output = sourceDefinition?.outputs.find(port => port.name === (connection.sourceHandle ?? 'out'));
+      const input = targetDefinition?.inputs.find(port => port.name === (connection.targetHandle ?? 'in'));
+      if (!output || !input || output.kind !== input.kind) {
+        return false;
+      }
+      const occupied = edges.some(
+        edge => edge.target === connection.target && (edge.targetHandle ?? 'in') === (connection.targetHandle ?? 'in')
+      );
+      return !occupied;
+    },
+    [nodes, edges]
+  );
+
+  const onConnect = useCallback(
+    (connection: Connection) => {
+      setEdges(current => addEdge(connection, current).map(edge => styleEdge(edge, nodes)));
+    },
+    [setEdges, nodes]
+  );
+
+  const addNode = useCallback(
+    (nodeType: string) => {
+      const shortName = nodeType.replace('source:', '');
+      setNodes(current => {
+        let id = `${shortName}-${nextNodeNumber.current}`;
+        while (current.some(node => node.id === id)) {
+          nextNodeNumber.current += 1;
+          id = `${shortName}-${nextNodeNumber.current}`;
+        }
+        nextNodeNumber.current += 1;
+        // Grid placement right of the palette so fresh nodes never hide behind it or each other.
+        const column = current.length % 4;
+        const row = Math.floor(current.length / 4);
+        const newNode: BuilderNode = {
+          data: {config: {}, nodeType},
+          id,
+          position: {x: 240 + column * 240, y: 40 + row * 300},
+          type: 'builder',
+        };
+        return [...current, newNode];
+      });
+    },
+    [setNodes]
+  );
+
+  useEffect(() => {
+    onGraphChange(toStrategyGraph(nodes, edges));
+  }, [nodes, edges, onGraphChange]);
+
+  return (
+    <div className="flex gap-3 items-stretch">
+      {/* Palette lives beside the canvas, never on top of it — nodes can't hide behind it. */}
+      <div className="w-44 shrink-0 bg-slate-800/50 border border-slate-700 rounded-lg p-2 space-y-1 self-start">
+        <div className="text-[10px] uppercase tracking-wide text-slate-500 px-1 pb-1">Building blocks</div>
+        {getNodeTypes().map(definition => (
+          <button
+            key={definition.type}
+            data-testid={`palette-${definition.type}`}
+            title={definition.description}
+            onClick={() => addNode(definition.type)}
+            className="w-full flex items-center gap-2 px-2 py-1.5 rounded text-xs text-slate-200 hover:bg-slate-700 transition-colors cursor-pointer text-left">
+            <span className={`h-2 w-2 rounded-full shrink-0 ${CATEGORY_DOTS[definition.category] ?? 'bg-slate-500'}`} />
+            <span>+ {definition.label}</span>
+          </button>
+        ))}
+        <div className="text-[10px] text-slate-500 px-1 pt-1 border-t border-slate-700">
+          Drag between matching-color ports to connect. Backspace deletes.
+        </div>
+      </div>
+      <div
+        className="flex-1 min-w-0 h-[640px] rounded-lg border border-slate-700 overflow-hidden"
+        data-testid="graph-canvas">
+        <ReactFlow
+          colorMode="dark"
+          nodes={nodes}
+          edges={edges}
+          nodeTypes={nodeTypes}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
+          onConnect={onConnect}
+          isValidConnection={isValidConnection}
+          deleteKeyCode={['Backspace', 'Delete']}
+          fitView
+          fitViewOptions={{padding: 0.1}}
+          minZoom={0.3}>
+          <Background gap={20} />
+          <Controls />
+        </ReactFlow>
+      </div>
+    </div>
+  );
+}

--- a/packages/trading-signals-docs/components/graph/nodeFields.ts
+++ b/packages/trading-signals-docs/components/graph/nodeFields.ts
@@ -1,0 +1,90 @@
+/**
+ * Editable config fields per node type, driving the forms rendered inside canvas nodes.
+ * Values are still validated by the engine's Zod schemas on every change — these
+ * descriptors only decide which widget to render, they can never bypass validation.
+ */
+export interface NodeFieldDescriptor {
+  key: string;
+  label: string;
+  widget: 'select' | 'number' | 'text';
+  options?: readonly {value: string; label: string}[];
+  placeholder?: string;
+}
+
+export const NODE_FIELDS: Record<string, readonly NodeFieldDescriptor[]> = {
+  advice: [
+    {
+      key: 'side',
+      label: 'Side',
+      options: [
+        {label: 'Buy', value: 'BUY'},
+        {label: 'Sell', value: 'SELL'},
+      ],
+      widget: 'select',
+    },
+    {
+      key: 'amountIn',
+      label: 'Amount in',
+      options: [
+        {label: 'Counter (cash)', value: 'counter'},
+        {label: 'Base (asset)', value: 'base'},
+      ],
+      widget: 'select',
+    },
+    {key: 'amount', label: 'Amount', placeholder: 'ALL_AVAILABLE_AMOUNT', widget: 'text'},
+    {key: 'reason', label: 'Reason', placeholder: 'Why this order fires', widget: 'text'},
+  ],
+  batcher: [{key: 'timeframe', label: 'Timeframe', placeholder: 'e.g. 5m', widget: 'text'}],
+  field: [
+    {
+      key: 'field',
+      label: 'Field',
+      options: [
+        {label: 'Close', value: 'close'},
+        {label: 'Open', value: 'open'},
+        {label: 'High', value: 'high'},
+        {label: 'Low', value: 'low'},
+        {label: 'Volume', value: 'volume'},
+        {label: 'Median price', value: 'medianPrice'},
+      ],
+      widget: 'select',
+    },
+  ],
+  if: [
+    {
+      key: 'operator',
+      label: 'Operator',
+      options: [
+        {label: 'A > B', value: 'gt'},
+        {label: 'A ≥ B', value: 'gte'},
+        {label: 'A < B', value: 'lt'},
+        {label: 'A ≤ B', value: 'lte'},
+        {label: 'A = B', value: 'eq'},
+      ],
+      widget: 'select',
+    },
+    {
+      key: 'trigger',
+      label: 'Fire',
+      options: [
+        {label: 'On change (crossover)', value: 'onChange'},
+        {label: 'Every matching candle', value: 'always'},
+      ],
+      widget: 'select',
+    },
+  ],
+  indicator: [
+    {
+      key: 'indicator',
+      label: 'Indicator',
+      options: [
+        {label: 'SMA', value: 'SMA'},
+        {label: 'EMA', value: 'EMA'},
+        {label: 'RSI', value: 'RSI'},
+      ],
+      widget: 'select',
+    },
+    {key: 'period', label: 'Period', widget: 'number'},
+  ],
+  'source:candle': [],
+};

--- a/packages/trading-signals-docs/e2e/graph-builder.spec.ts
+++ b/packages/trading-signals-docs/e2e/graph-builder.spec.ts
@@ -1,0 +1,115 @@
+import {expect, test} from '@playwright/test';
+
+import {GraphBuilderPage} from './pages/GraphBuilderPage';
+
+test.describe('Strategy Builder', () => {
+  test('loads the SMA crossover template as a valid, runnable graph', async ({page}) => {
+    const builder = new GraphBuilderPage(page);
+    await builder.goto();
+
+    await expect(builder.validationBanner()).toContainText('Graph is valid');
+    await expect(page.locator('.react-flow__node')).toHaveCount(10);
+    expect(await builder.connectionCount()).toBe(10);
+  });
+
+  test('runs a backtest from the template and renders results', async ({page}) => {
+    const builder = new GraphBuilderPage(page);
+    await builder.goto();
+    await builder.selectMarketCondition('Uptrend Shakeout (STX)');
+
+    await builder.runBacktest();
+
+    await expect(builder.results()).toContainText('Trade History');
+    expect(Number(await builder.readResultMetric('Total Trades'))).toBeGreaterThan(0);
+  });
+
+  test('flags an incomplete graph instead of letting it run', async ({page}) => {
+    const builder = new GraphBuilderPage(page);
+    await builder.goto();
+    await builder.clearCanvas();
+
+    await builder.addNode('advice');
+
+    await expect(builder.validationBanner()).toContainText('input port "when" is not connected');
+    await expect(page.getByTestId('graph-run-backtest')).toBeDisabled();
+  });
+
+  test('a strategy built from scratch matches the template backtest', async ({page}) => {
+    const builder = new GraphBuilderPage(page);
+    await builder.goto();
+    await builder.selectMarketCondition('Uptrend Shakeout (STX)');
+
+    // Reference run: the prebuilt template.
+    await builder.runBacktest();
+    const templateTrades = await builder.readResultMetric('Total Trades');
+    const templateRoi = await builder.readResultMetric('ROI');
+
+    // Rebuild the same strategy by hand: palette clicks, config edits, and port drags.
+    await builder.clearCanvas();
+    const candles = await builder.addNode('source:candle');
+    const fastBatcher = await builder.addNode('batcher');
+    const slowBatcher = await builder.addNode('batcher');
+    const fastClose = await builder.addNode('field');
+    const slowClose = await builder.addNode('field');
+    const fastSma = await builder.addNode('indicator');
+    const slowSma = await builder.addNode('indicator');
+    const crossover = await builder.addNode('if');
+    const buy = await builder.addNode('advice');
+    const sell = await builder.addNode('advice');
+    await builder.fitView();
+
+    await builder.configureNode(fastBatcher, 'timeframe', '1m');
+    await builder.configureNode(slowBatcher, 'timeframe', '5m');
+    await builder.configureNode(fastSma, 'period', '10');
+    await builder.configureNode(slowSma, 'period', '20');
+    await builder.configureNode(sell, 'side', 'SELL');
+    await builder.configureNode(sell, 'amountIn', 'base');
+
+    await builder.connect(candles, 'out', fastBatcher, 'in');
+    await builder.connect(candles, 'out', slowBatcher, 'in');
+    await builder.connect(fastBatcher, 'out', fastClose, 'in');
+    await builder.connect(slowBatcher, 'out', slowClose, 'in');
+    await builder.connect(fastClose, 'out', fastSma, 'in');
+    await builder.connect(slowClose, 'out', slowSma, 'in');
+    await builder.connect(fastSma, 'out', crossover, 'a');
+    await builder.connect(slowSma, 'out', crossover, 'b');
+    await builder.connect(crossover, 'true', buy, 'when');
+    await builder.connect(crossover, 'false', sell, 'when');
+
+    await expect(builder.validationBanner()).toContainText('Graph is valid');
+    await builder.runBacktest();
+
+    expect(await builder.readResultMetric('Total Trades')).toBe(templateTrades);
+    expect(await builder.readResultMetric('ROI')).toBe(templateRoi);
+  });
+
+  test('deletes a node and its connections via the ✕ button', async ({page}) => {
+    const builder = new GraphBuilderPage(page);
+    await builder.goto();
+    await builder.clearCanvas();
+    const candles = await builder.addNode('source:candle');
+    const field = await builder.addNode('field');
+    await builder.connect(candles, 'out', field, 'in');
+    expect(await builder.connectionCount()).toBe(1);
+
+    await builder.deleteNode(candles);
+
+    await expect(page.locator('.react-flow__node')).toHaveCount(1);
+    expect(await builder.connectionCount()).toBe(0);
+    await expect(builder.validationBanner()).toContainText('input port "in" is not connected');
+  });
+
+  test('refuses to connect mismatched port types', async ({page}) => {
+    const builder = new GraphBuilderPage(page);
+    await builder.goto();
+    await builder.clearCanvas();
+
+    const candles = await builder.addNode('source:candle');
+    const indicator = await builder.addNode('indicator');
+
+    // Candle output into a number input must not snap.
+    await builder.connect(candles, 'out', indicator, 'in');
+
+    expect(await builder.connectionCount()).toBe(0);
+  });
+});

--- a/packages/trading-signals-docs/e2e/pages/GraphBuilderPage.ts
+++ b/packages/trading-signals-docs/e2e/pages/GraphBuilderPage.ts
@@ -1,0 +1,102 @@
+import type {Locator, Page} from '@playwright/test';
+
+export class GraphBuilderPage {
+  constructor(private readonly page: Page) {}
+
+  async goto(): Promise<void> {
+    await this.page.goto('/graph-builder');
+    await this.page.getByTestId('graph-canvas').waitFor();
+    // The canvas is client-only; nodes appear once React Flow has hydrated.
+    await this.page.locator('.react-flow__node').first().waitFor();
+  }
+
+  async clearCanvas(): Promise<void> {
+    await this.page.getByTestId('graph-clear').click();
+  }
+
+  async loadTemplate(): Promise<void> {
+    await this.page.getByTestId('graph-load-template').click();
+    await this.page.locator('.react-flow__node').first().waitFor();
+  }
+
+  /** Adds a node via the palette and returns its generated id. */
+  async addNode(nodeType: string) {
+    const before = await this.page.locator('.react-flow__node').count();
+    await this.page.getByTestId(`palette-${nodeType}`).click();
+    const node = this.page.locator('.react-flow__node').nth(before);
+    await node.waitFor();
+    const id = await node.getAttribute('data-id');
+    if (!id) {
+      throw new Error(`Added node of type "${nodeType}" has no data-id`);
+    }
+    return id;
+  }
+
+  async fitView(): Promise<void> {
+    await this.page.locator('.react-flow__controls-fitview').click();
+  }
+
+  #handle(nodeId: string, port: string, kind: 'source' | 'target'): Locator {
+    return this.page.locator(
+      `.react-flow__node[data-id="${nodeId}"] .react-flow__handle.${kind}[data-handleid="${port}"]`
+    );
+  }
+
+  /** Drags a connection from an output port to an input port, like a user would. */
+  async connect(fromNode: string, fromPort: string, toNode: string, toPort: string): Promise<void> {
+    await this.page.getByTestId('graph-canvas').scrollIntoViewIfNeeded();
+    const source = this.#handle(fromNode, fromPort, 'source');
+    const target = this.#handle(toNode, toPort, 'target');
+    const sourceBox = (await source.boundingBox())!;
+    const targetBox = (await target.boundingBox())!;
+    await this.page.mouse.move(sourceBox.x + sourceBox.width / 2, sourceBox.y + sourceBox.height / 2);
+    await this.page.mouse.down();
+    await this.page.mouse.move(targetBox.x + targetBox.width / 2, targetBox.y + targetBox.height / 2, {steps: 12});
+    await this.page.mouse.up();
+  }
+
+  async deleteNode(nodeId: string): Promise<void> {
+    await this.page.getByTestId(`node-${nodeId}-delete`).click();
+  }
+
+  async configureNode(nodeId: string, field: string, value: string): Promise<void> {
+    const control = this.page.getByTestId(`node-${nodeId}-${field}`);
+    const tagName = await control.evaluate(element => element.tagName);
+    if (tagName === 'SELECT') {
+      await control.selectOption(value);
+    } else {
+      await control.fill(value);
+    }
+  }
+
+  async selectMarketCondition(label: string): Promise<void> {
+    await this.page.getByTestId('market-condition-select').selectOption({label});
+  }
+
+  async runBacktest(): Promise<void> {
+    await this.page.getByTestId('graph-run-backtest').click();
+    await this.page.getByTestId('graph-backtest-results').waitFor();
+  }
+
+  validationBanner(): Locator {
+    return this.page.getByTestId('graph-validation');
+  }
+
+  connectionCount() {
+    return this.page.locator('.react-flow__edge').count();
+  }
+
+  results(): Locator {
+    return this.page.getByTestId('graph-backtest-results');
+  }
+
+  /**
+   * Reads a metric like "Total Trades" from the result cards. The selected strategy's
+   * section renders before the baseline, so the first match is the strategy under test.
+   */
+  async readResultMetric(label: string) {
+    const text = await this.results().innerText();
+    const match = text.match(new RegExp(`${label}\\s*ⓘ?\\s*([^\\n]+)`));
+    return match?.[1].trim() ?? '';
+  }
+}

--- a/packages/trading-signals-docs/e2e/pages/GraphBuilderPage.ts
+++ b/packages/trading-signals-docs/e2e/pages/GraphBuilderPage.ts
@@ -11,6 +11,8 @@ export class GraphBuilderPage {
   }
 
   async clearCanvas(): Promise<void> {
+    // Clearing now asks for confirmation (accidental clicks used to wipe the whole graph).
+    this.page.once('dialog', dialog => dialog.accept());
     await this.page.getByTestId('graph-clear').click();
   }
 

--- a/packages/trading-signals-docs/package.json
+++ b/packages/trading-signals-docs/package.json
@@ -5,6 +5,7 @@
     "@testing-library/dom": "^10.4.1",
     "@typedtrader/candles": "0.1.0",
     "@typedtrader/exchange": "0.2.5",
+    "@xyflow/react": "^12.11.2",
     "highcharts": "^13.0.0",
     "next": "^16.2.10",
     "react": "^19.2.7",

--- a/packages/trading-signals-docs/pages/_app.tsx
+++ b/packages/trading-signals-docs/pages/_app.tsx
@@ -3,6 +3,7 @@ import type {AppProps} from 'next/app';
 import Link from 'next/link';
 import {useRouter} from 'next/router';
 import {useState} from 'react';
+import '@xyflow/react/dist/style.css';
 import '../styles/globals.css';
 
 Highcharts.setOptions({accessibility: {enabled: false}});
@@ -12,13 +13,14 @@ export default function App({Component, pageProps}: AppProps) {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
   const navigation = [
-    {name: 'Home', href: '/'},
-    {name: 'Trend', href: '/indicators/trend'},
-    {name: 'Momentum', href: '/indicators/momentum'},
-    {name: 'Volatility', href: '/indicators/volatility'},
-    {name: 'Volume', href: '/indicators/volume'},
-    {name: 'Utilities', href: '/indicators/utilities'},
-    {name: 'Backtest', href: '/backtest', highlight: true},
+    {href: '/', name: 'Home'},
+    {href: '/indicators/trend', name: 'Trend'},
+    {href: '/indicators/momentum', name: 'Momentum'},
+    {href: '/indicators/volatility', name: 'Volatility'},
+    {href: '/indicators/volume', name: 'Volume'},
+    {href: '/indicators/utilities', name: 'Utilities'},
+    {highlight: true, href: '/backtest', name: 'Backtest'},
+    {highlight: true, href: '/graph-builder', name: 'Builder'},
   ];
 
   const getNavClasses = (item: (typeof navigation)[number], isActive: boolean, isMobile = false) => {
@@ -32,9 +34,7 @@ export default function App({Component, pageProps}: AppProps) {
       }`;
     }
 
-    return `${base} ${
-      isActive ? 'bg-blue-600 text-white' : 'text-slate-300 hover:bg-slate-800 hover:text-white'
-    }`;
+    return `${base} ${isActive ? 'bg-blue-600 text-white' : 'text-slate-300 hover:bg-slate-800 hover:text-white'}`;
   };
 
   return (
@@ -48,10 +48,7 @@ export default function App({Component, pageProps}: AppProps) {
               </Link>
               <div className="hidden md:flex space-x-4">
                 {navigation.map(item => (
-                  <Link
-                    key={item.href}
-                    href={item.href}
-                    className={getNavClasses(item, router.pathname === item.href)}>
+                  <Link key={item.href} href={item.href} className={getNavClasses(item, router.pathname === item.href)}>
                     {item.name}
                   </Link>
                 ))}
@@ -82,7 +79,11 @@ export default function App({Component, pageProps}: AppProps) {
                   {mobileMenuOpen ? (
                     <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
                   ) : (
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"
+                    />
                   )}
                 </svg>
               </button>
@@ -119,7 +120,8 @@ export default function App({Component, pageProps}: AppProps) {
       <footer className="border-t border-slate-700 mt-16 py-8">
         <div className="container mx-auto px-4 text-center text-slate-400">
           <p>
-            Built with ❤️ by <a
+            Built with ❤️ by{' '}
+            <a
               href="https://github.com/sponsors/bennycode"
               target="_blank"
               rel="noopener noreferrer"

--- a/packages/trading-signals-docs/pages/graph-builder.tsx
+++ b/packages/trading-signals-docs/pages/graph-builder.tsx
@@ -15,6 +15,8 @@ import {BacktestResults} from '../components/BacktestResults';
 import {DatasetSelector} from '../components/DatasetSelector';
 import {datasets} from '../utils/datasets';
 import type {CandleDataset} from '../utils/types';
+import {useDebouncedValue} from '../utils/useDebouncedValue';
+import type {GraphResetSignal} from '../components/graph/GraphEditor';
 
 const GraphEditor = dynamic(() => import('../components/graph/GraphEditor').then(module => module.GraphEditor), {
   loading: () => (
@@ -24,6 +26,8 @@ const GraphEditor = dynamic(() => import('../components/graph/GraphEditor').then
   ),
   ssr: false,
 });
+
+const VALIDATION_DEBOUNCE_MS = 200;
 
 function createExchange(candles: Candle[], initialBase: string, initialCounter: string) {
   const base = candles[0]?.base ?? 'BTC';
@@ -36,8 +40,8 @@ function createExchange(candles: Candle[], initialBase: string, initialCounter: 
 }
 
 export default function GraphBuilderPage() {
-  const [loadedGraph, setLoadedGraph] = useState<StrategyGraphInput>(() => createSmaCrossoverGraph());
-  const [editorKey, setEditorKey] = useState(0);
+  const [loadedGraph] = useState<StrategyGraphInput>(() => createSmaCrossoverGraph());
+  const [resetSignal, setResetSignal] = useState<GraphResetSignal | null>(null);
   const [currentGraph, setCurrentGraph] = useState<StrategyGraphInput | null>(null);
   const [selectedDataset, setSelectedDataset] = useState(datasets[0].id);
   const [customDataset, setCustomDataset] = useState<CandleDataset | null>(null);
@@ -59,27 +63,35 @@ export default function GraphBuilderPage() {
     setCurrentGraph(graph);
   }, []);
 
+  /*
+   * Rebuilding the interpreter on every keystroke of a config field is wasted work — settle
+   * on a value briefly before re-validating.
+   */
+  const debouncedGraph = useDebouncedValue(currentGraph, VALIDATION_DEBOUNCE_MS);
+
   /**
    * The single source of truth for "is this strategy runnable": constructing the real
    * interpreter. Whatever error it throws is exactly what a backtest would hit.
    */
   const validationError = useMemo(() => {
-    if (!currentGraph || Object.keys(currentGraph.nodes).length === 0) {
+    if (!debouncedGraph || Object.keys(debouncedGraph.nodes).length === 0) {
       return 'Add nodes to build a strategy';
     }
     try {
-      new GraphStrategy(currentGraph);
+      new GraphStrategy(debouncedGraph);
       return null;
     } catch (error) {
       return error instanceof Error ? error.message : 'Invalid graph';
     }
-  }, [currentGraph]);
+  }, [debouncedGraph]);
 
   const loadGraph = useCallback((graph: StrategyGraphInput) => {
-    setLoadedGraph(graph);
-    // Sync immediately — validation must not lag until the client-only canvas re-hydrates.
+    /*
+     * Reset the canvas in place (no remount) — the editor keeps its viewport, and
+     * `currentGraph` is synced immediately so validation never shows stale state.
+     */
+    setResetSignal(current => ({graph, token: (current?.token ?? 0) + 1}));
     setCurrentGraph(graph);
-    setEditorKey(key => key + 1);
     setResult(null);
     setBaselineResult(null);
   }, []);
@@ -97,7 +109,13 @@ export default function GraphBuilderPage() {
     if (!currentGraph) {
       return;
     }
-    await navigator.clipboard.writeText(JSON.stringify(currentGraph, null, 2));
+    try {
+      await navigator.clipboard.writeText(JSON.stringify(currentGraph, null, 2));
+    } catch (error) {
+      setJsonError(error instanceof Error ? error.message : 'Could not copy to clipboard');
+      return;
+    }
+    setJsonError(null);
     if (copiedTimer.current) {
       clearTimeout(copiedTimer.current);
     }
@@ -164,7 +182,11 @@ export default function GraphBuilderPage() {
         <div className="flex gap-2">
           <button
             data-testid="graph-clear"
-            onClick={() => loadGraph({connections: [], nodes: {}, version: 1})}
+            onClick={() => {
+              if (window.confirm('Clear the canvas? This removes every node and connection and cannot be undone.')) {
+                loadGraph({connections: [], nodes: {}, version: 1});
+              }
+            }}
             className="py-2 px-4 rounded-lg text-sm font-medium bg-slate-700 hover:bg-slate-600 text-white transition-colors cursor-pointer">
             Clear canvas
           </button>
@@ -286,7 +308,7 @@ export default function GraphBuilderPage() {
 
         {/* Canvas */}
         <div className="flex-1 min-w-0">
-          <GraphEditor key={editorKey} initialGraph={loadedGraph} onGraphChange={onGraphChange} />
+          <GraphEditor initialGraph={loadedGraph} onGraphChange={onGraphChange} resetSignal={resetSignal} />
         </div>
       </div>
 

--- a/packages/trading-signals-docs/pages/graph-builder.tsx
+++ b/packages/trading-signals-docs/pages/graph-builder.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo, useRef, useState} from 'react';
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import dynamic from 'next/dynamic';
 import Big from 'big.js';
 import {AlpacaBrokerMock, TradingPair} from '@typedtrader/exchange';
@@ -77,9 +77,20 @@ export default function GraphBuilderPage() {
 
   const loadGraph = useCallback((graph: StrategyGraphInput) => {
     setLoadedGraph(graph);
+    // Sync immediately — validation must not lag until the client-only canvas re-hydrates.
+    setCurrentGraph(graph);
     setEditorKey(key => key + 1);
     setResult(null);
     setBaselineResult(null);
+  }, []);
+
+  // Clear the pending "Copied!" reset when navigating away mid-countdown.
+  useEffect(() => {
+    return () => {
+      if (copiedTimer.current) {
+        clearTimeout(copiedTimer.current);
+      }
+    };
   }, []);
 
   const copyJson = useCallback(async () => {
@@ -146,8 +157,8 @@ export default function GraphBuilderPage() {
         <div>
           <h1 className="text-2xl font-bold text-white">Strategy Builder</h1>
           <p className="text-slate-400 text-sm mt-1 max-w-2xl">
-            Stack building blocks into a trading strategy: candles flow through batchers and indicators into
-            conditions that fire order advice. The graph you see is exactly what runs in the backtest.
+            Stack building blocks into a trading strategy: candles flow through batchers and indicators into conditions
+            that fire order advice. The graph you see is exactly what runs in the backtest.
           </p>
         </div>
         <div className="flex gap-2">
@@ -244,7 +255,9 @@ export default function GraphBuilderPage() {
           )}
 
           <details className="bg-slate-800/50 border border-slate-700 rounded-lg p-4">
-            <summary className="text-sm font-semibold text-white cursor-pointer select-none">Share / Import JSON</summary>
+            <summary className="text-sm font-semibold text-white cursor-pointer select-none">
+              Share / Import JSON
+            </summary>
             <div className="mt-3 space-y-2">
               <button
                 data-testid="graph-copy-json"

--- a/packages/trading-signals-docs/pages/graph-builder.tsx
+++ b/packages/trading-signals-docs/pages/graph-builder.tsx
@@ -1,0 +1,287 @@
+import {useCallback, useMemo, useRef, useState} from 'react';
+import dynamic from 'next/dynamic';
+import Big from 'big.js';
+import {AlpacaBrokerMock, TradingPair} from '@typedtrader/exchange';
+import type {Candle} from '@typedtrader/exchange';
+import {
+  BacktestExecutor,
+  BuyOnceStrategy,
+  GraphStrategy,
+  StrategyGraphSchema,
+  createSmaCrossoverGraph,
+} from 'trading-strategies';
+import type {BacktestResult, StrategyGraphInput} from 'trading-strategies';
+import {BacktestResults} from '../components/BacktestResults';
+import {DatasetSelector} from '../components/DatasetSelector';
+import {datasets} from '../utils/datasets';
+import type {CandleDataset} from '../utils/types';
+
+const GraphEditor = dynamic(() => import('../components/graph/GraphEditor').then(module => module.GraphEditor), {
+  loading: () => (
+    <div className="h-[640px] rounded-lg border border-slate-700 flex items-center justify-center text-slate-500">
+      Loading canvas…
+    </div>
+  ),
+  ssr: false,
+});
+
+function createExchange(candles: Candle[], initialBase: string, initialCounter: string) {
+  const base = candles[0]?.base ?? 'BTC';
+  const counter = candles[0]?.counter ?? 'USD';
+  const balances = new Map([
+    [base, {available: new Big(initialBase || '0'), hold: new Big(0)}],
+    [counter, {available: new Big(initialCounter || '0'), hold: new Big(0)}],
+  ]);
+  return new AlpacaBrokerMock({balances});
+}
+
+export default function GraphBuilderPage() {
+  const [loadedGraph, setLoadedGraph] = useState<StrategyGraphInput>(() => createSmaCrossoverGraph());
+  const [editorKey, setEditorKey] = useState(0);
+  const [currentGraph, setCurrentGraph] = useState<StrategyGraphInput | null>(null);
+  const [selectedDataset, setSelectedDataset] = useState(datasets[0].id);
+  const [customDataset, setCustomDataset] = useState<CandleDataset | null>(null);
+  const [initialBase, setInitialBase] = useState('0');
+  const [initialCounter, setInitialCounter] = useState('10000');
+  const [result, setResult] = useState<BacktestResult | null>(null);
+  const [baselineResult, setBaselineResult] = useState<BacktestResult | null>(null);
+  const [running, setRunning] = useState(false);
+  const [runError, setRunError] = useState<string | null>(null);
+  const [jsonDraft, setJsonDraft] = useState('');
+  const [jsonError, setJsonError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const copiedTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const currentDataset = selectedDataset === 'custom' ? customDataset : datasets.find(d => d.id === selectedDataset)!;
+  const candles = currentDataset?.candles ?? [];
+
+  const onGraphChange = useCallback((graph: StrategyGraphInput) => {
+    setCurrentGraph(graph);
+  }, []);
+
+  /**
+   * The single source of truth for "is this strategy runnable": constructing the real
+   * interpreter. Whatever error it throws is exactly what a backtest would hit.
+   */
+  const validationError = useMemo(() => {
+    if (!currentGraph || Object.keys(currentGraph.nodes).length === 0) {
+      return 'Add nodes to build a strategy';
+    }
+    try {
+      new GraphStrategy(currentGraph);
+      return null;
+    } catch (error) {
+      return error instanceof Error ? error.message : 'Invalid graph';
+    }
+  }, [currentGraph]);
+
+  const loadGraph = useCallback((graph: StrategyGraphInput) => {
+    setLoadedGraph(graph);
+    setEditorKey(key => key + 1);
+    setResult(null);
+    setBaselineResult(null);
+  }, []);
+
+  const copyJson = useCallback(async () => {
+    if (!currentGraph) {
+      return;
+    }
+    await navigator.clipboard.writeText(JSON.stringify(currentGraph, null, 2));
+    if (copiedTimer.current) {
+      clearTimeout(copiedTimer.current);
+    }
+    setCopied(true);
+    copiedTimer.current = setTimeout(() => setCopied(false), 2000);
+  }, [currentGraph]);
+
+  const applyJson = useCallback(() => {
+    try {
+      const parsed = StrategyGraphSchema.parse(JSON.parse(jsonDraft));
+      new GraphStrategy(parsed); // validate node semantics too — bad JSON never reaches the canvas
+      setJsonError(null);
+      loadGraph(parsed);
+    } catch (error) {
+      setJsonError(error instanceof Error ? error.message : 'Invalid JSON');
+    }
+  }, [jsonDraft, loadGraph]);
+
+  const runBacktest = useCallback(async () => {
+    if (!currentGraph || validationError) {
+      return;
+    }
+    setRunning(true);
+    setRunError(null);
+    try {
+      const base = candles[0]?.base ?? 'BTC';
+      const counter = candles[0]?.counter ?? 'USD';
+      const tradingPair = new TradingPair(base, counter);
+
+      const [backtestResult, baseline] = await Promise.all([
+        new BacktestExecutor({
+          broker: createExchange(candles, initialBase, initialCounter),
+          candles,
+          strategy: new GraphStrategy(currentGraph),
+          tradingPair,
+        }).execute(),
+        new BacktestExecutor({
+          broker: createExchange(candles, initialBase, initialCounter),
+          candles,
+          strategy: new BuyOnceStrategy(),
+          tradingPair,
+        }).execute(),
+      ]);
+
+      setResult(backtestResult);
+      setBaselineResult(baseline);
+    } catch (error) {
+      setRunError(error instanceof Error ? error.message : 'Backtest failed');
+    } finally {
+      setRunning(false);
+    }
+  }, [currentGraph, validationError, candles, initialBase, initialCounter]);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between gap-4 flex-wrap">
+        <div>
+          <h1 className="text-2xl font-bold text-white">Strategy Builder</h1>
+          <p className="text-slate-400 text-sm mt-1 max-w-2xl">
+            Stack building blocks into a trading strategy: candles flow through batchers and indicators into
+            conditions that fire order advice. The graph you see is exactly what runs in the backtest.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <button
+            data-testid="graph-clear"
+            onClick={() => loadGraph({connections: [], nodes: {}, version: 1})}
+            className="py-2 px-4 rounded-lg text-sm font-medium bg-slate-700 hover:bg-slate-600 text-white transition-colors cursor-pointer">
+            Clear canvas
+          </button>
+          <button
+            data-testid="graph-load-template"
+            onClick={() => loadGraph(createSmaCrossoverGraph())}
+            className="py-2 px-4 rounded-lg text-sm font-medium bg-slate-700 hover:bg-slate-600 text-white transition-colors cursor-pointer">
+            Load SMA Crossover template
+          </button>
+        </div>
+      </div>
+
+      <div className="flex gap-6 items-start">
+        {/* Sidebar */}
+        <div className="w-64 shrink-0 space-y-4 sticky top-4 self-start">
+          <DatasetSelector
+            datasets={datasets}
+            selectedDataset={selectedDataset}
+            onDatasetChange={id => {
+              setSelectedDataset(id);
+              setResult(null);
+              setBaselineResult(null);
+            }}
+            onCustomDataset={(customCandles, name) => {
+              setCustomDataset({
+                candles: customCandles,
+                description: `Custom upload: ${name} (${customCandles.length} candles)`,
+                id: 'custom',
+                name,
+              });
+              setSelectedDataset('custom');
+              setResult(null);
+              setBaselineResult(null);
+            }}
+            customDatasetName={customDataset?.name}
+          />
+          <div className="bg-slate-800/50 border border-slate-700 rounded-lg p-4">
+            <h3 className="text-sm font-semibold text-white mb-3">Initial Balance</h3>
+            <div className="space-y-2">
+              <div>
+                <label className="block text-xs text-slate-400 mb-1">Base ({candles[0]?.base ?? 'Base'})</label>
+                <input
+                  type="text"
+                  value={initialBase}
+                  onChange={event => setInitialBase(event.target.value)}
+                  className="w-full bg-slate-900 border border-slate-600 rounded px-2 py-1.5 text-sm text-white focus:outline-none focus:border-purple-500"
+                />
+              </div>
+              <div>
+                <label className="block text-xs text-slate-400 mb-1">
+                  Counter ({candles[0]?.counter ?? 'Counter'})
+                </label>
+                <input
+                  type="text"
+                  value={initialCounter}
+                  onChange={event => setInitialCounter(event.target.value)}
+                  className="w-full bg-slate-900 border border-slate-600 rounded px-2 py-1.5 text-sm text-white focus:outline-none focus:border-purple-500"
+                />
+              </div>
+            </div>
+          </div>
+
+          <div
+            data-testid="graph-validation"
+            className={`rounded-lg p-3 border text-xs ${
+              validationError
+                ? 'bg-amber-900/20 border-amber-800/50 text-amber-300'
+                : 'bg-emerald-900/20 border-emerald-800/50 text-emerald-300'
+            }`}>
+            {validationError ?? '✓ Graph is valid and ready to run'}
+          </div>
+
+          <button
+            data-testid="graph-run-backtest"
+            onClick={runBacktest}
+            disabled={!!validationError || running || candles.length === 0}
+            className={`w-full py-2.5 px-4 rounded-lg text-sm font-medium transition-colors ${
+              validationError || running || candles.length === 0
+                ? 'bg-slate-700 text-slate-500 cursor-not-allowed'
+                : 'bg-purple-600 hover:bg-purple-700 text-white cursor-pointer'
+            }`}>
+            {running ? 'Running…' : 'Run Backtest'}
+          </button>
+          {runError && (
+            <div className="bg-red-900/20 border border-red-800/50 rounded-lg p-3">
+              <p className="text-red-400 text-xs">{runError}</p>
+            </div>
+          )}
+
+          <details className="bg-slate-800/50 border border-slate-700 rounded-lg p-4">
+            <summary className="text-sm font-semibold text-white cursor-pointer select-none">Share / Import JSON</summary>
+            <div className="mt-3 space-y-2">
+              <button
+                data-testid="graph-copy-json"
+                onClick={copyJson}
+                className="w-full py-2 px-3 rounded text-xs font-medium bg-slate-700 hover:bg-slate-600 text-white transition-colors cursor-pointer">
+                {copied ? 'Copied!' : 'Copy current graph as JSON'}
+              </button>
+              <textarea
+                data-testid="graph-json-input"
+                value={jsonDraft}
+                onChange={event => setJsonDraft(event.target.value)}
+                placeholder="Paste a strategy graph JSON here…"
+                rows={5}
+                className="w-full bg-slate-900 border border-slate-600 rounded px-2 py-1.5 text-xs text-white font-mono focus:outline-none focus:border-purple-500"
+              />
+              <button
+                data-testid="graph-apply-json"
+                onClick={applyJson}
+                className="w-full py-2 px-3 rounded text-xs font-medium bg-slate-700 hover:bg-slate-600 text-white transition-colors cursor-pointer">
+                Load JSON into canvas
+              </button>
+              {jsonError && <p className="text-red-400 text-xs">{jsonError}</p>}
+            </div>
+          </details>
+        </div>
+
+        {/* Canvas */}
+        <div className="flex-1 min-w-0">
+          <GraphEditor key={editorKey} initialGraph={loadedGraph} onGraphChange={onGraphChange} />
+        </div>
+      </div>
+
+      {result && (
+        <div data-testid="graph-backtest-results">
+          <BacktestResults result={result} baselineResult={baselineResult} candles={candles} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/trading-signals-docs/utils/graphIO.ts
+++ b/packages/trading-signals-docs/utils/graphIO.ts
@@ -1,0 +1,54 @@
+import type {Edge, Node} from '@xyflow/react';
+import type {StrategyGraphInput} from 'trading-strategies';
+
+export interface BuilderNodeData extends Record<string, unknown> {
+  nodeType: string;
+  config: Record<string, unknown>;
+}
+
+export type BuilderNode = Node<BuilderNodeData, 'builder'>;
+
+/**
+ * The canvas state and the engine's graph JSON are two views of the same strategy;
+ * these converters keep them losslessly interchangeable so copy/paste, templates,
+ * and the backtest runner all speak the exact format `GraphStrategy` executes.
+ */
+export function toStrategyGraph(nodes: BuilderNode[], edges: Edge[], name?: string): StrategyGraphInput {
+  return {
+    connections: edges.map(edge => ({
+      from: {node: edge.source, port: edge.sourceHandle ?? 'out'},
+      to: {node: edge.target, port: edge.targetHandle ?? 'in'},
+    })),
+    name,
+    nodes: Object.fromEntries(
+      nodes.map(node => [
+        node.id,
+        {
+          config: node.data.config,
+          position: {x: node.position.x, y: node.position.y},
+          type: node.data.nodeType,
+        },
+      ])
+    ),
+    version: 1,
+  };
+}
+
+export function fromStrategyGraph(graph: StrategyGraphInput): {nodes: BuilderNode[]; edges: Edge[]} {
+  const nodes: BuilderNode[] = Object.entries(graph.nodes).map(([id, node], index) => ({
+    data: {config: node.config ?? {}, nodeType: node.type},
+    id,
+    position: node.position ?? {x: 80 + index * 220, y: 80},
+    type: 'builder',
+  }));
+
+  const edges: Edge[] = graph.connections.map((connection, index) => ({
+    id: `edge-${index}`,
+    source: connection.from.node,
+    sourceHandle: connection.from.port ?? 'out',
+    target: connection.to.node,
+    targetHandle: connection.to.port ?? 'in',
+  }));
+
+  return {edges, nodes};
+}

--- a/packages/trading-signals-docs/utils/useDebouncedValue.ts
+++ b/packages/trading-signals-docs/utils/useDebouncedValue.ts
@@ -1,0 +1,17 @@
+import {useEffect, useState} from 'react';
+
+/**
+ * Delays a fast-changing value (e.g. every keystroke in a config field) so expensive work
+ * derived from it — like rebuilding a whole interpreter for validation — doesn't run on
+ * every intermediate state.
+ */
+export function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(timer);
+  }, [value, delayMs]);
+
+  return debounced;
+}


### PR DESCRIPTION
> **Stacked on #1190** (which stacks on #1189) — merge those first; GitHub retargets automatically.

## What

A visual, node-based strategy builder at `/graph-builder` — n8n/Scratch-style: drag building blocks, connect typed ports, configure them inline, and backtest. The canvas state **is** the graph JSON that `GraphStrategy` executes, so what users see is exactly what runs.

## Features

- **Palette from the engine's node registry** — nodes added via `registerNodeType()` appear automatically, no UI changes
- **Typed ports (Scratch guarantee):** mismatched kinds refuse to snap; occupied inputs reject a second writer; edge colors encode the value kind (candle/number/trigger)
- **Config forms inside nodes**, validated by the engine's Zod schemas
- **Live validation** by constructing the real interpreter on every change — the error shown is the error a backtest would throw, node-addressable
- **SMA crossover template**, clear canvas, per-node delete (✕ + Backspace), JSON share/import
- **Backtesting** via the existing `BacktestExecutor` with a buy-and-hold baseline, rendered by the existing `BacktestResults`

## Test plan

6 Playwright specs (class-based page object per repo e2e conventions), including the flagship: **build the SMA crossover from scratch** — palette clicks, config edits, 10 real mouse-dragged connections — and assert the backtest matches the template run exactly (trade count + ROI). Plus: template validity, results rendering, incomplete-graph rejection, type-mismatch refusal, node deletion. Full e2e suite 9/9 green; `next build` prerenders the page statically.