### PR TITLE
feat(trading-signals): add candlestick pattern recognition with BullishEngulfing

### DIFF
--- a/packages/trading-signals-docs/indicator-demos/patterns/BullishEngulfing.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/patterns/BullishEngulfing.demo.tsx
@@ -1,0 +1,20 @@
+import {BullishEngulfing as BullishEngulfingClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const BullishEngulfing: IndicatorConfig = {
+  chartTitle: 'Bullish Engulfing',
+  color: '#22c55e',
+  createIndicator: () => new BullishEngulfingClass(),
+  description: 'Bullish Engulfing Pattern',
+  details:
+    'A two-candle reversal pattern: a bearish candle followed by a bullish candle whose real body strictly engulfs the previous body (wicks are ignored). Returns 1 when the pattern completes on the current candle and 0 otherwise. Detects the pure candle shape without trend context — combine it with a trend indicator (e.g. EMA, ADX) to filter for reversals after a decline.',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['open', 'close']}),
+  id: 'bullish-engulfing',
+  name: 'Bullish Engulfing',
+  processData: makeProcessData({addInputs: ['open', 'high', 'low', 'close'], rowInputs: ['open', 'close']}),
+  requiredInputs: 2,
+  type: 'single',
+  yAxisLabel: 'Pattern',
+};

--- a/packages/trading-signals-docs/indicator-demos/patterns/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/patterns/index.tsx
@@ -1,0 +1,4 @@
+import {BullishEngulfing} from './BullishEngulfing.demo';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const indicators: IndicatorConfig[] = [BullishEngulfing];

--- a/packages/trading-signals-docs/pages/indicators/patterns.tsx
+++ b/packages/trading-signals-docs/pages/indicators/patterns.tsx
@@ -1,0 +1,45 @@
+import {useState} from 'react';
+import {DatasetSelector} from '../../components/DatasetSelector';
+import {IndicatorList} from '../../components/IndicatorList';
+import {useHashSelection} from '../../hooks/useHashSelection';
+import {indicators} from '../../indicator-demos/patterns';
+import {datasets} from '../../utils/datasets';
+import {renderSingleIndicator} from '../../utils/renderUtils';
+
+export default function PatternIndicators() {
+  const [selectedIndicator, selectIndicator] = useHashSelection(indicators, 'bullish-engulfing');
+  const [selectedDataset, setSelectedDataset] = useState<string>('uptrend');
+
+  const renderIndicatorContent = () => {
+    const config = indicators.find(ind => ind.id === selectedIndicator);
+    const dataset = datasets.find(ds => ds.id === selectedDataset);
+    if (!config || !dataset) {
+      return null;
+    }
+
+    if (config.type === 'single') {
+      return renderSingleIndicator(config, dataset.candles);
+    }
+
+    return config.customRender(config, dataset.candles);
+  };
+
+  return (
+    <div className="flex gap-6">
+      {/* Sidebar */}
+      <aside className="w-64 shrink-0">
+        <div className="sticky top-6 space-y-4">
+          <DatasetSelector datasets={datasets} selectedDataset={selectedDataset} onDatasetChange={setSelectedDataset} />
+          <IndicatorList
+            indicators={indicators}
+            selectedIndicator={selectedIndicator}
+            onIndicatorChange={selectIndicator}
+          />
+        </div>
+      </aside>
+
+      {/* Main Content */}
+      <main className="flex-1 min-w-0">{renderIndicatorContent()}</main>
+    </div>
+  );
+}

--- a/packages/trading-signals/src/index.ts
+++ b/packages/trading-signals/src/index.ts
@@ -1,5 +1,6 @@
 export * from './error/index.js';
 export * from './momentum/index.js';
+export * from './patterns/index.js';
 export * from './trend/index.js';
 export * from './types/index.js';
 export * from './util/index.js';

--- a/packages/trading-signals/src/patterns/ENGULFING/BullishEngulfing.test.ts
+++ b/packages/trading-signals/src/patterns/ENGULFING/BullishEngulfing.test.ts
@@ -1,0 +1,140 @@
+import {NotEnoughDataError} from '../../error/NotEnoughDataError.js';
+import {TradingSignal} from '../../types/Indicator.js';
+import {BullishEngulfing} from './BullishEngulfing.js';
+
+describe('BullishEngulfing', () => {
+  describe('add', () => {
+    it('detects a bullish candle whose body engulfs the previous bearish body', () => {
+      const candles = [
+        {close: 95, high: 101, low: 94, open: 100},
+        {close: 102, high: 103, low: 93, open: 94},
+      ] as const;
+      const expectations = [null, 1] as const;
+      const bullishEngulfing = new BullishEngulfing();
+
+      candles.forEach((candle, i) => {
+        const result = bullishEngulfing.add(candle);
+        expect(result).toBe(expectations[i]);
+      });
+
+      expect(bullishEngulfing.isStable).toBe(true);
+      expect(bullishEngulfing.getResultOrThrow()).toBe(1);
+    });
+
+    it('returns 0 when the previous candle is not bearish', () => {
+      const candles = [
+        {close: 100, high: 101, low: 94, open: 95},
+        {close: 102, high: 103, low: 93, open: 94},
+      ] as const;
+      const expectations = [null, 0] as const;
+      const bullishEngulfing = new BullishEngulfing();
+
+      candles.forEach((candle, i) => {
+        const result = bullishEngulfing.add(candle);
+        expect(result).toBe(expectations[i]);
+      });
+    });
+
+    it('returns 0 when the previous candle has no real body', () => {
+      const candles = [
+        {close: 100, high: 101, low: 94, open: 100},
+        {close: 102, high: 103, low: 93, open: 94},
+      ] as const;
+      const expectations = [null, 0] as const;
+      const bullishEngulfing = new BullishEngulfing();
+
+      candles.forEach((candle, i) => {
+        const result = bullishEngulfing.add(candle);
+        expect(result).toBe(expectations[i]);
+      });
+    });
+
+    it('returns 0 when the current body does not fully engulf the previous body', () => {
+      const candles = [
+        {close: 95, high: 101, low: 94, open: 100},
+        {close: 99, high: 100, low: 95, open: 96},
+      ] as const;
+      const expectations = [null, 0] as const;
+      const bullishEngulfing = new BullishEngulfing();
+
+      candles.forEach((candle, i) => {
+        const result = bullishEngulfing.add(candle);
+        expect(result).toBe(expectations[i]);
+      });
+    });
+
+    it('ignores wicks because engulfing is measured on real bodies only', () => {
+      const candles = [
+        {close: 95, high: 110, low: 90, open: 100},
+        {close: 102, high: 103, low: 93, open: 94},
+      ] as const;
+      const expectations = [null, 1] as const;
+      const bullishEngulfing = new BullishEngulfing();
+
+      candles.forEach((candle, i) => {
+        const result = bullishEngulfing.add(candle);
+        expect(result).toBe(expectations[i]);
+      });
+    });
+
+    it('throws a NotEnoughDataError when fewer than two candles were added', () => {
+      const bullishEngulfing = new BullishEngulfing();
+
+      bullishEngulfing.add({close: 95, high: 101, low: 94, open: 100});
+
+      expect(() => bullishEngulfing.getResultOrThrow()).toThrow(NotEnoughDataError);
+    });
+  });
+
+  describe('replace', () => {
+    it('replaces the most recently added candle', () => {
+      const bullishEngulfing = new BullishEngulfing();
+
+      bullishEngulfing.add({close: 95, high: 101, low: 94, open: 100});
+
+      const originalCandle = {close: 99, high: 100, low: 95, open: 96} as const;
+      const replacementCandle = {close: 102, high: 103, low: 93, open: 94} as const;
+
+      const originalResult = bullishEngulfing.add(originalCandle);
+      const replacedResult = bullishEngulfing.replace(replacementCandle);
+
+      expect(originalResult).toBe(0);
+      expect(replacedResult).toBe(1);
+
+      const restoredResult = bullishEngulfing.replace(originalCandle);
+
+      expect(restoredResult).toBe(originalResult);
+    });
+  });
+
+  describe('getSignal', () => {
+    it('turns bullish with a change notice when the pattern completes', () => {
+      const candles = [
+        {close: 100, high: 101, low: 94, open: 95},
+        {close: 95, high: 101, low: 94, open: 100},
+        {close: 102, high: 103, low: 93, open: 94},
+      ] as const;
+      const bullishEngulfing = new BullishEngulfing();
+
+      for (const candle of candles) {
+        bullishEngulfing.add(candle);
+      }
+
+      const signal = bullishEngulfing.getSignal();
+
+      expect(signal.state).toBe(TradingSignal.BULLISH);
+      expect(signal.hasChanged).toBe(true);
+    });
+
+    it('reports an unknown state before the pattern window is filled', () => {
+      const bullishEngulfing = new BullishEngulfing();
+
+      bullishEngulfing.add({close: 95, high: 101, low: 94, open: 100});
+
+      const signal = bullishEngulfing.getSignal();
+
+      expect(signal.state).toBe(TradingSignal.UNKNOWN);
+      expect(signal.hasChanged).toBe(false);
+    });
+  });
+});

--- a/packages/trading-signals/src/patterns/ENGULFING/BullishEngulfing.ts
+++ b/packages/trading-signals/src/patterns/ENGULFING/BullishEngulfing.ts
@@ -1,0 +1,57 @@
+import type {OpenHighLowClose} from '../../types/HighLowClose.js';
+import {TradingSignal, TrendIndicatorSeries} from '../../types/Indicator.js';
+import {pushUpdate} from '../../util/pushUpdate.js';
+
+/**
+ * Bullish Engulfing Pattern (BullishEngulfing)
+ * Type: Pattern
+ *
+ * A two-candle reversal pattern: a bearish candle followed by a bullish candle whose real body
+ * (the range between open and close, excluding wicks) strictly engulfs the previous real body.
+ * It suggests that buyers overwhelmed sellers within a single bar, often marking the end of a
+ * pullback.
+ *
+ * This implementation detects the pure candle shape and deliberately ignores trend context:
+ * a bullish engulfing is only meaningful after a decline, so gate its signal with a trend
+ * indicator (e.g. EMA, ADX) instead of relying on the pattern alone.
+ *
+ * Emits `1` when the pattern completes on the current candle and `0` otherwise.
+ *
+ * @see https://www.investopedia.com/terms/b/bullishengulfingpattern.asp
+ */
+export class BullishEngulfing extends TrendIndicatorSeries<OpenHighLowClose> {
+  readonly #candles: OpenHighLowClose[] = [];
+
+  override getRequiredInputs() {
+    return 2;
+  }
+
+  update(candle: OpenHighLowClose, replace: boolean) {
+    pushUpdate(this.#candles, replace, candle, this.getRequiredInputs());
+
+    if (this.#candles.length < this.getRequiredInputs()) {
+      return null;
+    }
+
+    const [previous, current] = this.#candles;
+    const isPreviousBearish = previous.close < previous.open;
+    const isCurrentBullish = current.close > current.open;
+    const engulfsPreviousBody = current.open < previous.close && current.close > previous.open;
+    const isEngulfing = isPreviousBearish && isCurrentBullish && engulfsPreviousBody;
+
+    return this.setResult(isEngulfing ? 1 : 0, replace);
+  }
+
+  protected calculateSignalState(result?: number | null | undefined) {
+    const hasResult = result !== null && result !== undefined;
+
+    switch (true) {
+      case !hasResult:
+        return TradingSignal.UNKNOWN;
+      case result === 1:
+        return TradingSignal.BULLISH;
+      default:
+        return TradingSignal.SIDEWAYS;
+    }
+  }
+}

--- a/packages/trading-signals/src/patterns/index.ts
+++ b/packages/trading-signals/src/patterns/index.ts
@@ -1,0 +1,1 @@
+export * from './ENGULFING/BullishEngulfing.js';


### PR DESCRIPTION
## Summary
Introduces a new **patterns** indicator category for candlestick pattern recognition, starting with the Bullish Engulfing pattern. This closes the main feature gap vs. the unmaintained `technicalindicators` package (see the migration guide in #1208) — and does it rule-based, keeping the zero-runtime-dependencies promise (no bundled ML model).

## API
```ts
const be = new BullishEngulfing();

be.add({open: 100, high: 101, low: 94, close: 95});  // null (warming up)
be.add({open: 94, high: 103, low: 93, close: 102});  // 1 — pattern completed

be.getSignal(); // {state: 'BULLISH', hasChanged: true}
```

## Design decisions
- **`TrendIndicatorSeries<OpenHighLowClose>`** — first real consumer of the `open` price in the type system; reuses `pushUpdate`, `setResult`, replace-mode, and signal tracking with zero framework changes
- **Result is `1`/`0`** (pattern completed on this candle / not), following the TDS precedent; `getSignal().hasChanged === true` fires at the exact candle the pattern completes
- **Pure shape detection** — strict real-body engulfing, wicks ignored, no trend gating; the docblock directs users to compose with a trend indicator (e.g. EMA, ADX), consistent with the library's composability philosophy
- Signals: `BULLISH` on detection, `SIDEWAYS` otherwise, `UNKNOWN` during warmup

## Docs
New `/indicators/patterns` category page with an interactive chart demo, following the existing category page structure. Reachable by URL; homepage navigation wiring is left for a follow-up to avoid touching components with pending changes.

## Follow-ups (not in this PR)
- Additional patterns from the same template: Doji, BearishEngulfing, Hammer, Shooting Star, Morning/Evening Star
- README "Supported Technical Indicators" list entry once the category has more than one member
- Homepage category card for patterns

## Test plan
- [x] 9 unit tests covering detection, non-bearish previous candle, empty real body, partial engulfing, wick independence, `NotEnoughDataError`, bidirectional `replace()`, and `getSignal()` states
- [x] Full suite: 462/462 tests pass, 100% coverage maintained on all four metrics
- [x] `tsc --noEmit` and ESLint clean in both packages
- [x] `dist` build verified: export resolves and computes correctly via CJS `require`
- [x] Docs Next.js build: `/indicators/patterns` prerenders