### PR TITLE
feat(trading-signals): add Money Flow Index (MFI)

### DIFF
--- a/packages/trading-signals/CLAUDE.md
+++ b/packages/trading-signals/CLAUDE.md
@@ -234,7 +234,7 @@ interface Indicator<Result, Input> {
 
 # Adding a New Indicator
 
-Reference implementation: [PR #1212 (Aroon)](https://github.com/bennycode/trading-signals/pull/1212) shows all steps end to end.
+Reference implementation: [PR #1214 (MFI)](https://github.com/bennycode/trading-signals/pull/1214) shows all steps end to end, including the signal conventions.
 
 1. **Pick the category folder** — `src/momentum/`, `src/trend/`, `src/volatility/` or `src/volume/`. Create a directory named after the indicator code in uppercase, with the class file named after the exported class: `src/trend/AROON/Aroon.ts`.
 2. **Extend the right base class** (`src/base/Indicator.ts`):

--- a/packages/trading-signals/CLAUDE.md
+++ b/packages/trading-signals/CLAUDE.md
@@ -1,3 +1,26 @@
+# Adding a New Indicator
+
+Reference implementation: [PR #1214 (MFI)](https://github.com/bennycode/trading-signals/pull/1214) shows all steps end to end, including the signal conventions.
+
+1. **Pick the category folder** — `src/momentum/`, `src/trend/`, `src/volatility/` or `src/volume/`. Create a directory named after the indicator code in uppercase, with the class file named after the exported class: `src/trend/AROON/Aroon.ts`.
+2. **Extend the right base class** (`src/base/Indicator.ts`):
+   - Single-number result → `IndicatorSeries` (or `TrendIndicatorSeries` for signal tracking). Use `setResult()`.
+   - Multi-value result (e.g. `{aroonUp, aroonDown}`) → `TechnicalIndicator<Result, Input>`. Export the result type. Here `this.result` is assigned directly — `setResult()` only exists on `IndicatorSeries`.
+3. **Use shared building blocks** — input types from `src/base/Candle.type.ts` (`HighLow`, `HighLowClose`, …), `pushUpdate()` from `src/util/` for the sliding candle window, and existing indicators (SMA, EMA, ATR, …) as internal components instead of reimplementing them.
+4. **Implement the contract** — `getRequiredInputs()` returns the warm-up count; `update(input, replace)` returns the result or `null` during warm-up. `replace()` must be correct: if the result is a pure function of the candle window, `pushUpdate()` handles it; if the indicator carries smoothing state, restore the previous state on replace.
+5. **No constructor parameter properties** — the codebase compiles with `erasableSyntaxOnly`, so declare fields explicitly and assign them in the constructor.
+6. **Write the class JSDoc with intent** — indicator name and code, type (Trend/Momentum/…), what it tells a trader, and `@see` links to sources (e.g. Investopedia, Tulip Indicators). When the indicator has an established interpretation (e.g. overbought/oversold thresholds), state it in an "Interpretation:" paragraph.
+7. **Encode the interpretation as a signal** — if the JSDoc claims an interpretation, implement it in `calculateSignalState` (via `TrendIndicatorSeries`, or a `getSignal()` like `StochasticOscillator` for multi-value results) so the claim is executable, not decorative. Convention: `TradingSignal` reports the direction of current pressure, not trade advice — overbought → `BULLISH`, oversold → `BEARISH` (see RSI, MFI, STOCH). Neutral or warm-up states must map to `SIDEWAYS` / `UNKNOWN` so a dead market never fabricates a directional signal.
+8. **Export it** — add the class to the category `index.ts` (alphabetical order) and add the indicator to the "Supported Technical Indicators" list in `README.md` (alphabetical order).
+9. **Write co-located tests** (`<Name>.test.ts`, 100% coverage is enforced):
+   - Verify results against external reference data. Prefer [Tulip Indicators test data](https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt), link the exact lines in a comment, and tag the test with `{tags: ['tulipindicators']}`.
+   - Add a single-instance bidirectional `replace()` test asserting exact values for the original, replaced and restored results.
+   - Add a `NotEnoughDataError` test for `getResultOrThrow()` before warm-up.
+   - Cover every signal state the indicator can emit (`UNKNOWN`, `BULLISH`, `BEARISH`, `SIDEWAYS`) with its own test.
+   - Cover behavioral edge cases so a mutated comparison operator fails the suite (e.g. tie-breaking of equal extremes in Aroon, zero total money flow in MFI).
+
+# Coding Conventions
+
 Wrap variables in quotes for log clarity.
 
 ```ts
@@ -231,24 +254,3 @@ interface Indicator<Result, Input> {
   add(input: Input): Result | null;
 }
 ```
-
-# Adding a New Indicator
-
-Reference implementation: [PR #1214 (MFI)](https://github.com/bennycode/trading-signals/pull/1214) shows all steps end to end, including the signal conventions.
-
-1. **Pick the category folder** — `src/momentum/`, `src/trend/`, `src/volatility/` or `src/volume/`. Create a directory named after the indicator code in uppercase, with the class file named after the exported class: `src/trend/AROON/Aroon.ts`.
-2. **Extend the right base class** (`src/base/Indicator.ts`):
-   - Single-number result → `IndicatorSeries` (or `TrendIndicatorSeries` for signal tracking). Use `setResult()`.
-   - Multi-value result (e.g. `{aroonUp, aroonDown}`) → `TechnicalIndicator<Result, Input>`. Export the result interface. Here `this.result` is assigned directly — `setResult()` only exists on `IndicatorSeries`.
-3. **Use shared building blocks** — input types from `src/base/Candle.type.ts` (`HighLow`, `HighLowClose`, …), `pushUpdate()` from `src/util/` for the sliding candle window, and existing indicators (SMA, EMA, ATR, …) as internal components instead of reimplementing them.
-4. **Implement the contract** — `getRequiredInputs()` returns the warm-up count; `update(input, replace)` returns the result or `null` during warm-up. `replace()` must be correct: if the result is a pure function of the candle window, `pushUpdate()` handles it; if the indicator carries smoothing state, restore the previous state on replace.
-5. **No constructor parameter properties** — the codebase compiles with `erasableSyntaxOnly`, so declare fields explicitly and assign them in the constructor.
-6. **Write the class JSDoc with intent** — indicator name and code, type (Trend/Momentum/…), what it tells a trader, and `@see` links to sources (e.g. Investopedia, Tulip Indicators). When the indicator has an established interpretation (e.g. overbought/oversold thresholds), state it in an "Interpretation:" paragraph.
-7. **Encode the interpretation as a signal** — if the JSDoc claims an interpretation, implement it in `calculateSignalState` (via `TrendIndicatorSeries`, or a `getSignal()` like `StochasticOscillator` for multi-value results) so the claim is executable, not decorative. Convention: `TradingSignal` reports the direction of current pressure, not trade advice — overbought → `BULLISH`, oversold → `BEARISH` (see RSI, MFI, STOCH). Neutral or warm-up states must map to `SIDEWAYS` / `UNKNOWN` so a dead market never fabricates a directional signal.
-8. **Export it** — add the class to the category `index.ts` (alphabetical order) and add the indicator to the "Supported Technical Indicators" list in `README.md` (alphabetical order).
-9. **Write co-located tests** (`<Name>.test.ts`, 100% coverage is enforced):
-   - Verify results against external reference data. Prefer [Tulip Indicators test data](https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt), link the exact lines in a comment, and tag the test with `{tags: ['tulipindicators']}`.
-   - Add a single-instance bidirectional `replace()` test asserting exact values for the original, replaced and restored results.
-   - Add a `NotEnoughDataError` test for `getResultOrThrow()` before warm-up.
-   - Cover every signal state the indicator can emit (`UNKNOWN`, `BULLISH`, `BEARISH`, `SIDEWAYS`) with its own test.
-   - Cover behavioral edge cases so a mutated comparison operator fails the suite (e.g. tie-breaking of equal extremes in Aroon, zero total money flow in MFI).

--- a/packages/trading-signals/CLAUDE.md
+++ b/packages/trading-signals/CLAUDE.md
@@ -243,10 +243,12 @@ Reference implementation: [PR #1212 (Aroon)](https://github.com/bennycode/tradin
 3. **Use shared building blocks** — input types from `src/base/Candle.type.ts` (`HighLow`, `HighLowClose`, …), `pushUpdate()` from `src/util/` for the sliding candle window, and existing indicators (SMA, EMA, ATR, …) as internal components instead of reimplementing them.
 4. **Implement the contract** — `getRequiredInputs()` returns the warm-up count; `update(input, replace)` returns the result or `null` during warm-up. `replace()` must be correct: if the result is a pure function of the candle window, `pushUpdate()` handles it; if the indicator carries smoothing state, restore the previous state on replace.
 5. **No constructor parameter properties** — the codebase compiles with `erasableSyntaxOnly`, so declare fields explicitly and assign them in the constructor.
-6. **Write the class JSDoc with intent** — indicator name and code, type (Trend/Momentum/…), what it tells a trader, and `@see` links to sources (e.g. Investopedia, Tulip Indicators).
-7. **Export it** — add the class to the category `index.ts` (alphabetical order) and add the indicator to the "Supported Technical Indicators" list in `README.md` (alphabetical order).
-8. **Write co-located tests** (`<Name>.test.ts`, 100% coverage is enforced):
+6. **Write the class JSDoc with intent** — indicator name and code, type (Trend/Momentum/…), what it tells a trader, and `@see` links to sources (e.g. Investopedia, Tulip Indicators). When the indicator has an established interpretation (e.g. overbought/oversold thresholds), state it in an "Interpretation:" paragraph.
+7. **Encode the interpretation as a signal** — if the JSDoc claims an interpretation, implement it in `calculateSignalState` (via `TrendIndicatorSeries`, or a `getSignal()` like `StochasticOscillator` for multi-value results) so the claim is executable, not decorative. Convention: `TradingSignal` reports the direction of current pressure, not trade advice — overbought → `BULLISH`, oversold → `BEARISH` (see RSI, MFI, STOCH). Neutral or warm-up states must map to `SIDEWAYS` / `UNKNOWN` so a dead market never fabricates a directional signal.
+8. **Export it** — add the class to the category `index.ts` (alphabetical order) and add the indicator to the "Supported Technical Indicators" list in `README.md` (alphabetical order).
+9. **Write co-located tests** (`<Name>.test.ts`, 100% coverage is enforced):
    - Verify results against external reference data. Prefer [Tulip Indicators test data](https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt), link the exact lines in a comment, and tag the test with `{tags: ['tulipindicators']}`.
    - Add a single-instance bidirectional `replace()` test asserting exact values for the original, replaced and restored results.
    - Add a `NotEnoughDataError` test for `getResultOrThrow()` before warm-up.
-   - Cover behavioral edge cases so a mutated comparison operator fails the suite (e.g. tie-breaking of equal extremes in Aroon).
+   - Cover every signal state the indicator can emit (`UNKNOWN`, `BULLISH`, `BEARISH`, `SIDEWAYS`) with its own test.
+   - Cover behavioral edge cases so a mutated comparison operator fails the suite (e.g. tie-breaking of equal extremes in Aroon, zero total money flow in MFI).

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -197,6 +197,7 @@ console.log(signal.hasChanged); // true if the signal state changed from the pre
 1. Linear Regression (LINREG)
 1. Mean Absolute Deviation (MAD)
 1. Momentum (MOM / MTM)
+1. Money Flow Index (MFI)
 1. Moving Average Convergence Divergence (MACD)
 1. On-Balance Volume (OBV)
 1. Parabolic SAR (PSAR)

--- a/packages/trading-signals/src/momentum/MFI/MFI.test.ts
+++ b/packages/trading-signals/src/momentum/MFI/MFI.test.ts
@@ -131,6 +131,24 @@ describe('MFI', () => {
       expect(mfi.getSignal().state).toBe(TradingSignal.BEARISH);
     });
 
+    it('respects custom overbought and oversold thresholds', () => {
+      const strictMfi = new MFI(5, {overbought: 90});
+      const looseMfi = new MFI(5, {oversold: 55});
+      const flatCandle = {close: 50, high: 51, low: 49, volume: 1_000_000} as const;
+
+      strictMfi.updates(candles, false);
+
+      expect(strictMfi.getResultOrThrow().toFixed(3)).toBe('84.647');
+      expect(strictMfi.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+
+      for (let i = 0; i < 6; i++) {
+        looseMfi.add(flatCandle);
+      }
+
+      expect(looseMfi.getResultOrThrow()).toBe(50);
+      expect(looseMfi.getSignal().state).toBe(TradingSignal.BEARISH);
+    });
+
     it('returns SIDEWAYS when the MFI is between the oversold and overbought thresholds', () => {
       const mfi = new MFI(5);
       const flatCandle = {close: 50, high: 51, low: 49, volume: 1_000_000} as const;

--- a/packages/trading-signals/src/momentum/MFI/MFI.test.ts
+++ b/packages/trading-signals/src/momentum/MFI/MFI.test.ts
@@ -1,0 +1,145 @@
+import {MFI} from './MFI.js';
+import {NotEnoughDataError} from '../../error/index.js';
+import {TradingSignal} from '../../base/index.js';
+
+describe('MFI', () => {
+  /*
+   * Test data verified with:
+   * https://tulipindicators.org/mfi
+   * @see https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt#L272-L277
+   */
+  const candles = [
+    {close: 81.59, high: 82.15, low: 81.29, volume: 5_653_100},
+    {close: 81.06, high: 81.89, low: 80.64, volume: 6_447_400},
+    {close: 82.87, high: 83.03, low: 81.31, volume: 7_690_900},
+    {close: 83.0, high: 83.3, low: 82.65, volume: 3_831_400},
+    {close: 83.61, high: 83.85, low: 83.07, volume: 4_455_100},
+    {close: 83.15, high: 83.9, low: 83.11, volume: 3_798_000},
+    {close: 82.84, high: 83.33, low: 82.49, volume: 3_936_200},
+    {close: 83.99, high: 84.3, low: 82.3, volume: 4_732_000},
+    {close: 84.55, high: 84.84, low: 84.15, volume: 4_841_300},
+    {close: 84.36, high: 85.0, low: 84.11, volume: 3_915_300},
+    {close: 85.53, high: 85.9, low: 84.03, volume: 6_830_800},
+    {close: 86.54, high: 86.58, low: 85.39, volume: 6_694_100},
+    {close: 86.89, high: 86.98, low: 85.76, volume: 5_293_600},
+    {close: 87.77, high: 88.0, low: 87.17, volume: 7_985_800},
+    {close: 87.29, high: 87.87, low: 87.01, volume: 4_807_900},
+  ] as const;
+  const expectations = [
+    '61.172',
+    '67.308',
+    '62.796',
+    '64.661',
+    '45.238',
+    '67.841',
+    '85.578',
+    '85.963',
+    '87.504',
+    '84.647',
+  ] as const;
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const mfi = new MFI(5);
+
+      mfi.updates(candles, false);
+
+      const originalValue = {close: 89.0, high: 90.0, low: 88.0, volume: 5_000_000} as const;
+      const replacedValue = {close: 83.0, high: 84.0, low: 82.0, volume: 5_000_000} as const;
+
+      const originalResult = mfi.add(originalValue);
+
+      expect(originalResult?.toFixed(2)).toBe('83.84');
+
+      const replacedResult = mfi.replace(replacedValue);
+
+      expect(replacedResult?.toFixed(2)).toBe('67.50');
+      expect(replacedResult).not.toBe(originalResult);
+
+      const restoredResult = mfi.replace(originalValue);
+
+      expect(restoredResult).toBe(originalResult);
+    });
+  });
+
+  describe('getResultOrThrow', () => {
+    it('is compatible with results from Tulip Indicators (TI)', {tags: ['tulipindicators']}, () => {
+      const interval = 5;
+      const mfi = new MFI(interval);
+      const offset = mfi.getRequiredInputs() - 1;
+
+      candles.forEach((candle, i) => {
+        const result = mfi.add(candle);
+
+        if (result) {
+          expect(result.toFixed(3)).toBe(expectations[i - offset]);
+        }
+      });
+
+      expect(mfi.isStable).toBe(true);
+      expect(mfi.getRequiredInputs()).toBe(interval + 1);
+    });
+
+    it('returns a neutral index when no money flows in either direction', () => {
+      const mfi = new MFI(5);
+      const flatCandle = {close: 50, high: 51, low: 49, volume: 1_000_000} as const;
+
+      for (let i = 0; i < 6; i++) {
+        mfi.add(flatCandle);
+      }
+
+      expect(mfi.getResultOrThrow()).toBe(50);
+    });
+
+    it('throws an error when there is not enough input data', () => {
+      const mfi = new MFI(5);
+
+      try {
+        mfi.getResultOrThrow();
+        throw new Error('Expected error');
+      } catch (error) {
+        expect(error).toBeInstanceOf(NotEnoughDataError);
+      }
+    });
+  });
+
+  describe('getSignal', () => {
+    it('returns UNKNOWN when there is no result', () => {
+      const mfi = new MFI(5);
+
+      expect(mfi.getSignal().state).toBe(TradingSignal.UNKNOWN);
+    });
+
+    it('returns BULLISH when the MFI indicates an overbought market', () => {
+      const mfi = new MFI(5);
+
+      mfi.updates(candles, false);
+
+      expect(mfi.getResultOrThrow()).toBeGreaterThanOrEqual(80);
+      expect(mfi.getSignal().state).toBe(TradingSignal.BULLISH);
+    });
+
+    it('returns BEARISH when the MFI indicates an oversold market', () => {
+      const mfi = new MFI(5);
+
+      for (let i = 0; i < 6; i++) {
+        const price = 100 - i;
+        mfi.add({close: price, high: price + 1, low: price - 1, volume: 1_000_000});
+      }
+
+      expect(mfi.getResultOrThrow()).toBe(0);
+      expect(mfi.getSignal().state).toBe(TradingSignal.BEARISH);
+    });
+
+    it('returns SIDEWAYS when the MFI is between the oversold and overbought thresholds', () => {
+      const mfi = new MFI(5);
+      const flatCandle = {close: 50, high: 51, low: 49, volume: 1_000_000} as const;
+
+      for (let i = 0; i < 6; i++) {
+        mfi.add(flatCandle);
+      }
+
+      expect(mfi.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+    });
+  });
+});

--- a/packages/trading-signals/src/momentum/MFI/MFI.ts
+++ b/packages/trading-signals/src/momentum/MFI/MFI.ts
@@ -1,0 +1,81 @@
+import type {HighLowCloseVolume} from '../../base/Candle.type.js';
+import {TradingSignal, TrendIndicatorSeries} from '../../base/Indicator.js';
+import {pushUpdate} from '../../util/pushUpdate.js';
+
+/**
+ * Money Flow Index (MFI)
+ * Type: Momentum
+ *
+ * The Money Flow Index was developed by Gene Quong and Avrum Soudack and is often described as a volume-weighted
+ * RSI: instead of measuring price changes alone, it weights each candle's typical price by its trading volume, so a
+ * move backed by heavy volume shifts the index more than the same move on thin volume. It oscillates between 0 and
+ * 100.
+ *
+ * Interpretation:
+ * An MFI of 80 or above indicates an overbought condition, 20 or below indicates an oversold condition. Divergence
+ * between MFI and price (e.g. price makes a new high while MFI does not) can signal an upcoming reversal.
+ *
+ * @see https://www.investopedia.com/terms/m/mfi.asp
+ * @see https://tulipindicators.org/mfi
+ */
+export class MFI extends TrendIndicatorSeries<HighLowCloseVolume<number>> {
+  readonly #candles: HighLowCloseVolume<number>[] = [];
+  public readonly interval: number;
+
+  constructor(interval: number) {
+    super();
+    this.interval = interval;
+  }
+
+  override getRequiredInputs() {
+    return this.interval + 1;
+  }
+
+  update(candle: HighLowCloseVolume<number>, replace: boolean) {
+    pushUpdate(this.#candles, replace, candle, this.getRequiredInputs());
+
+    if (this.#candles.length < this.getRequiredInputs()) {
+      return null;
+    }
+
+    const typicalPrices = this.#candles.map(({close, high, low}) => (high + low + close) / 3);
+    let positiveFlow = 0;
+    let negativeFlow = 0;
+
+    for (let i = 1; i < this.#candles.length; i++) {
+      const rawMoneyFlow = typicalPrices[i] * this.#candles[i].volume;
+
+      if (typicalPrices[i] > typicalPrices[i - 1]) {
+        positiveFlow += rawMoneyFlow;
+      } else if (typicalPrices[i] < typicalPrices[i - 1]) {
+        negativeFlow += rawMoneyFlow;
+      }
+    }
+
+    const totalFlow = positiveFlow + negativeFlow;
+
+    // A completely flat market moves no money in either direction, so the index is neutral
+    if (totalFlow === 0) {
+      return this.setResult(50, replace);
+    }
+
+    return this.setResult((100 * positiveFlow) / totalFlow, replace);
+  }
+
+  protected calculateSignalState(result: number | null | undefined) {
+    const hasResult = result !== null && result !== undefined;
+    const isOversold = hasResult && result <= 20;
+    const isOverbought = hasResult && result >= 80;
+
+    switch (true) {
+      case !hasResult:
+        return TradingSignal.UNKNOWN;
+      case isOversold:
+        return TradingSignal.BEARISH;
+      case isOverbought:
+        return TradingSignal.BULLISH;
+      default:
+        return TradingSignal.SIDEWAYS;
+    }
+  }
+}

--- a/packages/trading-signals/src/momentum/MFI/MFI.ts
+++ b/packages/trading-signals/src/momentum/MFI/MFI.ts
@@ -12,19 +12,31 @@ import {pushUpdate} from '../../util/pushUpdate.js';
  * 100.
  *
  * Interpretation:
- * An MFI of 80 or above indicates an overbought condition, 20 or below indicates an oversold condition. Divergence
+ * An MFI of 80 or above indicates an overbought condition, 20 or below indicates an oversold condition (both
+ * thresholds can be customized via the constructor). Divergence
  * between MFI and price (e.g. price makes a new high while MFI does not) can signal an upcoming reversal.
  *
  * @see https://www.investopedia.com/terms/m/mfi.asp
  * @see https://tulipindicators.org/mfi
  */
+export type MFIThresholds = {
+  /** MFI value at or above which the market counts as overbought (default: 80) */
+  overbought?: number;
+  /** MFI value at or below which the market counts as oversold (default: 20) */
+  oversold?: number;
+};
+
 export class MFI extends TrendIndicatorSeries<HighLowCloseVolume<number>> {
   readonly #candles: HighLowCloseVolume<number>[] = [];
+  readonly #overbought: number;
+  readonly #oversold: number;
   public readonly interval: number;
 
-  constructor(interval: number) {
+  constructor(interval: number, {overbought = 80, oversold = 20}: MFIThresholds = {}) {
     super();
     this.interval = interval;
+    this.#overbought = overbought;
+    this.#oversold = oversold;
   }
 
   override getRequiredInputs() {
@@ -64,8 +76,8 @@ export class MFI extends TrendIndicatorSeries<HighLowCloseVolume<number>> {
 
   protected calculateSignalState(result: number | null | undefined) {
     const hasResult = result !== null && result !== undefined;
-    const isOversold = hasResult && result <= 20;
-    const isOverbought = hasResult && result >= 80;
+    const isOversold = hasResult && result <= this.#oversold;
+    const isOverbought = hasResult && result >= this.#overbought;
 
     switch (true) {
       case !hasResult:

--- a/packages/trading-signals/src/momentum/index.ts
+++ b/packages/trading-signals/src/momentum/index.ts
@@ -4,6 +4,7 @@ export * from './CCI/CCI.js';
 export * from './CG/CG.js';
 export * from './ER/ER.js';
 export * from './MACD/MACD.js';
+export * from './MFI/MFI.js';
 export * from './MOM/MOM.js';
 export * from './OBV/OBV.js';
 export * from './REI/REI.js';


### PR DESCRIPTION
## Summary

Implements the [Money Flow Index](https://www.investopedia.com/terms/m/mfi.asp) by Gene Quong and Avrum Soudack — the volume-weighted RSI. Each candle's typical price `(high + low + close) / 3` is weighted by trading volume, so moves backed by heavy volume shift the index more than the same moves on thin volume. Oscillates 0–100; ≥80 overbought, ≤20 oversold.

Built following the new CLAUDE.md "Adding a New Indicator" guide:

- `MFI` in `src/momentum/MFI/` extending `TrendIndicatorSeries<HighLowCloseVolume<number>>` — first indicator consuming `HighLowCloseVolume` from `Candle.type.ts`
- Result is a pure function of the candle window (like Aroon), so `replace()` needs no state restoration
- Flat-market edge case: zero total flow returns a neutral 50
- `getSignal()`: BULLISH ≥80, BEARISH ≤20, SIDEWAYS between, UNKNOWN before warm-up
- Warm-up: `interval + 1` candles; exported via `momentum/index.ts` and listed in the README

## Tests

- Verified against [Tulip Indicators reference data](https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt#L272-L277) (`mfi 5`, 15 candles → 10 outputs, exact at 3 decimals), tagged `tulipindicators` — an independent reimplementation of the formula reproduces Tulip's outputs before the class was tested against them
- Single-instance bidirectional `replace()` test with exact values (83.84 → 67.50 → restored)
- Flat-market neutral test, `NotEnoughDataError` test, all four signal states
- 465/465 tests pass, coverage stays at 100%