### PR TITLE
chore(trading-signals-docs): enable ESLint for the docs package

### DIFF
--- a/eslint.config.base.mjs
+++ b/eslint.config.base.mjs
@@ -28,9 +28,12 @@ const configFileOverride = {
  */
 export function createConfig({ignores = []} = {}) {
   return defineConfig([
+    /*
+     * Global ignores: a config object with ONLY `ignores` excludes files entirely.
+     * Attached to a config that also has `files`, the same patterns would only exclude
+     * files from that one object and extended configs could still lint them.
+     */
     {
-      extends: [eslintConfig],
-      files: ['**/*.{ts,tsx,mts,cts,js,jsx,mjs,cjs}'],
       ignores: [
         '**/.dependency-cruiser.cjs',
         '**/coverage/**',
@@ -40,6 +43,10 @@ export function createConfig({ignores = []} = {}) {
         '**/vitest.config.ts',
         ...ignores,
       ],
+    },
+    {
+      extends: [eslintConfig],
+      files: ['**/*.{ts,tsx,mts,cts,js,jsx,mjs,cjs}'],
       rules: {
         /*
          * The codebase uses the idiomatic `const X = {...} as const` + `type X = ...`

--- a/packages/trading-signals-docs/components/BacktestResults.tsx
+++ b/packages/trading-signals-docs/components/BacktestResults.tsx
@@ -1,4 +1,5 @@
 import {Chart as HighchartsChart, type ChartOptions} from '@highcharts/react';
+import type {Big} from 'big.js';
 import {OrderSide} from '@typedtrader/exchange';
 import type {Candle} from '@typedtrader/exchange';
 import type {BacktestResult} from 'trading-strategies';
@@ -14,14 +15,14 @@ interface BacktestResultsProps extends ResultProps {
   baselineResult: BacktestResult | null;
 }
 
-function formatBig(val: import('big.js').Big, decimals = 2): string {
+function formatBig(val: Big, decimals = 2) {
   return Number(val.toFixed(decimals)).toLocaleString(undefined, {
-    minimumFractionDigits: decimals,
     maximumFractionDigits: decimals,
+    minimumFractionDigits: decimals,
   });
 }
 
-function PerformanceCards({result, candles}: ResultProps) {
+function PerformanceCards({candles, result}: ResultProps) {
   const {performance} = result;
   const returnPct = Number(performance.returnPercentage.toFixed(2));
   const winRate = Number(performance.winRate.toFixed(1));
@@ -32,18 +33,78 @@ function PerformanceCards({result, candles}: ResultProps) {
   const counter = candles[0]?.counter ?? 'Counter';
 
   const cards = [
-    {label: 'ROI', value: `${returnPct >= 0 ? '+' : ''}${returnPct}%`, positive: returnPct >= 0, info: 'Return on investment: percentage change in total portfolio value from start to end.'},
-    {label: 'Profit & Loss', value: `${pnl >= 0 ? '+' : '-'}$${formatBig(result.profitOrLoss.abs())}`, positive: pnl >= 0, info: 'Absolute gain or loss in counter currency compared to the starting portfolio value.'},
-    {label: 'Total Fees', value: `$${formatBig(result.totalFees)}`, positive: null, info: 'Total trading fees paid across all executed orders.'},
-    {label: 'Total Trades', value: String(performance.totalTrades), positive: null, info: 'Number of individual orders executed (buys + sells).'},
-    {label: 'Win Rate', value: hasCycles ? `${winRate}%` : <NotAvailable />, positive: hasCycles ? winRate >= 50 : null, info: 'Percentage of completed buy→sell cycles that closed at a profit.'},
-    {label: 'Loss Rate', value: lossRate !== null ? `${lossRate}%` : <NotAvailable />, positive: lossRate !== null ? Number(lossRate) < 50 : null, info: 'Percentage of completed buy→sell cycles that closed at a loss. Shown in green when below 50%.'},
-    {label: 'Max Win Streak', value: String(performance.maxWinStreak), positive: null, info: 'Longest consecutive sequence of profitable buy→sell cycles.'},
-    {label: 'Max Loss Streak', value: String(performance.maxLossStreak), positive: null, info: 'Longest consecutive sequence of losing buy→sell cycles.'},
-    {label: 'Start Value', value: `$${formatBig(performance.initialPortfolioValue)}`, positive: null, info: 'Initial portfolio value in counter currency (base × first open price + counter balance).'},
-    {label: 'Final Value', value: `$${formatBig(performance.finalPortfolioValue)}`, positive: null, info: 'Final portfolio value in counter currency (base × last close price + counter balance).'},
-    {label: `Final Base (${base})`, value: formatBig(result.finalBaseBalance, 6), positive: null, info: `Remaining ${base} balance at the end of the backtest.`},
-    {label: `Final Counter (${counter})`, value: `$${formatBig(result.finalCounterBalance)}`, positive: null, info: `Remaining ${counter} cash balance at the end of the backtest.`},
+    {
+      info: 'Return on investment: percentage change in total portfolio value from start to end.',
+      label: 'ROI',
+      positive: returnPct >= 0,
+      value: `${returnPct >= 0 ? '+' : ''}${returnPct}%`,
+    },
+    {
+      info: 'Absolute gain or loss in counter currency compared to the starting portfolio value.',
+      label: 'Profit & Loss',
+      positive: pnl >= 0,
+      value: `${pnl >= 0 ? '+' : '-'}$${formatBig(result.profitOrLoss.abs())}`,
+    },
+    {
+      info: 'Total trading fees paid across all executed orders.',
+      label: 'Total Fees',
+      positive: null,
+      value: `$${formatBig(result.totalFees)}`,
+    },
+    {
+      info: 'Number of individual orders executed (buys + sells).',
+      label: 'Total Trades',
+      positive: null,
+      value: String(performance.totalTrades),
+    },
+    {
+      info: 'Percentage of completed buy→sell cycles that closed at a profit.',
+      label: 'Win Rate',
+      positive: hasCycles ? winRate >= 50 : null,
+      value: hasCycles ? `${winRate}%` : <NotAvailable />,
+    },
+    {
+      info: 'Percentage of completed buy→sell cycles that closed at a loss. Shown in green when below 50%.',
+      label: 'Loss Rate',
+      positive: lossRate !== null ? Number(lossRate) < 50 : null,
+      value: lossRate !== null ? `${lossRate}%` : <NotAvailable />,
+    },
+    {
+      info: 'Longest consecutive sequence of profitable buy→sell cycles.',
+      label: 'Max Win Streak',
+      positive: null,
+      value: String(performance.maxWinStreak),
+    },
+    {
+      info: 'Longest consecutive sequence of losing buy→sell cycles.',
+      label: 'Max Loss Streak',
+      positive: null,
+      value: String(performance.maxLossStreak),
+    },
+    {
+      info: 'Initial portfolio value in counter currency (base × first open price + counter balance).',
+      label: 'Start Value',
+      positive: null,
+      value: `$${formatBig(performance.initialPortfolioValue)}`,
+    },
+    {
+      info: 'Final portfolio value in counter currency (base × last close price + counter balance).',
+      label: 'Final Value',
+      positive: null,
+      value: `$${formatBig(performance.finalPortfolioValue)}`,
+    },
+    {
+      info: `Remaining ${base} balance at the end of the backtest.`,
+      label: `Final Base (${base})`,
+      positive: null,
+      value: formatBig(result.finalBaseBalance, 6),
+    },
+    {
+      info: `Remaining ${counter} cash balance at the end of the backtest.`,
+      label: `Final Counter (${counter})`,
+      positive: null,
+      value: `$${formatBig(result.finalCounterBalance)}`,
+    },
   ];
 
   return (
@@ -72,15 +133,15 @@ function PerformanceCards({result, candles}: ResultProps) {
   );
 }
 
-function PriceChartWithTrades({result, candles}: ResultProps) {
+function PriceChartWithTrades({candles, result}: ResultProps) {
   const priceData = candles.map((c, i) => ({
-    x: i + 1,
-    y: Number(c.close),
-    open: Number(c.open),
+    close: Number(c.close),
     high: Number(c.high),
     low: Number(c.low),
-    close: Number(c.close),
+    open: Number(c.open),
     time: formatDate(c.openTimeInISO),
+    x: i + 1,
+    y: Number(c.close),
   }));
 
   const candleIndexByTime = new Map(candles.map((c, i) => [c.openTimeInISO, i + 1]));
@@ -89,7 +150,7 @@ function PriceChartWithTrades({result, candles}: ResultProps) {
     .filter(t => t.side === OrderSide.BUY)
     .map(t => {
       const x = candleIndexByTime.get(t.openTimeInISO) ?? 0;
-      return {x, y: Number(t.price.toFixed(2)), name: `BUY @ $${t.price.toFixed(2)}`};
+      return {name: `BUY @ $${t.price.toFixed(2)}`, x, y: Number(t.price.toFixed(2))};
     })
     .filter(m => m.x > 0);
 
@@ -97,36 +158,52 @@ function PriceChartWithTrades({result, candles}: ResultProps) {
     .filter(t => t.side === OrderSide.SELL)
     .map(t => {
       const x = candleIndexByTime.get(t.openTimeInISO) ?? 0;
-      return {x, y: Number(t.price.toFixed(2)), name: `SELL @ $${t.price.toFixed(2)}`};
+      return {name: `SELL @ $${t.price.toFixed(2)}`, x, y: Number(t.price.toFixed(2))};
     })
     .filter(m => m.x > 0);
 
   const options: ChartOptions = {
     chart: {backgroundColor: 'transparent', height: 350},
-    title: {text: 'Price Chart with Trades', style: {color: '#e2e8f0', fontSize: '16px', fontWeight: '600'}},
     credits: {enabled: false},
-    xAxis: {
-      title: {text: 'Period', style: {color: '#94a3b8'}},
-      labels: {style: {color: '#94a3b8'}},
-      gridLineColor: '#334155',
-    },
-    yAxis: {
-      title: {text: 'Price', style: {color: '#94a3b8'}},
-      labels: {style: {color: '#94a3b8'}},
-      gridLineColor: '#334155',
-    },
     legend: {
       itemStyle: {color: '#94a3b8'},
     },
+    series: [
+      {
+        color: '#3b82f6',
+        data: priceData,
+        lineWidth: 2,
+        marker: {enabled: false},
+        name: 'Price',
+        type: 'line',
+      },
+      {
+        color: '#22c55e',
+        data: buyMarkers.map(m => ({name: m.name, x: m.x, y: m.y})),
+        marker: {lineColor: '#22c55e', lineWidth: 1, radius: 6, symbol: 'triangle'},
+        name: 'BUY',
+        tooltip: {pointFormat: '{point.name}'},
+        type: 'scatter',
+      },
+      {
+        color: '#ef4444',
+        data: sellMarkers.map(m => ({name: m.name, x: m.x, y: m.y})),
+        marker: {lineColor: '#ef4444', lineWidth: 1, radius: 6, symbol: 'triangle-down'},
+        name: 'SELL',
+        tooltip: {pointFormat: '{point.name}'},
+        type: 'scatter',
+      },
+    ],
+    title: {style: {color: '#e2e8f0', fontSize: '16px', fontWeight: '600'}, text: 'Price Chart with Trades'},
     tooltip: {
       backgroundColor: '#1e293b',
       borderColor: '#475569',
-      style: {color: '#e2e8f0'},
-      shared: true,
-      formatter: function (): string {
+      formatter: function () {
         const points = (this as any).points as any[];
-        // The OHLC fields live on the line series points, not the scatter markers.
-        // Don't trust points[0] — find the point that actually carries the candle data.
+        /*
+         * The OHLC fields live on the line series points, not the scatter markers.
+         * Don't trust points[0] — find the point that actually carries the candle data.
+         */
         const ohlc = points?.find((p: any) => typeof p?.point?.open === 'number')?.point;
         let s = `<b>${ohlc?.time ?? 'Period ' + (this as any).x}</b><br/>`;
         if (ohlc) {
@@ -142,33 +219,19 @@ function PriceChartWithTrades({result, candles}: ResultProps) {
         });
         return s;
       },
+      shared: true,
+      style: {color: '#e2e8f0'},
     },
-    series: [
-      {
-        type: 'line',
-        name: 'Price',
-        data: priceData,
-        color: '#3b82f6',
-        marker: {enabled: false},
-        lineWidth: 2,
-      },
-      {
-        type: 'scatter',
-        name: 'BUY',
-        data: buyMarkers.map(m => ({x: m.x, y: m.y, name: m.name})),
-        color: '#22c55e',
-        marker: {symbol: 'triangle', radius: 6, lineColor: '#22c55e', lineWidth: 1},
-        tooltip: {pointFormat: '{point.name}'},
-      },
-      {
-        type: 'scatter',
-        name: 'SELL',
-        data: sellMarkers.map(m => ({x: m.x, y: m.y, name: m.name})),
-        color: '#ef4444',
-        marker: {symbol: 'triangle-down', radius: 6, lineColor: '#ef4444', lineWidth: 1},
-        tooltip: {pointFormat: '{point.name}'},
-      },
-    ],
+    xAxis: {
+      gridLineColor: '#334155',
+      labels: {style: {color: '#94a3b8'}},
+      title: {style: {color: '#94a3b8'}, text: 'Period'},
+    },
+    yAxis: {
+      gridLineColor: '#334155',
+      labels: {style: {color: '#94a3b8'}},
+      title: {style: {color: '#94a3b8'}, text: 'Price'},
+    },
   };
 
   return (
@@ -207,15 +270,11 @@ function TradeHistoryTable({result}: {result: BacktestResult}) {
           {result.trades.map((trade, i) => (
             <tr key={i} className="border-b border-slate-800 hover:bg-slate-700/30">
               <td className="py-2 px-3 text-slate-300">{i + 1}</td>
-              <td className="py-2 px-3 text-slate-300 font-mono text-xs">
-                {formatDate(trade.openTimeInISO)}
-              </td>
+              <td className="py-2 px-3 text-slate-300 font-mono text-xs">{formatDate(trade.openTimeInISO)}</td>
               <td className="py-2 px-3">
                 <span
                   className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${
-                    trade.side === OrderSide.BUY
-                      ? 'bg-green-900/50 text-green-400'
-                      : 'bg-red-900/50 text-red-400'
+                    trade.side === OrderSide.BUY ? 'bg-green-900/50 text-green-400' : 'bg-red-900/50 text-red-400'
                   }`}>
                   {trade.advice.side} {trade.advice.type}
                 </span>
@@ -240,7 +299,7 @@ function WinnerBadge() {
   );
 }
 
-export function BacktestResults({result, baselineResult, candles}: BacktestResultsProps) {
+export function BacktestResults({baselineResult, candles, result}: BacktestResultsProps) {
   const strategyWins = baselineResult
     ? result.performance.returnPercentage.gte(baselineResult.performance.returnPercentage)
     : null;

--- a/packages/trading-signals-docs/components/CalculatorDemo.tsx
+++ b/packages/trading-signals-docs/components/CalculatorDemo.tsx
@@ -18,7 +18,7 @@ export interface CalculatorExample {
   code: string;
 }
 
-function formatResult(value: number): string {
+function formatResult(value: number) {
   if (!Number.isFinite(value)) {
     return '—';
   }

--- a/packages/trading-signals-docs/components/CategoryCard.tsx
+++ b/packages/trading-signals-docs/components/CategoryCard.tsx
@@ -8,7 +8,7 @@ interface CategoryCardProps {
   indicators: string[];
 }
 
-export function CategoryCard({name, description, href, icon, indicators}: CategoryCardProps) {
+export function CategoryCard({description, href, icon, indicators, name}: CategoryCardProps) {
   return (
     <Link
       href={href}

--- a/packages/trading-signals-docs/components/Chart.tsx
+++ b/packages/trading-signals-docs/components/Chart.tsx
@@ -1,4 +1,5 @@
-import {Chart as HighchartsChart, ChartOptions, HighchartsReactRefObject} from '@highcharts/react';
+import type {ChartOptions, HighchartsReactRefObject} from '@highcharts/react';
+import {Chart as HighchartsChart} from '@highcharts/react';
 import {useRef} from 'react';
 
 export interface ChartDataPoint {
@@ -20,79 +21,79 @@ export interface ChartProps {
   flags?: FlagPoint[];
 }
 
-export default function Chart({title, data, yAxisLabel = 'Value', color = '#3b82f6'}: ChartProps) {
+export default function Chart({color = '#3b82f6', data, title, yAxisLabel = 'Value'}: ChartProps) {
   const chartRef = useRef<HighchartsReactRefObject>(null);
 
   const options: ChartOptions = {
     chart: {
-      type: 'line',
       backgroundColor: 'transparent',
       height: 300,
-    },
-    title: {
-      text: title,
-      style: {
-        color: '#e2e8f0',
-        fontSize: '16px',
-        fontWeight: '600',
-      },
+      type: 'line',
     },
     credits: {
       enabled: false,
-    },
-    xAxis: {
-      title: {
-        text: 'Period',
-        style: {color: '#94a3b8'},
-      },
-      labels: {
-        style: {color: '#94a3b8'},
-      },
-      gridLineColor: '#334155',
-    },
-    yAxis: {
-      title: {
-        text: yAxisLabel,
-        style: {color: '#94a3b8'},
-      },
-      labels: {
-        style: {color: '#94a3b8'},
-      },
-      gridLineColor: '#334155',
     },
     legend: {
       enabled: false,
     },
     plotOptions: {
       line: {
+        lineWidth: 2,
         marker: {
           enabled: true,
           radius: 3,
         },
-        lineWidth: 2,
       },
     },
     series: [
       {
-        type: 'line',
-        name: yAxisLabel,
-        id: 'main-series',
-        data: data.map(point => [point.x, point.y]),
         color: color,
+        data: data.map(point => [point.x, point.y]),
+        id: 'main-series',
         marker: {
           fillColor: color,
         },
+        name: yAxisLabel,
+        type: 'line',
       },
     ],
+    title: {
+      style: {
+        color: '#e2e8f0',
+        fontSize: '16px',
+        fontWeight: '600',
+      },
+      text: title,
+    },
     tooltip: {
       backgroundColor: '#1e293b',
       borderColor: '#475569',
-      style: {
-        color: '#e2e8f0',
-      },
       formatter: function () {
         const yValue = typeof this.y === 'number' ? this.y.toFixed(2) : 'N/A';
         return `<b>Period ${this.x}</b><br/>${yAxisLabel}: ${yValue}`;
+      },
+      style: {
+        color: '#e2e8f0',
+      },
+    },
+    xAxis: {
+      gridLineColor: '#334155',
+      labels: {
+        style: {color: '#94a3b8'},
+      },
+      title: {
+        style: {color: '#94a3b8'},
+        text: 'Period',
+      },
+    },
+    yAxis: {
+      gridLineColor: '#334155',
+      labels: {
+        style: {color: '#94a3b8'},
+      },
+      title: {
+        style: {color: '#94a3b8'},
+        text: yAxisLabel,
       },
     },
   };

--- a/packages/trading-signals-docs/components/CodeExample.tsx
+++ b/packages/trading-signals-docs/components/CodeExample.tsx
@@ -4,7 +4,7 @@ interface CodeExampleProps {
   language?: string;
 }
 
-export function CodeExample({title = 'Code Example', code, language = 'typescript'}: CodeExampleProps) {
+export function CodeExample({code, language = 'typescript', title = 'Code Example'}: CodeExampleProps) {
   return (
     <div className="bg-purple-900/20 border border-purple-800/50 rounded-lg p-4">
       <h3 className="text-lg font-semibold text-purple-400 mb-2">{title}</h3>

--- a/packages/trading-signals-docs/components/DataTable.tsx
+++ b/packages/trading-signals-docs/components/DataTable.tsx
@@ -13,7 +13,7 @@ interface DataTableProps<T> {
   data: T[];
 }
 
-export function DataTable<T extends Record<string, any>>({title, columns, data}: DataTableProps<T>) {
+export function DataTable<T extends Record<string, any>>({columns, data, title}: DataTableProps<T>) {
   return (
     <div className="bg-slate-800/50 border border-slate-700 rounded-lg p-4">
       {title && <h3 className="text-lg font-semibold text-white mb-3">{title}</h3>}

--- a/packages/trading-signals-docs/components/DemoCard.tsx
+++ b/packages/trading-signals-docs/components/DemoCard.tsx
@@ -10,7 +10,7 @@ interface DemoCardProps {
  * Outer card chrome shared by IndicatorDemo, CalculatorDemo, and UtilityInfoPanel:
  * dark panel with a bordered header (name + description) and a padded content area below.
  */
-export function DemoCard({name, description, children}: DemoCardProps) {
+export function DemoCard({children, description, name}: DemoCardProps) {
   return (
     <div className="bg-slate-800/50 border border-slate-700 rounded-lg overflow-hidden">
       <div className="border-b border-slate-700 p-4">

--- a/packages/trading-signals-docs/components/Hero.tsx
+++ b/packages/trading-signals-docs/components/Hero.tsx
@@ -5,7 +5,7 @@ interface HeroProps {
   githubUrl: string;
 }
 
-export function Hero({title, description, npmUrl, githubUrl}: HeroProps) {
+export function Hero({description, githubUrl, npmUrl, title}: HeroProps) {
   return (
     <div className="text-center space-y-4 py-12">
       <h1 className="text-5xl font-bold text-white">{title}</h1>

--- a/packages/trading-signals-docs/components/IndicatorDemo.tsx
+++ b/packages/trading-signals-docs/components/IndicatorDemo.tsx
@@ -7,17 +7,17 @@ export interface IndicatorExample {
   description: string;
   code: string;
   inputValues: number[];
-  calculate: (values: number[]) => {result: string | null; allResults: Array<{value: number; result: string | null}>};
+  calculate: (values: number[]) => {result: string | null; allResults: {value: number; result: string | null}[]};
 }
 
 export default function IndicatorDemo({example}: {example: IndicatorExample}) {
   const [customInput, setCustomInput] = useState('');
   const [values, setValues] = useState<number[]>(example.inputValues);
   const [currentResult, setCurrentResult] = useState<string | null>(null);
-  const [allResults, setAllResults] = useState<Array<{value: number; result: string | null}>>([]);
+  const [allResults, setAllResults] = useState<{value: number; result: string | null}[]>([]);
 
   useEffect(() => {
-    const {result, allResults} = example.calculate(values);
+    const {allResults, result} = example.calculate(values);
     setCurrentResult(result);
     setAllResults(allResults);
   }, [values, example]);

--- a/packages/trading-signals-docs/components/IndicatorHeader.tsx
+++ b/packages/trading-signals-docs/components/IndicatorHeader.tsx
@@ -6,7 +6,7 @@ interface IndicatorHeaderProps {
   details?: string;
 }
 
-export function IndicatorHeader({name, parameters, requiredInputs, description, details}: IndicatorHeaderProps) {
+export function IndicatorHeader({description, details, name, parameters, requiredInputs}: IndicatorHeaderProps) {
   return (
     <div>
       <h2 className="text-2xl font-bold text-white mb-2 select-text">

--- a/packages/trading-signals-docs/components/IndicatorList.tsx
+++ b/packages/trading-signals-docs/components/IndicatorList.tsx
@@ -13,8 +13,8 @@ interface IndicatorListProps {
 
 export function IndicatorList({
   indicators,
-  selectedIndicator,
   onIndicatorChange,
+  selectedIndicator,
   title = 'Momentum Indicators',
 }: IndicatorListProps) {
   return (

--- a/packages/trading-signals-docs/components/IndicatorSelector.tsx
+++ b/packages/trading-signals-docs/components/IndicatorSelector.tsx
@@ -1,10 +1,10 @@
 interface IndicatorSelectorProps {
-  indicators: Array<{id: string; name: string; description: string}>;
+  indicators: {id: string; name: string; description: string}[];
   selectedId: string;
   onSelect: (id: string) => void;
 }
 
-export function IndicatorSelector({indicators, selectedId, onSelect}: IndicatorSelectorProps) {
+export function IndicatorSelector({indicators, onSelect, selectedId}: IndicatorSelectorProps) {
   return (
     <div className="bg-slate-800/50 border border-slate-700 rounded-lg p-4 mb-6">
       <h3 className="text-lg font-semibold text-white mb-3">Select Indicator</h3>

--- a/packages/trading-signals-docs/components/MarketClock.tsx
+++ b/packages/trading-signals-docs/components/MarketClock.tsx
@@ -1,6 +1,6 @@
 import {useEffect, useState} from 'react';
 
-function getLocalTime(hour: number, minute: number): string {
+function getLocalTime(hour: number, minute: number) {
   const now = new Date();
   const etStr = now.toLocaleString('en-US', {timeZone: 'America/New_York'});
   const et = new Date(etStr);
@@ -9,10 +9,10 @@ function getLocalTime(hour: number, minute: number): string {
   const diff = et.getTime() - new Date(etStr).getTime();
   const local = new Date(now.getTime() + diff);
 
-  return local.toLocaleTimeString([], {hour: '2-digit', minute: '2-digit', hour12: false});
+  return local.toLocaleTimeString([], {hour: '2-digit', hour12: false, minute: '2-digit'});
 }
 
-function isMarketOpen(): boolean {
+function isMarketOpen() {
   const now = new Date();
   const et = new Date(now.toLocaleString('en-US', {timeZone: 'America/New_York'}));
   const day = et.getDay();
@@ -45,8 +45,13 @@ export function MarketClock() {
   return (
     <div className="text-center">
       <p className="text-slate-400 flex items-center justify-center gap-2">
-        Nasdaq trading hours today*: <span className="text-white font-mono">{openingTime} - {closingTime}</span> your local time
-        <span className={`px-2 py-0.5 rounded text-xs font-medium ${open ? 'bg-green-500/20 text-green-400' : 'bg-red-500/20 text-red-400'}`}>
+        Nasdaq trading hours today*:{' '}
+        <span className="text-white font-mono">
+          {openingTime} - {closingTime}
+        </span>{' '}
+        your local time
+        <span
+          className={`px-2 py-0.5 rounded text-xs font-medium ${open ? 'bg-green-500/20 text-green-400' : 'bg-red-500/20 text-red-400'}`}>
           {open ? 'Open' : 'Closed'}
         </span>
       </p>

--- a/packages/trading-signals-docs/components/PriceChart.tsx
+++ b/packages/trading-signals-docs/components/PriceChart.tsx
@@ -1,5 +1,6 @@
-import {Chart as HighchartsChart, ChartOptions, HighchartsReactRefObject} from '@highcharts/react';
-import { useRef } from 'react';
+import type {ChartOptions, HighchartsReactRefObject} from '@highcharts/react';
+import {Chart as HighchartsChart} from '@highcharts/react';
+import {useRef} from 'react';
 
 export interface PriceData {
   x: number;
@@ -14,115 +15,115 @@ export interface PriceChartProps {
   data: PriceData[];
 }
 
-export default function PriceChart({title, data}: PriceChartProps) {
+export default function PriceChart({data, title}: PriceChartProps) {
   const chartRef = useRef<HighchartsReactRefObject>(null);
 
   const options: ChartOptions = {
     chart: {
-      type: 'line',
       backgroundColor: 'transparent',
       height: 200,
+      type: 'line',
     },
+    credits: {
+      enabled: false,
+    },
+    legend: {
+      enabled: true,
+      itemHoverStyle: {
+        color: '#e2e8f0',
+      },
+      itemStyle: {
+        color: '#94a3b8',
+      },
+    },
+    plotOptions: {
+      line: {
+        lineWidth: 1.5,
+        marker: {
+          enabled: false,
+        },
+      },
+    },
+    series: [
+      {
+        color: '#a78bfa',
+        data: data.map(point => [point.x, point.open]),
+        marker: {
+          fillColor: '#a78bfa',
+        },
+        name: 'Open',
+        type: 'line',
+      },
+      {
+        color: '#10b981',
+        data: data.map(point => [point.x, point.high]),
+        marker: {
+          fillColor: '#10b981',
+        },
+        name: 'High',
+        type: 'line',
+      },
+      {
+        color: '#ef4444',
+        data: data.map(point => [point.x, point.low]),
+        marker: {
+          fillColor: '#ef4444',
+        },
+        name: 'Low',
+        type: 'line',
+      },
+      {
+        color: '#3b82f6',
+        data: data.map(point => [point.x, point.close]),
+        marker: {
+          fillColor: '#3b82f6',
+        },
+        name: 'Close',
+        type: 'line',
+      },
+    ],
     title: {
-      text: title,
       style: {
         color: '#e2e8f0',
         fontSize: '14px',
         fontWeight: '600',
       },
+      text: title,
     },
-    credits: {
-      enabled: false,
-    },
-    xAxis: {
-      title: {
-        text: 'Period',
-        style: {color: '#94a3b8'},
-      },
-      labels: {
-        style: {color: '#94a3b8'},
-      },
-      gridLineColor: '#334155',
-    },
-    yAxis: {
-      title: {
-        text: 'Price ($)',
-        style: {color: '#94a3b8'},
-      },
-      labels: {
-        style: {color: '#94a3b8'},
-      },
-      gridLineColor: '#334155',
-    },
-    legend: {
-      enabled: true,
-      itemStyle: {
-        color: '#94a3b8',
-      },
-      itemHoverStyle: {
-        color: '#e2e8f0',
-      },
-    },
-    plotOptions: {
-      line: {
-        marker: {
-          enabled: false,
-        },
-        lineWidth: 1.5,
-      },
-    },
-    series: [
-      {
-        type: 'line',
-        name: 'Open',
-        data: data.map(point => [point.x, point.open]),
-        color: '#a78bfa',
-        marker: {
-          fillColor: '#a78bfa',
-        },
-      },
-      {
-        type: 'line',
-        name: 'High',
-        data: data.map(point => [point.x, point.high]),
-        color: '#10b981',
-        marker: {
-          fillColor: '#10b981',
-        },
-      },
-      {
-        type: 'line',
-        name: 'Low',
-        data: data.map(point => [point.x, point.low]),
-        color: '#ef4444',
-        marker: {
-          fillColor: '#ef4444',
-        },
-      },
-      {
-        type: 'line',
-        name: 'Close',
-        data: data.map(point => [point.x, point.close]),
-        color: '#3b82f6',
-        marker: {
-          fillColor: '#3b82f6',
-        },
-      },
-    ],
     tooltip: {
       backgroundColor: '#1e293b',
       borderColor: '#475569',
-      style: {
-        color: '#e2e8f0',
-      },
-      shared: true,
-      formatter: function (): string {
+      formatter: function () {
         let s: string = `<b>Period ${(this as any).x}</b><br/>`;
         ((this as any).points as any[])?.forEach((point: any) => {
           const yValue = typeof point.y === 'number' ? `$${point.y.toFixed(2)}` : 'N/A';
           s += `${point.series.name}: ${yValue}<br/>`;
         });
         return s;
+      },
+      shared: true,
+      style: {
+        color: '#e2e8f0',
+      },
+    },
+    xAxis: {
+      gridLineColor: '#334155',
+      labels: {
+        style: {color: '#94a3b8'},
+      },
+      title: {
+        style: {color: '#94a3b8'},
+        text: 'Period',
+      },
+    },
+    yAxis: {
+      gridLineColor: '#334155',
+      labels: {
+        style: {color: '#94a3b8'},
+      },
+      title: {
+        style: {color: '#94a3b8'},
+        text: 'Price ($)',
       },
     },
   };

--- a/packages/trading-signals-docs/components/ProtectionModal.tsx
+++ b/packages/trading-signals-docs/components/ProtectionModal.tsx
@@ -12,9 +12,9 @@ interface GuardForm {
 
 const emptyGuard = (): GuardForm => ({
   enabled: false,
+  orderType: 'limit',
   triggerType: 'pct',
   value: '',
-  orderType: 'limit',
 });
 
 function toTriggerType(value: string): TriggerType {
@@ -39,36 +39,45 @@ function parseGuard(
   const orderType: OrderType = typeof order === 'string' ? toOrderType(order) : 'limit';
 
   if (typeof pct === 'string') {
-    return {enabled: true, triggerType: 'pct', value: pct, orderType};
+    return {enabled: true, orderType, triggerType: 'pct', value: pct};
   }
   if (typeof nominal === 'string') {
-    return {enabled: true, triggerType: 'nominal', value: nominal, orderType};
+    return {enabled: true, orderType, triggerType: 'nominal', value: nominal};
   }
   if (typeof price === 'string') {
-    return {enabled: true, triggerType: 'price', value: price, orderType};
+    return {enabled: true, orderType, triggerType: 'price', value: price};
   }
   return emptyGuard();
 }
 
-function buildProtectedConfig(
-  stopLoss: GuardForm,
-  takeProfit: GuardForm
-): Record<string, unknown> | undefined {
+function buildProtectedConfig(stopLoss: GuardForm, takeProfit: GuardForm): Record<string, unknown> | undefined {
   const result: Record<string, unknown> = {};
 
   if (stopLoss.enabled && stopLoss.value.trim()) {
     const value = stopLoss.value.trim();
-    if (stopLoss.triggerType === 'pct') result.stopLossPct = value;
-    if (stopLoss.triggerType === 'nominal') result.stopLossNominal = value;
-    if (stopLoss.triggerType === 'price') result.stopLossPrice = value;
+    if (stopLoss.triggerType === 'pct') {
+      result.stopLossPct = value;
+    }
+    if (stopLoss.triggerType === 'nominal') {
+      result.stopLossNominal = value;
+    }
+    if (stopLoss.triggerType === 'price') {
+      result.stopLossPrice = value;
+    }
     result.stopLossOrder = stopLoss.orderType;
   }
 
   if (takeProfit.enabled && takeProfit.value.trim()) {
     const value = takeProfit.value.trim();
-    if (takeProfit.triggerType === 'pct') result.takeProfitPct = value;
-    if (takeProfit.triggerType === 'nominal') result.takeProfitNominal = value;
-    if (takeProfit.triggerType === 'price') result.takeProfitPrice = value;
+    if (takeProfit.triggerType === 'pct') {
+      result.takeProfitPct = value;
+    }
+    if (takeProfit.triggerType === 'nominal') {
+      result.takeProfitNominal = value;
+    }
+    if (takeProfit.triggerType === 'price') {
+      result.takeProfitPrice = value;
+    }
     result.takeProfitOrder = takeProfit.orderType;
   }
 
@@ -82,7 +91,7 @@ interface ProtectionModalProps {
   onClose: () => void;
 }
 
-export function ProtectionModal({open, initialProtected, onSave, onClose}: ProtectionModalProps) {
+export function ProtectionModal({initialProtected, onClose, onSave, open}: ProtectionModalProps) {
   const [stopLoss, setStopLoss] = useState<GuardForm>(emptyGuard);
   const [takeProfit, setTakeProfit] = useState<GuardForm>(emptyGuard);
 
@@ -94,9 +103,11 @@ export function ProtectionModal({open, initialProtected, onSave, onClose}: Prote
       setStopLoss(parseGuard(initialProtected, 'stopLoss'));
       setTakeProfit(parseGuard(initialProtected, 'takeProfit'));
     } else {
-      // Fresh open with no existing protection: pre-enable stop-loss so the
-      // form is visible immediately. User just has to type a value and Save.
-      setStopLoss({enabled: true, triggerType: 'pct', value: '', orderType: 'limit'});
+      /*
+       * Fresh open with no existing protection: pre-enable stop-loss so the
+       * form is visible immediately. User just has to type a value and Save.
+       */
+      setStopLoss({enabled: true, orderType: 'limit', triggerType: 'pct', value: ''});
       setTakeProfit(emptyGuard());
     }
   }, [open, initialProtected]);
@@ -129,17 +140,15 @@ export function ProtectionModal({open, initialProtected, onSave, onClose}: Prote
   };
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4"
-      onClick={onClose}>
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4" onClick={onClose}>
       <div
         className="bg-slate-800 border border-slate-700 rounded-lg p-6 w-full max-w-md shadow-xl"
         onClick={e => e.stopPropagation()}>
         <h3 className="text-lg font-semibold text-white mb-2">Protection settings</h3>
         <p className="text-xs text-slate-400 mb-4">
-          Stop-loss and take-profit kill switches run on top of the selected strategy. Enable either or
-          both to have the backtester exit automatically when thresholds are reached. Once a guard fires,
-          the strategy is terminal for the session.
+          Stop-loss and take-profit kill switches run on top of the selected strategy. Enable either or both to have the
+          backtester exit automatically when thresholds are reached. Once a guard fires, the strategy is terminal for
+          the session.
         </p>
 
         <GuardSection title="Stop-loss" suffix="loss" guard={stopLoss} onChange={setStopLoss} />
@@ -182,7 +191,7 @@ interface GuardSectionProps {
   onChange: (guard: GuardForm) => void;
 }
 
-function GuardSection({title, suffix, guard, onChange}: GuardSectionProps) {
+function GuardSection({guard, onChange, suffix, title}: GuardSectionProps) {
   const update = (patch: Partial<GuardForm>) => onChange({...guard, ...patch});
 
   const valueLabel =

--- a/packages/trading-signals-docs/components/SchemaReference.tsx
+++ b/packages/trading-signals-docs/components/SchemaReference.tsx
@@ -7,11 +7,11 @@ interface SchemaReferenceProps {
 }
 
 export function SchemaReference({schema}: SchemaReferenceProps) {
-  const {topLevel, protectedProps} = useMemo(() => {
+  const {protectedProps, topLevel} = useMemo(() => {
     const all = extractProperties(schema);
     const top = all.filter(p => p.name !== 'protected');
     const nested = extractNestedProperties(schema, 'protected');
-    return {topLevel: top, protectedProps: nested};
+    return {protectedProps: nested, topLevel: top};
   }, [schema]);
 
   if (topLevel.length === 0 && protectedProps.length === 0) {

--- a/packages/trading-signals-docs/components/StrategyConfigurator.tsx
+++ b/packages/trading-signals-docs/components/StrategyConfigurator.tsx
@@ -12,12 +12,12 @@ interface StrategyConfiguratorProps {
 }
 
 export function StrategyConfigurator({
-  selectedStrategy,
-  onStrategyChange,
+  candles,
   configJson,
   onConfigJsonChange,
+  onStrategyChange,
+  selectedStrategy,
   validationError,
-  candles,
 }: StrategyConfiguratorProps) {
   const definition = strategyDefinitions.find(s => s.id === selectedStrategy)!;
 

--- a/packages/trading-signals-docs/e2e/homepage.spec.ts
+++ b/packages/trading-signals-docs/e2e/homepage.spec.ts
@@ -11,11 +11,11 @@ test.describe('Homepage', () => {
 
     await expect(page.getByRole('link', {name: 'View on NPM'})).toHaveAttribute(
       'href',
-      'https://www.npmjs.com/package/trading-signals',
+      'https://www.npmjs.com/package/trading-signals'
     );
     await expect(page.getByRole('link', {name: 'View on GitHub'})).toHaveAttribute(
       'href',
-      'https://github.com/bennycode/trading-signals',
+      'https://github.com/bennycode/trading-signals'
     );
 
     await expect(page.getByRole('heading', {level: 2, name: 'Indicator Categories'})).toBeVisible();

--- a/packages/trading-signals-docs/e2e/pages/HomePage.ts
+++ b/packages/trading-signals-docs/e2e/pages/HomePage.ts
@@ -8,6 +8,9 @@ export class HomePage {
   }
 
   async openCategory(category: string): Promise<void> {
-    await this.page.getByRole('link', {name: new RegExp(category)}).first().click();
+    await this.page
+      .getByRole('link', {name: new RegExp(category)})
+      .first()
+      .click();
   }
 }

--- a/packages/trading-signals-docs/eslint.config.mjs
+++ b/packages/trading-signals-docs/eslint.config.mjs
@@ -1,0 +1,12 @@
+import {createConfig} from '../../eslint.config.base.mjs';
+
+export default createConfig({
+  ignores: [
+    '**/.next/**',
+    '**/next-env.d.ts',
+    '**/out/**',
+    '**/playwright-report/**',
+    '**/postcss.config.js',
+    '**/test-results/**',
+  ],
+});

--- a/packages/trading-signals-docs/indicator-demos/momentum/AC.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/AC.demo.tsx
@@ -4,17 +4,17 @@ import {buildTableColumns} from '../../utils/tableColumns';
 import type {IndicatorConfig} from '../../utils/types';
 
 export const AC: IndicatorConfig = {
-  id: 'ac',
-  name: 'AC',
-  description: 'Accelerator Oscillator',
+  chartTitle: 'Accelerator Oscillator (5,34,5)',
   color: '#6366f1',
-  type: 'single',
-  requiredInputs: 39,
+  createIndicator: () => new ACClass(5, 34, 5),
+  description: 'Accelerator Oscillator',
   details:
     'Shows acceleration or deceleration of the current driving force. Earlier signal of potential trend change than AO.',
-  createIndicator: () => new ACClass(5, 34, 5),
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['high', 'low']}),
+  id: 'ac',
+  name: 'AC',
   processData: makeProcessData({rowInputs: ['high', 'low']}),
-  getTableColumns: indicator => buildTableColumns({inputs: ['high', 'low'], indicator}),
-  chartTitle: 'Accelerator Oscillator (5,34,5)',
+  requiredInputs: 39,
+  type: 'single',
   yAxisLabel: 'AC',
 };

--- a/packages/trading-signals-docs/indicator-demos/momentum/AO.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/AO.demo.tsx
@@ -4,17 +4,17 @@ import {buildTableColumns} from '../../utils/tableColumns';
 import type {IndicatorConfig} from '../../utils/types';
 
 export const AO: IndicatorConfig = {
-  id: 'ao',
-  name: 'AO',
-  description: 'Awesome Oscillator',
+  chartTitle: 'Awesome Oscillator (5,34)',
   color: '#06b6d4',
-  type: 'single',
-  requiredInputs: 34,
+  createIndicator: () => new AOClass(5, 34),
+  description: 'Awesome Oscillator',
   details:
     "Measures market momentum using the difference between a 5-period and 34-period simple moving average of the bar's midpoints.",
-  createIndicator: () => new AOClass(5, 34),
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['high', 'low']}),
+  id: 'ao',
+  name: 'AO',
   processData: makeProcessData({rowInputs: ['high', 'low']}),
-  getTableColumns: indicator => buildTableColumns({inputs: ['high', 'low'], indicator}),
-  chartTitle: 'Awesome Oscillator (5,34)',
+  requiredInputs: 34,
+  type: 'single',
   yAxisLabel: 'AO',
 };

--- a/packages/trading-signals-docs/indicator-demos/momentum/CCI.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/CCI.demo.tsx
@@ -4,16 +4,17 @@ import {buildTableColumns} from '../../utils/tableColumns';
 import type {IndicatorConfig} from '../../utils/types';
 
 export const CCI: IndicatorConfig = {
+  chartTitle: 'CCI (20)',
+  color: '#f59e0b',
+  createIndicator: () => new CCIClass(20),
+  description: 'Commodity Channel Index',
+  details:
+    'Measures deviation from the average price. Readings above +100 suggest overbought, below -100 suggest oversold.',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
   id: 'cci',
   name: 'CCI',
-  description: 'Commodity Channel Index',
-  color: '#f59e0b',
-  type: 'single',
+  processData: makeProcessData({addInputs: ['high', 'low', 'close'], rowInputs: ['close']}),
   requiredInputs: 20,
-  details: 'Measures deviation from the average price. Readings above +100 suggest overbought, below -100 suggest oversold.',
-  createIndicator: () => new CCIClass(20),
-  processData: makeProcessData({rowInputs: ['close'], addInputs: ['high', 'low', 'close']}),
-  getTableColumns: indicator => buildTableColumns({inputs: ['close'], indicator}),
-  chartTitle: 'CCI (20)',
+  type: 'single',
   yAxisLabel: 'CCI',
 };

--- a/packages/trading-signals-docs/indicator-demos/momentum/CG.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/CG.demo.tsx
@@ -4,16 +4,16 @@ import {buildTableColumns} from '../../utils/tableColumns';
 import type {IndicatorConfig} from '../../utils/types';
 
 export const CG: IndicatorConfig = {
+  chartTitle: 'Center of Gravity (10,10)',
+  color: '#f97316',
+  createIndicator: () => new CGClass(10, 10),
+  description: 'Center of Gravity',
+  details: 'Identifies turning points with minimal lag. Oscillates around zero line.',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
   id: 'cg',
   name: 'CG',
-  description: 'Center of Gravity',
-  color: '#f97316',
-  type: 'single',
-  requiredInputs: 10,
-  details: 'Identifies turning points with minimal lag. Oscillates around zero line.',
-  createIndicator: () => new CGClass(10, 10),
   processData: makeProcessData({rowInputs: ['close']}),
-  getTableColumns: indicator => buildTableColumns({inputs: ['close'], indicator}),
-  chartTitle: 'Center of Gravity (10,10)',
+  requiredInputs: 10,
+  type: 'single',
   yAxisLabel: 'CG',
 };

--- a/packages/trading-signals-docs/indicator-demos/momentum/ER.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/ER.demo.tsx
@@ -4,17 +4,17 @@ import {buildTableColumns} from '../../utils/tableColumns';
 import type {IndicatorConfig} from '../../utils/types';
 
 export const ER: IndicatorConfig = {
-  id: 'er',
-  name: 'ER',
-  description: 'Range Efficiency',
+  chartTitle: 'Range Efficiency (14)',
   color: '#f59e0b',
-  type: 'single',
-  requiredInputs: 14,
+  createIndicator: () => new ERClass(14),
+  description: 'Range Efficiency',
   details:
     'Measures how much of the price range was directional movement versus noise. Returns a value between 0 and 1 — near 0 means choppy/range-bound, near 1 means strongly trending. Formula: |close_now − close_N_ago| / (highest_high − lowest_low).',
-  createIndicator: () => new ERClass(14),
-  processData: makeProcessData({rowInputs: ['close'], addInputs: ['high', 'low', 'close']}),
-  getTableColumns: indicator => buildTableColumns({inputs: ['close'], indicator}),
-  chartTitle: 'Range Efficiency (14)',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
+  id: 'er',
+  name: 'ER',
+  processData: makeProcessData({addInputs: ['high', 'low', 'close'], rowInputs: ['close']}),
+  requiredInputs: 14,
+  type: 'single',
   yAxisLabel: 'ER',
 };

--- a/packages/trading-signals-docs/indicator-demos/momentum/MACD.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/MACD.demo.tsx
@@ -16,7 +16,7 @@ const renderMACD = (config: IndicatorConfig, selectedCandles: Candle[]) => {
   const chartDataSignal: ChartDataPoint[] = [];
   const chartDataHistogram: ChartDataPoint[] = [];
   const priceData: PriceData[] = [];
-  const sampleValues: Array<{period: number; date: string; close: number; result: ReactNode; signal: string}> = [];
+  const sampleValues: {period: number; date: string; close: number; result: ReactNode; signal: string}[] = [];
 
   selectedCandles.forEach((candle, idx) => {
     macd.add(Number(candle.close));
@@ -29,9 +29,9 @@ const renderMACD = (config: IndicatorConfig, selectedCandles: Candle[]) => {
     priceData.push(collectPriceData(candle, idx));
 
     sampleValues.push({
-      period: idx + 1,
-      date: formatDate(candle.openTimeInISO),
       close: Number(candle.close),
+      date: formatDate(candle.openTimeInISO),
+      period: idx + 1,
       result: result ? `${result.macd.toFixed(4)}` : <NotAvailable />,
       signal: trendSignal.state,
     });
@@ -53,53 +53,41 @@ const renderMACD = (config: IndicatorConfig, selectedCandles: Candle[]) => {
       <div className="bg-slate-800/50 border border-slate-700 rounded-lg p-4">
         <HighchartsChart
           options={{
-            chart: {type: 'line', backgroundColor: 'transparent', height: 300},
-            title: {text: 'MACD (12,26,9)', style: {color: '#e2e8f0', fontSize: '16px', fontWeight: '600'}},
+            chart: {backgroundColor: 'transparent', height: 300, type: 'line'},
             credits: {enabled: false},
-            xAxis: {
-              title: {text: 'Period', style: {color: '#94a3b8'}},
-              labels: {style: {color: '#94a3b8'}},
-              gridLineColor: '#334155',
-            },
-            yAxis: {
-              title: {text: 'Value', style: {color: '#94a3b8'}},
-              labels: {style: {color: '#94a3b8'}},
-              gridLineColor: '#334155',
-            },
             legend: {enabled: true, itemStyle: {color: '#e2e8f0'}},
             plotOptions: {
-              line: {marker: {enabled: true, radius: 3}, lineWidth: 2},
               column: {borderWidth: 0},
+              line: {lineWidth: 2, marker: {enabled: true, radius: 3}},
             },
             series: [
               {
-                type: 'line',
-                name: 'MACD',
-                data: chartDataMACD.map(point => [point.x, point.y]),
                 color: config.color,
+                data: chartDataMACD.map(point => [point.x, point.y]),
                 marker: {fillColor: config.color},
-              },
-              {
+                name: 'MACD',
                 type: 'line',
-                name: 'Signal',
-                data: chartDataSignal.map(point => [point.x, point.y]),
-                color: '#f97316',
-                marker: {fillColor: '#f97316'},
               },
               {
-                type: 'column',
-                name: 'Histogram',
-                data: chartDataHistogram.map(point => [point.x, point.y]),
+                color: '#f97316',
+                data: chartDataSignal.map(point => [point.x, point.y]),
+                marker: {fillColor: '#f97316'},
+                name: 'Signal',
+                type: 'line',
+              },
+              {
                 color: '#6366f1',
+                data: chartDataHistogram.map(point => [point.x, point.y]),
+                name: 'Histogram',
                 opacity: 0.5,
+                type: 'column',
               },
             ],
+            title: {style: {color: '#e2e8f0', fontSize: '16px', fontWeight: '600'}, text: 'MACD (12,26,9)'},
             tooltip: {
               backgroundColor: '#1e293b',
               borderColor: '#475569',
-              style: {color: '#e2e8f0'},
-              shared: true,
-              formatter: function (): string {
+              formatter: function () {
                 let s: string = `<b>Period ${(this as any).x}</b><br/>`;
                 ((this as any).points as any[])?.forEach((point: any) => {
                   const yValue = typeof point.y === 'number' ? point.y.toFixed(4) : 'N/A';
@@ -107,6 +95,18 @@ const renderMACD = (config: IndicatorConfig, selectedCandles: Candle[]) => {
                 });
                 return s;
               },
+              shared: true,
+              style: {color: '#e2e8f0'},
+            },
+            xAxis: {
+              gridLineColor: '#334155',
+              labels: {style: {color: '#94a3b8'}},
+              title: {style: {color: '#94a3b8'}, text: 'Period'},
+            },
+            yAxis: {
+              gridLineColor: '#334155',
+              labels: {style: {color: '#94a3b8'}},
+              title: {style: {color: '#94a3b8'}, text: 'Value'},
             },
           }}
         />
@@ -148,12 +148,12 @@ const renderMACD = (config: IndicatorConfig, selectedCandles: Candle[]) => {
 };
 
 export const MACD: IndicatorConfig = {
-  id: 'macd',
-  name: 'MACD',
-  description: 'Moving Average Convergence Divergence',
   color: '#3b82f6',
-  type: 'custom',
-  requiredInputs: 33,
   createIndicator: () => new MACDClass(new EMA(12), new EMA(26), new EMA(9)),
   customRender: renderMACD,
+  description: 'Moving Average Convergence Divergence',
+  id: 'macd',
+  name: 'MACD',
+  requiredInputs: 33,
+  type: 'custom',
 };

--- a/packages/trading-signals-docs/indicator-demos/momentum/MOM.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/MOM.demo.tsx
@@ -4,17 +4,17 @@ import {buildTableColumns} from '../../utils/tableColumns';
 import type {IndicatorConfig} from '../../utils/types';
 
 export const MOM: IndicatorConfig = {
-  id: 'mom',
-  name: 'MOM',
-  description: 'Momentum',
+  chartTitle: 'Momentum (5)',
   color: '#84cc16',
-  type: 'single',
-  requiredInputs: 5,
+  createIndicator: () => new MOMClass(5),
+  description: 'Momentum',
   details:
     'Momentum measures the change in price over n periods. Bullish when momentum is positive (price rising), bearish when momentum is negative (price falling).',
-  createIndicator: () => new MOMClass(5),
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
+  id: 'mom',
+  name: 'MOM',
   processData: makeProcessData({rowInputs: ['close']}),
-  getTableColumns: indicator => buildTableColumns({inputs: ['close'], indicator}),
-  chartTitle: 'Momentum (5)',
+  requiredInputs: 5,
+  type: 'single',
   yAxisLabel: 'MOM',
 };

--- a/packages/trading-signals-docs/indicator-demos/momentum/OBV.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/OBV.demo.tsx
@@ -4,16 +4,16 @@ import {buildTableColumns} from '../../utils/tableColumns';
 import type {IndicatorConfig} from '../../utils/types';
 
 export const OBV: IndicatorConfig = {
+  chartTitle: 'On-Balance Volume (5)',
+  color: '#14b8a6',
+  createIndicator: () => new OBVClass(5),
+  description: 'On-Balance Volume',
+  details: 'Cumulative volume-based indicator. Rising OBV with rising prices confirms uptrend.',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close', 'volume']}),
   id: 'obv',
   name: 'OBV',
-  description: 'On-Balance Volume',
-  color: '#14b8a6',
-  type: 'single',
+  processData: makeProcessData({alwaysStable: true, rowInputs: ['close', 'volume']}),
   requiredInputs: 1,
-  details: 'Cumulative volume-based indicator. Rising OBV with rising prices confirms uptrend.',
-  createIndicator: () => new OBVClass(5),
-  processData: makeProcessData({rowInputs: ['close', 'volume'], alwaysStable: true}),
-  getTableColumns: indicator => buildTableColumns({inputs: ['close', 'volume'], indicator}),
-  chartTitle: 'On-Balance Volume (5)',
+  type: 'single',
   yAxisLabel: 'OBV',
 };

--- a/packages/trading-signals-docs/indicator-demos/momentum/REI.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/REI.demo.tsx
@@ -4,16 +4,16 @@ import {buildTableColumns} from '../../utils/tableColumns';
 import type {IndicatorConfig} from '../../utils/types';
 
 export const REI: IndicatorConfig = {
+  chartTitle: 'Range Expansion Index (5)',
+  color: '#a855f7',
+  createIndicator: () => new REIClass(5),
+  description: 'Range Expansion Index',
+  details: 'Measures range expansion to identify potential breakouts.',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
   id: 'rei',
   name: 'REI',
-  description: 'Range Expansion Index',
-  color: '#a855f7',
-  type: 'single',
+  processData: makeProcessData({addInputs: ['high', 'low', 'close', 'open'], rowInputs: ['close']}),
   requiredInputs: 5,
-  details: 'Measures range expansion to identify potential breakouts.',
-  createIndicator: () => new REIClass(5),
-  processData: makeProcessData({rowInputs: ['close'], addInputs: ['high', 'low', 'close', 'open']}),
-  getTableColumns: indicator => buildTableColumns({inputs: ['close'], indicator}),
-  chartTitle: 'Range Expansion Index (5)',
+  type: 'single',
   yAxisLabel: 'REI',
 };

--- a/packages/trading-signals-docs/indicator-demos/momentum/ROC.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/ROC.demo.tsx
@@ -4,17 +4,17 @@ import {buildTableColumns} from '../../utils/tableColumns';
 import type {IndicatorConfig} from '../../utils/types';
 
 export const ROC: IndicatorConfig = {
-  id: 'roc',
-  name: 'ROC',
-  description: 'Rate of Change',
+  chartTitle: 'ROC (9)',
   color: '#10b981',
-  type: 'single',
-  requiredInputs: 9,
+  createIndicator: () => new ROCClass(9),
+  description: 'Rate of Change',
   details:
     'Measures the percentage change in price from n periods ago. Positive values indicate upward momentum, negative values indicate downward momentum.',
-  createIndicator: () => new ROCClass(9),
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
+  id: 'roc',
+  name: 'ROC',
   processData: makeProcessData({rowInputs: ['close']}),
-  getTableColumns: indicator => buildTableColumns({inputs: ['close'], indicator}),
-  chartTitle: 'ROC (9)',
+  requiredInputs: 9,
+  type: 'single',
   yAxisLabel: 'ROC %',
 };

--- a/packages/trading-signals-docs/indicator-demos/momentum/RSI.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/RSI.demo.tsx
@@ -4,17 +4,17 @@ import {buildTableColumns} from '../../utils/tableColumns';
 import type {IndicatorConfig} from '../../utils/types';
 
 export const RSI: IndicatorConfig = {
-  id: 'rsi',
-  name: 'RSI',
-  description: 'Relative Strength Index',
+  chartTitle: 'RSI (14)',
   color: '#8b5cf6',
-  type: 'single',
-  requiredInputs: 14,
+  createIndicator: () => new RSIClass(14),
+  description: 'Relative Strength Index',
   details:
     'RSI measures the magnitude of recent price changes to evaluate overbought or oversold conditions. Values above 70 indicate overbought, below 30 indicate oversold.',
-  createIndicator: () => new RSIClass(14),
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
+  id: 'rsi',
+  name: 'RSI',
   processData: makeProcessData({rowInputs: ['close']}),
-  getTableColumns: indicator => buildTableColumns({inputs: ['close'], indicator}),
-  chartTitle: 'RSI (14)',
+  requiredInputs: 14,
+  type: 'single',
   yAxisLabel: 'RSI',
 };

--- a/packages/trading-signals-docs/indicator-demos/momentum/StochasticOscillator.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/StochasticOscillator.demo.tsx
@@ -15,10 +15,10 @@ const renderStochastic = (config: IndicatorConfig, selectedCandles: Candle[]) =>
   const chartDataK: ChartDataPoint[] = [];
   const chartDataD: ChartDataPoint[] = [];
   const priceData: PriceData[] = [];
-  const sampleValues: Array<{period: number; date: string; close: number; k: ReactNode; d: ReactNode; signal: string}> = [];
+  const sampleValues: {period: number; date: string; close: number; k: ReactNode; d: ReactNode; signal: string}[] = [];
 
   selectedCandles.forEach((candle, idx) => {
-    stoch.add({high: Number(candle.high), low: Number(candle.low), close: Number(candle.close)});
+    stoch.add({close: Number(candle.close), high: Number(candle.high), low: Number(candle.low)});
     const result = stoch.isStable ? stoch.getResult() : null;
     const signal = stoch.getSignal();
     chartDataK.push({x: idx + 1, y: result?.stochK ?? null});
@@ -27,11 +27,11 @@ const renderStochastic = (config: IndicatorConfig, selectedCandles: Candle[]) =>
     priceData.push(collectPriceData(candle, idx));
 
     sampleValues.push({
-      period: idx + 1,
-      date: formatDate(candle.openTimeInISO),
       close: Number(candle.close),
-      k: result ? result.stochK.toFixed(2) : <NotAvailable />,
       d: result ? result.stochD.toFixed(2) : <NotAvailable />,
+      date: formatDate(candle.openTimeInISO),
+      k: result ? result.stochK.toFixed(2) : <NotAvailable />,
+      period: idx + 1,
       signal: signal.state,
     });
   });
@@ -51,43 +51,34 @@ const renderStochastic = (config: IndicatorConfig, selectedCandles: Candle[]) =>
       <div className="bg-slate-800/50 border border-slate-700 rounded-lg p-4">
         <HighchartsChart
           options={{
-            chart: {type: 'line', backgroundColor: 'transparent', height: 300},
-            title: {text: 'Stochastic Oscillator (14,3,3)', style: {color: '#e2e8f0', fontSize: '16px', fontWeight: '600'}},
+            chart: {backgroundColor: 'transparent', height: 300, type: 'line'},
             credits: {enabled: false},
-            xAxis: {
-              title: {text: 'Period', style: {color: '#94a3b8'}},
-              labels: {style: {color: '#94a3b8'}},
-              gridLineColor: '#334155',
-            },
-            yAxis: {
-              title: {text: 'Value', style: {color: '#94a3b8'}},
-              labels: {style: {color: '#94a3b8'}},
-              gridLineColor: '#334155',
-            },
             legend: {enabled: true, itemStyle: {color: '#e2e8f0'}},
-            plotOptions: {line: {marker: {enabled: true, radius: 3}, lineWidth: 2}},
+            plotOptions: {line: {lineWidth: 2, marker: {enabled: true, radius: 3}}},
             series: [
               {
-                type: 'line',
-                name: '%K',
-                data: chartDataK.map(point => [point.x, point.y]),
                 color: config.color,
+                data: chartDataK.map(point => [point.x, point.y]),
                 marker: {fillColor: config.color},
+                name: '%K',
+                type: 'line',
               },
               {
-                type: 'line',
-                name: '%D',
-                data: chartDataD.map(point => [point.x, point.y]),
                 color: '#f97316',
+                data: chartDataD.map(point => [point.x, point.y]),
                 marker: {fillColor: '#f97316'},
+                name: '%D',
+                type: 'line',
               },
             ],
+            title: {
+              style: {color: '#e2e8f0', fontSize: '16px', fontWeight: '600'},
+              text: 'Stochastic Oscillator (14,3,3)',
+            },
             tooltip: {
               backgroundColor: '#1e293b',
               borderColor: '#475569',
-              style: {color: '#e2e8f0'},
-              shared: true,
-              formatter: function (): string {
+              formatter: function () {
                 let s: string = `<b>Period ${(this as any).x}</b><br/>`;
                 ((this as any).points as any[])?.forEach((point: any) => {
                   const yValue = typeof point.y === 'number' ? point.y.toFixed(2) : 'N/A';
@@ -95,6 +86,18 @@ const renderStochastic = (config: IndicatorConfig, selectedCandles: Candle[]) =>
                 });
                 return s;
               },
+              shared: true,
+              style: {color: '#e2e8f0'},
+            },
+            xAxis: {
+              gridLineColor: '#334155',
+              labels: {style: {color: '#94a3b8'}},
+              title: {style: {color: '#94a3b8'}, text: 'Period'},
+            },
+            yAxis: {
+              gridLineColor: '#334155',
+              labels: {style: {color: '#94a3b8'}},
+              title: {style: {color: '#94a3b8'}, text: 'Value'},
             },
           }}
         />
@@ -138,12 +141,12 @@ const renderStochastic = (config: IndicatorConfig, selectedCandles: Candle[]) =>
 };
 
 export const StochasticOscillator: IndicatorConfig = {
-  id: 'stoch',
-  name: 'Stochastic',
-  description: 'Stochastic Oscillator',
   color: '#ec4899',
-  type: 'custom',
-  requiredInputs: 17,
   createIndicator: () => new StochasticOscillatorClass(14, 3, 3),
   customRender: renderStochastic,
+  description: 'Stochastic Oscillator',
+  id: 'stoch',
+  name: 'Stochastic',
+  requiredInputs: 17,
+  type: 'custom',
 };

--- a/packages/trading-signals-docs/indicator-demos/momentum/StochasticRSI.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/StochasticRSI.demo.tsx
@@ -4,16 +4,16 @@ import {buildTableColumns} from '../../utils/tableColumns';
 import type {IndicatorConfig} from '../../utils/types';
 
 export const StochasticRSI: IndicatorConfig = {
+  chartTitle: 'Stochastic RSI (14)',
+  color: '#ef4444',
+  createIndicator: () => new StochasticRSIClass(14),
+  description: 'Stochastic RSI',
+  details: 'Applies Stochastic Oscillator to RSI values. More sensitive to overbought/oversold than standard RSI.',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
   id: 'stochrsi',
   name: 'StochRSI',
-  description: 'Stochastic RSI',
-  color: '#ef4444',
-  type: 'single',
-  requiredInputs: 14,
-  details: 'Applies Stochastic Oscillator to RSI values. More sensitive to overbought/oversold than standard RSI.',
-  createIndicator: () => new StochasticRSIClass(14),
   processData: makeProcessData({rowInputs: ['close']}),
-  getTableColumns: indicator => buildTableColumns({inputs: ['close'], indicator}),
-  chartTitle: 'Stochastic RSI (14)',
+  requiredInputs: 14,
+  type: 'single',
   yAxisLabel: 'StochRSI',
 };

--- a/packages/trading-signals-docs/indicator-demos/momentum/TDS.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/TDS.demo.tsx
@@ -4,17 +4,17 @@ import {buildTableColumns} from '../../utils/tableColumns';
 import type {IndicatorConfig} from '../../utils/types';
 
 export const TDS: IndicatorConfig = {
-  id: 'tds',
-  name: 'TDS',
-  description: 'Tom DeMark Sequential',
+  chartTitle: 'Tom DeMark Sequential',
   color: '#ec4899',
-  type: 'single',
-  requiredInputs: 1,
+  createIndicator: () => new TDSClass(),
+  description: 'Tom DeMark Sequential',
   details:
     'TDS tracks consecutive closes compared to the close 4 bars earlier. Bullish Setup: 9 consecutive closes greater than the close 4 bars earlier (returns 1, signals potential reversal - BEARISH). Bearish Setup: 9 consecutive closes less than the close 4 bars earlier (returns -1, signals potential reversal - BULLISH).',
-  createIndicator: () => new TDSClass(),
-  processData: makeProcessData({rowInputs: ['close'], alwaysStable: true}),
-  getTableColumns: indicator => buildTableColumns({inputs: ['close'], indicator}),
-  chartTitle: 'Tom DeMark Sequential',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
+  id: 'tds',
+  name: 'TDS',
+  processData: makeProcessData({alwaysStable: true, rowInputs: ['close']}),
+  requiredInputs: 1,
+  type: 'single',
   yAxisLabel: 'TDS',
 };

--- a/packages/trading-signals-docs/indicator-demos/momentum/WilliamsR.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/WilliamsR.demo.tsx
@@ -4,17 +4,17 @@ import {buildTableColumns} from '../../utils/tableColumns';
 import type {IndicatorConfig} from '../../utils/types';
 
 export const WilliamsR: IndicatorConfig = {
-  id: 'willr',
-  name: 'Williams %R',
-  description: 'Williams Percent Range',
+  chartTitle: 'Williams %R (14)',
   color: '#22d3ee',
-  type: 'single',
-  requiredInputs: 14,
+  createIndicator: () => new WilliamsRClass(14),
+  description: 'Williams Percent Range',
   details:
     'Measures overbought and oversold levels on an inverted scale from 0 to -100. Values from 0 to -20 indicate overbought conditions, while -80 to -100 indicate oversold conditions.',
-  createIndicator: () => new WilliamsRClass(14),
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['high', 'low', 'close']}),
+  id: 'willr',
+  name: 'Williams %R',
   processData: makeProcessData({rowInputs: ['high', 'low', 'close']}),
-  getTableColumns: indicator => buildTableColumns({inputs: ['high', 'low', 'close'], indicator}),
-  chartTitle: 'Williams %R (14)',
+  requiredInputs: 14,
+  type: 'single',
   yAxisLabel: 'Williams %R',
 };

--- a/packages/trading-signals-docs/indicator-demos/trend/ADX.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/ADX.demo.tsx
@@ -4,17 +4,17 @@ import {buildTableColumns} from '../../utils/tableColumns';
 import type {IndicatorConfig} from '../../utils/types';
 
 export const ADX: IndicatorConfig = {
-  id: 'adx',
-  name: 'ADX',
-  description: 'Average Directional Index',
+  chartTitle: 'ADX (14)',
   color: '#a855f7',
-  type: 'single',
-  requiredInputs: 14,
+  createIndicator: () => new ADXClass(14),
+  description: 'Average Directional Index',
   details:
     'Measures trend strength regardless of direction. Values above 25 indicate a strong trend, below 20 suggest a weak trend.',
-  createIndicator: () => new ADXClass(14),
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['high', 'low', 'close']}),
+  id: 'adx',
+  name: 'ADX',
   processData: makeProcessData({rowInputs: ['high', 'low', 'close']}),
-  getTableColumns: indicator => buildTableColumns({inputs: ['high', 'low', 'close'], indicator}),
-  chartTitle: 'ADX (14)',
+  requiredInputs: 14,
+  type: 'single',
   yAxisLabel: 'ADX',
 };

--- a/packages/trading-signals-docs/indicator-demos/trend/BreakoutBarLow.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/BreakoutBarLow.demo.tsx
@@ -4,17 +4,17 @@ import {buildTableColumns} from '../../utils/tableColumns';
 import type {IndicatorConfig} from '../../utils/types';
 
 export const BreakoutBarLow: IndicatorConfig = {
-  id: 'breakout-bar-low',
-  name: 'BreakoutBarLow',
-  description: 'Breakout-Bar Low',
+  chartTitle: 'Breakout-Bar Low (20)',
   color: '#f59e0b',
-  type: 'single',
-  requiredInputs: 21,
+  createIndicator: () => new BreakoutBarLowClass({lookback: 20}),
+  description: 'Breakout-Bar Low',
   details:
     'Emits the low of any candle whose high strictly exceeds the highest high of the prior N candles — a breakout bar. The breakout-bar low is commonly used as a momentum-based stop: if price trades back below it, the breakout has failed.',
-  createIndicator: () => new BreakoutBarLowClass({lookback: 20}),
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['high', 'low']}),
+  id: 'breakout-bar-low',
+  name: 'BreakoutBarLow',
   processData: makeProcessData({rowInputs: ['high', 'low']}),
-  getTableColumns: indicator => buildTableColumns({inputs: ['high', 'low'], indicator}),
-  chartTitle: 'Breakout-Bar Low (20)',
+  requiredInputs: 21,
+  type: 'single',
   yAxisLabel: 'Price',
 };

--- a/packages/trading-signals-docs/indicator-demos/trend/DEMA.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/DEMA.demo.tsx
@@ -4,16 +4,17 @@ import {buildTableColumns} from '../../utils/tableColumns';
 import type {IndicatorConfig} from '../../utils/types';
 
 export const DEMA: IndicatorConfig = {
+  chartTitle: 'DEMA (5)',
+  color: '#ec4899',
+  createIndicator: () => new DEMAClass(5),
+  description: 'Double Exponential Moving Average',
+  details:
+    'Reduces lag by applying EMA twice, providing faster signals than standard EMA while maintaining smoothness.',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
   id: 'dema',
   name: 'DEMA',
-  description: 'Double Exponential Moving Average',
-  color: '#ec4899',
-  type: 'single',
-  requiredInputs: 9,
-  details: 'Reduces lag by applying EMA twice, providing faster signals than standard EMA while maintaining smoothness.',
-  createIndicator: () => new DEMAClass(5),
   processData: makeProcessData({rowInputs: ['close']}),
-  getTableColumns: indicator => buildTableColumns({inputs: ['close'], indicator}),
-  chartTitle: 'DEMA (5)',
+  requiredInputs: 9,
+  type: 'single',
   yAxisLabel: 'Price',
 };

--- a/packages/trading-signals-docs/indicator-demos/trend/DMA.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/DMA.demo.tsx
@@ -15,14 +15,14 @@ const renderDMA = (config: IndicatorConfig, selectedCandles: Candle[]) => {
   const chartDataShort: ChartDataPoint[] = [];
   const chartDataLong: ChartDataPoint[] = [];
   const priceData: PriceData[] = [];
-  const sampleValues: Array<{
+  const sampleValues: {
     period: number;
     date: string;
     close: number;
     short: ReactNode;
     long: ReactNode;
     signal: string;
-  }> = [];
+  }[] = [];
 
   selectedCandles.forEach((candle, idx) => {
     dma.add(Number(candle.close));
@@ -30,18 +30,18 @@ const renderDMA = (config: IndicatorConfig, selectedCandles: Candle[]) => {
     const signal =
       'getSignal' in dma
         ? (dma.getSignal as () => {state: string; hasChanged: boolean})()
-        : {state: 'UNKNOWN', hasChanged: false};
+        : {hasChanged: false, state: 'UNKNOWN'};
     chartDataShort.push({x: idx + 1, y: result?.short ?? null});
     chartDataLong.push({x: idx + 1, y: result?.long ?? null});
 
     priceData.push(collectPriceData(candle, idx));
 
     sampleValues.push({
-      period: idx + 1,
-      date: formatDate(candle.openTimeInISO),
       close: Number(candle.close),
-      short: result ? result.short.toFixed(2) : <NotAvailable />,
+      date: formatDate(candle.openTimeInISO),
       long: result ? result.long.toFixed(2) : <NotAvailable />,
+      period: idx + 1,
+      short: result ? result.short.toFixed(2) : <NotAvailable />,
       signal: signal.state,
     });
   });
@@ -59,43 +59,31 @@ const renderDMA = (config: IndicatorConfig, selectedCandles: Candle[]) => {
       <div className="bg-slate-800/50 border border-slate-700 rounded-lg p-4">
         <HighchartsChart
           options={{
-            chart: {type: 'line', backgroundColor: 'transparent', height: 300},
-            title: {text: 'Dual Moving Average (5,9)', style: {color: '#e2e8f0', fontSize: '16px', fontWeight: '600'}},
+            chart: {backgroundColor: 'transparent', height: 300, type: 'line'},
             credits: {enabled: false},
-            xAxis: {
-              title: {text: 'Period', style: {color: '#94a3b8'}},
-              labels: {style: {color: '#94a3b8'}},
-              gridLineColor: '#334155',
-            },
-            yAxis: {
-              title: {text: 'Price', style: {color: '#94a3b8'}},
-              labels: {style: {color: '#94a3b8'}},
-              gridLineColor: '#334155',
-            },
             legend: {enabled: true, itemStyle: {color: '#e2e8f0'}},
-            plotOptions: {line: {marker: {enabled: true, radius: 3}, lineWidth: 2}},
+            plotOptions: {line: {lineWidth: 2, marker: {enabled: true, radius: 3}}},
             series: [
               {
-                type: 'line',
-                name: 'Short MA (5)',
-                data: chartDataShort.map(point => [point.x, point.y]),
                 color: config.color,
+                data: chartDataShort.map(point => [point.x, point.y]),
                 marker: {fillColor: config.color},
+                name: 'Short MA (5)',
+                type: 'line',
               },
               {
-                type: 'line',
-                name: 'Long MA (9)',
-                data: chartDataLong.map(point => [point.x, point.y]),
                 color: '#f97316',
+                data: chartDataLong.map(point => [point.x, point.y]),
                 marker: {fillColor: '#f97316'},
+                name: 'Long MA (9)',
+                type: 'line',
               },
             ],
+            title: {style: {color: '#e2e8f0', fontSize: '16px', fontWeight: '600'}, text: 'Dual Moving Average (5,9)'},
             tooltip: {
               backgroundColor: '#1e293b',
               borderColor: '#475569',
-              style: {color: '#e2e8f0'},
-              shared: true,
-              formatter: function (): string {
+              formatter: function () {
                 let s: string = `<b>Period ${(this as any).x}</b><br/>`;
                 ((this as any).points as any[])?.forEach((point: any) => {
                   const yValue = typeof point.y === 'number' ? point.y.toFixed(2) : 'N/A';
@@ -103,6 +91,18 @@ const renderDMA = (config: IndicatorConfig, selectedCandles: Candle[]) => {
                 });
                 return s;
               },
+              shared: true,
+              style: {color: '#e2e8f0'},
+            },
+            xAxis: {
+              gridLineColor: '#334155',
+              labels: {style: {color: '#94a3b8'}},
+              title: {style: {color: '#94a3b8'}, text: 'Period'},
+            },
+            yAxis: {
+              gridLineColor: '#334155',
+              labels: {style: {color: '#94a3b8'}},
+              title: {style: {color: '#94a3b8'}, text: 'Price'},
             },
           }}
         />
@@ -146,14 +146,14 @@ const renderDMA = (config: IndicatorConfig, selectedCandles: Candle[]) => {
 };
 
 export const DMA: IndicatorConfig = {
-  id: 'dma',
-  name: 'DMA',
-  description: 'Dual Moving Average',
   color: '#22d3ee',
-  type: 'custom',
-  requiredInputs: 9,
-  details:
-    'Compares two moving averages. When the short MA crosses above the long MA, it signals a potential buy opportunity.',
   createIndicator: () => new DMAClass(5, 9, SMA),
   customRender: renderDMA,
+  description: 'Dual Moving Average',
+  details:
+    'Compares two moving averages. When the short MA crosses above the long MA, it signals a potential buy opportunity.',
+  id: 'dma',
+  name: 'DMA',
+  requiredInputs: 9,
+  type: 'custom',
 };

--- a/packages/trading-signals-docs/indicator-demos/trend/DX.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/DX.demo.tsx
@@ -4,16 +4,16 @@ import {buildTableColumns} from '../../utils/tableColumns';
 import type {IndicatorConfig} from '../../utils/types';
 
 export const DX: IndicatorConfig = {
+  chartTitle: 'DX (14)',
+  color: '#84cc16',
+  createIndicator: () => new DXClass(14),
+  description: 'Directional Movement Index',
+  details: 'Measures the strength of directional movement. The ADX is derived from smoothing the DX values over time.',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['high', 'low', 'close']}),
   id: 'dx',
   name: 'DX',
-  description: 'Directional Movement Index',
-  color: '#84cc16',
-  type: 'single',
-  requiredInputs: 14,
-  details: 'Measures the strength of directional movement. The ADX is derived from smoothing the DX values over time.',
-  createIndicator: () => new DXClass(14),
   processData: makeProcessData({rowInputs: ['high', 'low', 'close']}),
-  getTableColumns: indicator => buildTableColumns({inputs: ['high', 'low', 'close'], indicator}),
-  chartTitle: 'DX (14)',
+  requiredInputs: 14,
+  type: 'single',
   yAxisLabel: 'DX',
 };

--- a/packages/trading-signals-docs/indicator-demos/trend/EMA.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/EMA.demo.tsx
@@ -4,17 +4,17 @@ import {buildTableColumns} from '../../utils/tableColumns';
 import type {IndicatorConfig} from '../../utils/types';
 
 export const EMA: IndicatorConfig = {
-  id: 'ema',
-  name: 'EMA',
-  description: 'Exponential Moving Average',
+  chartTitle: 'EMA (5)',
   color: '#8b5cf6',
-  type: 'single',
-  requiredInputs: 5,
+  createIndicator: () => new EMAClass(5),
+  description: 'Exponential Moving Average',
   details:
     'Gives more weight to recent prices, reacting faster to price changes than SMA. Popular for identifying short-term trends.',
-  createIndicator: () => new EMAClass(5),
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
+  id: 'ema',
+  name: 'EMA',
   processData: makeProcessData({rowInputs: ['close']}),
-  getTableColumns: indicator => buildTableColumns({inputs: ['close'], indicator}),
-  chartTitle: 'EMA (5)',
+  requiredInputs: 5,
+  type: 'single',
   yAxisLabel: 'Price',
 };

--- a/packages/trading-signals-docs/indicator-demos/trend/HigherLowTrail.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/HigherLowTrail.demo.tsx
@@ -4,17 +4,17 @@ import {buildTableColumns} from '../../utils/tableColumns';
 import type {IndicatorConfig} from '../../utils/types';
 
 export const HigherLowTrail: IndicatorConfig = {
-  id: 'higher-low-trail',
-  name: 'HigherLowTrail',
-  description: 'Higher-Low Trailing Stop',
+  chartTitle: 'Higher-Low Trail (lookback 1)',
   color: '#84cc16',
-  type: 'single',
-  requiredInputs: 2,
+  createIndicator: () => new HigherLowTrailClass({lookback: 1}),
+  description: 'Higher-Low Trailing Stop',
   details:
     'Tracks a progressively rising stop-loss level by detecting one-sided pullback lows. Unlike a symmetric swing low, only right-side confirmation is required, so the trail responds faster. In monotonic mode (the default), the emitted level only ever rises.',
-  createIndicator: () => new HigherLowTrailClass({lookback: 1}),
-  processData: makeProcessData({rowInputs: ['low', 'close'], addInputs: ['high', 'low']}),
-  getTableColumns: indicator => buildTableColumns({inputs: ['low', 'close'], indicator}),
-  chartTitle: 'Higher-Low Trail (lookback 1)',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['low', 'close']}),
+  id: 'higher-low-trail',
+  name: 'HigherLowTrail',
+  processData: makeProcessData({addInputs: ['high', 'low'], rowInputs: ['low', 'close']}),
+  requiredInputs: 2,
+  type: 'single',
   yAxisLabel: 'Price',
 };

--- a/packages/trading-signals-docs/indicator-demos/trend/LinearRegression.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/LinearRegression.demo.tsx
@@ -4,37 +4,37 @@ import {buildTableColumns} from '../../utils/tableColumns';
 import type {IndicatorConfig} from '../../utils/types';
 
 export const LinearRegression: IndicatorConfig = {
-  id: 'linreg',
-  name: 'LINREG',
-  description: 'Linear Regression',
+  chartTitle: 'Linear Regression (14)',
   color: '#ec4899',
-  type: 'single',
-  requiredInputs: 14,
+  createIndicator: () => new LinearRegressionClass(14),
+  description: 'Linear Regression',
   details:
     'Fits a straight line to recent prices using least-squares. The prediction is the point on the line at the latest bar; the slope indicates trend direction and strength.',
-  createIndicator: () => new LinearRegressionClass(14),
+  getTableColumns: indicator =>
+    buildTableColumns({
+      extra: [
+        {
+          className: 'text-slate-300 font-mono py-2 px-3',
+          header: 'Slope',
+          key: 'slope',
+          render: val => (val === null || val === undefined ? <NotAvailable /> : val.toFixed(4)),
+        },
+      ],
+      indicator,
+      inputs: ['close'],
+    }),
+  id: 'linreg',
+  name: 'LINREG',
   processData: (indicator, candle) => {
     indicator.add(Number(candle.close));
     const full = indicator.isStable ? indicator.getResult() : null;
     return {
+      close: Number(candle.close),
       result: full?.prediction ?? null,
       slope: full?.slope ?? null,
-      close: Number(candle.close),
     };
   },
-  getTableColumns: indicator =>
-    buildTableColumns({
-      inputs: ['close'],
-      indicator,
-      extra: [
-        {
-          header: 'Slope',
-          key: 'slope',
-          render: val => (val === null || val === undefined ? <NotAvailable /> : val.toFixed(4)),
-          className: 'text-slate-300 font-mono py-2 px-3',
-        },
-      ],
-    }),
-  chartTitle: 'Linear Regression (14)',
+  requiredInputs: 14,
+  type: 'single',
   yAxisLabel: 'Price',
 };

--- a/packages/trading-signals-docs/indicator-demos/trend/PSAR.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/PSAR.demo.tsx
@@ -4,17 +4,17 @@ import {buildTableColumns} from '../../utils/tableColumns';
 import type {IndicatorConfig} from '../../utils/types';
 
 export const PSAR: IndicatorConfig = {
-  id: 'psar',
-  name: 'PSAR',
-  description: 'Parabolic SAR',
+  chartTitle: 'Parabolic SAR',
   color: '#f97316',
-  type: 'single',
-  requiredInputs: 2,
+  createIndicator: () => new PSARClass({accelerationMax: 0.2, accelerationStep: 0.02}),
+  description: 'Parabolic SAR',
   details:
     'Identifies potential reversal points by placing dots above or below price. Dots below = uptrend, dots above = downtrend.',
-  createIndicator: () => new PSARClass({accelerationStep: 0.02, accelerationMax: 0.2}),
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['high', 'low', 'close']}),
+  id: 'psar',
+  name: 'PSAR',
   processData: makeProcessData({rowInputs: ['high', 'low', 'close']}),
-  getTableColumns: indicator => buildTableColumns({inputs: ['high', 'low', 'close'], indicator}),
-  chartTitle: 'Parabolic SAR',
+  requiredInputs: 2,
+  type: 'single',
   yAxisLabel: 'Price',
 };

--- a/packages/trading-signals-docs/indicator-demos/trend/RMA.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/RMA.demo.tsx
@@ -4,17 +4,17 @@ import {buildTableColumns} from '../../utils/tableColumns';
 import type {IndicatorConfig} from '../../utils/types';
 
 export const RMA: IndicatorConfig = {
-  id: 'rma',
-  name: 'RMA',
-  description: "Relative Moving Average (Wilder's MA)",
+  chartTitle: 'RMA (5)',
   color: '#f59e0b',
-  type: 'single',
-  requiredInputs: 5,
+  createIndicator: () => new RMAClass(5),
+  description: "Relative Moving Average (Wilder's MA)",
   details:
     'Developed by J. Welles Wilder Jr., this smoothed moving average gives more weight to historical data, resulting in a smoother line.',
-  createIndicator: () => new RMAClass(5),
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
+  id: 'rma',
+  name: 'RMA',
   processData: makeProcessData({rowInputs: ['close']}),
-  getTableColumns: indicator => buildTableColumns({inputs: ['close'], indicator}),
-  chartTitle: 'RMA (5)',
+  requiredInputs: 5,
+  type: 'single',
   yAxisLabel: 'Price',
 };

--- a/packages/trading-signals-docs/indicator-demos/trend/SMA.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/SMA.demo.tsx
@@ -4,17 +4,17 @@ import {buildTableColumns} from '../../utils/tableColumns';
 import type {IndicatorConfig} from '../../utils/types';
 
 export const SMA: IndicatorConfig = {
-  id: 'sma',
-  name: 'SMA',
-  description: 'Simple Moving Average',
+  chartTitle: 'SMA (5)',
   color: '#3b82f6',
-  type: 'single',
-  requiredInputs: 5,
+  createIndicator: () => new SMAClass(5),
+  description: 'Simple Moving Average',
   details:
     'Calculates the arithmetic mean of prices over a specified period. Smooths out price fluctuations to identify the trend direction.',
-  createIndicator: () => new SMAClass(5),
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
+  id: 'sma',
+  name: 'SMA',
   processData: makeProcessData({rowInputs: ['close']}),
-  getTableColumns: indicator => buildTableColumns({inputs: ['close'], indicator}),
-  chartTitle: 'SMA (5)',
+  requiredInputs: 5,
+  type: 'single',
   yAxisLabel: 'Price',
 };

--- a/packages/trading-signals-docs/indicator-demos/trend/SMA15.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/SMA15.demo.tsx
@@ -4,17 +4,17 @@ import {buildTableColumns} from '../../utils/tableColumns';
 import type {IndicatorConfig} from '../../utils/types';
 
 export const SMA15: IndicatorConfig = {
-  id: 'sma15',
-  name: 'SMA15',
-  description: "Spencer's 15-Point Moving Average",
+  chartTitle: "Spencer's 15-Point MA",
   color: '#14b8a6',
-  type: 'single',
-  requiredInputs: 15,
+  createIndicator: () => new SMA15Class(15),
+  description: "Spencer's 15-Point Moving Average",
   details:
     'A specialized 15-point weighted moving average using Spencer’s fixed weights, designed to preserve trend while filtering seasonal and irregular variations.',
-  createIndicator: () => new SMA15Class(15),
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
+  id: 'sma15',
+  name: 'SMA15',
   processData: makeProcessData({rowInputs: ['close']}),
-  getTableColumns: indicator => buildTableColumns({inputs: ['close'], indicator}),
-  chartTitle: "Spencer's 15-Point MA",
+  requiredInputs: 15,
+  type: 'single',
   yAxisLabel: 'Price',
 };

--- a/packages/trading-signals-docs/indicator-demos/trend/SwingHigh.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/SwingHigh.demo.tsx
@@ -4,17 +4,17 @@ import {buildTableColumns} from '../../utils/tableColumns';
 import type {IndicatorConfig} from '../../utils/types';
 
 export const SwingHigh: IndicatorConfig = {
-  id: 'swing-high',
-  name: 'SwingHigh',
-  description: 'Swing High Detector',
+  chartTitle: 'Swing High (lookback 2)',
   color: '#ef4444',
-  type: 'single',
-  requiredInputs: 5,
+  createIndicator: () => new SwingHighClass({lookback: SwingLookback.BILL_WILLIAMS}),
+  description: 'Swing High Detector',
   details:
     'Detects symmetric pivot highs (fractal pivots). A candle is confirmed as a swing high once the configured number of candles on each side print strictly lower highs. Commonly used to mark resistance and breakout targets.',
-  createIndicator: () => new SwingHighClass({lookback: SwingLookback.BILL_WILLIAMS}),
-  processData: makeProcessData({rowInputs: ['high', 'close'], addInputs: ['high', 'low']}),
-  getTableColumns: indicator => buildTableColumns({inputs: ['high', 'close'], indicator}),
-  chartTitle: 'Swing High (lookback 2)',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['high', 'close']}),
+  id: 'swing-high',
+  name: 'SwingHigh',
+  processData: makeProcessData({addInputs: ['high', 'low'], rowInputs: ['high', 'close']}),
+  requiredInputs: 5,
+  type: 'single',
   yAxisLabel: 'Price',
 };

--- a/packages/trading-signals-docs/indicator-demos/trend/SwingLow.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/SwingLow.demo.tsx
@@ -4,17 +4,17 @@ import {buildTableColumns} from '../../utils/tableColumns';
 import type {IndicatorConfig} from '../../utils/types';
 
 export const SwingLow: IndicatorConfig = {
-  id: 'swing-low',
-  name: 'SwingLow',
-  description: 'Swing Low Detector',
+  chartTitle: 'Swing Low (lookback 2)',
   color: '#10b981',
-  type: 'single',
-  requiredInputs: 5,
+  createIndicator: () => new SwingLowClass({lookback: SwingLookback.BILL_WILLIAMS}),
+  description: 'Swing Low Detector',
   details:
     'Detects symmetric pullback lows (fractal pivots). A candle is confirmed as a swing low once the configured number of candles on each side print strictly higher lows. Commonly used to mark support levels and structural stop-loss references.',
-  createIndicator: () => new SwingLowClass({lookback: SwingLookback.BILL_WILLIAMS}),
-  processData: makeProcessData({rowInputs: ['low', 'close'], addInputs: ['high', 'low']}),
-  getTableColumns: indicator => buildTableColumns({inputs: ['low', 'close'], indicator}),
-  chartTitle: 'Swing Low (lookback 2)',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['low', 'close']}),
+  id: 'swing-low',
+  name: 'SwingLow',
+  processData: makeProcessData({addInputs: ['high', 'low'], rowInputs: ['low', 'close']}),
+  requiredInputs: 5,
+  type: 'single',
   yAxisLabel: 'Price',
 };

--- a/packages/trading-signals-docs/indicator-demos/trend/VWAP.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/VWAP.demo.tsx
@@ -4,17 +4,21 @@ import {buildTableColumns} from '../../utils/tableColumns';
 import type {IndicatorConfig} from '../../utils/types';
 
 export const VWAP: IndicatorConfig = {
-  id: 'vwap',
-  name: 'VWAP',
-  description: 'Volume Weighted Average Price',
+  chartTitle: 'VWAP',
   color: '#ef4444',
-  type: 'single',
-  requiredInputs: 1,
+  createIndicator: () => new VWAPClass(),
+  description: 'Volume Weighted Average Price',
   details:
     'Calculates the average price weighted by volume. Used to assess whether trades are being executed at favorable prices.',
-  createIndicator: () => new VWAPClass(),
-  processData: makeProcessData({rowInputs: ['close', 'volume'], addInputs: ['high', 'low', 'close', 'volume'], alwaysStable: true}),
-  getTableColumns: indicator => buildTableColumns({inputs: ['close', 'volume'], indicator}),
-  chartTitle: 'VWAP',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close', 'volume']}),
+  id: 'vwap',
+  name: 'VWAP',
+  processData: makeProcessData({
+    addInputs: ['high', 'low', 'close', 'volume'],
+    alwaysStable: true,
+    rowInputs: ['close', 'volume'],
+  }),
+  requiredInputs: 1,
+  type: 'single',
   yAxisLabel: 'Price',
 };

--- a/packages/trading-signals-docs/indicator-demos/trend/WMA.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/WMA.demo.tsx
@@ -4,16 +4,16 @@ import {buildTableColumns} from '../../utils/tableColumns';
 import type {IndicatorConfig} from '../../utils/types';
 
 export const WMA: IndicatorConfig = {
+  chartTitle: 'WMA (5)',
+  color: '#10b981',
+  createIndicator: () => new WMAClass(5),
+  description: 'Weighted Moving Average',
+  details: 'Assigns linearly increasing weights to recent data points. The most recent price has the highest weight.',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
   id: 'wma',
   name: 'WMA',
-  description: 'Weighted Moving Average',
-  color: '#10b981',
-  type: 'single',
-  requiredInputs: 5,
-  details: 'Assigns linearly increasing weights to recent data points. The most recent price has the highest weight.',
-  createIndicator: () => new WMAClass(5),
   processData: makeProcessData({rowInputs: ['close']}),
-  getTableColumns: indicator => buildTableColumns({inputs: ['close'], indicator}),
-  chartTitle: 'WMA (5)',
+  requiredInputs: 5,
+  type: 'single',
   yAxisLabel: 'Price',
 };

--- a/packages/trading-signals-docs/indicator-demos/trend/WSMA.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/WSMA.demo.tsx
@@ -4,16 +4,17 @@ import {buildTableColumns} from '../../utils/tableColumns';
 import type {IndicatorConfig} from '../../utils/types';
 
 export const WSMA: IndicatorConfig = {
+  chartTitle: 'WSMA (5)',
+  color: '#06b6d4',
+  createIndicator: () => new WSMAClass(5),
+  description: "Wilder's Smoothed Moving Average",
+  details:
+    'Similar to RMA, this is a smoothed moving average that reduces noise and provides a clearer view of the trend.',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
   id: 'wsma',
   name: 'WSMA',
-  description: "Wilder's Smoothed Moving Average",
-  color: '#06b6d4',
-  type: 'single',
-  requiredInputs: 5,
-  details: 'Similar to RMA, this is a smoothed moving average that reduces noise and provides a clearer view of the trend.',
-  createIndicator: () => new WSMAClass(5),
   processData: makeProcessData({rowInputs: ['close']}),
-  getTableColumns: indicator => buildTableColumns({inputs: ['close'], indicator}),
-  chartTitle: 'WSMA (5)',
+  requiredInputs: 5,
+  type: 'single',
   yAxisLabel: 'Price',
 };

--- a/packages/trading-signals-docs/indicator-demos/trend/ZigZag.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/ZigZag.demo.tsx
@@ -4,17 +4,17 @@ import {buildTableColumns} from '../../utils/tableColumns';
 import type {IndicatorConfig} from '../../utils/types';
 
 export const ZigZag: IndicatorConfig = {
-  id: 'zigzag',
-  name: 'ZigZag',
-  description: 'ZigZag Indicator',
+  chartTitle: 'ZigZag (5% deviation)',
   color: '#f43f5e',
-  type: 'single',
-  requiredInputs: 1,
+  createIndicator: () => new ZigZagClass({deviation: 5}),
+  description: 'ZigZag Indicator',
   details:
     'Filters out minor price movements by connecting significant pivot highs and lows. A new pivot is only confirmed once price reverses by at least the configured percentage (deviation).',
-  createIndicator: () => new ZigZagClass({deviation: 5}),
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['high', 'low']}),
+  id: 'zigzag',
+  name: 'ZigZag',
   processData: makeProcessData({rowInputs: ['high', 'low']}),
-  getTableColumns: indicator => buildTableColumns({inputs: ['high', 'low'], indicator}),
-  chartTitle: 'ZigZag (5% deviation)',
+  requiredInputs: 1,
+  type: 'single',
   yAxisLabel: 'Price',
 };

--- a/packages/trading-signals-docs/indicator-demos/utilities/addPercentageChange.demo.ts
+++ b/packages/trading-signals-docs/indicator-demos/utilities/addPercentageChange.demo.ts
@@ -2,15 +2,6 @@ import {addPercentageChange} from 'trading-signals';
 import type {UtilityCalculatorConfig} from './types';
 
 export const addPercentageChangeDemo: UtilityCalculatorConfig = {
-  kind: 'calculator',
-  id: 'add-percentage-change',
-  name: 'Add Percentage Change',
-  description: 'Apply a percentage change to a starting value to get the final value.',
-  inputs: [
-    {label: 'Starting Value', defaultValue: '100'},
-    {label: 'Percentage Change (%)', defaultValue: '50'},
-  ],
-  outputLabel: 'Final Value',
   calculate: (from, percentage) => addPercentageChange(from, percentage),
   code: `import { addPercentageChange } from 'trading-signals';
 
@@ -18,4 +9,13 @@ export const addPercentageChangeDemo: UtilityCalculatorConfig = {
 const target = addPercentageChange(100, 50);
 
 console.log(target); // 150`,
+  description: 'Apply a percentage change to a starting value to get the final value.',
+  id: 'add-percentage-change',
+  inputs: [
+    {defaultValue: '100', label: 'Starting Value'},
+    {defaultValue: '50', label: 'Percentage Change (%)'},
+  ],
+  kind: 'calculator',
+  name: 'Add Percentage Change',
+  outputLabel: 'Final Value',
 };

--- a/packages/trading-signals-docs/indicator-demos/utilities/getAverage.demo.ts
+++ b/packages/trading-signals-docs/indicator-demos/utilities/getAverage.demo.ts
@@ -2,24 +2,24 @@ import {getAverage} from 'trading-signals';
 import type {UtilityConfig} from './types';
 
 export const getAverageDemo: UtilityConfig = {
-  kind: 'demo',
-  id: 'average',
-  name: 'Average / Mean',
-  description: 'Calculates the arithmetic mean of a set of values',
+  calculate: values => {
+    const result = values.length > 0 ? getAverage(values).toFixed(2) : null;
+    const allResults = values.map((value, idx) => ({
+      result: getAverage(values.slice(0, idx + 1)).toFixed(2),
+      value,
+    }));
+
+    return {allResults, result};
+  },
   code: `import { getAverage } from 'trading-signals';
 
 const values = [10, 20, 30, 40, 50];
 const avg = getAverage(values);
 
 console.log(avg); // 30`,
+  description: 'Calculates the arithmetic mean of a set of values',
+  id: 'average',
   inputValues: [10, 20, 30, 40, 50],
-  calculate: values => {
-    const result = values.length > 0 ? getAverage(values).toFixed(2) : null;
-    const allResults = values.map((value, idx) => ({
-      value,
-      result: getAverage(values.slice(0, idx + 1)).toFixed(2),
-    }));
-
-    return {result, allResults};
-  },
+  kind: 'demo',
+  name: 'Average / Mean',
 };

--- a/packages/trading-signals-docs/indicator-demos/utilities/getMaxMin.demo.ts
+++ b/packages/trading-signals-docs/indicator-demos/utilities/getMaxMin.demo.ts
@@ -2,20 +2,9 @@ import {getMaximum, getMinimum} from 'trading-signals';
 import type {UtilityConfig} from './types';
 
 export const getMaxMinDemo: UtilityConfig = {
-  kind: 'demo',
-  id: 'max-min',
-  name: 'Maximum & Minimum',
-  description: 'Finds the highest and lowest values in a dataset',
-  code: `import { getMaximum, getMinimum } from 'trading-signals';
-
-const values = [25, 50, 75, 100, 125];
-
-console.log(getMaximum(values)); // 125
-console.log(getMinimum(values)); // 25`,
-  inputValues: [25, 50, 75, 100, 125, 150],
   calculate: values => {
     if (values.length === 0) {
-      return {result: null, allResults: []};
+      return {allResults: [], result: null};
     }
     const max = getMaximum(values);
     const min = getMinimum(values);
@@ -23,11 +12,22 @@ console.log(getMinimum(values)); // 25`,
     const allResults = values.map((value, idx) => {
       const subset = values.slice(0, idx + 1);
       return {
-        value,
         result: `Max: ${getMaximum(subset)}, Min: ${getMinimum(subset)}`,
+        value,
       };
     });
 
-    return {result, allResults};
+    return {allResults, result};
   },
+  code: `import { getMaximum, getMinimum } from 'trading-signals';
+
+const values = [25, 50, 75, 100, 125];
+
+console.log(getMaximum(values)); // 125
+console.log(getMinimum(values)); // 25`,
+  description: 'Finds the highest and lowest values in a dataset',
+  id: 'max-min',
+  inputValues: [25, 50, 75, 100, 125, 150],
+  kind: 'demo',
+  name: 'Maximum & Minimum',
 };

--- a/packages/trading-signals-docs/indicator-demos/utilities/getMedian.demo.ts
+++ b/packages/trading-signals-docs/indicator-demos/utilities/getMedian.demo.ts
@@ -2,24 +2,24 @@ import {getMedian} from 'trading-signals';
 import type {UtilityConfig} from './types';
 
 export const getMedianDemo: UtilityConfig = {
-  kind: 'demo',
-  id: 'median',
-  name: 'Median',
-  description: 'Finds the middle value in a sorted dataset',
+  calculate: values => {
+    const result = values.length > 0 ? getMedian(values).toFixed(2) : null;
+    const allResults = values.map((value, idx) => ({
+      result: getMedian(values.slice(0, idx + 1)).toFixed(2),
+      value,
+    }));
+
+    return {allResults, result};
+  },
   code: `import { getMedian } from 'trading-signals';
 
 const values = [7, 31, 47, 75, 87];
 const median = getMedian(values);
 
 console.log(median); // 47`,
+  description: 'Finds the middle value in a sorted dataset',
+  id: 'median',
   inputValues: [7, 31, 47, 75, 87, 115, 119],
-  calculate: values => {
-    const result = values.length > 0 ? getMedian(values).toFixed(2) : null;
-    const allResults = values.map((value, idx) => ({
-      value,
-      result: getMedian(values.slice(0, idx + 1)).toFixed(2),
-    }));
-
-    return {result, allResults};
-  },
+  kind: 'demo',
+  name: 'Median',
 };

--- a/packages/trading-signals-docs/indicator-demos/utilities/getPercentageChange.demo.ts
+++ b/packages/trading-signals-docs/indicator-demos/utilities/getPercentageChange.demo.ts
@@ -2,16 +2,6 @@ import {getPercentageChange} from 'trading-signals';
 import type {UtilityCalculatorConfig} from './types';
 
 export const getPercentageChangeDemo: UtilityCalculatorConfig = {
-  kind: 'calculator',
-  id: 'percentage-change',
-  name: 'Percentage Change',
-  description: 'Calculate the percentage change between a starting and a final value.',
-  inputs: [
-    {label: 'Starting Value', defaultValue: '100'},
-    {label: 'Final Value', defaultValue: '150'},
-  ],
-  outputLabel: 'Percentage Change',
-  outputSuffix: '%',
   calculate: (from, to) => getPercentageChange(from, to),
   code: `import { getPercentageChange } from 'trading-signals';
 
@@ -19,4 +9,14 @@ export const getPercentageChangeDemo: UtilityCalculatorConfig = {
 const change = getPercentageChange(100, 150);
 
 console.log(change); // 50`,
+  description: 'Calculate the percentage change between a starting and a final value.',
+  id: 'percentage-change',
+  inputs: [
+    {defaultValue: '100', label: 'Starting Value'},
+    {defaultValue: '150', label: 'Final Value'},
+  ],
+  kind: 'calculator',
+  name: 'Percentage Change',
+  outputLabel: 'Percentage Change',
+  outputSuffix: '%',
 };

--- a/packages/trading-signals-docs/indicator-demos/utilities/getShare.demo.ts
+++ b/packages/trading-signals-docs/indicator-demos/utilities/getShare.demo.ts
@@ -2,16 +2,6 @@ import {getShare} from 'trading-signals';
 import type {UtilityCalculatorConfig} from './types';
 
 export const getShareDemo: UtilityCalculatorConfig = {
-  kind: 'calculator',
-  id: 'share',
-  name: 'Share of Total',
-  description: 'Calculate what percentage your share represents of a total.',
-  inputs: [
-    {label: 'Your Share', defaultValue: '40'},
-    {label: 'Total', defaultValue: '100'},
-  ],
-  outputLabel: 'Your Share',
-  outputSuffix: '%',
   calculate: (share, total) => getShare(share, total),
   code: `import { getShare } from 'trading-signals';
 
@@ -19,4 +9,14 @@ export const getShareDemo: UtilityCalculatorConfig = {
 const share = getShare(40, 100);
 
 console.log(share); // 40`,
+  description: 'Calculate what percentage your share represents of a total.',
+  id: 'share',
+  inputs: [
+    {defaultValue: '40', label: 'Your Share'},
+    {defaultValue: '100', label: 'Total'},
+  ],
+  kind: 'calculator',
+  name: 'Share of Total',
+  outputLabel: 'Your Share',
+  outputSuffix: '%',
 };

--- a/packages/trading-signals-docs/indicator-demos/utilities/getStandardDeviation.demo.ts
+++ b/packages/trading-signals-docs/indicator-demos/utilities/getStandardDeviation.demo.ts
@@ -2,30 +2,30 @@ import {getStandardDeviation} from 'trading-signals';
 import type {UtilityConfig} from './types';
 
 export const getStandardDeviationDemo: UtilityConfig = {
-  kind: 'demo',
-  id: 'standard-deviation',
-  name: 'Standard Deviation',
-  description: 'Measures the amount of variation or dispersion in a dataset',
+  calculate: values => {
+    if (values.length < 2) {
+      return {
+        allResults: values.map(value => ({result: null, value})),
+        result: null,
+      };
+    }
+    const result = getStandardDeviation(values).toFixed(2);
+    const allResults = values.map((value, idx) => ({
+      result: idx > 0 ? getStandardDeviation(values.slice(0, idx + 1)).toFixed(2) : null,
+      value,
+    }));
+
+    return {allResults, result};
+  },
   code: `import { getStandardDeviation } from 'trading-signals';
 
 const values = [10, 12, 14, 16, 18];
 const stdDev = getStandardDeviation(values);
 
 console.log(stdDev);`,
+  description: 'Measures the amount of variation or dispersion in a dataset',
+  id: 'standard-deviation',
   inputValues: [10, 12, 14, 16, 18, 20, 22],
-  calculate: values => {
-    if (values.length < 2) {
-      return {
-        result: null,
-        allResults: values.map(value => ({value, result: null})),
-      };
-    }
-    const result = getStandardDeviation(values).toFixed(2);
-    const allResults = values.map((value, idx) => ({
-      value,
-      result: idx > 0 ? getStandardDeviation(values.slice(0, idx + 1)).toFixed(2) : null,
-    }));
-
-    return {result, allResults};
-  },
+  kind: 'demo',
+  name: 'Standard Deviation',
 };

--- a/packages/trading-signals-docs/indicator-demos/utilities/otherUtilities.ts
+++ b/packages/trading-signals-docs/indicator-demos/utilities/otherUtilities.ts
@@ -2,50 +2,50 @@ import type {UtilityInfoConfig} from './types';
 
 export const otherUtilities: UtilityInfoConfig[] = [
   {
-    kind: 'info',
-    id: 'quartile',
-    name: 'getQuartile',
     description: 'Returns a single quartile (Q1, median, or Q3) from a dataset',
-    signature: 'getQuartile(values: number[], q: 0.25 | 0.5 | 0.75): number',
     details:
       'Pass `0.25` for the first quartile (Q1, 25th percentile), `0.5` for the median (Q2), or `0.75` for the third quartile (Q3, 75th percentile). Useful for measuring spread and detecting outliers (e.g. computing the interquartile range as `Q3 − Q1`).',
+    id: 'quartile',
+    kind: 'info',
+    name: 'getQuartile',
+    signature: 'getQuartile(values: number[], q: 0.25 | 0.5 | 0.75): number',
   },
   {
-    kind: 'info',
-    id: 'grid',
-    name: 'getGrid',
     description: 'Generates price grid levels for grid trading strategies',
-    signature:
-      "getGrid({ lower, upper, levels, spacing, tickSize? }): number[]\n// spacing: 'arithmetic' | 'geometric'",
     details:
       'Splits a price range into `levels` evenly spaced points between `lower` and `upper`. Choose `arithmetic` for equal price steps or `geometric` for equal percentage steps. An optional `tickSize` rounds each level to a tradable increment. Used by grid trading strategies that place buy/sell orders at fixed intervals.',
+    id: 'grid',
+    kind: 'info',
+    name: 'getGrid',
+    signature:
+      "getGrid({ lower, upper, levels, spacing, tickSize? }): number[]\n// spacing: 'arithmetic' | 'geometric'",
   },
   {
-    kind: 'info',
-    id: 'streaks',
-    name: 'getStreaks',
     description: 'Returns the lengths and percentage moves of continuous up- or down-streaks in a price series',
-    signature:
-      "getStreaks(prices: number[], keepSide: 'up' | 'down'): Streak[]\n// type Streak = { length: number; percentage: number }",
     details:
       'Walks the price series and groups consecutive moves in the same direction. Pass `up` to keep uptrends, `down` for downtrends. Each returned `Streak` reports the number of consecutive moves and the total percentage change across the streak. Useful for momentum analysis and indicators that need streak length as input (e.g. Connors RSI).',
+    id: 'streaks',
+    kind: 'info',
+    name: 'getStreaks',
+    signature:
+      "getStreaks(prices: number[], keepSide: 'up' | 'down'): Streak[]\n// type Streak = { length: number; percentage: number }",
   },
   {
-    kind: 'info',
-    id: 'weekday-helpers',
-    name: 'isMonday / isTuesday / …',
     description: 'Boolean helpers that test whether a date falls on a given weekday in a specific timezone',
-    signature: 'isMonday(timezone: string, date?: Date): boolean\n// also: isTuesday, isWednesday, …, isSunday',
     details:
       'Each helper takes an IANA timezone identifier (e.g. `"America/New_York"`, `"Europe/London"`) and an optional `Date` (defaults to now). Useful for filtering strategies by trading session or analysing day-of-week effects without pulling in a heavy date library.',
+    id: 'weekday-helpers',
+    kind: 'info',
+    name: 'isMonday / isTuesday / …',
+    signature: 'isMonday(timezone: string, date?: Date): boolean\n// also: isTuesday, isWednesday, …, isSunday',
   },
   {
-    kind: 'info',
-    id: 'push-update',
-    name: 'pushUpdate',
     description: 'Appends or replaces the last value in a bounded ring buffer',
-    signature: 'pushUpdate<T>(array: T[], replace: boolean, item: T, maxLength: number): T | null | undefined',
     details:
       'Helper used when implementing custom indicators. Pass `replace: false` to append a new value, `replace: true` to overwrite the most recent one (for streaming/live candles). When the array would exceed `maxLength`, the oldest element is shifted out and returned; otherwise the function returns `null`.',
+    id: 'push-update',
+    kind: 'info',
+    name: 'pushUpdate',
+    signature: 'pushUpdate<T>(array: T[], replace: boolean, item: T, maxLength: number): T | null | undefined',
   },
 ];

--- a/packages/trading-signals-docs/indicator-demos/volatility/ATR.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volatility/ATR.demo.tsx
@@ -4,17 +4,17 @@ import {buildTableColumns} from '../../utils/tableColumns';
 import type {IndicatorConfig} from '../../utils/types';
 
 export const ATR: IndicatorConfig = {
-  id: 'atr',
-  name: 'ATR',
-  description: 'Average True Range',
+  chartTitle: 'ATR (14)',
   color: '#f59e0b',
-  type: 'single',
-  requiredInputs: 14,
+  createIndicator: () => new ATRClass(14),
+  description: 'Average True Range',
   details:
     'Measures market volatility by analyzing the range of price movements. Higher values indicate higher volatility; useful for setting stop-loss levels.',
-  createIndicator: () => new ATRClass(14),
-  processData: makeProcessData({rowInputs: ['close'], addInputs: ['high', 'low', 'close']}),
-  getTableColumns: indicator => buildTableColumns({inputs: ['close'], indicator}),
-  chartTitle: 'ATR (14)',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
+  id: 'atr',
+  name: 'ATR',
+  processData: makeProcessData({addInputs: ['high', 'low', 'close'], rowInputs: ['close']}),
+  requiredInputs: 14,
+  type: 'single',
   yAxisLabel: 'ATR',
 };

--- a/packages/trading-signals-docs/indicator-demos/volatility/AccelerationBands.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volatility/AccelerationBands.demo.tsx
@@ -3,21 +3,21 @@ import type {IndicatorConfig} from '../../utils/types';
 import {renderBands} from './renderBands';
 
 export const AccelerationBands: IndicatorConfig = {
-  id: 'abands',
-  name: 'ABANDS',
-  description: 'Acceleration Bands',
   color: '#8b5cf6',
-  type: 'custom',
-  requiredInputs: 20,
   createIndicator: () => new AccelerationBandsClass(20, 4),
   customRender: (cfg, candles) =>
     renderBands(cfg, candles, {
-      label: 'AccelerationBands',
-      paramString: '20, 4',
-      createIndicator: () => new AccelerationBandsClass(20, 4),
       addCandle: (indicator, candle) =>
-        indicator.add({high: Number(candle.high), low: Number(candle.low), close: Number(candle.close)}),
+        indicator.add({close: Number(candle.close), high: Number(candle.high), low: Number(candle.low)}),
+      createIndicator: () => new AccelerationBandsClass(20, 4),
       details:
         'Volatility bands based on price momentum. Two consecutive closes outside Acceleration Bands suggest an entry point in the direction of the breakout.',
+      label: 'AccelerationBands',
+      paramString: '20, 4',
     }),
+  description: 'Acceleration Bands',
+  id: 'abands',
+  name: 'ABANDS',
+  requiredInputs: 20,
+  type: 'custom',
 };

--- a/packages/trading-signals-docs/indicator-demos/volatility/BollingerBands.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volatility/BollingerBands.demo.tsx
@@ -3,20 +3,20 @@ import type {IndicatorConfig} from '../../utils/types';
 import {renderBands} from './renderBands';
 
 export const BollingerBands: IndicatorConfig = {
-  id: 'bbands',
-  name: 'Bollinger Bands',
-  description: 'Bollinger Bands',
   color: '#3b82f6',
-  type: 'custom',
-  requiredInputs: 20,
   createIndicator: () => new BollingerBandsClass(20, 2),
   customRender: (cfg, candles) =>
     renderBands(cfg, candles, {
-      label: 'BollingerBands',
-      paramString: '20, 2',
-      createIndicator: () => new BollingerBandsClass(20, 2),
       addCandle: (indicator, candle) => indicator.add(Number(candle.close)),
+      createIndicator: () => new BollingerBandsClass(20, 2),
       details:
         'Shows price volatility using standard deviations from a moving average. Price touching the upper band may indicate overbought, touching lower band may indicate oversold.',
+      label: 'BollingerBands',
+      paramString: '20, 2',
     }),
+  description: 'Bollinger Bands',
+  id: 'bbands',
+  name: 'Bollinger Bands',
+  requiredInputs: 20,
+  type: 'custom',
 };

--- a/packages/trading-signals-docs/indicator-demos/volatility/BollingerBandsWidth.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volatility/BollingerBandsWidth.demo.tsx
@@ -4,17 +4,17 @@ import {buildTableColumns} from '../../utils/tableColumns';
 import type {IndicatorConfig} from '../../utils/types';
 
 export const BollingerBandsWidth: IndicatorConfig = {
-  id: 'bbw',
-  name: 'BBW',
-  description: 'Bollinger Bands Width',
+  chartTitle: 'BBW (20, 2)',
   color: '#10b981',
-  type: 'single',
-  requiredInputs: 20,
+  createIndicator: () => new BollingerBandsWidthClass(new BollingerBands(20, 2)),
+  description: 'Bollinger Bands Width',
   details:
     'Measures the width between the upper and lower Bollinger Bands relative to the middle band. Useful for identifying squeezes and potential breakouts.',
-  createIndicator: () => new BollingerBandsWidthClass(new BollingerBands(20, 2)),
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
+  id: 'bbw',
+  name: 'BBW',
   processData: makeProcessData({rowInputs: ['close']}),
-  getTableColumns: indicator => buildTableColumns({inputs: ['close'], indicator}),
-  chartTitle: 'BBW (20, 2)',
+  requiredInputs: 20,
+  type: 'single',
   yAxisLabel: 'BBW',
 };

--- a/packages/trading-signals-docs/indicator-demos/volatility/IQR.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volatility/IQR.demo.tsx
@@ -4,17 +4,17 @@ import {buildTableColumns} from '../../utils/tableColumns';
 import type {IndicatorConfig} from '../../utils/types';
 
 export const IQR: IndicatorConfig = {
-  id: 'iqr',
-  name: 'IQR',
-  description: 'Interquartile Range',
+  chartTitle: 'IQR (13)',
   color: '#6366f1',
-  type: 'single',
-  requiredInputs: 13,
+  createIndicator: () => new IQRClass(13),
+  description: 'Interquartile Range',
   details:
     'Statistical measure of variability showing the middle 50% of data. Robust measure of spread that is less sensitive to outliers than standard deviation.',
-  createIndicator: () => new IQRClass(13),
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
+  id: 'iqr',
+  name: 'IQR',
   processData: makeProcessData({rowInputs: ['close']}),
-  getTableColumns: indicator => buildTableColumns({inputs: ['close'], indicator}),
-  chartTitle: 'IQR (13)',
+  requiredInputs: 13,
+  type: 'single',
   yAxisLabel: 'IQR',
 };

--- a/packages/trading-signals-docs/indicator-demos/volatility/MAD.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volatility/MAD.demo.tsx
@@ -4,17 +4,17 @@ import {buildTableColumns} from '../../utils/tableColumns';
 import type {IndicatorConfig} from '../../utils/types';
 
 export const MAD: IndicatorConfig = {
-  id: 'mad',
-  name: 'MAD',
-  description: 'Mean Absolute Deviation',
+  chartTitle: 'MAD (10)',
   color: '#ef4444',
-  type: 'single',
-  requiredInputs: 10,
+  createIndicator: () => new MADClass(10),
+  description: 'Mean Absolute Deviation',
   details:
     'Average absolute deviation from the mean. Measures the average distance between each data point and the mean of the dataset.',
-  createIndicator: () => new MADClass(10),
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
+  id: 'mad',
+  name: 'MAD',
   processData: makeProcessData({rowInputs: ['close']}),
-  getTableColumns: indicator => buildTableColumns({inputs: ['close'], indicator}),
-  chartTitle: 'MAD (10)',
+  requiredInputs: 10,
+  type: 'single',
   yAxisLabel: 'MAD',
 };

--- a/packages/trading-signals-docs/indicator-demos/volatility/TR.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volatility/TR.demo.tsx
@@ -4,17 +4,17 @@ import {buildTableColumns} from '../../utils/tableColumns';
 import type {IndicatorConfig} from '../../utils/types';
 
 export const TR: IndicatorConfig = {
-  id: 'tr',
-  name: 'TR',
-  description: 'True Range',
+  chartTitle: 'True Range',
   color: '#ec4899',
-  type: 'single',
-  requiredInputs: 2,
+  createIndicator: () => new TRClass(),
+  description: 'True Range',
   details:
     'Measures the greatest of: current high minus current low, absolute value of current high minus previous close, or absolute value of current low minus previous close. Low values indicate a sideways trend with little volatility.',
-  createIndicator: () => new TRClass(),
-  processData: makeProcessData({rowInputs: ['close'], addInputs: ['high', 'low', 'close']}),
-  getTableColumns: indicator => buildTableColumns({inputs: ['close'], indicator}),
-  chartTitle: 'True Range',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
+  id: 'tr',
+  name: 'TR',
+  processData: makeProcessData({addInputs: ['high', 'low', 'close'], rowInputs: ['close']}),
+  requiredInputs: 2,
+  type: 'single',
   yAxisLabel: 'TR',
 };

--- a/packages/trading-signals-docs/indicator-demos/volatility/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volatility/index.tsx
@@ -7,4 +7,12 @@ import {MAD} from './MAD.demo';
 import {TR} from './TR.demo';
 import type {IndicatorConfig} from '../../utils/types';
 
-export const indicators: IndicatorConfig[] = [BollingerBands, AccelerationBands, ATR, TR, BollingerBandsWidth, IQR, MAD];
+export const indicators: IndicatorConfig[] = [
+  BollingerBands,
+  AccelerationBands,
+  ATR,
+  TR,
+  BollingerBandsWidth,
+  IQR,
+  MAD,
+];

--- a/packages/trading-signals-docs/indicator-demos/volatility/renderBands.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volatility/renderBands.tsx
@@ -23,7 +23,7 @@ export const renderBands = (config: IndicatorConfig, selectedCandles: Candle[], 
   const chartDataMiddle: ChartDataPoint[] = [];
   const chartDataLower: ChartDataPoint[] = [];
   const priceData: PriceData[] = [];
-  const sampleValues: Array<{
+  const sampleValues: {
     period: number;
     date: string;
     close: number;
@@ -31,7 +31,7 @@ export const renderBands = (config: IndicatorConfig, selectedCandles: Candle[], 
     middle: ReactNode;
     lower: ReactNode;
     signal: string;
-  }> = [];
+  }[] = [];
 
   selectedCandles.forEach((candle, idx) => {
     options.addCandle(indicator, candle);
@@ -39,7 +39,7 @@ export const renderBands = (config: IndicatorConfig, selectedCandles: Candle[], 
     const signal =
       'getSignal' in indicator
         ? (indicator.getSignal as () => {state: string; hasChanged: boolean})()
-        : {state: 'UNKNOWN', hasChanged: false};
+        : {hasChanged: false, state: 'UNKNOWN'};
 
     chartDataUpper.push({x: idx + 1, y: result?.upper ?? null});
     chartDataMiddle.push({x: idx + 1, y: result?.middle ?? null});
@@ -48,13 +48,13 @@ export const renderBands = (config: IndicatorConfig, selectedCandles: Candle[], 
     priceData.push(collectPriceData(candle, idx));
 
     sampleValues.push({
-      period: idx + 1,
-      date: formatDate(candle.openTimeInISO),
       close: Number(candle.close),
-      upper: result ? result.upper.toFixed(2) : <NotAvailable />,
-      middle: result ? result.middle.toFixed(2) : <NotAvailable />,
+      date: formatDate(candle.openTimeInISO),
       lower: result ? result.lower.toFixed(2) : <NotAvailable />,
+      middle: result ? result.middle.toFixed(2) : <NotAvailable />,
+      period: idx + 1,
       signal: signal.state,
+      upper: result ? result.upper.toFixed(2) : <NotAvailable />,
     });
   });
 
@@ -71,50 +71,41 @@ export const renderBands = (config: IndicatorConfig, selectedCandles: Candle[], 
       <div className="bg-slate-800/50 border border-slate-700 rounded-lg p-4">
         <HighchartsChart
           options={{
-            chart: {type: 'line', backgroundColor: 'transparent', height: 300},
-            title: {text: `${options.label} (${options.paramString})`, style: {color: '#e2e8f0', fontSize: '16px', fontWeight: '600'}},
+            chart: {backgroundColor: 'transparent', height: 300, type: 'line'},
             credits: {enabled: false},
-            xAxis: {
-              title: {text: 'Period', style: {color: '#94a3b8'}},
-              labels: {style: {color: '#94a3b8'}},
-              gridLineColor: '#334155',
-            },
-            yAxis: {
-              title: {text: 'Price', style: {color: '#94a3b8'}},
-              labels: {style: {color: '#94a3b8'}},
-              gridLineColor: '#334155',
-            },
             legend: {enabled: true, itemStyle: {color: '#e2e8f0'}},
-            plotOptions: {line: {marker: {enabled: true, radius: 3}, lineWidth: 2}},
+            plotOptions: {line: {lineWidth: 2, marker: {enabled: true, radius: 3}}},
             series: [
               {
-                type: 'line',
-                name: 'Upper',
-                data: chartDataUpper.map(point => [point.x, point.y]),
                 color: '#ef4444',
+                data: chartDataUpper.map(point => [point.x, point.y]),
                 marker: {fillColor: '#ef4444'},
+                name: 'Upper',
+                type: 'line',
               },
               {
-                type: 'line',
-                name: 'Middle',
-                data: chartDataMiddle.map(point => [point.x, point.y]),
                 color: config.color,
+                data: chartDataMiddle.map(point => [point.x, point.y]),
                 marker: {fillColor: config.color},
+                name: 'Middle',
+                type: 'line',
               },
               {
-                type: 'line',
-                name: 'Lower',
-                data: chartDataLower.map(point => [point.x, point.y]),
                 color: '#10b981',
+                data: chartDataLower.map(point => [point.x, point.y]),
                 marker: {fillColor: '#10b981'},
+                name: 'Lower',
+                type: 'line',
               },
             ],
+            title: {
+              style: {color: '#e2e8f0', fontSize: '16px', fontWeight: '600'},
+              text: `${options.label} (${options.paramString})`,
+            },
             tooltip: {
               backgroundColor: '#1e293b',
               borderColor: '#475569',
-              style: {color: '#e2e8f0'},
-              shared: true,
-              formatter: function (): string {
+              formatter: function () {
                 let s: string = `<b>Period ${(this as any).x}</b><br/>`;
                 ((this as any).points as any[])?.forEach((point: any) => {
                   const yValue = typeof point.y === 'number' ? point.y.toFixed(2) : 'N/A';
@@ -122,6 +113,18 @@ export const renderBands = (config: IndicatorConfig, selectedCandles: Candle[], 
                 });
                 return s;
               },
+              shared: true,
+              style: {color: '#e2e8f0'},
+            },
+            xAxis: {
+              gridLineColor: '#334155',
+              labels: {style: {color: '#94a3b8'}},
+              title: {style: {color: '#94a3b8'}, text: 'Period'},
+            },
+            yAxis: {
+              gridLineColor: '#334155',
+              labels: {style: {color: '#94a3b8'}},
+              title: {style: {color: '#94a3b8'}, text: 'Price'},
             },
           }}
         />

--- a/packages/trading-signals-docs/indicator-demos/volume/AD.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volume/AD.demo.tsx
@@ -10,10 +10,14 @@ export const AD: IndicatorConfig = {
   description: 'Accumulation/Distribution',
   details:
     'Uses the relationship between close price and high-low range, weighted by volume, to measure money flow. Rising AD confirms an uptrend, falling AD confirms a downtrend.',
-  getTableColumns: indicator => buildTableColumns({inputs: ['close', 'volume'], indicator}),
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close', 'volume']}),
   id: 'ad',
   name: 'AD',
-  processData: makeProcessData({rowInputs: ['close', 'volume'], addInputs: ['close', 'high', 'low', 'volume'], alwaysStable: true}),
+  processData: makeProcessData({
+    addInputs: ['close', 'high', 'low', 'volume'],
+    alwaysStable: true,
+    rowInputs: ['close', 'volume'],
+  }),
   requiredInputs: 1,
   type: 'single',
   yAxisLabel: 'AD',

--- a/packages/trading-signals-docs/indicator-demos/volume/CMF.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volume/CMF.demo.tsx
@@ -10,10 +10,10 @@ export const CMF: IndicatorConfig = {
   description: 'Chaikin Money Flow',
   details:
     'Measures buying and selling pressure over a period. Oscillates between -1 and +1. Values above 0 indicate accumulation (buying pressure), below 0 indicate distribution (selling pressure).',
-  getTableColumns: indicator => buildTableColumns({inputs: ['close', 'volume'], indicator}),
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close', 'volume']}),
   id: 'cmf',
   name: 'CMF',
-  processData: makeProcessData({rowInputs: ['close', 'volume'], addInputs: ['close', 'high', 'low', 'volume']}),
+  processData: makeProcessData({addInputs: ['close', 'high', 'low', 'volume'], rowInputs: ['close', 'volume']}),
   requiredInputs: 20,
   type: 'single',
   yAxisLabel: 'CMF',

--- a/packages/trading-signals-docs/indicator-demos/volume/EMV.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volume/EMV.demo.tsx
@@ -10,10 +10,10 @@ export const EMV: IndicatorConfig = {
   description: 'Ease of Movement',
   details:
     'Relates price change to volume to assess trend strength. Positive EMV means prices are advancing with ease, negative EMV means prices are declining easily. Uses SMA smoothing.',
-  getTableColumns: indicator => buildTableColumns({inputs: ['close', 'volume'], indicator}),
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close', 'volume']}),
   id: 'emv',
   name: 'EMV',
-  processData: makeProcessData({rowInputs: ['close', 'volume'], addInputs: ['close', 'high', 'low', 'volume']}),
+  processData: makeProcessData({addInputs: ['close', 'high', 'low', 'volume'], rowInputs: ['close', 'volume']}),
   requiredInputs: 15,
   type: 'single',
   yAxisLabel: 'EMV',

--- a/packages/trading-signals-docs/indicator-demos/volume/PVT.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volume/PVT.demo.tsx
@@ -10,10 +10,14 @@ export const PVT: IndicatorConfig = {
   description: 'Price Volume Trend',
   details:
     'Cumulative indicator that adds a proportional amount of volume based on percentage price change. More sensitive than OBV because it weights volume by price change rather than adding full volume.',
-  getTableColumns: indicator => buildTableColumns({inputs: ['close', 'volume'], indicator}),
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close', 'volume']}),
   id: 'pvt',
   name: 'PVT',
-  processData: makeProcessData({rowInputs: ['close', 'volume'], addInputs: ['close', 'high', 'low', 'volume'], alwaysStable: true}),
+  processData: makeProcessData({
+    addInputs: ['close', 'high', 'low', 'volume'],
+    alwaysStable: true,
+    rowInputs: ['close', 'volume'],
+  }),
   requiredInputs: 2,
   type: 'single',
   yAxisLabel: 'PVT',

--- a/packages/trading-signals-docs/indicator-demos/volume/VROC.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volume/VROC.demo.tsx
@@ -10,7 +10,7 @@ export const VROC: IndicatorConfig = {
   description: 'Volume Rate of Change',
   details:
     'Measures percentage change in volume over a period. Positive VROC indicates increasing volume (confirms trend), negative VROC indicates declining volume (weakening trend).',
-  getTableColumns: indicator => buildTableColumns({inputs: ['volume'], indicator}),
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['volume']}),
   id: 'vroc',
   name: 'VROC',
   processData: makeProcessData({rowInputs: ['volume']}),

--- a/packages/trading-signals-docs/indicator-demos/volume/VWMA.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volume/VWMA.demo.tsx
@@ -10,10 +10,10 @@ export const VWMA: IndicatorConfig = {
   description: 'Volume Weighted Moving Average',
   details:
     'Similar to SMA but weights each price by its volume. High-volume bars have more influence. Uses a signal line (SMA by default) for crossover signals. When VWMA crosses above the signal line, it indicates bullish momentum.',
-  getTableColumns: indicator => buildTableColumns({inputs: ['close', 'volume'], indicator}),
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close', 'volume']}),
   id: 'vwma',
   name: 'VWMA',
-  processData: makeProcessData({rowInputs: ['close', 'volume'], addInputs: ['close', 'high', 'low', 'volume']}),
+  processData: makeProcessData({addInputs: ['close', 'high', 'low', 'volume'], rowInputs: ['close', 'volume']}),
   requiredInputs: 20,
   type: 'single',
   yAxisLabel: 'VWMA',

--- a/packages/trading-signals-docs/package.json
+++ b/packages/trading-signals-docs/package.json
@@ -32,7 +32,7 @@
     "build": "next build",
     "dev": "next dev",
     "dist": "npm run build",
-    "lint": "exit 0",
+    "lint": "eslint .",
     "start": "next start",
     "test": "npm run test:types && npm run test:units",
     "test:e2e": "playwright test",

--- a/packages/trading-signals-docs/pages/_app.tsx
+++ b/packages/trading-signals-docs/pages/_app.tsx
@@ -12,13 +12,13 @@ export default function App({Component, pageProps}: AppProps) {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
   const navigation = [
-    {name: 'Home', href: '/'},
-    {name: 'Trend', href: '/indicators/trend'},
-    {name: 'Momentum', href: '/indicators/momentum'},
-    {name: 'Volatility', href: '/indicators/volatility'},
-    {name: 'Volume', href: '/indicators/volume'},
-    {name: 'Utilities', href: '/indicators/utilities'},
-    {name: 'Backtest', href: '/backtest', highlight: true},
+    {href: '/', name: 'Home'},
+    {href: '/indicators/trend', name: 'Trend'},
+    {href: '/indicators/momentum', name: 'Momentum'},
+    {href: '/indicators/volatility', name: 'Volatility'},
+    {href: '/indicators/volume', name: 'Volume'},
+    {href: '/indicators/utilities', name: 'Utilities'},
+    {highlight: true, href: '/backtest', name: 'Backtest'},
   ];
 
   const getNavClasses = (item: (typeof navigation)[number], isActive: boolean, isMobile = false) => {
@@ -32,9 +32,7 @@ export default function App({Component, pageProps}: AppProps) {
       }`;
     }
 
-    return `${base} ${
-      isActive ? 'bg-blue-600 text-white' : 'text-slate-300 hover:bg-slate-800 hover:text-white'
-    }`;
+    return `${base} ${isActive ? 'bg-blue-600 text-white' : 'text-slate-300 hover:bg-slate-800 hover:text-white'}`;
   };
 
   return (
@@ -48,10 +46,7 @@ export default function App({Component, pageProps}: AppProps) {
               </Link>
               <div className="hidden md:flex space-x-4">
                 {navigation.map(item => (
-                  <Link
-                    key={item.href}
-                    href={item.href}
-                    className={getNavClasses(item, router.pathname === item.href)}>
+                  <Link key={item.href} href={item.href} className={getNavClasses(item, router.pathname === item.href)}>
                     {item.name}
                   </Link>
                 ))}
@@ -82,7 +77,11 @@ export default function App({Component, pageProps}: AppProps) {
                   {mobileMenuOpen ? (
                     <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
                   ) : (
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"
+                    />
                   )}
                 </svg>
               </button>
@@ -119,7 +118,8 @@ export default function App({Component, pageProps}: AppProps) {
       <footer className="border-t border-slate-700 mt-16 py-8">
         <div className="container mx-auto px-4 text-center text-slate-400">
           <p>
-            Built with ❤️ by <a
+            Built with ❤️ by{' '}
+            <a
               href="https://github.com/sponsors/bennycode"
               target="_blank"
               rel="noopener noreferrer"

--- a/packages/trading-signals-docs/pages/index.tsx
+++ b/packages/trading-signals-docs/pages/index.tsx
@@ -1,49 +1,49 @@
-import { CategoryCard } from '../components/CategoryCard';
-import { Hero } from '../components/Hero';
-import { MarketClock } from '../components/MarketClock';
-import { QuickStart } from '../components/QuickStart';
+import {CategoryCard} from '../components/CategoryCard';
+import {Hero} from '../components/Hero';
+import {MarketClock} from '../components/MarketClock';
+import {QuickStart} from '../components/QuickStart';
 
 export default function Home() {
   const categories = [
     {
-      name: 'Trend Indicators',
+      color: 'from-blue-500 to-cyan-500',
       description: 'Measure the direction of a trend (uptrend, downtrend or sideways trend)',
       href: '/indicators/trend',
       icon: '📈',
       indicators: ['SMA', 'EMA', 'DEMA', 'WMA', 'MACD', 'ADX', 'PSAR', 'VWAP'],
-      color: 'from-blue-500 to-cyan-500',
+      name: 'Trend Indicators',
     },
     {
-      name: 'Momentum Indicators',
+      color: 'from-purple-500 to-pink-500',
       description: 'Measure the speed and strength of price movements',
       href: '/indicators/momentum',
       icon: '⚡',
       indicators: ['RSI', 'Stochastic', 'CCI', 'ROC', 'AO', 'AC', 'MOM', 'OBV'],
-      color: 'from-purple-500 to-pink-500',
+      name: 'Momentum Indicators',
     },
     {
-      name: 'Volatility Indicators',
+      color: 'from-orange-500 to-red-500',
       description: 'Measure the degree of variation in prices over time',
       href: '/indicators/volatility',
       icon: '🌊',
       indicators: ['Bollinger Bands', 'ATR', 'BBW', 'IQR', 'MAD', 'TR'],
-      color: 'from-orange-500 to-red-500',
+      name: 'Volatility Indicators',
     },
     {
-      name: 'Volume Indicators',
+      color: 'from-emerald-500 to-teal-500',
       description: 'Analyze trading volume to confirm trends and identify reversals',
       href: '/indicators/volume',
       icon: '📊',
       indicators: ['AD', 'CMF', 'PVT', 'EMV', 'VROC', 'VWMA'],
-      color: 'from-emerald-500 to-teal-500',
+      name: 'Volume Indicators',
     },
     {
-      name: 'Utility Functions',
+      color: 'from-slate-500 to-slate-600',
       description: 'Mathematical utilities for technical analysis',
       href: '/indicators/utilities',
       icon: '🛠️',
       indicators: ['Average', 'Median', 'Standard Deviation', 'Min/Max', 'Quartiles'],
-      color: 'from-slate-500 to-slate-600',
+      name: 'Utility Functions',
     },
   ];
 

--- a/packages/trading-signals-docs/pages/indicators/momentum.tsx
+++ b/packages/trading-signals-docs/pages/indicators/momentum.tsx
@@ -13,7 +13,9 @@ export default function MomentumIndicators() {
   const renderIndicatorContent = () => {
     const config = indicators.find(ind => ind.id === selectedIndicator);
     const dataset = datasets.find(ds => ds.id === selectedDataset);
-    if (!config || !dataset) return null;
+    if (!config || !dataset) {
+      return null;
+    }
 
     if (config.type === 'single') {
       return renderSingleIndicator(config, dataset.candles);

--- a/packages/trading-signals-docs/pages/indicators/trend.tsx
+++ b/packages/trading-signals-docs/pages/indicators/trend.tsx
@@ -13,7 +13,9 @@ export default function TrendIndicators() {
   const renderIndicatorContent = () => {
     const config = indicators.find(ind => ind.id === selectedIndicator);
     const dataset = datasets.find(ds => ds.id === selectedDataset);
-    if (!config || !dataset) return null;
+    if (!config || !dataset) {
+      return null;
+    }
 
     if (config.type === 'single') {
       return renderSingleIndicator(config, dataset.candles);

--- a/packages/trading-signals-docs/pages/indicators/utilities.tsx
+++ b/packages/trading-signals-docs/pages/indicators/utilities.tsx
@@ -42,13 +42,17 @@ export default function UtilityFunctions() {
         <div className="sticky top-6 space-y-4">
           <IndicatorList
             title="Utility Functions"
-            indicators={interactiveUtilities.map(util => ({id: util.id, name: util.name, description: util.description}))}
+            indicators={interactiveUtilities.map(util => ({
+              description: util.description,
+              id: util.id,
+              name: util.name,
+            }))}
             selectedIndicator={selectedUtility}
             onIndicatorChange={selectUtility}
           />
           <IndicatorList
             title="Other Utility Functions"
-            indicators={otherUtilities.map(util => ({id: util.id, name: util.name, description: util.description}))}
+            indicators={otherUtilities.map(util => ({description: util.description, id: util.id, name: util.name}))}
             selectedIndicator={selectedUtility}
             onIndicatorChange={selectUtility}
           />

--- a/packages/trading-signals-docs/pages/indicators/volatility.tsx
+++ b/packages/trading-signals-docs/pages/indicators/volatility.tsx
@@ -13,7 +13,9 @@ export default function VolatilityIndicators() {
   const renderIndicatorContent = () => {
     const config = indicators.find(ind => ind.id === selectedIndicator);
     const dataset = datasets.find(ds => ds.id === selectedDataset);
-    if (!config || !dataset) return null;
+    if (!config || !dataset) {
+      return null;
+    }
 
     if (config.type === 'single') {
       return renderSingleIndicator(config, dataset.candles);

--- a/packages/trading-signals-docs/pages/indicators/volume.tsx
+++ b/packages/trading-signals-docs/pages/indicators/volume.tsx
@@ -13,7 +13,9 @@ export default function VolumeIndicators() {
   const renderIndicatorContent = () => {
     const config = indicators.find(ind => ind.id === selectedIndicator);
     const dataset = datasets.find(ds => ds.id === selectedDataset);
-    if (!config || !dataset) return null;
+    if (!config || !dataset) {
+      return null;
+    }
 
     if (config.type === 'single') {
       return renderSingleIndicator(config, dataset.candles);

--- a/packages/trading-signals-docs/utils/formatDate.ts
+++ b/packages/trading-signals-docs/utils/formatDate.ts
@@ -1,8 +1,8 @@
-export function formatDate(isoString: string): string {
+export function formatDate(isoString: string) {
   const date = new Date(isoString);
   // Fixed locale + UTC timezone prevents SSR/client hydration mismatches in Next.js
   return date.toLocaleString('en-US', {
-    timeZone: 'UTC',
     hour12: false,
+    timeZone: 'UTC',
   });
 }

--- a/packages/trading-signals-docs/utils/processData.ts
+++ b/packages/trading-signals-docs/utils/processData.ts
@@ -20,16 +20,16 @@ export function makeProcessData(opts: ProcessDataOptions): SingleIndicatorConfig
       indicator.add(candleField(candle, addInputs[0]));
     } else {
       const payload: Record<string, number> = {};
-      for (const key of addInputs) payload[key] = candleField(candle, key);
+      for (const key of addInputs) {
+        payload[key] = candleField(candle, key);
+      }
       indicator.add(payload);
     }
-    const result = opts.alwaysStable
-      ? indicator.getResult()
-      : indicator.isStable
-        ? indicator.getResult()
-        : null;
+    const result = opts.alwaysStable ? indicator.getResult() : indicator.isStable ? indicator.getResult() : null;
     const row: Record<string, unknown> = {result};
-    for (const key of opts.rowInputs) row[key] = candleField(candle, key);
+    for (const key of opts.rowInputs) {
+      row[key] = candleField(candle, key);
+    }
     if ('getSignal' in indicator) {
       row.signal = indicator.getSignal();
     }

--- a/packages/trading-signals-docs/utils/renderUtils.tsx
+++ b/packages/trading-signals-docs/utils/renderUtils.tsx
@@ -11,30 +11,37 @@ import {IndicatorHeader} from '../components/IndicatorHeader';
 import {NotAvailable} from '../components/NotAvailable';
 
 export const collectPriceData = (candle: Candle, idx: number): PriceData => ({
-  x: idx + 1,
-  open: Number(candle.open),
+  close: Number(candle.close),
   high: Number(candle.high),
   low: Number(candle.low),
-  close: Number(candle.close),
+  open: Number(candle.open),
+  x: idx + 1,
 });
+
+/** Shape shared by every demo's `processData` result — extra indicator-specific keys pass through to the sample table. */
+type ProcessedIndicatorData = {
+  result?: number | null;
+  signal?: {state?: string};
+  [key: string]: unknown;
+};
 
 export const renderSingleIndicator = (config: SingleIndicatorConfig, selectedCandles: Candle[]) => {
   const indicator = config.createIndicator();
   const chartData: ChartDataPoint[] = [];
   const priceData: PriceData[] = [];
-  const sampleValues: Array<{
+  const sampleValues: {
     period: number;
     date: string;
     result: ReactNode;
     signal?: string;
     [key: string]: any;
-  }> = [];
+  }[] = [];
 
   selectedCandles.forEach((candle, idx) => {
-    const processedData = config.processData(indicator, candle, idx);
+    const processedData: ProcessedIndicatorData = config.processData(indicator, candle, idx);
     const chartPoint = config.getChartData
       ? config.getChartData(processedData)
-      : {x: idx + 1, y: (processedData.result as number | null) ?? null};
+      : {x: idx + 1, y: processedData.result ?? null};
 
     if (Array.isArray(chartPoint)) {
       chartData.push(...chartPoint);
@@ -45,11 +52,15 @@ export const renderSingleIndicator = (config: SingleIndicatorConfig, selectedCan
     priceData.push(collectPriceData(candle, idx));
 
     sampleValues.push({
-      period: idx + 1,
       date: formatDate(candle.openTimeInISO),
+      period: idx + 1,
       ...processedData,
       result:
-        processedData.result !== null && processedData.result !== undefined ? processedData.result.toFixed(2) : <NotAvailable />,
+        processedData.result !== null && processedData.result !== undefined ? (
+          processedData.result.toFixed(2)
+        ) : (
+          <NotAvailable />
+        ),
       signal: processedData.signal?.state,
     });
   });

--- a/packages/trading-signals-docs/utils/schemaProperties.ts
+++ b/packages/trading-signals-docs/utils/schemaProperties.ts
@@ -21,19 +21,19 @@ interface JsonSchemaNode {
   additionalProperties?: boolean;
 }
 
-function collectProperties(
-  node: JsonSchemaNode,
-  requiredSet: Set<string>,
-  result: Map<string, SchemaProperty>
-): void {
+function collectProperties(node: JsonSchemaNode, requiredSet: Set<string>, result: Map<string, SchemaProperty>): void {
   if (node.properties) {
     for (const [name, prop] of Object.entries(node.properties)) {
-      if (prop.not) continue;
-      if (result.has(name)) continue;
+      if (prop.not) {
+        continue;
+      }
+      if (result.has(name)) {
+        continue;
+      }
       result.set(name, {
         name,
-        type: formatType(prop),
         required: requiredSet.has(name) && prop.default === undefined,
+        type: formatType(prop),
         ...(prop.enum && {enum: prop.enum}),
         ...(prop.pattern && {pattern: prop.pattern}),
       });
@@ -54,10 +54,16 @@ function collectProperties(
   }
 }
 
-function formatType(prop: JsonSchemaNode): string {
-  if (prop.enum) return prop.enum.map(v => `"${v}"`).join(' | ');
-  if (prop.type === 'object') return 'object';
-  if (prop.pattern) return 'string (numeric)';
+function formatType(prop: JsonSchemaNode) {
+  if (prop.enum) {
+    return prop.enum.map(v => `"${v}"`).join(' | ');
+  }
+  if (prop.type === 'object') {
+    return 'object';
+  }
+  if (prop.pattern) {
+    return 'string (numeric)';
+  }
   return prop.type ?? 'unknown';
 }
 
@@ -73,16 +79,22 @@ export function extractNestedProperties(schema: z.ZodType, key: string): SchemaP
   const jsonSchema = z.toJSONSchema(schema) as JsonSchemaNode;
 
   function findNested(node: JsonSchemaNode): JsonSchemaNode | undefined {
-    if (node.properties?.[key]) return node.properties[key];
+    if (node.properties?.[key]) {
+      return node.properties[key];
+    }
     for (const child of node.allOf ?? []) {
       const found = findNested(child);
-      if (found) return found;
+      if (found) {
+        return found;
+      }
     }
     return undefined;
   }
 
   const nested = findNested(jsonSchema);
-  if (!nested) return [];
+  if (!nested) {
+    return [];
+  }
   const result = new Map<string, SchemaProperty>();
   const nestedRequired = new Set(nested.required ?? []);
   collectProperties(nested, nestedRequired, result);

--- a/packages/trading-signals-docs/utils/strategySchemas.ts
+++ b/packages/trading-signals-docs/utils/strategySchemas.ts
@@ -1,10 +1,41 @@
-import {z} from 'zod';
+import type {z} from 'zod';
 import type {Candle} from '@typedtrader/exchange';
-import {BuyOnceSchema, BuyBelowSellAboveSchema, CoinFlipSchema, MultiIndicatorConfluenceSchema, ScalpSchema, MeanReversionSchema, SmaCrossoverSchema, ProtectedStrategySchema, TrailingStopSchema, suggestScalpOffset} from 'trading-strategies';
+import {
+  BuyOnceSchema,
+  BuyBelowSellAboveSchema,
+  CoinFlipSchema,
+  MultiIndicatorConfluenceSchema,
+  ScalpSchema,
+  MeanReversionSchema,
+  SmaCrossoverSchema,
+  ProtectedStrategySchema,
+  TrailingStopSchema,
+  suggestScalpOffset,
+} from 'trading-strategies';
 
-export {BuyOnceSchema, BuyBelowSellAboveSchema, CoinFlipSchema, MultiIndicatorConfluenceSchema, ScalpSchema, MeanReversionSchema, SmaCrossoverSchema, ProtectedStrategySchema, TrailingStopSchema};
+export {
+  BuyOnceSchema,
+  BuyBelowSellAboveSchema,
+  CoinFlipSchema,
+  MultiIndicatorConfluenceSchema,
+  ScalpSchema,
+  MeanReversionSchema,
+  SmaCrossoverSchema,
+  ProtectedStrategySchema,
+  TrailingStopSchema,
+};
 
-export type StrategyId = 'buy-and-hold' | 'buy-once' | 'buy-below-sell-above' | 'coin-flip' | 'multi-indicator-confluence' | 'scalp' | 'mean-reversion' | 'sma-crossover' | 'protection-only' | 'trailing-stop';
+export type StrategyId =
+  | 'buy-and-hold'
+  | 'buy-once'
+  | 'buy-below-sell-above'
+  | 'coin-flip'
+  | 'multi-indicator-confluence'
+  | 'scalp'
+  | 'mean-reversion'
+  | 'sma-crossover'
+  | 'protection-only'
+  | 'trailing-stop';
 
 export interface StrategyDefinition {
   id: StrategyId;
@@ -16,7 +47,7 @@ export interface StrategyDefinition {
 
 function getPriceStats(candles: Candle[]): {firstClose: number; minClose: number; maxClose: number} {
   if (candles.length === 0) {
-    return {firstClose: 100, minClose: 90, maxClose: 110};
+    return {firstClose: 100, maxClose: 110, minClose: 90};
   }
   const firstClose = parseFloat(candles[0].close);
   let minClose = firstClose;
@@ -32,76 +63,74 @@ function getPriceStats(candles: Candle[]): {firstClose: number; minClose: number
     }
   }
 
-  return {firstClose, minClose, maxClose};
+  return {firstClose, maxClose, minClose};
 }
 
 export const strategyDefinitions: StrategyDefinition[] = [
   {
+    description: 'Buys once at the first candle and holds for the entire period. Simplest baseline strategy.',
+    getDefaultConfig: () => ({}),
     id: 'buy-and-hold',
     name: 'Buy & Hold',
-    description: 'Buys once at the first candle and holds for the entire period. Simplest baseline strategy.',
     schema: BuyOnceSchema,
-    getDefaultConfig: () => ({}),
   },
   {
-    id: 'buy-once',
-    name: 'Buy Once',
     description:
       'Places a single limit buy when the close price drops to or below a predefined price. After the buy triggers, the strategy stays silent.',
-    schema: BuyOnceSchema,
     getDefaultConfig: candles => {
       const {firstClose, minClose} = getPriceStats(candles);
       const buyAt = (firstClose + minClose) / 2;
       return {buyAt: buyAt.toFixed(2)};
     },
+    id: 'buy-once',
+    name: 'Buy Once',
+    schema: BuyOnceSchema,
   },
   {
+    description:
+      'Randomly buys or sells on every candle with 50/50 probability. Useful as a baseline to confirm any strategy beats pure chance.',
+    getDefaultConfig: () => ({}),
     id: 'coin-flip',
     name: 'Coin Flip',
-    description: 'Randomly buys or sells on every candle with 50/50 probability. Useful as a baseline to confirm any strategy beats pure chance.',
     schema: CoinFlipSchema,
-    getDefaultConfig: () => ({}),
   },
   {
-    id: 'buy-below-sell-above',
-    name: 'Buy Below / Sell Above',
     description:
       'Buys when the close price drops below a threshold and sells when it rises above another. Repeats on every qualifying candle.',
-    schema: BuyBelowSellAboveSchema,
     getDefaultConfig: candles => {
-      const {minClose, maxClose} = getPriceStats(candles);
+      const {maxClose, minClose} = getPriceStats(candles);
       const range = maxClose - minClose;
       return {
         buyBelow: (minClose + range * 0.3).toFixed(2),
         sellAbove: (maxClose - range * 0.3).toFixed(2),
       };
     },
+    id: 'buy-below-sell-above',
+    name: 'Buy Below / Sell Above',
+    schema: BuyBelowSellAboveSchema,
   },
   {
-    id: 'multi-indicator-confluence',
-    name: 'Multi-Indicator Confluence',
     description:
       'Combines EMA trend, MACD momentum, Bollinger Bands mean-reversion, and RSI filters. Buys on bullish confluence at the lower band; sells on bearish confluence at the upper band.',
-    schema: MultiIndicatorConfluenceSchema,
     getDefaultConfig: () => ({
-      emaShortPeriod: 9,
-      emaLongPeriod: 15,
-      macdShortPeriod: 5,
-      macdLongPeriod: 7,
-      macdSignalPeriod: 9,
-      bollingerPeriod: 5,
       bollingerDeviationMultiplier: 0.5,
-      rsiPeriod: 14,
+      bollingerPeriod: 5,
+      emaLongPeriod: 15,
+      emaShortPeriod: 9,
+      macdLongPeriod: 7,
+      macdShortPeriod: 5,
+      macdSignalPeriod: 9,
       rsiOverbought: 65,
       rsiOversold: 45,
+      rsiPeriod: 14,
     }),
+    id: 'multi-indicator-confluence',
+    name: 'Multi-Indicator Confluence',
+    schema: MultiIndicatorConfluenceSchema,
   },
   {
-    id: 'scalp',
-    name: 'Scalp',
     description:
       'Waits for price to cross above EMA, then market buys. Sells at fill + offset, re-buys at fill - offset, and repeats. Offset can be auto-tuned from ATR.',
-    schema: ScalpSchema,
     getDefaultConfig: candles => {
       let offset = '0.10';
 
@@ -111,45 +140,48 @@ export const strategyDefinitions: StrategyDefinition[] = [
         // Not enough candles for ATR — use fallback
       }
 
-      return {offset, emaPeriod: 5};
+      return {emaPeriod: 5, offset};
     },
+    id: 'scalp',
+    name: 'Scalp',
+    schema: ScalpSchema,
   },
   {
-    id: 'mean-reversion',
-    name: 'Mean Reversion',
     description:
       'Batches 1-minute candles into 1-hour bars and applies Bollinger Bands (20, 2.5). Sells when price breaks above the upper band; rebuys when it returns to the middle band.',
-    schema: MeanReversionSchema,
     getDefaultConfig: () => ({}),
+    id: 'mean-reversion',
+    name: 'Mean Reversion',
+    schema: MeanReversionSchema,
   },
   {
-    id: 'sma-crossover',
-    name: 'SMA Crossover',
     description:
       'Crosses a fast SMA against a slow SMA — each with its own period and timeframe (e.g. SMA5 on 1m bars vs SMA10 on 2m bars). Buys when the fast SMA crosses above the slow one and sells when it crosses below (market orders).',
-    schema: SmaCrossoverSchema,
     getDefaultConfig: () => ({fastPeriod: 5, fastTimeframe: '1m', slowPeriod: 10, slowTimeframe: '2m'}),
+    id: 'sma-crossover',
+    name: 'SMA Crossover',
+    schema: SmaCrossoverSchema,
   },
   {
-    id: 'protection-only',
-    name: 'Protection Only',
     description:
       'Never opens a position. Use with seedFromBalance to attach stop-loss / take-profit guards to an existing position opened manually or by another strategy.',
-    schema: ProtectedStrategySchema,
     getDefaultConfig: () => ({
       protected: {
+        seedFromBalance: true,
         stopLossPct: '5',
         takeProfitPct: '10',
-        seedFromBalance: true,
       },
     }),
+    id: 'protection-only',
+    name: 'Protection Only',
+    schema: ProtectedStrategySchema,
   },
   {
-    id: 'trailing-stop',
-    name: 'Trailing Stop',
     description:
       'Exit-only trailing stop. Attaches to an existing base balance, tracks the highest candle high since attach, and emits a sell-all advice when the close drops by trailDownPct from the peak. Set initialBase > 0 in the backtest setup so the strategy has a position to protect.',
+    getDefaultConfig: () => ({exitOrder: 'limit', trailDownPct: '10'}),
+    id: 'trailing-stop',
+    name: 'Trailing Stop',
     schema: TrailingStopSchema,
-    getDefaultConfig: () => ({trailDownPct: '10', exitOrder: 'limit'}),
   },
 ];

--- a/packages/trading-signals-docs/utils/tableColumns.tsx
+++ b/packages/trading-signals-docs/utils/tableColumns.tsx
@@ -4,11 +4,11 @@ import type {ColumnDef} from './types';
 export type PriceColumnKey = 'open' | 'high' | 'low' | 'close' | 'volume';
 
 const priceColumns: Record<PriceColumnKey, ColumnDef> = {
-  open: {header: 'Open', key: 'open', render: val => `$${val.toFixed(2)}`, className: 'text-slate-300 py-2 px-3'},
-  high: {header: 'High', key: 'high', render: val => `$${val.toFixed(2)}`, className: 'text-slate-300 py-2 px-3'},
-  low: {header: 'Low', key: 'low', render: val => `$${val.toFixed(2)}`, className: 'text-slate-300 py-2 px-3'},
-  close: {header: 'Close', key: 'close', render: val => `$${val.toFixed(2)}`, className: 'text-slate-300 py-2 px-3'},
-  volume: {header: 'Volume', key: 'volume', className: 'text-slate-300 py-2 px-3'},
+  close: {className: 'text-slate-300 py-2 px-3', header: 'Close', key: 'close', render: val => `$${val.toFixed(2)}`},
+  high: {className: 'text-slate-300 py-2 px-3', header: 'High', key: 'high', render: val => `$${val.toFixed(2)}`},
+  low: {className: 'text-slate-300 py-2 px-3', header: 'Low', key: 'low', render: val => `$${val.toFixed(2)}`},
+  open: {className: 'text-slate-300 py-2 px-3', header: 'Open', key: 'open', render: val => `$${val.toFixed(2)}`},
+  volume: {className: 'text-slate-300 py-2 px-3', header: 'Volume', key: 'volume'},
 };
 
 interface BuildOptions {
@@ -17,20 +17,20 @@ interface BuildOptions {
   extra?: ColumnDef[];
 }
 
-export function buildTableColumns({inputs, indicator, extra = []}: BuildOptions): ColumnDef[] {
+export function buildTableColumns({extra = [], indicator, inputs}: BuildOptions): ColumnDef[] {
   const cols: ColumnDef[] = [
     {header: 'Period', key: 'period'},
     {header: 'Date', key: 'date'},
     ...inputs.map(key => priceColumns[key]),
-    {header: 'Result', key: 'result', className: 'text-white font-mono py-2 px-3'},
+    {className: 'text-white font-mono py-2 px-3', header: 'Result', key: 'result'},
     ...extra,
   ];
   if (indicator && typeof indicator === 'object' && 'getSignal' in indicator) {
     cols.push({
+      className: 'py-2 px-3',
       header: 'Signal',
       key: 'signal',
       render: val => <SignalBadge signal={val} />,
-      className: 'py-2 px-3',
     });
   }
   return cols;

--- a/packages/trading-signals-docs/utils/types.ts
+++ b/packages/trading-signals-docs/utils/types.ts
@@ -34,8 +34,7 @@ export interface CustomIndicatorConfig<TIndicator = any> extends BaseIndicatorCo
 }
 
 export type IndicatorConfig<TIndicator = any, TResult = any> =
-  | SingleIndicatorConfig<TIndicator, TResult>
-  | CustomIndicatorConfig<TIndicator>;
+  SingleIndicatorConfig<TIndicator, TResult> | CustomIndicatorConfig<TIndicator>;
 
 export interface CandleDataset {
   id: string;


### PR DESCRIPTION
## What

The docs package stubbed its lint script with `exit 0`, so the `lerna run lint` sweep silently skipped it — the only package in the workspace without linting. It now runs `eslint .` through the shared config like every sibling.

## Changes

- **Package `eslint.config.mjs`** using the shared `createConfig()` factory, with docs-specific ignores (`.next/`, `out/`, playwright artifacts, `postcss.config.js`).
- **Fixes a latent bug in the shared `eslint.config.base.mjs`**: the ignore patterns sat on a config object that also declared `files`. Per-object ignores only exclude files from that one object — configs pulled in via `extends` could still lint them, which is how `.next/` build chunks ended up producing hundreds of lint errors. The ignores are now a standalone global-ignores object (a config with *only* `ignores`), which excludes files entirely. This benefits every package.
- **Applies the resulting findings** across ~90 files: ~800 auto-fixes (`perfectionist/sort-objects` key ordering, prettier formatting) and 14 manual fixes — dropped explicit primitive return types in favor of inference, replaced an inline `import('big.js').Big` annotation with a proper type import, and typed the `processData` result in `renderUtils.tsx` to eliminate an unsafe `any` argument.

## Verification

- `eslint .` clean across all 6 packages (root `npm run lint` green)
- `tsc --noEmit` clean, `next build` succeeds
- Playwright e2e: 3/3 passed as a runtime smoke test after the bulk auto-fixes

No dependency changes — `package-lock.json` untouched, so this merges independently of #1202/#1203/#1204.