### PR TITLE
test(trading-signals): tag Tulip-verified tests with tulipindicators

### DIFF
--- a/packages/trading-signals/src/momentum/AO/AO.test.ts
+++ b/packages/trading-signals/src/momentum/AO/AO.test.ts
@@ -33,7 +33,7 @@ describe('AO', () => {
   ] as const;
 
   describe('getResultOrThrow', () => {
-    it('works with an interval setting of 5/34', () => {
+    it('works with an interval setting of 5/34', {tags: ['tulipindicators']}, () => {
       const shortInterval = 5;
       const longInterval = 34;
 

--- a/packages/trading-signals/src/momentum/CCI/CCI.test.ts
+++ b/packages/trading-signals/src/momentum/CCI/CCI.test.ts
@@ -62,7 +62,7 @@ describe('CCI', () => {
   });
 
   describe('getResultOrThrow', () => {
-    it('calculates the Commodity Channel Index (CCI)', () => {
+    it('calculates the Commodity Channel Index (CCI)', {tags: ['tulipindicators']}, () => {
       const interval = 5;
       const cci = new CCI(interval);
       const offset = cci.getRequiredInputs() - 1;

--- a/packages/trading-signals/src/momentum/MACD/MACD.test.ts
+++ b/packages/trading-signals/src/momentum/MACD/MACD.test.ts
@@ -44,7 +44,7 @@ describe('MACD', () => {
   });
 
   describe('getResultOrThrow', () => {
-    it('is compatible with results from Tulip Indicators (TI)', () => {
+    it('is compatible with results from Tulip Indicators (TI)', {tags: ['tulipindicators']}, () => {
       /*
        * Test data verified with:
        * https://tulipindicators.org/macd

--- a/packages/trading-signals/src/momentum/MOM/MOM.test.ts
+++ b/packages/trading-signals/src/momentum/MOM/MOM.test.ts
@@ -21,7 +21,7 @@ describe('MOM', () => {
   });
 
   describe('getResultOrThrow', () => {
-    it('returns the price 5 intervals ago', () => {
+    it('returns the price 5 intervals ago', {tags: ['tulipindicators']}, () => {
       /*
        * Test data verified with:
        * https://github.com/TulipCharts/tulipindicators/blob/v0.8.0/tests/untest.txt#L286-L288

--- a/packages/trading-signals/src/momentum/ROC/ROC.test.ts
+++ b/packages/trading-signals/src/momentum/ROC/ROC.test.ts
@@ -4,7 +4,7 @@ import {TradingSignal} from '../../types/Indicator.js';
 
 describe('ROC', () => {
   describe('getResultOrThrow', () => {
-    it('identifies an up-trending asset by a positive ROC', () => {
+    it('identifies an up-trending asset by a positive ROC', {tags: ['tulipindicators']}, () => {
       /*
        * Test data verified with:
        * https://tulipindicators.org/roc

--- a/packages/trading-signals/src/momentum/RSI/RSI.test.ts
+++ b/packages/trading-signals/src/momentum/RSI/RSI.test.ts
@@ -23,7 +23,7 @@ describe('RSI', () => {
   });
 
   describe('getResultOrThrow', () => {
-    it('calculates the relative strength index', () => {
+    it('calculates the relative strength index', {tags: ['tulipindicators']}, () => {
       /*
        * Test data verified with:
        * https://github.com/TulipCharts/tulipindicators/blob/v0.8.0/tests/untest.txt#L347-L349

--- a/packages/trading-signals/src/momentum/STOCH/StochasticOscillator.test.ts
+++ b/packages/trading-signals/src/momentum/STOCH/StochasticOscillator.test.ts
@@ -5,7 +5,7 @@ import candles from '../../fixtures/STOCH/candles.json' with {type: 'json'};
 
 describe('StochasticOscillator', () => {
   describe('update', () => {
-    it('calculates the StochasticOscillator', () => {
+    it('calculates the StochasticOscillator', {tags: ['tulipindicators']}, () => {
       /*
        * Test data verified with:
        * https://tulipindicators.org/stoch

--- a/packages/trading-signals/src/momentum/STOCHRSI/StochasticRSI.test.ts
+++ b/packages/trading-signals/src/momentum/STOCHRSI/StochasticRSI.test.ts
@@ -19,7 +19,7 @@ describe('StochasticRSI', () => {
   });
 
   describe('getResultOrThrow', () => {
-    it('calculates the Stochastic RSI', () => {
+    it('calculates the Stochastic RSI', {tags: ['tulipindicators']}, () => {
       /*
        * Test data verified with:
        * https://github.com/TulipCharts/tulipindicators/blob/0bc8dfc46cfc89366bf8cef6dfad1fb6f81b3b7b/tests/untest.txt#L382-L384

--- a/packages/trading-signals/src/trend/ADX/ADX.test.ts
+++ b/packages/trading-signals/src/trend/ADX/ADX.test.ts
@@ -51,7 +51,7 @@ describe('ADX', () => {
   });
 
   describe('getResultOrThrow', () => {
-    it('calculates the Average Directional Index (ADX)', () => {
+    it('calculates the Average Directional Index (ADX)', {tags: ['tulipindicators']}, () => {
       const interval = 5;
       const adx = new ADX(interval);
       const offset = adx.getRequiredInputs() - 1;

--- a/packages/trading-signals/src/trend/DX/DX.test.ts
+++ b/packages/trading-signals/src/trend/DX/DX.test.ts
@@ -62,7 +62,7 @@ describe('DX', () => {
   });
 
   describe('getResultOrThrow', () => {
-    it('calculates the Directional Movement Index (DX)', () => {
+    it('calculates the Directional Movement Index (DX)', {tags: ['tulipindicators']}, () => {
       const interval = 5;
       const dx = new DX(interval);
       const offset = dx.getRequiredInputs() - 1;

--- a/packages/trading-signals/src/trend/EMA/EMA.test.ts
+++ b/packages/trading-signals/src/trend/EMA/EMA.test.ts
@@ -81,7 +81,7 @@ describe('EMA', () => {
   });
 
   describe('getResultOrThrow', () => {
-    it('calculates the Exponential Moving Average over a period of 5', () => {
+    it('calculates the Exponential Moving Average over a period of 5', {tags: ['tulipindicators']}, () => {
       const interval = 5;
       const ema = new EMA(interval);
 

--- a/packages/trading-signals/src/trend/LINREG/LinearRegression.test.ts
+++ b/packages/trading-signals/src/trend/LINREG/LinearRegression.test.ts
@@ -3,7 +3,7 @@ import {NotEnoughDataError} from '../../error/index.js';
 
 describe('LinearRegression', () => {
   describe('intercept (linregintercept)', () => {
-    it('calculates the intercept values correctly', () => {
+    it('calculates the intercept values correctly', {tags: ['tulipindicators']}, () => {
       /*
        * Test data verified with:
        * https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt#L226

--- a/packages/trading-signals/src/trend/PSAR/PSAR.test.ts
+++ b/packages/trading-signals/src/trend/PSAR/PSAR.test.ts
@@ -25,7 +25,7 @@ describe('PSAR', () => {
     {date: '2005-11-21', high: 87.87, low: 87.01, psar: 85.76},
   ] as const;
 
-  it('calculates PSAR correctly', () => {
+  it('calculates PSAR correctly', {tags: ['tulipindicators']}, () => {
     const psar = new PSAR({accelerationMax: 0.2, accelerationStep: 0.02});
 
     const results = testData.map(candle => psar.add({high: candle.high, low: candle.low}));

--- a/packages/trading-signals/src/trend/SMA/SMA.test.ts
+++ b/packages/trading-signals/src/trend/SMA/SMA.test.ts
@@ -73,7 +73,7 @@ describe('SMA', () => {
   });
 
   describe('getResultOrThrow', () => {
-    it('calculates the moving average based on the last 5 prices', () => {
+    it('calculates the moving average based on the last 5 prices', {tags: ['tulipindicators']}, () => {
       /*
        * Test data verified with:
        * https://github.com/TulipCharts/tulipindicators/blob/v0.8.0/tests/untest.txt#L359-L361

--- a/packages/trading-signals/src/trend/WSMA/WSMA.test.ts
+++ b/packages/trading-signals/src/trend/WSMA/WSMA.test.ts
@@ -76,7 +76,7 @@ describe('WSMA', () => {
       expect(wsma.getResultOrThrow().toFixed(2)).toBe('18.97');
     });
 
-    it('is compatible with results from Tulip Indicators (TI)', () => {
+    it('is compatible with results from Tulip Indicators (TI)', {tags: ['tulipindicators']}, () => {
       /*
        * Test data verified with:
        * https://github.com/TulipCharts/tulipindicators/blob/v0.8.0/tests/atoz.txt#L299-L302

--- a/packages/trading-signals/src/types/Period.test.ts
+++ b/packages/trading-signals/src/types/Period.test.ts
@@ -47,7 +47,7 @@ describe('Period', () => {
   });
 
   describe('isStable', () => {
-    it('returns the lowest and highest value during the period when it is stable', () => {
+    it('returns the lowest and highest value during the period when it is stable', {tags: ['tulipindicators']}, () => {
       /*
        * Test data verified with:
        * https://tulipindicators.org/min

--- a/packages/trading-signals/src/volatility/ATR/ATR.test.ts
+++ b/packages/trading-signals/src/volatility/ATR/ATR.test.ts
@@ -59,7 +59,7 @@ describe('ATR', () => {
   });
 
   describe('getResultOrThrow', () => {
-    it('calculates the Average True Range (ATR)', () => {
+    it('calculates the Average True Range (ATR)', {tags: ['tulipindicators']}, () => {
       const interval = 5;
       const atr = new ATR(interval);
 

--- a/packages/trading-signals/src/volatility/BBANDS/BollingerBands.test.ts
+++ b/packages/trading-signals/src/volatility/BBANDS/BollingerBands.test.ts
@@ -60,7 +60,7 @@ describe('BollingerBands', () => {
       }
     });
 
-    it('is compatible with results from Tulip Indicators (TI)', () => {
+    it('is compatible with results from Tulip Indicators (TI)', {tags: ['tulipindicators']}, () => {
       /*
        * Test data verified with:
        * https://tulipindicators.org/bbands

--- a/packages/trading-signals/src/volatility/MAD/MAD.test.ts
+++ b/packages/trading-signals/src/volatility/MAD/MAD.test.ts
@@ -58,7 +58,7 @@ describe('MAD', () => {
       expect(mad.getResultOrThrow()).toBe(3.6);
     });
 
-    it('is compatible with results from Tulip Indicators (TI)', () => {
+    it('is compatible with results from Tulip Indicators (TI)', {tags: ['tulipindicators']}, () => {
       const mad = new MAD(5);
       const offset = mad.getRequiredInputs() - 1;
 

--- a/packages/trading-signals/src/volatility/TR/TR.test.ts
+++ b/packages/trading-signals/src/volatility/TR/TR.test.ts
@@ -41,7 +41,7 @@ describe('TR', () => {
   ] as const;
 
   describe('getResultOrThrow', () => {
-    it('calculates the True Range (TR)', () => {
+    it('calculates the True Range (TR)', {tags: ['tulipindicators']}, () => {
       const tr = new TR();
 
       candles.forEach((candle, i) => {

--- a/packages/trading-signals/vitest.config.ts
+++ b/packages/trading-signals/vitest.config.ts
@@ -15,7 +15,7 @@ export default mergeConfig(
       },
       tags: [
         {
-          description: 'Verifies indicator results against Tulip Indicators reference data.',
+          description: 'Verifies indicator results against Tulip Indicators reference data (https://tulipindicators.org/).',
           name: 'tulipindicators',
         },
       ],

--- a/packages/trading-signals/vitest.config.ts
+++ b/packages/trading-signals/vitest.config.ts
@@ -13,6 +13,12 @@ export default mergeConfig(
           statements: 100,
         },
       },
+      tags: [
+        {
+          description: 'Verifies indicator results against Tulip Indicators reference data.',
+          name: 'tulipindicators',
+        },
+      ],
     },
   })
 );


### PR DESCRIPTION
## Summary

Uses the new [test tags](https://vitest.dev/guide/test-tags) feature from Vitest 4.1 to mark all tests whose expected values are verified against [Tulip Indicators](https://tulipindicators.org) reference data.

- Declares a `tulipindicators` tag in `packages/trading-signals/vitest.config.ts` (Vitest validates tags strictly by default, so unknown tags fail at runtime)
- Tags the 20 tests asserting Tulip reference values via the test options parameter: ADX, AO, ATR, BBANDS, CCI, DX, EMA, LINREG, MACD, MAD, MOM, Period, PSAR, ROC, RSI, SMA, STOCH, STOCHRSI, TR, WSMA

Only tests that assert Tulip-derived expectations are tagged — neighbor tests (e.g. `replace` tests) that merely reuse the Tulip input candles are not.

## Usage

```sh
npx vitest --tags-filter="tulipindicators"   # only Tulip-verified tests
npx vitest --tags-filter="!tulipindicators"  # everything else
```

## Test plan

- `npx vitest run --tags-filter="tulipindicators"` → exactly 20 tests pass
- Full suite: 453/453 pass