### PR TITLE
test: enable restoreMocks and use typed vi.mock imports

### DIFF
--- a/.claude/rules/vitest-mocking.md
+++ b/.claude/rules/vitest-mocking.md
@@ -1,0 +1,81 @@
+# Vitest Module Mocking
+
+## Always use the typed `import()` form
+
+Never pass a string path to `vi.mock` — pass the module via `import()`. The factory is then checked against the real module's shape, so a renamed or removed export fails at type-check instead of at runtime, and `importOriginal` is fully typed (no generics needed).
+
+```ts
+// ❌ Bad: untyped — a renamed export only fails at runtime
+vi.mock('./getBrokerClient.js', () => ({
+  getBrokerClient: vi.fn(),
+}));
+
+// ❌ Bad: untyped importOriginal needs a hand-written generic
+vi.mock('trading-strategies', async importActual => {
+  const actual = await importActual<Record<string, unknown>>();
+  return {...actual, createStrategy: vi.fn()};
+});
+
+// ✅ Good: export names are compiler-checked, importActual is typed
+vi.mock(import('./getBrokerClient.js'), () => ({
+  getBrokerClient: vi.fn() as unknown as typeof getBrokerClient,
+}));
+
+vi.mock(import('trading-strategies'), async importActual => {
+  const actual = await importActual();
+  return {...actual, createStrategy: vi.fn() as unknown as typeof createStrategy};
+});
+```
+
+## Prefer a bare automock when the test only needs stubs
+
+`vi.mock(import('...'))` without a factory replaces every export with a typed `vi.fn()` returning `undefined` — no casts, no hand-rolled object. Use it whenever the test never asserts on specific return values.
+
+```ts
+// ❌ Bad: hand-written factory that recreates what automock generates
+vi.mock(import('@grammyjs/auto-retry'), () => ({
+  autoRetry: vi.fn(() => vi.fn()),
+}));
+
+// ✅ Good: bare automock
+vi.mock(import('@grammyjs/auto-retry'));
+```
+
+Caveat: automock **imports the real module** to discover its exports. Only use it when that import is side-effect-free.
+
+## Use a factory when the real module must not execute
+
+Database models (Sequelize registration), the logger (pino setup), and anything else with import side effects must be mocked with a factory — the factory prevents the original module from loading at all.
+
+```ts
+// ✅ Good: factory keeps the Sequelize model module from executing
+vi.mock(import('../database/models/Account.js'), () => ({
+  Account: mockAccountModel as unknown as typeof Account,
+}));
+```
+
+A factory is also required when the mock carries behavior the test drives or asserts on (canned return values, captured callbacks, stub classes).
+
+## Cast partial mocks per export, as narrowly as possible
+
+A partial stand-in (a stub class, a model with only `findByPk`) will not satisfy the real type — cast it with `as unknown as typeof X` on the **individual export**, never on the whole factory return. That way the export names stay compiler-checked and only the member shape is loosened. Use `import type` for the referenced types so nothing real is loaded.
+
+```ts
+// ❌ Bad: whole-module cast disables export-name checking
+vi.mock(import('./api/AlpacaAPI.js'), () => ({mockedStuff}) as unknown as typeof import('./api/AlpacaAPI.js'));
+
+// ✅ Good: narrow cast per export
+import type {AlpacaAPI} from './api/AlpacaAPI.js';
+
+vi.mock(import('./api/AlpacaAPI.js'), () => ({
+  AlpacaAPI: class {
+    getAccount = mockMethods.getAccount;
+  } as unknown as typeof AlpacaAPI,
+}));
+```
+
+Mocked constants must match their literal types exactly (e.g. `MESSAGE_BREAK: '\f' as const`) — the typed factory will flag a widened `string`.
+
+## No manual mock restoration
+
+`restoreMocks: true` is enabled in `vitest.config.base.ts`, so spies created with `vi.spyOn` are restored automatically before each test. Do not add `vi.restoreAllMocks()` in `afterEach`.

--- a/packages/exchange/src/broker/alpaca/AlpacaBroker.test.ts
+++ b/packages/exchange/src/broker/alpaca/AlpacaBroker.test.ts
@@ -6,7 +6,6 @@ import {AlpacaAssetClass, AlpacaOrderSide, AlpacaOrderStatus, AlpacaOrderType} f
 import {PositionSide} from './api/schema/PositionSchema.js';
 import {TradeUpdateEvent} from './api/schema/TradingStreamSchema.js';
 import type {AlpacaAPI} from './api/AlpacaAPI.js';
-import type {alpacaWebSocket} from './AlpacaWebSocket.js';
 import type {alpacaTradingWebSocket} from './AlpacaTradingWebSocket.js';
 
 // Shared mock references
@@ -40,13 +39,7 @@ vi.mock(import('./api/AlpacaAPI.js'), () => ({
   } as unknown as typeof AlpacaAPI,
 }));
 
-vi.mock(import('./AlpacaWebSocket.js'), () => ({
-  alpacaWebSocket: {
-    connect: vi.fn(),
-    subscribeToBars: vi.fn(),
-    unsubscribeFromBars: vi.fn(),
-  } as unknown as typeof alpacaWebSocket,
-}));
+vi.mock(import('./AlpacaWebSocket.js'));
 
 const mockTradingWebSocket = {
   connect: vi.fn().mockResolvedValue({connectionId: 'trading-conn', stream: {}}),

--- a/packages/exchange/src/broker/alpaca/AlpacaBroker.test.ts
+++ b/packages/exchange/src/broker/alpaca/AlpacaBroker.test.ts
@@ -5,6 +5,9 @@ import {OrderPosition, OrderSide, OrderType} from '../Broker.js';
 import {AlpacaAssetClass, AlpacaOrderSide, AlpacaOrderStatus, AlpacaOrderType} from './api/schema/OrderSchema.js';
 import {PositionSide} from './api/schema/PositionSchema.js';
 import {TradeUpdateEvent} from './api/schema/TradingStreamSchema.js';
+import type {AlpacaAPI} from './api/AlpacaAPI.js';
+import type {alpacaWebSocket} from './AlpacaWebSocket.js';
+import type {alpacaTradingWebSocket} from './AlpacaTradingWebSocket.js';
 
 // Shared mock references
 const mockMethods = {
@@ -21,7 +24,7 @@ const mockMethods = {
   postOrder: vi.fn(),
 };
 
-vi.mock('./api/AlpacaAPI.js', () => ({
+vi.mock(import('./api/AlpacaAPI.js'), () => ({
   AlpacaAPI: class {
     deleteOrder = mockMethods.deleteOrder;
     getAccount = mockMethods.getAccount;
@@ -34,15 +37,15 @@ vi.mock('./api/AlpacaAPI.js', () => ({
     getStockBars = mockMethods.getStockBars;
     getStockBarsLatest = mockMethods.getStockBarsLatest;
     postOrder = mockMethods.postOrder;
-  },
+  } as unknown as typeof AlpacaAPI,
 }));
 
-vi.mock('./AlpacaWebSocket.js', () => ({
+vi.mock(import('./AlpacaWebSocket.js'), () => ({
   alpacaWebSocket: {
     connect: vi.fn(),
     subscribeToBars: vi.fn(),
     unsubscribeFromBars: vi.fn(),
-  },
+  } as unknown as typeof alpacaWebSocket,
 }));
 
 const mockTradingWebSocket = {
@@ -52,8 +55,8 @@ const mockTradingWebSocket = {
   onTradeUpdate: vi.fn(),
 };
 
-vi.mock('./AlpacaTradingWebSocket.js', () => ({
-  alpacaTradingWebSocket: mockTradingWebSocket,
+vi.mock(import('./AlpacaTradingWebSocket.js'), () => ({
+  alpacaTradingWebSocket: mockTradingWebSocket as unknown as typeof alpacaTradingWebSocket,
 }));
 
 // Import after mocking

--- a/packages/exchange/src/broker/getAuthenticatedBrokerClient.test.ts
+++ b/packages/exchange/src/broker/getAuthenticatedBrokerClient.test.ts
@@ -1,4 +1,5 @@
 import {beforeEach, describe, expect, it, vi} from 'vitest';
+import type {getBrokerClient} from './getBrokerClient.js';
 
 const {getBrokerClientMock, verifyCredentialsMock} = vi.hoisted(() => {
   const verifyCredentials = vi.fn();
@@ -8,8 +9,8 @@ const {getBrokerClientMock, verifyCredentialsMock} = vi.hoisted(() => {
   };
 });
 
-vi.mock('./getBrokerClient.js', () => ({
-  getBrokerClient: getBrokerClientMock,
+vi.mock(import('./getBrokerClient.js'), () => ({
+  getBrokerClient: getBrokerClientMock as unknown as typeof getBrokerClient,
 }));
 
 const {getAuthenticatedBrokerClient} = await import('./getAuthenticatedBrokerClient.js');

--- a/packages/exchange/src/broker/trading212/Trading212Broker.test.ts
+++ b/packages/exchange/src/broker/trading212/Trading212Broker.test.ts
@@ -1,16 +1,17 @@
 import {beforeEach, describe, expect, it, vi} from 'vitest';
 import type {Candle} from '../Broker.js';
 import {MarketDataSource} from '../MarketDataSource.js';
+import type {Trading212API} from './api/Trading212API.js';
 
 // Shared mock references
 const mockMethods = {
   getAccountCash: vi.fn(),
 };
 
-vi.mock('./api/Trading212API.js', () => ({
+vi.mock(import('./api/Trading212API.js'), () => ({
   Trading212API: class {
     getAccountCash = mockMethods.getAccountCash;
-  },
+  } as unknown as typeof Trading212API,
 }));
 
 // Import after mocking

--- a/packages/exchange/src/util/isEarningsDay.test.ts
+++ b/packages/exchange/src/util/isEarningsDay.test.ts
@@ -1,11 +1,13 @@
 import {describe, expect, it, vi, beforeEach} from 'vitest';
+import type {AxiosStatic} from 'axios';
+import type axiosRetry from 'axios-retry';
 
 const mockGet = vi.fn();
 
-vi.mock('axios', () => ({
+vi.mock(import('axios'), () => ({
   default: {
     create: vi.fn(() => ({get: mockGet})),
-  },
+  } as unknown as AxiosStatic,
 }));
 
 /*
@@ -14,8 +16,8 @@ vi.mock('axios', () => ({
  * interceptors — the real retry behavior is exercised by the production
  * client, not by these unit tests.
  */
-vi.mock('axios-retry', () => ({
-  default: vi.fn(),
+vi.mock(import('axios-retry'), () => ({
+  default: vi.fn() as unknown as typeof axiosRetry,
 }));
 
 const {isEarningsDay} = await import('./isEarningsDay.js');

--- a/packages/exchange/src/util/isEarningsDay.test.ts
+++ b/packages/exchange/src/util/isEarningsDay.test.ts
@@ -1,6 +1,5 @@
 import {describe, expect, it, vi, beforeEach} from 'vitest';
 import type {AxiosStatic} from 'axios';
-import type axiosRetry from 'axios-retry';
 
 const mockGet = vi.fn();
 
@@ -16,9 +15,7 @@ vi.mock(import('axios'), () => ({
  * interceptors — the real retry behavior is exercised by the production
  * client, not by these unit tests.
  */
-vi.mock(import('axios-retry'), () => ({
-  default: vi.fn() as unknown as typeof axiosRetry,
-}));
+vi.mock(import('axios-retry'));
 
 const {isEarningsDay} = await import('./isEarningsDay.js');
 

--- a/packages/messaging/src/broker/getAccountBrokerClient.test.ts
+++ b/packages/messaging/src/broker/getAccountBrokerClient.test.ts
@@ -1,5 +1,6 @@
 import {describe, it, expect, vi, beforeEach} from 'vitest';
-import type {AccountAttributes} from '../database/models/Account.js';
+import type {AlpacaBroker, AlpacaMarketData, getBrokerClient} from '@typedtrader/exchange';
+import type {Account, AccountAttributes} from '../database/models/Account.js';
 
 const {AlpacaMarketDataMock, getBrokerClientMock, mockAccountModel} = vi.hoisted(() => {
   return {
@@ -11,14 +12,14 @@ const {AlpacaMarketDataMock, getBrokerClientMock, mockAccountModel} = vi.hoisted
   };
 });
 
-vi.mock('@typedtrader/exchange', () => ({
-  AlpacaBroker: {NAME: 'Alpaca'},
-  AlpacaMarketData: AlpacaMarketDataMock,
-  getBrokerClient: getBrokerClientMock,
+vi.mock(import('@typedtrader/exchange'), () => ({
+  AlpacaBroker: {NAME: 'Alpaca'} as unknown as typeof AlpacaBroker,
+  AlpacaMarketData: AlpacaMarketDataMock as unknown as typeof AlpacaMarketData,
+  getBrokerClient: getBrokerClientMock as unknown as typeof getBrokerClient,
 }));
 
-vi.mock('../database/models/Account.js', () => ({
-  Account: mockAccountModel,
+vi.mock(import('../database/models/Account.js'), () => ({
+  Account: mockAccountModel as unknown as typeof Account,
 }));
 
 const {buildMarketDataFromAccount, getAccountBrokerClient} = await import('./getAccountBrokerClient.js');

--- a/packages/messaging/src/platform/TelegramPlatform.test.ts
+++ b/packages/messaging/src/platform/TelegramPlatform.test.ts
@@ -1,5 +1,8 @@
 import {describe, it, expect, vi, beforeEach} from 'vitest';
-import type {Context} from 'grammy';
+import type {Bot as GrammyBot, Context} from 'grammy';
+import type {conversations, createConversation} from '@grammyjs/conversations';
+import type {getAvailableReportNames} from 'trading-strategies';
+import type {Account} from '../database/models/Account.js';
 import {TelegramPlatform, lowercaseCommandMiddleware} from './TelegramPlatform.js';
 import {reportAdd} from '../command/report/reportAdd.js';
 import {logger} from '../logger.js';
@@ -14,30 +17,30 @@ const mockUse = vi.fn();
 const botInfo = {username: 'testbot'};
 const mockedReportAdd = vi.mocked(reportAdd);
 
-vi.mock('trading-strategies', () => ({
-  getAvailableReportNames: vi.fn().mockReturnValue([]),
-  MESSAGE_BREAK: '\f',
+vi.mock(import('trading-strategies'), () => ({
+  getAvailableReportNames: vi.fn().mockReturnValue([]) as unknown as typeof getAvailableReportNames,
+  MESSAGE_BREAK: '\f' as const,
 }));
 
-vi.mock('../command/report/reportAdd.js', () => ({
+vi.mock(import('../command/report/reportAdd.js'), () => ({
   reportAdd: vi.fn(),
 }));
 
 const mockFindByUserId = vi.fn().mockReturnValue([]);
 const mockFindByUserIdAndId = vi.fn().mockReturnValue(undefined);
-vi.mock('../database/models/Account.js', () => ({
+vi.mock(import('../database/models/Account.js'), () => ({
   Account: {
     findByUserId: (...args: unknown[]) => mockFindByUserId(...args),
     findByUserIdAndId: (...args: unknown[]) => mockFindByUserIdAndId(...args),
-  },
+  } as unknown as typeof Account,
 }));
 
-vi.mock('@grammyjs/conversations', () => ({
-  conversations: vi.fn(() => 'conversations-middleware'),
-  createConversation: vi.fn(() => 'create-conversation-middleware'),
+vi.mock(import('@grammyjs/conversations'), () => ({
+  conversations: vi.fn(() => 'conversations-middleware') as unknown as typeof conversations,
+  createConversation: vi.fn(() => 'create-conversation-middleware') as unknown as typeof createConversation,
 }));
 
-vi.mock('grammy', () => {
+vi.mock(import('grammy'), () => {
   function Bot() {
     return {
       api: {
@@ -56,10 +59,10 @@ vi.mock('grammy', () => {
     };
   }
 
-  return {Bot};
+  return {Bot: Bot as unknown as typeof GrammyBot};
 });
 
-vi.mock('@grammyjs/auto-retry', () => ({
+vi.mock(import('@grammyjs/auto-retry'), () => ({
   autoRetry: vi.fn(() => vi.fn()),
 }));
 

--- a/packages/messaging/src/platform/TelegramPlatform.test.ts
+++ b/packages/messaging/src/platform/TelegramPlatform.test.ts
@@ -1,6 +1,5 @@
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import type {Bot as GrammyBot, Context} from 'grammy';
-import type {conversations, createConversation} from '@grammyjs/conversations';
 import type {getAvailableReportNames} from 'trading-strategies';
 import type {Account} from '../database/models/Account.js';
 import {TelegramPlatform, lowercaseCommandMiddleware} from './TelegramPlatform.js';
@@ -22,9 +21,7 @@ vi.mock(import('trading-strategies'), () => ({
   MESSAGE_BREAK: '\f' as const,
 }));
 
-vi.mock(import('../command/report/reportAdd.js'), () => ({
-  reportAdd: vi.fn(),
-}));
+vi.mock(import('../command/report/reportAdd.js'));
 
 const mockFindByUserId = vi.fn().mockReturnValue([]);
 const mockFindByUserIdAndId = vi.fn().mockReturnValue(undefined);
@@ -35,10 +32,7 @@ vi.mock(import('../database/models/Account.js'), () => ({
   } as unknown as typeof Account,
 }));
 
-vi.mock(import('@grammyjs/conversations'), () => ({
-  conversations: vi.fn(() => 'conversations-middleware') as unknown as typeof conversations,
-  createConversation: vi.fn(() => 'create-conversation-middleware') as unknown as typeof createConversation,
-}));
+vi.mock(import('@grammyjs/conversations'));
 
 vi.mock(import('grammy'), () => {
   function Bot() {
@@ -62,9 +56,7 @@ vi.mock(import('grammy'), () => {
   return {Bot: Bot as unknown as typeof GrammyBot};
 });
 
-vi.mock(import('@grammyjs/auto-retry'), () => ({
-  autoRetry: vi.fn(() => vi.fn()),
-}));
+vi.mock(import('@grammyjs/auto-retry'));
 
 describe('TelegramPlatform', () => {
   beforeEach(() => {

--- a/packages/messaging/src/service/StrategyMonitor.test.ts
+++ b/packages/messaging/src/service/StrategyMonitor.test.ts
@@ -3,8 +3,11 @@ import {describe, it, expect, vi, beforeEach} from 'vitest';
 import {OrderSide} from '@typedtrader/exchange';
 import {OrderSizeBelowMinimumError} from 'trading-strategies';
 import {logger} from '../logger.js';
+import type {getBrokerClient, TradingPair} from '@typedtrader/exchange';
+import type {createStrategy, TradingSession} from 'trading-strategies';
 import type {MessagingPlatform} from '../platform/MessagingPlatform.js';
-import type {StrategyAttributes} from '../database/models/Strategy.js';
+import type {Account} from '../database/models/Account.js';
+import type {Strategy, StrategyAttributes} from '../database/models/Strategy.js';
 
 const {mockAccountModel, mockSession, mockStrategy, mockStrategyModel, TradingSessionMock} = vi.hoisted(() => {
   const session = {on: vi.fn(), start: vi.fn(), stop: vi.fn()};
@@ -37,34 +40,34 @@ const {mockAccountModel, mockSession, mockStrategy, mockStrategyModel, TradingSe
   };
 });
 
-vi.mock('@typedtrader/exchange', async importActual => {
-  const actual = await importActual<Record<string, unknown>>();
+vi.mock(import('@typedtrader/exchange'), async importActual => {
+  const actual = await importActual();
   return {
     ...actual,
-    getBrokerClient: vi.fn(() => ({})),
-    TradingPair: {fromString: vi.fn(() => ({base: 'BTC', counter: 'USD'}))},
+    getBrokerClient: vi.fn(() => ({})) as unknown as typeof getBrokerClient,
+    TradingPair: {fromString: vi.fn(() => ({base: 'BTC', counter: 'USD'}))} as unknown as typeof TradingPair,
   };
 });
 
-vi.mock('trading-strategies', async importActual => {
-  const actual = await importActual<Record<string, unknown>>();
+vi.mock(import('trading-strategies'), async importActual => {
+  const actual = await importActual();
   return {
     ...actual,
-    createStrategy: vi.fn(() => mockStrategy),
-    TradingSession: TradingSessionMock,
+    createStrategy: vi.fn(() => mockStrategy) as unknown as typeof createStrategy,
+    TradingSession: TradingSessionMock as unknown as typeof TradingSession,
   };
 });
 
-vi.mock('../logger.js', () => ({
-  logger: {debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn()},
+vi.mock(import('../logger.js'), () => ({
+  logger: {debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn()} as unknown as typeof logger,
 }));
 
-vi.mock('../database/models/Account.js', () => ({
-  Account: mockAccountModel,
+vi.mock(import('../database/models/Account.js'), () => ({
+  Account: mockAccountModel as unknown as typeof Account,
 }));
 
-vi.mock('../database/models/Strategy.js', () => ({
-  Strategy: mockStrategyModel,
+vi.mock(import('../database/models/Strategy.js'), () => ({
+  Strategy: mockStrategyModel as unknown as typeof Strategy,
 }));
 
 const {formatStrategyMessage, STRATEGY_ERROR_LOG_MESSAGE, StrategyMonitor} = await import('./StrategyMonitor.js');

--- a/packages/messaging/src/service/WatchMonitor.test.ts
+++ b/packages/messaging/src/service/WatchMonitor.test.ts
@@ -1,6 +1,8 @@
 import {describe, it, expect, vi, beforeEach} from 'vitest';
+import type {getBrokerClient, TradingPair} from '@typedtrader/exchange';
 import type {MessagingPlatform} from '../platform/MessagingPlatform.js';
-import type {WatchAttributes} from '../database/models/Watch.js';
+import type {Account} from '../database/models/Account.js';
+import type {Watch, WatchAttributes} from '../database/models/Watch.js';
 
 const {mockAccountModel, mockExchange, mockWatchModel} = vi.hoisted(() => ({
   mockAccountModel: {findByPk: vi.fn()},
@@ -18,17 +20,17 @@ const {mockAccountModel, mockExchange, mockWatchModel} = vi.hoisted(() => ({
   },
 }));
 
-vi.mock('@typedtrader/exchange', () => ({
-  getBrokerClient: vi.fn(() => mockExchange),
-  TradingPair: {fromString: vi.fn(() => ({base: 'BTC', counter: 'USD'}))},
+vi.mock(import('@typedtrader/exchange'), () => ({
+  getBrokerClient: vi.fn(() => mockExchange) as unknown as typeof getBrokerClient,
+  TradingPair: {fromString: vi.fn(() => ({base: 'BTC', counter: 'USD'}))} as unknown as typeof TradingPair,
 }));
 
-vi.mock('../database/models/Account.js', () => ({
-  Account: mockAccountModel,
+vi.mock(import('../database/models/Account.js'), () => ({
+  Account: mockAccountModel as unknown as typeof Account,
 }));
 
-vi.mock('../database/models/Watch.js', () => ({
-  Watch: mockWatchModel,
+vi.mock(import('../database/models/Watch.js'), () => ({
+  Watch: mockWatchModel as unknown as typeof Watch,
 }));
 
 const {WatchMonitor} = await import('./WatchMonitor.js');

--- a/vitest.config.base.ts
+++ b/vitest.config.base.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     },
     environment: 'node',
     globals: true,
+    // https://main.vitest.dev/guide/learn/writing-tests-with-ai.html#mock-cleanup
     restoreMocks: true,
     sequence: {
       concurrent: true,

--- a/vitest.config.base.ts
+++ b/vitest.config.base.ts
@@ -16,6 +16,7 @@ export default defineConfig({
     },
     environment: 'node',
     globals: true,
+    restoreMocks: true,
     sequence: {
       concurrent: true,
       shuffle: true,


### PR DESCRIPTION
## Summary

- **Enable `restoreMocks: true`** in `vitest.config.base.ts` so spies/mocks are automatically restored before each test across all packages using the base config (`candles`, `exchange`, `trading-signals`, `trading-strategies`).
- **Convert all 23 `vi.mock('path', ...)` call sites** (8 test files in `exchange` and `messaging`) to the typed `vi.mock(import('path'), ...)` form:
  - Mocked export names are now verified by the compiler — a renamed export fails at type-check instead of at runtime.
  - `importOriginal` is fully typed; the `importActual<Record<string, unknown>>()` generics in `StrategyMonitor.test.ts` are gone.
  - Partial mocks use narrow `as unknown as typeof X` casts per export, keeping the module shape checked while allowing partial member stubs.
  - The typed factories caught one real mismatch: `MESSAGE_BREAK` is the literal type `'\f'` and the mock had widened it to `string`.

## Not included (evaluated & rejected)

`experimental.viteModuleRunner: false` (Vitest 4.1) was tried but reverted: the native Node runner cannot resolve the repo's `.js` import specifiers to `.ts` sources — all test files fail with `Cannot find module`. Revisit if the repo ever migrates to `.ts` specifiers via `rewriteRelativeImportExtensions`.

## Test plan

- [x] `tsc --noEmit` clean in `exchange` and `messaging`
- [x] ESLint + Prettier clean on all changed files
- [x] All suites pass: exchange (89), messaging (84), trading-signals (453), candles (52), trading-strategies (259)