### PR TITLE
feat(trading-signals): add Aroon indicator (AROON)

### DIFF
--- a/packages/trading-signals/CLAUDE.md
+++ b/packages/trading-signals/CLAUDE.md
@@ -209,3 +209,22 @@ override update(candle: HighLowClose<number>, replace: boolean) {
   return this.setResult(calculatedValue, replace);
 }
 ```
+
+# Adding a New Indicator
+
+Reference implementation: [PR #1212 (Aroon)](https://github.com/bennycode/trading-signals/pull/1212) shows all steps end to end.
+
+1. **Pick the category folder** — `src/momentum/`, `src/trend/`, `src/volatility/` or `src/volume/`. Create a directory named after the indicator code in uppercase, with the class file named after the exported class: `src/trend/AROON/Aroon.ts`.
+2. **Extend the right base class** (`src/types/Indicator.ts`):
+   - Single-number result → `IndicatorSeries` (or `TrendIndicatorSeries` for signal tracking). Use `setResult()`.
+   - Multi-value result (e.g. `{aroonUp, aroonDown}`) → `TechnicalIndicator<Result, Input>`. Export the result interface. Here `this.result` is assigned directly — `setResult()` only exists on `IndicatorSeries`.
+3. **Use shared building blocks** — input types from `src/types/HighLowClose.ts` (`HighLow`, `HighLowClose`, …), `pushUpdate()` from `src/util/` for the sliding candle window, and existing indicators (SMA, EMA, ATR, …) as internal components instead of reimplementing them.
+4. **Implement the contract** — `getRequiredInputs()` returns the warm-up count; `update(input, replace)` returns the result or `null` during warm-up. `replace()` must be correct: if the result is a pure function of the candle window, `pushUpdate()` handles it; if the indicator carries smoothing state, restore the previous state on replace.
+5. **No constructor parameter properties** — the codebase compiles with `erasableSyntaxOnly`, so declare fields explicitly and assign them in the constructor.
+6. **Write the class JSDoc with intent** — indicator name and code, type (Trend/Momentum/…), what it tells a trader, and `@see` links to sources (e.g. Investopedia, Tulip Indicators).
+7. **Export it** — add the class to the category `index.ts` (alphabetical order) and add the indicator to the "Supported Technical Indicators" list in `README.md` (alphabetical order).
+8. **Write co-located tests** (`<Name>.test.ts`, 100% coverage is enforced):
+   - Verify results against external reference data. Prefer [Tulip Indicators test data](https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt), link the exact lines in a comment, and tag the test with `{tags: ['tulipindicators']}`.
+   - Add a single-instance bidirectional `replace()` test asserting exact values for the original, replaced and restored results.
+   - Add a `NotEnoughDataError` test for `getResultOrThrow()` before warm-up.
+   - Cover behavioral edge cases so a mutated comparison operator fails the suite (e.g. tie-breaking of equal extremes in Aroon).

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -178,6 +178,7 @@ console.log(signal.hasChanged); // true if the signal state changed from the pre
 1. Acceleration Bands (ABANDS)
 1. Accelerator Oscillator (AC)
 1. Accumulation/Distribution (AD)
+1. Aroon (AROON)
 1. Average Directional Index (ADX)
 1. Average True Range (ATR)
 1. Awesome Oscillator (AO)

--- a/packages/trading-signals/src/trend/AROON/Aroon.test.ts
+++ b/packages/trading-signals/src/trend/AROON/Aroon.test.ts
@@ -51,26 +51,26 @@ describe('Aroon', () => {
 
   describe('replace', () => {
     it('replaces the most recently added value', () => {
-      const interval = 5;
-      const aroon = new Aroon(interval);
-      const aroonWithReplace = new Aroon(interval);
-
-      const correct = {high: 90.0, low: 89.0} as const;
-      const wrong = {high: 82.0, low: 79.0} as const;
+      const aroon = new Aroon(5);
 
       aroon.updates(candles, false);
-      aroonWithReplace.updates(candles, false);
 
-      const originalResult = aroon.add(correct);
-      const replacedResult = aroonWithReplace.add(wrong);
+      const originalValue = {high: 90.0, low: 89.0} as const;
+      const replacedValue = {high: 82.0, low: 79.0} as const;
 
-      expect(replacedResult?.aroonDown).not.toBe(originalResult?.aroonDown);
-      expect(replacedResult?.aroonUp).not.toBe(originalResult?.aroonUp);
+      // New highest high on the most recent candle, lowest low 5 candles ago
+      const originalResult = aroon.add(originalValue);
 
-      const restoredResult = aroonWithReplace.replace(correct);
+      expect(originalResult).toEqual({aroonDown: 0, aroonUp: 100});
 
-      expect(restoredResult?.aroonDown).toBe(originalResult?.aroonDown);
-      expect(restoredResult?.aroonUp).toBe(originalResult?.aroonUp);
+      // New lowest low on the most recent candle, highest high 2 candles ago
+      const replacedResult = aroon.replace(replacedValue);
+
+      expect(replacedResult).toEqual({aroonDown: 100, aroonUp: 60});
+
+      const restoredResult = aroon.replace(originalValue);
+
+      expect(restoredResult).toEqual(originalResult);
     });
   });
 

--- a/packages/trading-signals/src/trend/AROON/Aroon.test.ts
+++ b/packages/trading-signals/src/trend/AROON/Aroon.test.ts
@@ -67,6 +67,7 @@ describe('Aroon', () => {
       const replacedResult = aroon.replace(replacedValue);
 
       expect(replacedResult).toEqual({aroonDown: 100, aroonUp: 60});
+      expect(replacedResult).not.toEqual(originalResult);
 
       const restoredResult = aroon.replace(originalValue);
 

--- a/packages/trading-signals/src/trend/AROON/Aroon.test.ts
+++ b/packages/trading-signals/src/trend/AROON/Aroon.test.ts
@@ -1,0 +1,106 @@
+import {Aroon} from './Aroon.js';
+import {NotEnoughDataError} from '../../error/index.js';
+
+describe('Aroon', () => {
+  /*
+   * Test data verified with:
+   * https://tulipindicators.org/aroon
+   * @see https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt#L54-L58
+   */
+  const candles = [
+    {high: 82.15, low: 81.29},
+    {high: 81.89, low: 80.64},
+    {high: 83.03, low: 81.31},
+    {high: 83.3, low: 82.65},
+    {high: 83.85, low: 83.07},
+    {high: 83.9, low: 83.11},
+    {high: 83.33, low: 82.49},
+    {high: 84.3, low: 82.3},
+    {high: 84.84, low: 84.15},
+    {high: 85.0, low: 84.11},
+    {high: 85.9, low: 84.03},
+    {high: 86.58, low: 85.39},
+    {high: 86.98, low: 85.76},
+    {high: 88.0, low: 87.17},
+    {high: 87.87, low: 87.01},
+  ] as const;
+  const expectedDowns = [
+    '20.000',
+    '0.000',
+    '0.000',
+    '80.000',
+    '60.000',
+    '40.000',
+    '20.000',
+    '0.000',
+    '40.000',
+    '20.000',
+  ] as const;
+  const expectedUps = [
+    '100.000',
+    '80.000',
+    '100.000',
+    '100.000',
+    '100.000',
+    '100.000',
+    '100.000',
+    '100.000',
+    '100.000',
+    '80.000',
+  ] as const;
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const interval = 5;
+      const aroon = new Aroon(interval);
+      const aroonWithReplace = new Aroon(interval);
+
+      const correct = {high: 90.0, low: 89.0} as const;
+      const wrong = {high: 82.0, low: 79.0} as const;
+
+      aroon.updates(candles, false);
+      aroonWithReplace.updates(candles, false);
+
+      const originalResult = aroon.add(correct);
+      const replacedResult = aroonWithReplace.add(wrong);
+
+      expect(replacedResult?.aroonDown).not.toBe(originalResult?.aroonDown);
+
+      const restoredResult = aroonWithReplace.replace(correct);
+
+      expect(restoredResult?.aroonDown).toBe(originalResult?.aroonDown);
+      expect(restoredResult?.aroonUp).toBe(originalResult?.aroonUp);
+    });
+  });
+
+  describe('getResultOrThrow', () => {
+    it('is compatible with results from Tulip Indicators (TI)', {tags: ['tulipindicators']}, () => {
+      const interval = 5;
+      const aroon = new Aroon(interval);
+      const offset = aroon.getRequiredInputs() - 1;
+
+      candles.forEach((candle, i) => {
+        const result = aroon.add(candle);
+
+        if (result) {
+          expect(result.aroonDown.toFixed(3)).toBe(expectedDowns[i - offset]);
+          expect(result.aroonUp.toFixed(3)).toBe(expectedUps[i - offset]);
+        }
+      });
+
+      expect(aroon.isStable).toBe(true);
+      expect(aroon.getRequiredInputs()).toBe(interval + 1);
+    });
+
+    it('throws an error when there is not enough input data', () => {
+      const aroon = new Aroon(5);
+
+      try {
+        aroon.getResultOrThrow();
+        throw new Error('Expected error');
+      } catch (error) {
+        expect(error).toBeInstanceOf(NotEnoughDataError);
+      }
+    });
+  });
+});

--- a/packages/trading-signals/src/trend/AROON/Aroon.test.ts
+++ b/packages/trading-signals/src/trend/AROON/Aroon.test.ts
@@ -65,6 +65,7 @@ describe('Aroon', () => {
       const replacedResult = aroonWithReplace.add(wrong);
 
       expect(replacedResult?.aroonDown).not.toBe(originalResult?.aroonDown);
+      expect(replacedResult?.aroonUp).not.toBe(originalResult?.aroonUp);
 
       const restoredResult = aroonWithReplace.replace(correct);
 
@@ -90,6 +91,22 @@ describe('Aroon', () => {
 
       expect(aroon.isStable).toBe(true);
       expect(aroon.getRequiredInputs()).toBe(interval + 1);
+    });
+
+    it('uses the most recent occurrence when the highest high or lowest low is tied', () => {
+      const aroon = new Aroon(5);
+      const candlesWithTies = [
+        {high: 10, low: 5},
+        {high: 12, low: 3},
+        {high: 11, low: 4},
+        {high: 12, low: 3},
+        {high: 11, low: 4},
+        {high: 10, low: 5},
+      ] as const;
+
+      aroon.updates(candlesWithTies, false);
+
+      expect(aroon.getResultOrThrow()).toEqual({aroonDown: 60, aroonUp: 60});
     });
 
     it('throws an error when there is not enough input data', () => {

--- a/packages/trading-signals/src/trend/AROON/Aroon.test.ts
+++ b/packages/trading-signals/src/trend/AROON/Aroon.test.ts
@@ -58,12 +58,10 @@ describe('Aroon', () => {
       const originalValue = {high: 90.0, low: 89.0} as const;
       const replacedValue = {high: 82.0, low: 79.0} as const;
 
-      // New highest high on the most recent candle, lowest low 5 candles ago
       const originalResult = aroon.add(originalValue);
 
       expect(originalResult).toEqual({aroonDown: 0, aroonUp: 100});
 
-      // New lowest low on the most recent candle, highest high 2 candles ago
       const replacedResult = aroon.replace(replacedValue);
 
       expect(replacedResult).toEqual({aroonDown: 100, aroonUp: 60});

--- a/packages/trading-signals/src/trend/AROON/Aroon.ts
+++ b/packages/trading-signals/src/trend/AROON/Aroon.ts
@@ -1,0 +1,64 @@
+import type {HighLow} from '../../types/HighLowClose.js';
+import {TechnicalIndicator} from '../../types/Indicator.js';
+import {pushUpdate} from '../../util/pushUpdate.js';
+
+export interface AroonResult {
+  /** Measures how recently the lowest low occurred (100 = this candle, 0 = interval candles ago) */
+  aroonDown: number;
+  /** Measures how recently the highest high occurred (100 = this candle, 0 = interval candles ago) */
+  aroonUp: number;
+}
+
+/**
+ * Aroon (AROON)
+ * Type: Trend
+ *
+ * The Aroon indicator was developed by Tushar Chande and identifies emerging trends by measuring the time between
+ * highs and lows: prices regularly hitting new highs signal an uptrend, prices regularly hitting new lows signal a
+ * downtrend. Both lines oscillate between 0 and 100. An Aroon Up above 70 with an Aroon Down below 30 indicates a
+ * strong uptrend (and vice versa for a downtrend). Crossovers of the two lines can signal trend changes.
+ *
+ * @see https://www.investopedia.com/terms/a/aroon.asp
+ * @see https://tulipindicators.org/aroon
+ */
+export class Aroon extends TechnicalIndicator<AroonResult, HighLow<number>> {
+  readonly #candles: HighLow<number>[] = [];
+  public readonly interval: number;
+
+  constructor(interval: number) {
+    super();
+    this.interval = interval;
+  }
+
+  override getRequiredInputs() {
+    return this.interval + 1;
+  }
+
+  update(candle: HighLow<number>, replace: boolean) {
+    pushUpdate(this.#candles, replace, candle, this.getRequiredInputs());
+
+    if (this.#candles.length < this.getRequiredInputs()) {
+      return null;
+    }
+
+    // When the extreme occurs multiple times, the most recent occurrence wins (matches Tulip Indicators)
+    let highestIndex = 0;
+    let lowestIndex = 0;
+
+    this.#candles.forEach(({high, low}, i) => {
+      if (high >= this.#candles[highestIndex].high) {
+        highestIndex = i;
+      }
+
+      if (low <= this.#candles[lowestIndex].low) {
+        lowestIndex = i;
+      }
+    });
+
+    const newestIndex = this.#candles.length - 1;
+    const aroonDown = (100 * (this.interval - (newestIndex - lowestIndex))) / this.interval;
+    const aroonUp = (100 * (this.interval - (newestIndex - highestIndex))) / this.interval;
+
+    return (this.result = {aroonDown, aroonUp});
+  }
+}

--- a/packages/trading-signals/src/trend/index.ts
+++ b/packages/trading-signals/src/trend/index.ts
@@ -1,4 +1,5 @@
 export * from './ADX/ADX.js';
+export * from './AROON/Aroon.js';
 export * from './BREAKOUT_BAR_LOW/BreakoutBarLow.js';
 export * from './DEMA/DEMA.js';
 export * from './DMA/DMA.js';


### PR DESCRIPTION
## Summary

Implements [Tushar Chande's Aroon indicator](https://www.investopedia.com/terms/a/aroon.asp), which identifies emerging trends by measuring how recently the highest high and lowest low occurred within the interval.

- `Aroon` class in `src/trend/AROON/` extending `TechnicalIndicator<AroonResult, HighLow<number>>` — streaming, replace-capable, no smoothing state (result is a pure function of the candle window)
- Returns `{aroonUp, aroonDown}`, both 0–100
- Tie-break matches Tulip Indicators: the most recent extreme wins
- Warm-up: `interval + 1` candles
- Listed in the README

## Tests

- Verified against [Tulip Indicators reference data](https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt#L54-L58) (`aroon 5`, 15 candles → 10 outputs, exact match at 3 decimals) and tagged `tulipindicators`
- Bidirectional `replace()` test and `NotEnoughDataError` test
- Coverage stays at 100% across the package (456 tests)

> **Stacked on #1211** — uses the `tulipindicators` test tag declared there. Merge #1211 first, then rebase this onto `main`.