### PR TITLE
fix(trading-strategies): declare ms as a runtime dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11713,7 +11713,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -14370,11 +14369,11 @@
         "@typedtrader/exchange": "0.2.5",
         "@types/big.js": "^7.0.0",
         "big.js": "^7.0.1",
+        "ms": "4.0.0-nightly.202508271359",
         "trading-signals": "7.4.3",
         "zod": "^4.4.3"
       },
       "devDependencies": {
-        "ms": "4.0.0-nightly.202508271359",
         "tsx": "^4.22.5"
       }
     },
@@ -14382,7 +14381,6 @@
       "version": "4.0.0-nightly.202508271359",
       "resolved": "https://registry.npmjs.org/ms/-/ms-4.0.0-nightly.202508271359.tgz",
       "integrity": "sha512-WC/Eo7NzFrOV/RRrTaI0fxKVbNCzEy76j2VqNV8SxDf9D69gSE2Lh0QwYvDlhiYmheBYExAvEAxVf5NoN0cj2A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"

--- a/packages/trading-strategies/package.json
+++ b/packages/trading-strategies/package.json
@@ -6,12 +6,12 @@
     "@typedtrader/exchange": "0.2.5",
     "@types/big.js": "^7.0.0",
     "big.js": "^7.0.1",
+    "ms": "4.0.0-nightly.202508271359",
     "trading-signals": "7.4.3",
     "zod": "^4.4.3"
   },
   "description": "Trading strategies to run trading bots with JavaScript / TypeScript.",
   "devDependencies": {
-    "ms": "4.0.0-nightly.202508271359",
     "tsx": "^4.22.5"
   },
   "exports": "./dist/index.js",


### PR DESCRIPTION
## Problem

`SmaCrossoverStrategy.ts` does a runtime `import {ms} from 'ms'`, and the strategy is exported from `src/index.ts` and registered in the `StrategyRegistry` — but `ms` was only listed in **devDependencies**. Consumers installing `trading-strategies` from npm get a missing module unless hoisting happens to provide it.

## Fix

Move `ms` from devDependencies to dependencies. The exact nightly pin (`4.0.0-nightly.202508271359`) is kept intentionally: the code relies on the v4 named-export API (`{ms, format, parse, StringValue}`), which has no stable release yet.

## Verification

- `npm test` in `packages/trading-strategies`: 259 tests passed

> Note: this PR touches `package-lock.json`, as do #TBD dependency-cleanup PRs from the same review — merge in any order and refresh the lockfile with `npm install` on rebase.