### PR TITLE
refactor(exchange): declare retry policy per endpoint with a @retry decorator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5191,18 +5191,6 @@
         "proxy-from-env": "^2.1.0"
       }
     },
-    "node_modules/axios-retry": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-4.5.0.tgz",
-      "integrity": "sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "is-retry-allowed": "^2.2.0"
-      },
-      "peerDependencies": {
-        "axios": "0.x || 1.x"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -8439,18 +8427,6 @@
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/is-retry-allowed": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
-      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/is-ssh": {
       "version": "1.4.1",
@@ -14275,7 +14251,6 @@
         "@types/big.js": "^7.0.0",
         "@types/jsonabc": "^2.3.3",
         "axios": "^1.18.1",
-        "axios-retry": "^4.5.0",
         "big.js": "^7.0.1",
         "dotenv-defaults": "^6.0.0",
         "jsonabc": "^2.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6662,18 +6662,6 @@
         "proxy-from-env": "^2.1.0"
       }
     },
-    "node_modules/axios-retry": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-4.5.0.tgz",
-      "integrity": "sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "is-retry-allowed": "^2.2.0"
-      },
-      "peerDependencies": {
-        "axios": "0.x || 1.x"
-      }
-    },
     "node_modules/axios/node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -9745,18 +9733,6 @@
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/is-retry-allowed": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
-      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/is-ssh": {
       "version": "1.4.1",
@@ -15553,7 +15529,6 @@
       "dependencies": {
         "@types/big.js": "^7.0.0",
         "axios": "^1.18.1",
-        "axios-retry": "^4.5.0",
         "big.js": "^7.0.1",
         "ms": "4.0.0-nightly.202508271359",
         "ts-retry-promise": "^0.8.1",

--- a/packages/exchange/package.json
+++ b/packages/exchange/package.json
@@ -6,7 +6,6 @@
     "@types/big.js": "^7.0.0",
     "@types/jsonabc": "^2.3.3",
     "axios": "^1.18.1",
-    "axios-retry": "^4.5.0",
     "big.js": "^7.0.1",
     "dotenv-defaults": "^6.0.0",
     "jsonabc": "^2.3.1",

--- a/packages/exchange/package.json
+++ b/packages/exchange/package.json
@@ -51,7 +51,6 @@
   "dependencies": {
     "@types/big.js": "^7.0.0",
     "axios": "^1.18.1",
-    "axios-retry": "^4.5.0",
     "big.js": "^7.0.1",
     "ms": "4.0.0-nightly.202508271359",
     "ts-retry-promise": "^0.8.1",

--- a/packages/exchange/src/broker/alpaca/api/AlpacaAPI.test.ts
+++ b/packages/exchange/src/broker/alpaca/api/AlpacaAPI.test.ts
@@ -1,14 +1,13 @@
-import {AxiosError, AxiosHeaders, type AxiosResponse, type InternalAxiosRequestConfig} from 'axios';
 import {shouldRetryAlpacaRequest} from './AlpacaAPI.js';
+import {SimplifiedHttpError} from '../../../util/SimplifiedHttpError.js';
 
-function httpError(status: number, data: unknown = {}): AxiosError {
-  const config: InternalAxiosRequestConfig = {headers: new AxiosHeaders()};
-  const response: AxiosResponse = {config, data, headers: new AxiosHeaders(), status, statusText: ''};
-  return new AxiosError(`Request failed with status ${status}`, 'ERR_BAD_RESPONSE', config, undefined, response);
+function httpError(status: number, data: unknown = {}) {
+  return new SimplifiedHttpError({data, status});
 }
 
-function networkError(code: string): AxiosError {
-  return new AxiosError(`Network error: ${code}`, code);
+// Network failures (e.g. EAI_AGAIN) carry no HTTP response, so simplifyError normalizes them to status 0.
+function networkError(code: string) {
+  return new SimplifiedHttpError({data: code, status: undefined});
 }
 
 describe('shouldRetryAlpacaRequest', () => {
@@ -34,5 +33,9 @@ describe('shouldRetryAlpacaRequest', () => {
 
   it('does not retry short-selling rejections (Alpaca code 40310000)', () => {
     expect(shouldRetryAlpacaRequest(httpError(403, {code: 40310000}))).toBe(false);
+  });
+
+  it('does not retry errors that were not normalized by simplifyError', () => {
+    expect(shouldRetryAlpacaRequest(new Error('boom'))).toBe(false);
   });
 });

--- a/packages/exchange/src/broker/alpaca/api/AlpacaAPI.test.ts
+++ b/packages/exchange/src/broker/alpaca/api/AlpacaAPI.test.ts
@@ -1,19 +1,16 @@
 import axios, {AxiosError, AxiosHeaders, type AxiosResponse, type InternalAxiosRequestConfig} from 'axios';
 import {z} from 'zod';
 import {AlpacaAPI, shouldRetryAlpacaRequest} from './AlpacaAPI.js';
+import {SimplifiedHttpError} from '../../../util/SimplifiedHttpError.js';
 import type {Order} from './schema/OrderSchema.js';
 
-type Request = {method: string; url: string};
-
-function httpError(status: number, data: unknown = {}, request?: Request): AxiosError {
-  const config: InternalAxiosRequestConfig = {headers: new AxiosHeaders(), ...request};
-  const response: AxiosResponse = {config, data, headers: new AxiosHeaders(), status, statusText: ''};
-  return new AxiosError(`Request failed with status ${status}`, 'ERR_BAD_RESPONSE', config, undefined, response);
+function httpError(status: number, data: unknown = {}) {
+  return new SimplifiedHttpError({data, status});
 }
 
-function networkError(code: string, request?: Request): AxiosError {
-  const config: InternalAxiosRequestConfig = {headers: new AxiosHeaders(), ...request};
-  return new AxiosError(`Network error: ${code}`, code, config);
+// Network failures (e.g. EAI_AGAIN) carry no HTTP response, so simplifyError normalizes them to status 0.
+function networkError(code: string) {
+  return new SimplifiedHttpError({data: code, status: undefined});
 }
 
 describe('shouldRetryAlpacaRequest', () => {
@@ -41,20 +38,8 @@ describe('shouldRetryAlpacaRequest', () => {
     expect(shouldRetryAlpacaRequest(httpError(403, {code: 40310000}))).toBe(false);
   });
 
-  describe('order placement (POST /v2/orders)', () => {
-    const placeOrder: Request = {method: 'post', url: '/v2/orders'};
-
-    it('retries server errors (HTTP 503) because the client order id keeps a re-submission from duplicating the order', () => {
-      expect(shouldRetryAlpacaRequest(httpError(503, {}, placeOrder))).toBe(true);
-    });
-
-    it('retries network errors (EAI_AGAIN)', () => {
-      expect(shouldRetryAlpacaRequest(networkError('EAI_AGAIN', placeOrder))).toBe(true);
-    });
-
-    it('does not retry business rejections (Alpaca code 40310100)', () => {
-      expect(shouldRetryAlpacaRequest(httpError(403, {code: 40310100}, placeOrder))).toBe(false);
-    });
+  it('does not retry errors that were not normalized by simplifyError', () => {
+    expect(shouldRetryAlpacaRequest(new Error('boom'))).toBe(false);
   });
 });
 

--- a/packages/exchange/src/broker/alpaca/api/AlpacaAPI.ts
+++ b/packages/exchange/src/broker/alpaca/api/AlpacaAPI.ts
@@ -1,5 +1,4 @@
-import axios, {type AxiosError} from 'axios';
-import axiosRetry from 'axios-retry';
+import axios from 'axios';
 import {ms} from 'ms';
 import {AccountSchema} from './schema/AccountSchema.js';
 import {AssetSchema} from './schema/AssetSchema.js';
@@ -7,13 +6,18 @@ import {BarsResponseSchema, LatestBarsResponseSchema} from './schema/BarSchema.j
 import {ClockSchema} from './schema/ClockSchema.js';
 import {OrderSchema, type AlpacaAssetClass} from './schema/OrderSchema.js';
 import {PositionSchema} from './schema/PositionSchema.js';
+import {isTransientHttpError, retry} from '../../../util/retry.js';
+import {SimplifiedHttpError} from '../../../util/SimplifiedHttpError.js';
 import {simplifyError} from '../../../util/simplifyError.js';
 import {SnapshotsResponseSchema} from './schema/SnapshotSchema.js';
 import {z} from 'zod';
 
-function hasResponseCode(error: AxiosError): error is AxiosError<{code: number}> {
-  const data = error.response?.data;
-  return !!data && typeof data === 'object' && 'code' in data && typeof data.code === 'number';
+function getAlpacaErrorCode(error: unknown) {
+  if (!(error instanceof SimplifiedHttpError)) {
+    return undefined;
+  }
+  const data = error.data;
+  return !!data && typeof data === 'object' && 'code' in data && typeof data.code === 'number' ? data.code : undefined;
 }
 
 /**
@@ -22,8 +26,8 @@ function hasResponseCode(error: AxiosError): error is AxiosError<{code: number}>
  *
  * @see https://docs.alpaca.markets/us/docs/user-protection#pattern-day-trader-pdt-protection-at-alpaca
  */
-function isPatternDayTrader(error: AxiosError) {
-  return hasResponseCode(error) && error.response?.data.code === 40310100;
+function isPatternDayTrader(error: unknown) {
+  return getAlpacaErrorCode(error) === 40310100;
 }
 
 /**
@@ -32,19 +36,26 @@ function isPatternDayTrader(error: AxiosError) {
  *
  * @see https://docs.alpaca.markets/us/docs/margin-and-short-selling
  */
-function isNotAllowedToShort(error: AxiosError) {
-  return hasResponseCode(error) && error.response?.data.code === 40310000;
+function isNotAllowedToShort(error: unknown) {
+  return getAlpacaErrorCode(error) === 40310000;
 }
 
-export function shouldRetryAlpacaRequest(error: AxiosError) {
+export function shouldRetryAlpacaRequest(error: unknown) {
   if (isPatternDayTrader(error)) {
     return false;
   }
   if (isNotAllowedToShort(error)) {
     return false;
   }
-  return axiosRetry.isRetryableError(error);
+  return isTransientHttpError(error);
 }
+
+// Alpaca applies one rate-limit policy across all endpoints, so every method shares this decorator.
+const retryAlpaca = retry({
+  delayMs: attempt => attempt * ms('1s'),
+  isRetryable: shouldRetryAlpacaRequest,
+  retries: 20,
+});
 
 export class AlpacaAPI {
   readonly #tradingClient;
@@ -56,19 +67,10 @@ export class AlpacaAPI {
       'APCA-API-SECRET-KEY': options.apiSecret,
     };
 
-    const retryConfig: Parameters<typeof axiosRetry>[1] = {
-      retries: 20,
-      retryCondition: shouldRetryAlpacaRequest,
-      retryDelay: retryCount => {
-        return retryCount * ms('1s');
-      },
-    };
-
     this.#tradingClient = axios.create({
       baseURL: options.usePaperTrading ? 'https://paper-api.alpaca.markets' : 'https://api.alpaca.markets',
       headers,
     });
-    axiosRetry(this.#tradingClient, retryConfig);
     simplifyError(this.#tradingClient);
 
     // @see https://docs.alpaca.markets/us/docs/market-data-faq#checklist-for-broker-partners
@@ -76,29 +78,32 @@ export class AlpacaAPI {
       baseURL: options.usePaperTrading ? 'https://data.sandbox.alpaca.markets' : 'https://data.alpaca.markets',
       headers,
     });
-    axiosRetry(this.#marketDataClient, retryConfig);
     simplifyError(this.#marketDataClient);
   }
 
   /** @see https://docs.alpaca.markets/reference/get-v2-clock */
+  @retryAlpaca
   async getClock() {
     const response = await this.#tradingClient.get('/v2/clock');
     return ClockSchema.parse(response.data);
   }
 
   /** @see https://docs.alpaca.markets/reference/stocklatestbars */
+  @retryAlpaca
   async getStockBarsLatest(params: {feed: string; symbols: string}) {
     const response = await this.#marketDataClient.get('/v2/stocks/bars/latest', {params});
     return LatestBarsResponseSchema.parse(response.data);
   }
 
   /** @see https://docs.alpaca.markets/reference/cryptolatestbars */
+  @retryAlpaca
   async getCryptoBarsLatest(params: {symbols: string}) {
     const response = await this.#marketDataClient.get('/v1beta3/crypto/us/latest/bars', {params});
     return LatestBarsResponseSchema.parse(response.data);
   }
 
   /** @see https://docs.alpaca.markets/reference/stockbars */
+  @retryAlpaca
   async getStockBars(params: {
     end: string;
     feed: string;
@@ -113,12 +118,14 @@ export class AlpacaAPI {
   }
 
   /** @see https://docs.alpaca.markets/reference/stocksnapshots-1 */
+  @retryAlpaca
   async getStockSnapshots(params: {feed: string; symbols: string}) {
     const response = await this.#marketDataClient.get('/v2/stocks/snapshots', {params});
     return SnapshotsResponseSchema.parse(response.data);
   }
 
   /** @see https://docs.alpaca.markets/reference/cryptobars-1 */
+  @retryAlpaca
   async getCryptoBars(params: {
     end: string;
     limit: number;
@@ -132,29 +139,34 @@ export class AlpacaAPI {
   }
 
   /** @see https://docs.alpaca.markets/reference/getaccount-1 */
+  @retryAlpaca
   async getAccount() {
     const response = await this.#tradingClient.get('/v2/account');
     return AccountSchema.parse(response.data);
   }
 
   /** @see https://docs.alpaca.markets/reference/getallopenpositions */
+  @retryAlpaca
   async getPositions() {
     const response = await this.#tradingClient.get('/v2/positions');
     return z.array(PositionSchema).parse(response.data);
   }
 
   /** @see https://docs.alpaca.markets/reference/getallorders */
+  @retryAlpaca
   async getOrders(params: {status: string; symbols?: string}) {
     const response = await this.#tradingClient.get('/v2/orders', {params});
     return z.array(OrderSchema).parse(response.data);
   }
 
   /** @see https://docs.alpaca.markets/reference/deleteorderbyorderid */
+  @retryAlpaca
   async deleteOrder(orderId: string) {
     await this.#tradingClient.delete(`/v2/orders/${orderId}`);
   }
 
   /** @see https://docs.alpaca.markets/reference/postorder */
+  @retryAlpaca
   async postOrder(params: {
     extended_hours?: boolean;
     limit_price?: string;
@@ -170,6 +182,7 @@ export class AlpacaAPI {
   }
 
   /** @see https://docs.alpaca.markets/reference/get-v2-assets */
+  @retryAlpaca
   async getAssets(params: {asset_class: AlpacaAssetClass}) {
     const response = await this.#tradingClient.get('/v2/assets', {params});
     return z.array(AssetSchema).parse(response.data);

--- a/packages/exchange/src/broker/alpaca/api/AlpacaAPI.ts
+++ b/packages/exchange/src/broker/alpaca/api/AlpacaAPI.ts
@@ -1,5 +1,4 @@
-import axios, {type AxiosError} from 'axios';
-import axiosRetry from 'axios-retry';
+import axios from 'axios';
 import {ms} from 'ms';
 import {AccountSchema} from './schema/AccountSchema.js';
 import {AssetSchema} from './schema/AssetSchema.js';
@@ -7,13 +6,18 @@ import {BarsResponseSchema, LatestBarsResponseSchema} from './schema/BarSchema.j
 import {ClockSchema} from './schema/ClockSchema.js';
 import {OrderSchema, type AlpacaAssetClass} from './schema/OrderSchema.js';
 import {PositionSchema} from './schema/PositionSchema.js';
+import {isTransientHttpError, retry} from '../../../util/retry.js';
+import {SimplifiedHttpError} from '../../../util/SimplifiedHttpError.js';
 import {simplifyError} from '../../../util/simplifyError.js';
 import {SnapshotsResponseSchema} from './schema/SnapshotSchema.js';
 import {z} from 'zod';
 
-function hasResponseCode(error: AxiosError): error is AxiosError<{code: number}> {
-  const data = error.response?.data;
-  return !!data && typeof data === 'object' && 'code' in data && typeof data.code === 'number';
+function getAlpacaErrorCode(error: unknown) {
+  if (!(error instanceof SimplifiedHttpError)) {
+    return undefined;
+  }
+  const data = error.data;
+  return !!data && typeof data === 'object' && 'code' in data && typeof data.code === 'number' ? data.code : undefined;
 }
 
 /**
@@ -22,8 +26,8 @@ function hasResponseCode(error: AxiosError): error is AxiosError<{code: number}>
  *
  * @see https://docs.alpaca.markets/us/docs/user-protection#pattern-day-trader-pdt-protection-at-alpaca
  */
-function isPatternDayTrader(error: AxiosError) {
-  return hasResponseCode(error) && error.response?.data.code === 40310100;
+function isPatternDayTrader(error: unknown) {
+  return getAlpacaErrorCode(error) === 40310100;
 }
 
 /**
@@ -32,19 +36,26 @@ function isPatternDayTrader(error: AxiosError) {
  *
  * @see https://docs.alpaca.markets/us/docs/margin-and-short-selling
  */
-function isNotAllowedToShort(error: AxiosError) {
-  return hasResponseCode(error) && error.response?.data.code === 40310000;
+function isNotAllowedToShort(error: unknown) {
+  return getAlpacaErrorCode(error) === 40310000;
 }
 
-export function shouldRetryAlpacaRequest(error: AxiosError) {
+export function shouldRetryAlpacaRequest(error: unknown) {
   if (isPatternDayTrader(error)) {
     return false;
   }
   if (isNotAllowedToShort(error)) {
     return false;
   }
-  return axiosRetry.isRetryableError(error);
+  return isTransientHttpError(error);
 }
+
+// Alpaca applies one rate-limit policy across all endpoints, so every method shares this decorator.
+const retryAlpaca = retry({
+  delayMs: attempt => attempt * ms('1s'),
+  isRetryable: shouldRetryAlpacaRequest,
+  retries: 20,
+});
 
 export class AlpacaAPI {
   readonly #tradingClient;
@@ -56,19 +67,10 @@ export class AlpacaAPI {
       'APCA-API-SECRET-KEY': options.apiSecret,
     };
 
-    const retryConfig: Parameters<typeof axiosRetry>[1] = {
-      retries: 20,
-      retryCondition: shouldRetryAlpacaRequest,
-      retryDelay: retryCount => {
-        return retryCount * ms('1s');
-      },
-    };
-
     this.#tradingClient = axios.create({
       baseURL: options.usePaperTrading ? 'https://paper-api.alpaca.markets' : 'https://api.alpaca.markets',
       headers,
     });
-    axiosRetry(this.#tradingClient, retryConfig);
     simplifyError(this.#tradingClient);
 
     // @see https://docs.alpaca.markets/us/docs/market-data-faq#checklist-for-broker-partners
@@ -76,29 +78,32 @@ export class AlpacaAPI {
       baseURL: options.usePaperTrading ? 'https://data.sandbox.alpaca.markets' : 'https://data.alpaca.markets',
       headers,
     });
-    axiosRetry(this.#marketDataClient, retryConfig);
     simplifyError(this.#marketDataClient);
   }
 
   /** @see https://docs.alpaca.markets/reference/get-v2-clock */
+  @retryAlpaca
   async getClock() {
     const response = await this.#tradingClient.get('/v2/clock');
     return ClockSchema.parse(response.data);
   }
 
   /** @see https://docs.alpaca.markets/reference/stocklatestbars */
+  @retryAlpaca
   async getStockBarsLatest(params: {feed: string; symbols: string}) {
     const response = await this.#marketDataClient.get('/v2/stocks/bars/latest', {params});
     return LatestBarsResponseSchema.parse(response.data);
   }
 
   /** @see https://docs.alpaca.markets/reference/cryptolatestbars */
+  @retryAlpaca
   async getCryptoBarsLatest(params: {symbols: string}) {
     const response = await this.#marketDataClient.get('/v1beta3/crypto/us/latest/bars', {params});
     return LatestBarsResponseSchema.parse(response.data);
   }
 
   /** @see https://docs.alpaca.markets/reference/stockbars */
+  @retryAlpaca
   async getStockBars(params: {
     end: string;
     feed: string;
@@ -113,12 +118,14 @@ export class AlpacaAPI {
   }
 
   /** @see https://docs.alpaca.markets/reference/stocksnapshots-1 */
+  @retryAlpaca
   async getStockSnapshots(params: {feed: string; symbols: string}) {
     const response = await this.#marketDataClient.get('/v2/stocks/snapshots', {params});
     return SnapshotsResponseSchema.parse(response.data);
   }
 
   /** @see https://docs.alpaca.markets/reference/cryptobars-1 */
+  @retryAlpaca
   async getCryptoBars(params: {
     end: string;
     limit: number;
@@ -132,24 +139,28 @@ export class AlpacaAPI {
   }
 
   /** @see https://docs.alpaca.markets/reference/getaccount-1 */
+  @retryAlpaca
   async getAccount() {
     const response = await this.#tradingClient.get('/v2/account');
     return AccountSchema.parse(response.data);
   }
 
   /** @see https://docs.alpaca.markets/reference/getallopenpositions */
+  @retryAlpaca
   async getPositions() {
     const response = await this.#tradingClient.get('/v2/positions');
     return z.array(PositionSchema).parse(response.data);
   }
 
   /** @see https://docs.alpaca.markets/reference/getallorders */
+  @retryAlpaca
   async getOrders(params: {status: string; symbols?: string}) {
     const response = await this.#tradingClient.get('/v2/orders', {params});
     return z.array(OrderSchema).parse(response.data);
   }
 
   /** @see https://docs.alpaca.markets/reference/deleteorderbyorderid */
+  @retryAlpaca
   async deleteOrder(orderId: string) {
     await this.#tradingClient.delete(`/v2/orders/${orderId}`);
   }
@@ -158,6 +169,7 @@ export class AlpacaAPI {
    * @see https://docs.alpaca.markets/reference/postorder
    * @see https://docs.alpaca.markets/us/docs/working-with-orders#using-client-order-ids
    */
+  @retryAlpaca
   async postOrder(params: {
     client_order_id: string;
     extended_hours?: boolean;
@@ -174,6 +186,7 @@ export class AlpacaAPI {
   }
 
   /** @see https://docs.alpaca.markets/reference/get-v2-assets */
+  @retryAlpaca
   async getAssets(params: {asset_class: AlpacaAssetClass}) {
     const response = await this.#tradingClient.get('/v2/assets', {params});
     return z.array(AssetSchema).parse(response.data);

--- a/packages/exchange/src/broker/trading212/api/Trading212API.ts
+++ b/packages/exchange/src/broker/trading212/api/Trading212API.ts
@@ -1,6 +1,6 @@
-import axios, {type AxiosDefaults, type AxiosError, type AxiosInstance} from 'axios';
-import axiosRetry from 'axios-retry';
+import axios, {type AxiosDefaults, type AxiosInstance} from 'axios';
 import {z} from 'zod';
+import {retry} from '../../../util/retry.js';
 import {simplifyError} from '../../../util/simplifyError.js';
 import {AccountCashSchema, AccountInfoSchema} from './schema/AccountSchema.js';
 import {HistoryOrderPageSchema, type HistoryOrder} from './schema/HistoryOrderSchema.js';
@@ -26,42 +26,11 @@ const URL = {
 } as const;
 
 /**
- * Per-endpoint retry delays (ms) calibrated to Trading212's documented rate limits.
+ * The `@retry` delay on each method is calibrated to Trading212's documented rate limit
+ * for that endpoint.
  *
  * @see https://t212public-api-docs.redoc.ly/
  */
-function getRetryDelay(retryCount: number, error: AxiosError) {
-  const url = error.config?.url ?? '';
-  const method = error.config?.method;
-
-  if (method === 'get' && url.startsWith(`${URL.ORDERS}/`)) {
-    return 1_000;
-  }
-
-  /*
-   * HISTORY_ORDERS pagination follows vendor-supplied `nextPagePath` URLs that include a
-   * query string (e.g. "/api/v0/equity/history/orders?cursor=…"), so a strict `===` match
-   * would miss every page after the first and fall through to the 1s default.
-   */
-  if (url.startsWith(URL.HISTORY_ORDERS)) {
-    return 60_000;
-  }
-
-  switch (url) {
-    case URL.ACCOUNT_CASH:
-      return 2_000;
-    case URL.ORDERS:
-    case URL.PORTFOLIO:
-      return 5_000;
-    case URL.ACCOUNT_INFO:
-      return 30_000;
-    case URL.METADATA_INSTRUMENTS:
-      return 50_000;
-    default:
-      return retryCount * 1_000;
-  }
-}
-
 export class Trading212API {
   static readonly URL = URL;
 
@@ -82,14 +51,6 @@ export class Trading212API {
       return config;
     });
 
-    axiosRetry(this.#httpClient, {
-      retries: Infinity,
-      retryCondition: (error: AxiosError) => {
-        return axiosRetry.isRetryableError(error);
-      },
-      retryDelay: getRetryDelay,
-    });
-
     simplifyError(this.#httpClient);
   }
 
@@ -102,47 +63,55 @@ export class Trading212API {
   }
 
   /** @see https://t212public-api-docs.redoc.ly/#operation/accountCash */
+  @retry({delayMs: 2_000})
   async getAccountCash() {
     const response = await this.#httpClient.get(URL.ACCOUNT_CASH);
     return AccountCashSchema.parse(response.data);
   }
 
   /** @see https://t212public-api-docs.redoc.ly/#operation/account */
+  @retry({delayMs: 30_000})
   async getAccountInfo() {
     const response = await this.#httpClient.get(URL.ACCOUNT_INFO);
     return AccountInfoSchema.parse(response.data);
   }
 
   /** @see https://t212public-api-docs.redoc.ly/#operation/portfolio */
+  @retry({delayMs: 5_000})
   async getPositions() {
     const response = await this.#httpClient.get(URL.PORTFOLIO);
     return z.array(PositionSchema).parse(response.data);
   }
 
   /** @see https://t212public-api-docs.redoc.ly/#operation/positionByTicker */
+  @retry()
   async getPositionByTicker(ticker: string) {
     const response = await this.#httpClient.get(`${URL.PORTFOLIO}/${ticker}`);
     return PositionSchema.parse(response.data);
   }
 
   /** @see https://t212public-api-docs.redoc.ly/#operation/orders */
+  @retry({delayMs: 5_000})
   async getOrders() {
     const response = await this.#httpClient.get(URL.ORDERS);
     return z.array(OrderSchema).parse(response.data);
   }
 
   /** @see https://t212public-api-docs.redoc.ly/#operation/orderById */
+  @retry({delayMs: 1_000})
   async getOrderById(id: number) {
     const response = await this.#httpClient.get(`${URL.ORDERS}/${id}`);
     return OrderSchema.parse(response.data);
   }
 
   /** @see https://t212public-api-docs.redoc.ly/#operation/cancelOrder */
+  @retry()
   async cancelOrder(id: number): Promise<void> {
     await this.#httpClient.delete(`${URL.ORDERS}/${id}`);
   }
 
   /** @see https://t212public-api-docs.redoc.ly/#operation/placeMarketOrder */
+  @retry()
   async placeMarketOrder(request: PlaceMarketOrderRequest) {
     const validated = PlaceMarketOrderRequestSchema.parse(request);
     const response = await this.#httpClient.post(URL.ORDERS_MARKET, validated);
@@ -150,6 +119,7 @@ export class Trading212API {
   }
 
   /** @see https://t212public-api-docs.redoc.ly/#operation/placeLimitOrder */
+  @retry()
   async placeLimitOrder(request: PlaceLimitOrderRequest) {
     const validated = PlaceLimitOrderRequestSchema.parse(request);
     const response = await this.#httpClient.post(URL.ORDERS_LIMIT, validated);
@@ -157,6 +127,7 @@ export class Trading212API {
   }
 
   /** @see https://t212public-api-docs.redoc.ly/#operation/instruments */
+  @retry({delayMs: 50_000})
   async getInstruments() {
     const response = await this.#httpClient.get(URL.METADATA_INSTRUMENTS);
     return z.array(InstrumentSchema).parse(response.data);
@@ -169,6 +140,7 @@ export class Trading212API {
    *
    * @see https://t212public-api-docs.redoc.ly/#operation/orders_1
    */
+  @retry({delayMs: 60_000})
   async getHistoryOrdersPage(options?: {nextPath?: string; ticker?: string}) {
     if (options?.nextPath) {
       const response = await this.#httpClient.get(options.nextPath);
@@ -183,25 +155,20 @@ export class Trading212API {
   }
 
   /**
-   * Fetches all historical orders (auto-paginates via `nextPagePath`).
+   * Fetches all historical orders (auto-paginates via `nextPagePath`). Deliberately not decorated
+   * with `@retry` — each page is fetched through {@link getHistoryOrdersPage}, so a transient
+   * failure retries only the affected page instead of restarting the whole pagination.
    *
    * @see https://t212public-api-docs.redoc.ly/#operation/orders_1
    */
   async getHistoryOrders(ticker?: string): Promise<HistoryOrder[]> {
     const items: HistoryOrder[] = [];
-    let nextPath: string | null = null;
-    const params: Record<string, string> = {limit: '50'};
-    if (ticker) {
-      params.ticker = ticker;
-    }
+    let nextPath: string | undefined = undefined;
 
     do {
-      const response = nextPath
-        ? await this.#httpClient.get(nextPath)
-        : await this.#httpClient.get(URL.HISTORY_ORDERS, {params});
-      const page = HistoryOrderPageSchema.parse(response.data);
+      const page = await this.getHistoryOrdersPage({nextPath, ticker});
       items.push(...page.items);
-      nextPath = page.nextPagePath;
+      nextPath = page.nextPagePath ?? undefined;
     } while (nextPath);
 
     return items;

--- a/packages/exchange/src/util/isEarningsDay.test.ts
+++ b/packages/exchange/src/util/isEarningsDay.test.ts
@@ -8,16 +8,6 @@ vi.mock('axios', () => ({
   },
 }));
 
-/*
- * axios-retry runs at module-load time and wraps interceptors on the axios
- * instance. We bypass it because the mocked axios instance has no
- * interceptors — the real retry behavior is exercised by the production
- * client, not by these unit tests.
- */
-vi.mock('axios-retry', () => ({
-  default: vi.fn(),
-}));
-
 const {isEarningsDay} = await import('./isEarningsDay.js');
 
 describe('isEarningsDay', () => {

--- a/packages/exchange/src/util/isEarningsDay.test.ts
+++ b/packages/exchange/src/util/isEarningsDay.test.ts
@@ -9,14 +9,6 @@ vi.mock(import('axios'), () => ({
   } as unknown as AxiosStatic,
 }));
 
-/*
- * axios-retry runs at module-load time and wraps interceptors on the axios
- * instance. We bypass it because the mocked axios instance has no
- * interceptors — the real retry behavior is exercised by the production
- * client, not by these unit tests.
- */
-vi.mock(import('axios-retry'));
-
 const {isEarningsDay} = await import('./isEarningsDay.js');
 
 describe('isEarningsDay', () => {

--- a/packages/exchange/src/util/isEarningsDay.ts
+++ b/packages/exchange/src/util/isEarningsDay.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
-import axiosRetry from 'axios-retry';
 import {z} from 'zod';
+import {withRetry} from './retry.js';
 
 const EarningsEntrySchema = z.looseObject({
   date: z.string(),
@@ -24,11 +24,10 @@ const client = axios.create({
   baseURL: 'https://finnhub.io/api/v1',
 });
 
-axiosRetry(client, {
-  retries: 3,
-  retryCondition: error => axiosRetry.isNetworkError(error) || error.response?.status === 429,
-  retryDelay: retryCount => retryCount * 1_000,
-});
+// This client skips simplifyError, so errors arrive as raw AxiosError — not SimplifiedHttpError.
+function isRetryableFinnhubError(error: unknown) {
+  return axios.isAxiosError(error) && (!error.response || error.response.status === 429);
+}
 
 /**
  * Checks whether a symbol is reporting quarterly earnings on the given UTC date.
@@ -37,14 +36,18 @@ axiosRetry(client, {
  */
 export async function isEarningsDay(options: {apiKey: string; date: Date; symbol: string}) {
   const isoDate = toIsoDate(options.date);
-  const response = await client.get('/calendar/earnings', {
-    params: {
-      from: isoDate,
-      symbol: options.symbol,
-      to: isoDate,
-      token: options.apiKey,
-    },
-  });
+  const response = await withRetry(
+    () =>
+      client.get('/calendar/earnings', {
+        params: {
+          from: isoDate,
+          symbol: options.symbol,
+          to: isoDate,
+          token: options.apiKey,
+        },
+      }),
+    {isRetryable: isRetryableFinnhubError, retries: 3}
+  );
   const parsed = EarningsCalendarResponseSchema.parse(response.data);
   const entries = parsed.earningsCalendar ?? [];
   return entries.some(entry => entry.symbol === options.symbol && entry.date === isoDate);

--- a/packages/exchange/src/util/retry.test.ts
+++ b/packages/exchange/src/util/retry.test.ts
@@ -1,0 +1,114 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {retry} from './retry.js';
+import {SimplifiedHttpError} from './SimplifiedHttpError.js';
+
+function rateLimitError() {
+  return new SimplifiedHttpError({data: 'Too Many Requests', status: 429});
+}
+
+// Sequential: fake timers are process-global, so concurrently running tests would advance each other's clocks.
+describe.sequential('retry', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('retries transient failures until the method succeeds', async () => {
+    const attempts = vi.fn();
+
+    class Api {
+      @retry({delayMs: 1_000})
+      async load() {
+        attempts();
+        if (attempts.mock.calls.length < 3) {
+          throw rateLimitError();
+        }
+        return 'ok';
+      }
+    }
+
+    const pending = new Api().load();
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    await expect(pending).resolves.toBe('ok');
+    expect(attempts).toHaveBeenCalledTimes(3);
+  });
+
+  it('rethrows non-retryable errors without retrying', async () => {
+    const attempts = vi.fn();
+    const badRequest = new SimplifiedHttpError({data: 'Bad Request', status: 400});
+
+    class Api {
+      @retry()
+      async load() {
+        attempts();
+        throw badRequest;
+      }
+    }
+
+    await expect(new Api().load()).rejects.toBe(badRequest);
+    expect(attempts).toHaveBeenCalledTimes(1);
+  });
+
+  it('gives up once the retry limit is exhausted', async () => {
+    const attempts = vi.fn();
+
+    class Api {
+      @retry({delayMs: 10, retries: 2})
+      async load() {
+        attempts();
+        throw rateLimitError();
+      }
+    }
+
+    const pending = new Api().load();
+    const assertion = expect(pending).rejects.toBeInstanceOf(SimplifiedHttpError);
+    await vi.advanceTimersByTimeAsync(20);
+
+    await assertion;
+    expect(attempts).toHaveBeenCalledTimes(3);
+  });
+
+  it('waits according to the attempt-based delay function', async () => {
+    const attempts = vi.fn();
+
+    class Api {
+      @retry({delayMs: attempt => attempt * 500})
+      async load() {
+        attempts();
+        if (attempts.mock.calls.length < 3) {
+          throw rateLimitError();
+        }
+        return 'ok';
+      }
+    }
+
+    const pending = new Api().load();
+
+    await vi.advanceTimersByTimeAsync(499);
+    expect(attempts).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(attempts).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await expect(pending).resolves.toBe('ok');
+    expect(attempts).toHaveBeenCalledTimes(3);
+  });
+
+  it('preserves access to private fields of the decorated instance', async () => {
+    class Api {
+      readonly #token = 'secret';
+
+      @retry()
+      async whoAmI() {
+        return this.#token;
+      }
+    }
+
+    await expect(new Api().whoAmI()).resolves.toBe('secret');
+  });
+});

--- a/packages/exchange/src/util/retry.ts
+++ b/packages/exchange/src/util/retry.ts
@@ -18,33 +18,37 @@ export function isTransientHttpError(error: unknown) {
   return error.status === 0 || error.status === 429 || (error.status >= 500 && error.status <= 599);
 }
 
+/** Function form of {@link retry} for call sites that have no method to decorate. */
+export async function withRetry<Result>(
+  run: () => Promise<Result>,
+  {delayMs = attempt => attempt * 1_000, isRetryable = isTransientHttpError, retries = Infinity}: RetryOptions = {}
+): Promise<Result> {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await run();
+    } catch (error) {
+      if (attempt > retries || !isRetryable(error)) {
+        throw error;
+      }
+      const delay = typeof delayMs === 'function' ? delayMs(attempt) : delayMs;
+      await new Promise(resolve => setTimeout(resolve, delay));
+    }
+  }
+}
+
 /**
  * Method decorator (TC39 standard mode) that retries transient failures. It lets each API method
  * declare its own rate-limit policy right where the endpoint is called, instead of maintaining a
  * URL-matching table in a shared HTTP interceptor that can silently fall out of sync with the
  * methods it covers.
  */
-export function retry({
-  delayMs = attempt => attempt * 1_000,
-  isRetryable = isTransientHttpError,
-  retries = Infinity,
-}: RetryOptions = {}) {
+export function retry(options: RetryOptions = {}) {
   return function <This, Args extends unknown[], Result>(
     target: AsyncMethod<This, Args, Result>,
     _context: ClassMethodDecoratorContext<This, AsyncMethod<This, Args, Result>>
   ): AsyncMethod<This, Args, Result> {
-    return async function (this: This, ...args: Args): Promise<Result> {
-      for (let attempt = 1; ; attempt++) {
-        try {
-          return await target.apply(this, args);
-        } catch (error) {
-          if (attempt > retries || !isRetryable(error)) {
-            throw error;
-          }
-          const delay = typeof delayMs === 'function' ? delayMs(attempt) : delayMs;
-          await new Promise(resolve => setTimeout(resolve, delay));
-        }
-      }
+    return function (this: This, ...args: Args): Promise<Result> {
+      return withRetry(() => target.apply(this, args), options);
     };
   };
 }

--- a/packages/exchange/src/util/retry.ts
+++ b/packages/exchange/src/util/retry.ts
@@ -10,7 +10,8 @@ export interface RetryOptions {
   retries?: number;
 }
 
-function isTransientHttpError(error: unknown) {
+/** Retryable transient failures as normalized into {@link SimplifiedHttpError}: network errors (status 0), 429 rate limits, and 5xx responses. */
+export function isTransientHttpError(error: unknown) {
   if (!(error instanceof SimplifiedHttpError)) {
     return false;
   }

--- a/packages/exchange/src/util/retry.ts
+++ b/packages/exchange/src/util/retry.ts
@@ -1,0 +1,49 @@
+import {SimplifiedHttpError} from './SimplifiedHttpError.js';
+
+type AsyncMethod<This, Args extends unknown[], Result> = (this: This, ...args: Args) => Promise<Result>;
+
+export interface RetryOptions {
+  /** Fixed delay in milliseconds, or a function of the attempt number (starting at 1). Defaults to `attempt * 1_000`. */
+  delayMs?: number | ((attempt: number) => number);
+  /** Defaults to retrying transient HTTP failures: network errors, 429 rate limits, and 5xx responses. */
+  isRetryable?: (error: unknown) => boolean;
+  retries?: number;
+}
+
+function isTransientHttpError(error: unknown) {
+  if (!(error instanceof SimplifiedHttpError)) {
+    return false;
+  }
+  return error.status === 0 || error.status === 429 || (error.status >= 500 && error.status <= 599);
+}
+
+/**
+ * Method decorator (TC39 standard mode) that retries transient failures. It lets each API method
+ * declare its own rate-limit policy right where the endpoint is called, instead of maintaining a
+ * URL-matching table in a shared HTTP interceptor that can silently fall out of sync with the
+ * methods it covers.
+ */
+export function retry({
+  delayMs = attempt => attempt * 1_000,
+  isRetryable = isTransientHttpError,
+  retries = Infinity,
+}: RetryOptions = {}) {
+  return function <This, Args extends unknown[], Result>(
+    target: AsyncMethod<This, Args, Result>,
+    _context: ClassMethodDecoratorContext<This, AsyncMethod<This, Args, Result>>
+  ): AsyncMethod<This, Args, Result> {
+    return async function (this: This, ...args: Args): Promise<Result> {
+      for (let attempt = 1; ; attempt++) {
+        try {
+          return await target.apply(this, args);
+        } catch (error) {
+          if (attempt > retries || !isRetryable(error)) {
+            throw error;
+          }
+          const delay = typeof delayMs === 'function' ? delayMs(attempt) : delayMs;
+          await new Promise(resolve => setTimeout(resolve, delay));
+        }
+      }
+    };
+  };
+}

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -1,9 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "emitDecoratorMetadata": false,
     "erasableSyntaxOnly": true,
-    "experimentalDecorators": true,
     "forceConsistentCasingInFileNames": true,
     "lib": ["es2023"],
     "module": "node20",

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -1,9 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "emitDecoratorMetadata": false,
     "erasableSyntaxOnly": true,
-    "experimentalDecorators": true,
     "forceConsistentCasingInFileNames": true,
     "lib": ["es2025"],
     "module": "node20",

--- a/vitest.config.base.ts
+++ b/vitest.config.base.ts
@@ -1,11 +1,31 @@
+import {transform} from 'esbuild';
 import {defineConfig} from 'vitest/config';
 
 export default defineConfig({
-  esbuild: {
-    // Allows using the "accessor" keyword in TypeScript:
-    // https://github.com/vitest-dev/vitest/issues/5976#issuecomment-2190804966
+  oxc: {
+    // Downlevels syntax Node cannot parse natively yet (e.g. the "accessor" keyword).
+    // Vite 8 (rolldown) transforms with oxc; the former `esbuild` options are ignored.
     target: 'es2022',
   },
+  plugins: [
+    {
+      enforce: 'pre',
+      name: 'standard-decorators',
+      /*
+       * oxc (rolldown's transformer) can only downlevel legacy `experimentalDecorators`,
+       * not TC39 standard decorators, so decorator-bearing files would reach Node as raw
+       * decorator syntax and fail to parse. esbuild (already present via tsx) downlevels
+       * them; scoped to files that actually use decorators so everything else stays on oxc.
+       * Drop this plugin once oxc ships standard-decorator support.
+       */
+      async transform(code, id) {
+        if (!/\.tsx?$/.test(id) || !/^\s*@[A-Za-z_$]/m.test(code)) {
+          return null;
+        }
+        return transform(code, {loader: 'ts', sourcefile: id, sourcemap: true, target: 'es2022'});
+      },
+    },
+  ],
   test: {
     bail: 1,
     coverage: {

--- a/vitest.shared.ts
+++ b/vitest.shared.ts
@@ -1,3 +1,4 @@
+import {transform} from 'esbuild';
 import {defineConfig} from 'vitest/config';
 
 export default defineConfig({
@@ -8,6 +9,25 @@ export default defineConfig({
      */
     target: 'es2022',
   },
+  plugins: [
+    {
+      enforce: 'pre',
+      name: 'standard-decorators',
+      /*
+       * oxc (rolldown's transformer) can only downlevel legacy `experimentalDecorators`,
+       * not TC39 standard decorators, so decorator-bearing files would reach Node as raw
+       * decorator syntax and fail to parse. esbuild (already present via tsx) downlevels
+       * them; scoped to files that actually use decorators so everything else stays on oxc.
+       * Drop this plugin once oxc ships standard-decorator support.
+       */
+      async transform(code, id) {
+        if (!/\.tsx?$/.test(id) || !/^\s*@[A-Za-z_$]/m.test(code)) {
+          return null;
+        }
+        return transform(code, {loader: 'ts', sourcefile: id, sourcemap: true, target: 'es2022'});
+      },
+    },
+  ],
   test: {
     bail: 1,
     coverage: {

--- a/vitest.shared.ts
+++ b/vitest.shared.ts
@@ -1,13 +1,17 @@
 import {transform} from 'esbuild';
 import {defineConfig} from 'vitest/config';
+import tsconfig from './tsconfig.lib.json';
+
+/*
+ * Vitest transpiles tests with target "node18" by default, which downlevels newer syntax
+ * (e.g. the "accessor" keyword: https://github.com/vitest-dev/vitest/issues/5976).
+ * Reusing the tsconfig target keeps tests on the same language level that ships in dist.
+ */
+const target = tsconfig.compilerOptions.target;
 
 export default defineConfig({
   esbuild: {
-    /*
-     * Allows using the "accessor" keyword in TypeScript:
-     * https://github.com/vitest-dev/vitest/issues/5976#issuecomment-2190804966
-     */
-    target: 'es2022',
+    target,
   },
   plugins: [
     {
@@ -24,7 +28,7 @@ export default defineConfig({
         if (!/\.tsx?$/.test(id) || !/^\s*@[A-Za-z_$]/m.test(code)) {
           return null;
         }
-        return transform(code, {loader: 'ts', sourcefile: id, sourcemap: true, target: 'es2022'});
+        return transform(code, {loader: 'ts', sourcefile: id, sourcemap: true, target});
       },
     },
   ],


### PR DESCRIPTION
## Why

Both API clients configured retries through `axios-retry` interceptors that had to reverse-map failed request URLs/config back to policy. `Trading212API`'s `getRetryDelay` matched URLs via string comparison — a design that already produced one silent bug (strict `===` missing paginated `nextPagePath` URLs — see the apology comment it carried), and every new endpoint risked silently falling through to the default delay.

## What

**`@retry` method decorator** (TC39 standard mode, `packages/exchange/src/util/retry.ts`): each API method declares its own rate-limit policy right where the endpoint lives — no URL-matching table to keep in sync.

```ts
/** @see https://t212public-api-docs.redoc.ly/#operation/accountCash */
@retry({delayMs: 2_000})
async getAccountCash() { ... }
```

- Default retryable predicate matches the old `axiosRetry.isRetryableError` set: network errors, 429, 5xx (as `SimplifiedHttpError` statuses `0`/`429`/`5xx`, since `simplifyError` runs at the interceptor level).
- Per-endpoint delays carried over 1:1 from the old table.
- `getHistoryOrders` now pages through the decorated `getHistoryOrdersPage`, preserving **per-page** retry semantics (a decorator on the aggregate would restart pagination) and deleting the duplicated pagination loop.

**`AlpacaAPI` converted too** (second commit): Alpaca applies one rate-limit policy across all endpoints, so a single shared `retryAlpaca` decorator (20 retries, linear 1s backoff) replaces the axios-retry wiring on both axios clients. `shouldRetryAlpacaRequest` now operates on `SimplifiedHttpError` instead of raw `AxiosError`; the PDT (40310100) and short-selling (40310000) exclusions are preserved and covered by the existing test suite (+1 new case).

**Toolchain enablement:**

- Dropped vestigial `experimentalDecorators`/`emitDecoratorMetadata` from `tsconfig.lib.json` — no legacy decorators exist in the repo, and the flag forced legacy semantics that break standard-mode decorators.
- Added a scoped pre-transform plugin to `vitest.config.base.ts`: oxc (rolldown-vite/Vitest 4) cannot downlevel standard decorators yet, so decorator-bearing files route through esbuild (already present via tsx). Remove once oxc ships support.

## Behavior notes

- Order placement/cancel endpoints keep the old default backoff (`attempt × 1s`) — unchanged.
- `ECONNABORTED` timeouts would now retry where `axios-retry` excluded them; moot since neither client configures a timeout.
- `axios-retry` is fully removed as a dependency (third commit): the retry loop is extracted into a plain `withRetry()` that the decorator now adapts, and `isEarningsDay` — the last consumer — uses the function form with its original policy (network or 429, 3 retries, linear 1s backoff) against raw `AxiosError`s, since its finnhub client skips `simplifyError`. Its `vi.mock(.axios-retry.)` workaround is gone too. (`ts-retry-promise` in the WebSocket managers is a different domain — left as is.)

## Verified

- Typecheck: all 5 packages
- Tests: exchange 95, trading-signals 453, trading-strategies 259, messaging 84 — all green
- `tsc` emit + runtime smoke test of built `dist/` class
- Next.js docs build (compiles exchange from source via tsconfig paths)
- eslint clean; `tsx` demo scripts unaffected (esbuild 0.28 downlevels standard decorators)