### PR TITLE
feat(trading-signals)!: configurable signal thresholds + named StochasticOscillator config

### DIFF
--- a/packages/trading-signals-docs/indicator-demos/momentum/StochasticOscillator.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/StochasticOscillator.demo.tsx
@@ -11,7 +11,7 @@ import {collectPriceData} from '../../utils/renderUtils';
 import type {IndicatorConfig} from '../../utils/types';
 
 const renderStochastic = (config: IndicatorConfig, selectedCandles: Candle[]) => {
-  const stoch = new StochasticOscillatorClass(14, 3, 3);
+  const stoch = new StochasticOscillatorClass({dPeriod: 3, kPeriod: 14, kSlowingPeriod: 3});
   const chartDataK: ChartDataPoint[] = [];
   const chartDataD: ChartDataPoint[] = [];
   const priceData: PriceData[] = [];
@@ -40,7 +40,8 @@ const renderStochastic = (config: IndicatorConfig, selectedCandles: Candle[]) =>
     <div className="space-y-6">
       <div>
         <h2 className="text-2xl font-bold text-white mb-2 select-text">
-          StochasticOscillator({stoch.n}, {stoch.m}, {stoch.p}) / Required Inputs: {stoch.getRequiredInputs()}
+          StochasticOscillator({stoch.kPeriod}, {stoch.kSlowingPeriod}, {stoch.dPeriod}) / Required Inputs:{' '}
+          {stoch.getRequiredInputs()}
         </h2>
         <p className="text-slate-300 select-text">{config.description}</p>
         <p className="text-slate-400 text-sm mt-2 select-text">
@@ -142,7 +143,7 @@ const renderStochastic = (config: IndicatorConfig, selectedCandles: Candle[]) =>
 
 export const StochasticOscillator: IndicatorConfig = {
   color: '#ec4899',
-  createIndicator: () => new StochasticOscillatorClass(14, 3, 3),
+  createIndicator: () => new StochasticOscillatorClass({dPeriod: 3, kPeriod: 14, kSlowingPeriod: 3}),
   customRender: renderStochastic,
   description: 'Stochastic Oscillator',
   id: 'stoch',

--- a/packages/trading-signals/CLAUDE.md
+++ b/packages/trading-signals/CLAUDE.md
@@ -179,7 +179,7 @@ When testing the `replace()` method, verify bidirectional replacement by testing
 ```ts
 // ❌ Bad: Only tests that replace changes the value
 it('can replace recently added values', () => {
-  const stoch = new StochasticOscillator(5, 3, 3);
+  const stoch = new StochasticOscillator({dPeriod: 3, kPeriod: 5, kSlowingPeriod: 3});
 
   for (let i = 0; i < 9; i++) {
     stoch.add({close: 50 + i, high: 100, low: 10});
@@ -197,7 +197,7 @@ it('can replace recently added values', () => {
 
 // ✅ Good: Tests replacement and restoration to verify replace functionality
 it('replaces the most recently added value', () => {
-  const stoch = new StochasticOscillator(5, 3, 3);
+  const stoch = new StochasticOscillator({dPeriod: 3, kPeriod: 5, kSlowingPeriod: 3});
 
   for (let i = 0; i < 9; i++) {
     stoch.add({close: 50 + i, high: 100, low: 10});

--- a/packages/trading-signals/src/base/SignalThresholds.type.ts
+++ b/packages/trading-signals/src/base/SignalThresholds.type.ts
@@ -1,0 +1,9 @@
+/**
+ * Overrides the territory in which an oscillator reports an overbought or oversold market.
+ * Defaults are indicator-specific (e.g. 70/30 for RSI, 80/20 for MFI) and follow the
+ * literature; tighten or widen them to match the traded asset's volatility.
+ */
+export type SignalThresholds = {
+  overbought?: number;
+  oversold?: number;
+};

--- a/packages/trading-signals/src/base/index.ts
+++ b/packages/trading-signals/src/base/index.ts
@@ -2,3 +2,4 @@ export * from './BandsResult.type.js';
 export * from './Candle.type.js';
 export * from './Indicator.js';
 export * from './Period.js';
+export * from './SignalThresholds.type.js';

--- a/packages/trading-signals/src/momentum/CCI/CCI.test.ts
+++ b/packages/trading-signals/src/momentum/CCI/CCI.test.ts
@@ -99,6 +99,25 @@ describe('CCI', () => {
       expect(signal.state).toBe(TradingSignal.UNKNOWN);
     });
 
+    it('respects custom overbought and oversold thresholds', () => {
+      const risingCandles = [
+        {close: 60, high: 61, low: 59},
+        {close: 70, high: 71, low: 69},
+        {close: 80, high: 81, low: 79},
+        {close: 90, high: 91, low: 89},
+        {close: 100, high: 101, low: 99},
+      ] as const;
+      const strictCci = new CCI(5, {overbought: 120});
+      const sensitiveCci = new CCI(5, {overbought: 110});
+
+      strictCci.updates(risingCandles, false);
+      sensitiveCci.updates(risingCandles, false);
+
+      expect(strictCci.getResultOrThrow().toFixed(2)).toBe('111.11');
+      expect(strictCci.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+      expect(sensitiveCci.getSignal().state).toBe(TradingSignal.BULLISH);
+    });
+
     it('returns OVERSOLD when CCI <= -100', () => {
       const cci = new CCI(5);
 

--- a/packages/trading-signals/src/momentum/CCI/CCI.ts
+++ b/packages/trading-signals/src/momentum/CCI/CCI.ts
@@ -1,6 +1,7 @@
 import {SMA} from '../../trend/SMA/SMA.js';
 import type {HighLowClose} from '../../base/Candle.type.js';
 import {TradingSignal, TrendIndicatorSeries} from '../../base/Indicator.js';
+import type {SignalThresholds} from '../../base/SignalThresholds.type.js';
 import {pushUpdate} from '../../util/index.js';
 import {MAD} from '../../volatility/MAD/MAD.js';
 
@@ -31,13 +32,17 @@ import {MAD} from '../../volatility/MAD/MAD.js';
 export class CCI extends TrendIndicatorSeries<HighLowClose<number>> {
   readonly #sma: SMA;
   readonly #typicalPrices: number[];
+  readonly #overbought: number;
+  readonly #oversold: number;
   public readonly interval: number;
 
-  constructor(interval: number) {
+  constructor(interval: number, {overbought = 100, oversold = -100}: SignalThresholds = {}) {
     super();
     this.interval = interval;
     this.#sma = new SMA(this.interval);
     this.#typicalPrices = [];
+    this.#overbought = overbought;
+    this.#oversold = oversold;
   }
 
   override getRequiredInputs() {
@@ -67,8 +72,8 @@ export class CCI extends TrendIndicatorSeries<HighLowClose<number>> {
 
   protected calculateSignalState(result?: number | null | undefined) {
     const hasResult = result !== null && result !== undefined;
-    const isOversold = hasResult && result <= -100;
-    const isOverbought = hasResult && result >= 100;
+    const isOversold = hasResult && result <= this.#oversold;
+    const isOverbought = hasResult && result >= this.#overbought;
 
     switch (true) {
       case !hasResult:

--- a/packages/trading-signals/src/momentum/ER/ER.test.ts
+++ b/packages/trading-signals/src/momentum/ER/ER.test.ts
@@ -110,6 +110,22 @@ describe('ER', () => {
       expect(er.getSignal().state).toBe(TradingSignal.UNKNOWN);
     });
 
+    it('respects a custom trending threshold', () => {
+      const er = new ER(3, {trending: 0.8});
+      const candles = [
+        {close: 100, high: 101, low: 99},
+        {close: 103, high: 104, low: 102},
+        {close: 106, high: 107, low: 105},
+      ] as const;
+
+      for (const candle of candles) {
+        er.add(candle);
+      }
+
+      expect(er.getResultOrThrow()).toBe(0.75);
+      expect(er.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+    });
+
     it('returns BULLISH when efficiency >= 0.5 (trending)', () => {
       const er = new ER(3);
 

--- a/packages/trading-signals/src/momentum/ER/ER.ts
+++ b/packages/trading-signals/src/momentum/ER/ER.ts
@@ -4,6 +4,11 @@ import {getMaximum} from '../../util/getMaximum.js';
 import {getMinimum} from '../../util/getMinimum.js';
 import {pushUpdate} from '../../util/pushUpdate.js';
 
+export type ERThresholds = {
+  /** ER value at or above which the market counts as trending (default: 0.5) */
+  trending?: number;
+};
+
 /**
  * Range Efficiency (ER)
  * Type: Momentum
@@ -23,10 +28,12 @@ export class ER extends TrendIndicatorSeries<HighLowClose> {
   readonly #lows: number[] = [];
 
   public readonly interval: number;
+  readonly #trending: number;
 
-  constructor(interval: number) {
+  constructor(interval: number, {trending = 0.5}: ERThresholds = {}) {
     super();
     this.interval = interval;
+    this.#trending = trending;
   }
 
   override getRequiredInputs() {
@@ -59,7 +66,7 @@ export class ER extends TrendIndicatorSeries<HighLowClose> {
       return TradingSignal.UNKNOWN;
     }
 
-    if (result >= 0.5) {
+    if (result >= this.#trending) {
       return TradingSignal.BULLISH;
     }
 

--- a/packages/trading-signals/src/momentum/MFI/MFI.ts
+++ b/packages/trading-signals/src/momentum/MFI/MFI.ts
@@ -1,5 +1,6 @@
 import type {HighLowCloseVolume} from '../../base/Candle.type.js';
 import {TradingSignal, TrendIndicatorSeries} from '../../base/Indicator.js';
+import type {SignalThresholds} from '../../base/SignalThresholds.type.js';
 import {pushUpdate} from '../../util/pushUpdate.js';
 
 /**
@@ -19,20 +20,13 @@ import {pushUpdate} from '../../util/pushUpdate.js';
  * @see https://www.investopedia.com/terms/m/mfi.asp
  * @see https://tulipindicators.org/mfi
  */
-export type MFIThresholds = {
-  /** MFI value at or above which the market counts as overbought (default: 80) */
-  overbought?: number;
-  /** MFI value at or below which the market counts as oversold (default: 20) */
-  oversold?: number;
-};
-
 export class MFI extends TrendIndicatorSeries<HighLowCloseVolume<number>> {
   readonly #candles: HighLowCloseVolume<number>[] = [];
   readonly #overbought: number;
   readonly #oversold: number;
   public readonly interval: number;
 
-  constructor(interval: number, {overbought = 80, oversold = 20}: MFIThresholds = {}) {
+  constructor(interval: number, {overbought = 80, oversold = 20}: SignalThresholds = {}) {
     super();
     this.interval = interval;
     this.#overbought = overbought;

--- a/packages/trading-signals/src/momentum/REI/REI.test.ts
+++ b/packages/trading-signals/src/momentum/REI/REI.test.ts
@@ -218,6 +218,16 @@ describe('REI', () => {
       expect(signal.state).toBe(TradingSignal.UNKNOWN);
     });
 
+    it('respects custom overbought and oversold thresholds', () => {
+      const rei = new REI(8, {overbought: 80, oversold: -80});
+      const calculateSignal = rei['calculateSignalState'].bind(rei);
+
+      expect(calculateSignal(61)).toBe(TradingSignal.SIDEWAYS);
+      expect(calculateSignal(81)).toBe(TradingSignal.BULLISH);
+      expect(calculateSignal(-61)).toBe(TradingSignal.SIDEWAYS);
+      expect(calculateSignal(-81)).toBe(TradingSignal.BEARISH);
+    });
+
     it('returns OVERBOUGHT when REI > 60', () => {
       const rei = new REI(8);
       const calculateSignal = rei['calculateSignalState'].bind(rei);

--- a/packages/trading-signals/src/momentum/REI/REI.ts
+++ b/packages/trading-signals/src/momentum/REI/REI.ts
@@ -1,5 +1,6 @@
 import type {HighLowClose} from '../../base/Candle.type.js';
 import {TradingSignal, TrendIndicatorSeries} from '../../base/Indicator.js';
+import type {SignalThresholds} from '../../base/SignalThresholds.type.js';
 
 /**
  * Range Expansion Index (REI)
@@ -26,16 +27,20 @@ export class REI extends TrendIndicatorSeries<HighLowClose<number>> {
   readonly #closes: number[] = [];
 
   public readonly interval: number;
+  readonly #overbought: number;
+  readonly #oversold: number;
 
-  constructor(interval: number) {
+  constructor(interval: number, {overbought = 60, oversold = -60}: SignalThresholds = {}) {
     super();
     this.interval = interval;
+    this.#overbought = overbought;
+    this.#oversold = oversold;
   }
 
   protected calculateSignalState(result?: number | null | undefined) {
     const hasResult = result !== null && result !== undefined;
-    const isOverbought = hasResult && result > 60;
-    const isOversold = hasResult && result < -60;
+    const isOverbought = hasResult && result > this.#overbought;
+    const isOversold = hasResult && result < this.#oversold;
 
     switch (true) {
       case !hasResult:

--- a/packages/trading-signals/src/momentum/RSI/RSI.test.ts
+++ b/packages/trading-signals/src/momentum/RSI/RSI.test.ts
@@ -1,6 +1,7 @@
 import {RSI} from './RSI.js';
 import {NotEnoughDataError} from '../../error/index.js';
 import {TradingSignal} from '../../base/index.js';
+import {WSMA} from '../../trend/WSMA/WSMA.js';
 
 describe('RSI', () => {
   describe('update', () => {
@@ -87,6 +88,24 @@ describe('RSI', () => {
       const rsi = new RSI(5);
       const signal = rsi.getSignal();
       expect(signal.state).toBe(TradingSignal.UNKNOWN);
+    });
+
+    it('respects custom overbought and oversold thresholds', () => {
+      const prices = [100, 100.5, 100, 99.5, 100, 100.5] as const;
+      const sensitiveBull = new RSI(5, WSMA, {overbought: 30});
+      const sensitiveBear = new RSI(5, WSMA, {oversold: 70});
+
+      for (const price of prices) {
+        sensitiveBull.add(price);
+        sensitiveBear.add(price);
+      }
+
+      const result = sensitiveBull.getResultOrThrow();
+
+      expect(result).toBeGreaterThan(30);
+      expect(result).toBeLessThan(70);
+      expect(sensitiveBull.getSignal().state).toBe(TradingSignal.BULLISH);
+      expect(sensitiveBear.getSignal().state).toBe(TradingSignal.BEARISH);
     });
 
     it('returns OVERSOLD when RSI <= 30', () => {

--- a/packages/trading-signals/src/momentum/RSI/RSI.ts
+++ b/packages/trading-signals/src/momentum/RSI/RSI.ts
@@ -1,4 +1,5 @@
 import {TradingSignal, TrendIndicatorSeries} from '../../base/Indicator.js';
+import type {SignalThresholds} from '../../base/SignalThresholds.type.js';
 import type {MovingAverage} from '../../trend/MA/MovingAverage.js';
 import type {MovingAverageTypes} from '../../trend/MA/MovingAverageTypes.js';
 import {pushUpdate} from '../../util/pushUpdate.js';
@@ -24,14 +25,22 @@ export class RSI extends TrendIndicatorSeries {
   readonly #avgGain: MovingAverage;
   readonly #avgLoss: MovingAverage;
   readonly #maxValue = 100;
+  readonly #overbought: number;
+  readonly #oversold: number;
 
   public readonly interval: number;
 
-  constructor(interval: number, SmoothingIndicator: MovingAverageTypes = WSMA) {
+  constructor(
+    interval: number,
+    SmoothingIndicator: MovingAverageTypes = WSMA,
+    {overbought = 70, oversold = 30}: SignalThresholds = {}
+  ) {
     super();
     this.interval = interval;
     this.#avgGain = new SmoothingIndicator(this.interval);
     this.#avgLoss = new SmoothingIndicator(this.interval);
+    this.#overbought = overbought;
+    this.#oversold = oversold;
   }
 
   override getRequiredInputs() {
@@ -72,8 +81,8 @@ export class RSI extends TrendIndicatorSeries {
 
   protected calculateSignalState(result: number | null | undefined) {
     const hasResult = result !== null && result !== undefined;
-    const isOversold = hasResult && result <= 30;
-    const isOverbought = hasResult && result >= 70;
+    const isOversold = hasResult && result <= this.#oversold;
+    const isOverbought = hasResult && result >= this.#overbought;
 
     switch (true) {
       case !hasResult:

--- a/packages/trading-signals/src/momentum/STOCH/StochasticOscillator.test.ts
+++ b/packages/trading-signals/src/momentum/STOCH/StochasticOscillator.test.ts
@@ -107,6 +107,20 @@ describe('StochasticOscillator', () => {
       expect(signal.state).toBe(TradingSignal.UNKNOWN);
     });
 
+    it('respects custom overbought and oversold thresholds', () => {
+      const sensitiveBull = new StochasticOscillator(5, 3, 3, {overbought: 40});
+      const sensitiveBear = new StochasticOscillator(5, 3, 3, {oversold: 50});
+
+      for (let i = 0; i < 9; i++) {
+        sensitiveBull.add({close: 50, high: 100, low: 10});
+        sensitiveBear.add({close: 50, high: 100, low: 10});
+      }
+
+      expect(sensitiveBull.getResultOrThrow().stochK.toFixed(2)).toBe('44.44');
+      expect(sensitiveBull.getSignal().state).toBe(TradingSignal.BULLISH);
+      expect(sensitiveBear.getSignal().state).toBe(TradingSignal.BEARISH);
+    });
+
     it('returns OVERSOLD when stochK <= 20', () => {
       const stoch = new StochasticOscillator(5, 3, 3);
       // Build data that creates oversold condition

--- a/packages/trading-signals/src/momentum/STOCH/StochasticOscillator.test.ts
+++ b/packages/trading-signals/src/momentum/STOCH/StochasticOscillator.test.ts
@@ -13,7 +13,7 @@ describe('StochasticOscillator', () => {
       const stochKs = ['77.39', '83.13', '84.87', '88.36', '95.25', '96.74', '91.09'] as const;
       const stochDs = ['75.70', '78.01', '81.79', '85.45', '89.49', '93.45', '94.36'] as const;
 
-      const stoch = new StochasticOscillator(5, 3, 3);
+      const stoch = new StochasticOscillator({dPeriod: 3, kPeriod: 5, kSlowingPeriod: 3});
       const offset = stoch.getRequiredInputs() - 1;
 
       candles.forEach((candle, i) => {
@@ -34,7 +34,7 @@ describe('StochasticOscillator', () => {
 
   describe('replace', () => {
     it('replaces the most recently added value', () => {
-      const stoch = new StochasticOscillator(5, 3, 3);
+      const stoch = new StochasticOscillator({dPeriod: 3, kPeriod: 5, kSlowingPeriod: 3});
 
       // Add enough data to make it stable
       for (let i = 0; i < 9; i++) {
@@ -62,7 +62,7 @@ describe('StochasticOscillator', () => {
 
   describe('getResultOrThrow', () => {
     it('throws an error when there is not enough input data', () => {
-      const stoch = new StochasticOscillator(5, 3, 3);
+      const stoch = new StochasticOscillator({dPeriod: 3, kPeriod: 5, kSlowingPeriod: 3});
 
       stoch.add({close: 1, high: 1, low: 1});
       stoch.add({close: 1, high: 2, low: 1});
@@ -80,7 +80,7 @@ describe('StochasticOscillator', () => {
     });
 
     it('prevents division by zero errors when highest high and lowest low have the same value', () => {
-      const stoch = new StochasticOscillator(5, 3, 3);
+      const stoch = new StochasticOscillator({dPeriod: 3, kPeriod: 5, kSlowingPeriod: 3});
       stoch.updates(
         [
           {close: 100, high: 100, low: 100},
@@ -102,14 +102,14 @@ describe('StochasticOscillator', () => {
 
   describe('getSignal', () => {
     it('returns UNKNOWN when there is no result', () => {
-      const stoch = new StochasticOscillator(5, 3, 3);
+      const stoch = new StochasticOscillator({dPeriod: 3, kPeriod: 5, kSlowingPeriod: 3});
       const signal = stoch.getSignal();
       expect(signal.state).toBe(TradingSignal.UNKNOWN);
     });
 
     it('respects custom overbought and oversold thresholds', () => {
-      const sensitiveBull = new StochasticOscillator(5, 3, 3, {overbought: 40});
-      const sensitiveBear = new StochasticOscillator(5, 3, 3, {oversold: 50});
+      const sensitiveBull = new StochasticOscillator({dPeriod: 3, kPeriod: 5, kSlowingPeriod: 3}, {overbought: 40});
+      const sensitiveBear = new StochasticOscillator({dPeriod: 3, kPeriod: 5, kSlowingPeriod: 3}, {oversold: 50});
 
       for (let i = 0; i < 9; i++) {
         sensitiveBull.add({close: 50, high: 100, low: 10});
@@ -122,7 +122,7 @@ describe('StochasticOscillator', () => {
     });
 
     it('returns OVERSOLD when stochK <= 20', () => {
-      const stoch = new StochasticOscillator(5, 3, 3);
+      const stoch = new StochasticOscillator({dPeriod: 3, kPeriod: 5, kSlowingPeriod: 3});
       // Build data that creates oversold condition
       for (let i = 0; i < 9; i++) {
         stoch.add({close: 20, high: 100, low: 10});
@@ -133,7 +133,7 @@ describe('StochasticOscillator', () => {
     });
 
     it('returns OVERBOUGHT when stochK >= 80', () => {
-      const stoch = new StochasticOscillator(5, 3, 3);
+      const stoch = new StochasticOscillator({dPeriod: 3, kPeriod: 5, kSlowingPeriod: 3});
       // Build data that creates overbought condition
       for (let i = 0; i < 9; i++) {
         stoch.add({close: 95, high: 100, low: 10});
@@ -144,7 +144,7 @@ describe('StochasticOscillator', () => {
     });
 
     it('returns NEUTRAL when stochK is between 20 and 80', () => {
-      const stoch = new StochasticOscillator(5, 3, 3);
+      const stoch = new StochasticOscillator({dPeriod: 3, kPeriod: 5, kSlowingPeriod: 3});
       // Build data that creates neutral condition
       for (let i = 0; i < 9; i++) {
         stoch.add({close: 50, high: 100, low: 10});

--- a/packages/trading-signals/src/momentum/STOCH/StochasticOscillator.ts
+++ b/packages/trading-signals/src/momentum/STOCH/StochasticOscillator.ts
@@ -11,6 +11,15 @@ export type StochasticResult = {
   stochK: number;
 };
 
+export type StochasticOscillatorConfig = {
+  /** Period of the moving average over %k values, producing the slow %d line */
+  dPeriod: number;
+  /** Number of candles used for the high/low trading range of the fast %k line */
+  kPeriod: number;
+  /** Slowing period applied to the raw %k values */
+  kSlowingPeriod: number;
+};
+
 /**
  * Stochastic Oscillator (STOCH)
  * Type: Momentum
@@ -31,48 +40,46 @@ export type StochasticResult = {
  */
 export class StochasticOscillator extends TechnicalIndicator<StochasticResult, HighLowClose<number>> {
   public readonly candles: HighLowClose<number>[] = [];
-  readonly #periodM: SMA;
-  readonly #periodP: SMA;
+  readonly #smoothK: SMA;
+  readonly #smoothD: SMA;
   #previousResult?: StochasticResult;
 
-  /**
-   * @param n The %k period
-   * @param m The %k slowing period
-   * @param p The %d period
-   */
-  public n: number;
-  public m: number;
-  public p: number;
+  public readonly kPeriod: number;
+  public readonly kSlowingPeriod: number;
+  public readonly dPeriod: number;
   readonly #overbought: number;
   readonly #oversold: number;
 
-  constructor(n: number, m: number, p: number, {overbought = 80, oversold = 20}: SignalThresholds = {}) {
+  constructor(
+    {dPeriod, kPeriod, kSlowingPeriod}: StochasticOscillatorConfig,
+    {overbought = 80, oversold = 20}: SignalThresholds = {}
+  ) {
     super();
-    this.n = n;
-    this.m = m;
-    this.p = p;
-    this.#periodM = new SMA(m);
-    this.#periodP = new SMA(p);
+    this.kPeriod = kPeriod;
+    this.kSlowingPeriod = kSlowingPeriod;
+    this.dPeriod = dPeriod;
+    this.#smoothK = new SMA(kSlowingPeriod);
+    this.#smoothD = new SMA(dPeriod);
     this.#overbought = overbought;
     this.#oversold = oversold;
   }
 
   override getRequiredInputs() {
-    return this.n + this.p + 1;
+    return this.kPeriod + this.dPeriod + 1;
   }
 
   update(candle: HighLowClose<number>, replace: boolean) {
-    pushUpdate(this.candles, replace, candle, this.n);
+    pushUpdate(this.candles, replace, candle, this.kPeriod);
 
-    if (this.candles.length === this.n) {
+    if (this.candles.length === this.kPeriod) {
       const highest = Math.max(...this.candles.map(candle => candle.high));
       const lowest = Math.min(...this.candles.map(candle => candle.low));
       const divisor = highest - lowest;
       let fastK = (candle.close - lowest) * 100;
       // Prevent division by zero
       fastK = fastK / (divisor === 0 ? 1 : divisor);
-      const stochK = this.#periodM.update(fastK, replace); // (stoch_k, %k)
-      const stochD = stochK && this.#periodP.update(stochK, replace); // (stoch_d, %d)
+      const stochK = this.#smoothK.update(fastK, replace); // (stoch_k, %k)
+      const stochD = stochK && this.#smoothD.update(stochK, replace); // (stoch_d, %d)
 
       if (stochK !== null && stochD !== null) {
         if (replace) {

--- a/packages/trading-signals/src/momentum/STOCH/StochasticOscillator.ts
+++ b/packages/trading-signals/src/momentum/STOCH/StochasticOscillator.ts
@@ -1,6 +1,7 @@
 import {SMA} from '../../trend/SMA/SMA.js';
 import type {HighLowClose} from '../../base/Candle.type.js';
 import {TechnicalIndicator, TradingSignal} from '../../base/Indicator.js';
+import type {SignalThresholds} from '../../base/SignalThresholds.type.js';
 import {pushUpdate} from '../../util/pushUpdate.js';
 
 export type StochasticResult = {
@@ -42,14 +43,18 @@ export class StochasticOscillator extends TechnicalIndicator<StochasticResult, H
   public n: number;
   public m: number;
   public p: number;
+  readonly #overbought: number;
+  readonly #oversold: number;
 
-  constructor(n: number, m: number, p: number) {
+  constructor(n: number, m: number, p: number, {overbought = 80, oversold = 20}: SignalThresholds = {}) {
     super();
     this.n = n;
     this.m = m;
     this.p = p;
     this.#periodM = new SMA(m);
     this.#periodP = new SMA(p);
+    this.#overbought = overbought;
+    this.#oversold = oversold;
   }
 
   override getRequiredInputs() {
@@ -88,8 +93,8 @@ export class StochasticOscillator extends TechnicalIndicator<StochasticResult, H
 
   protected calculateSignal(result?: StochasticResult | null | undefined) {
     const hasResult = result !== null && result !== undefined;
-    const isOversold = hasResult && result.stochK <= 20;
-    const isOverbought = hasResult && result.stochK >= 80;
+    const isOversold = hasResult && result.stochK <= this.#oversold;
+    const isOverbought = hasResult && result.stochK >= this.#overbought;
 
     switch (true) {
       case !hasResult:

--- a/packages/trading-signals/src/momentum/STOCHRSI/StochasticRSI.test.ts
+++ b/packages/trading-signals/src/momentum/STOCHRSI/StochasticRSI.test.ts
@@ -116,6 +116,25 @@ describe('StochasticRSI', () => {
       expect(signal.state).toBe(TradingSignal.UNKNOWN);
     });
 
+    it('respects custom overbought and oversold thresholds', () => {
+      const prices = [50, 51, 50.5, 51.5, 50.2, 51.8, 50.7, 51.2, 50.9, 51.1, 50.6, 51.4, 50.4, 51.6, 50.8] as const;
+      const smoothing = () => ({d: new SMA(3), k: new SMA(3)});
+      const sensitiveBull = new StochasticRSI(5, WSMA, smoothing(), {overbought: 0.2, oversold: 0.1});
+      const sensitiveBear = new StochasticRSI(5, WSMA, smoothing(), {oversold: 0.8});
+
+      for (const price of prices) {
+        sensitiveBull.add(price);
+        sensitiveBear.add(price);
+      }
+
+      const result = sensitiveBull.getResultOrThrow();
+
+      expect(result).toBeGreaterThan(0.2);
+      expect(result).toBeLessThan(0.8);
+      expect(sensitiveBull.getSignal().state).toBe(TradingSignal.BULLISH);
+      expect(sensitiveBear.getSignal().state).toBe(TradingSignal.BEARISH);
+    });
+
     it('returns UNKNOWN when StochRSI is in mid-range (between 0.2 and 0.8)', () => {
       const stochRSI = new StochasticRSI(5);
       // Sideways movement to produce mid-range RSI and StochRSI

--- a/packages/trading-signals/src/momentum/STOCHRSI/StochasticRSI.ts
+++ b/packages/trading-signals/src/momentum/STOCHRSI/StochasticRSI.ts
@@ -4,6 +4,7 @@ import {SMA} from '../../trend/SMA/SMA.js';
 import {WSMA} from '../../trend/WSMA/WSMA.js';
 import {TradingSignal, TrendIndicatorSeries} from '../../base/Indicator.js';
 import {Period} from '../../base/Period.js';
+import type {SignalThresholds} from '../../base/SignalThresholds.type.js';
 import {RSI} from '../RSI/RSI.js';
 
 /**
@@ -35,6 +36,9 @@ export class StochasticRSI extends TrendIndicatorSeries {
     readonly d: MovingAverage;
   };
 
+  readonly #overbought: number;
+  readonly #oversold: number;
+
   constructor(
     interval: number,
     SmoothingRSI: MovingAverageTypes = WSMA,
@@ -44,13 +48,16 @@ export class StochasticRSI extends TrendIndicatorSeries {
     } = {
       d: new SMA(3),
       k: new SMA(3),
-    }
+    },
+    {overbought = 0.8, oversold = 0.2}: SignalThresholds = {}
   ) {
     super();
     this.interval = interval;
     this.smoothing = smoothing;
     this.#period = new Period(interval);
     this.#rsi = new RSI(interval, SmoothingRSI);
+    this.#overbought = overbought;
+    this.#oversold = oversold;
   }
 
   override getRequiredInputs() {
@@ -84,8 +91,8 @@ export class StochasticRSI extends TrendIndicatorSeries {
 
   protected calculateSignalState(result?: number | null | undefined) {
     const hasResult = result !== null && result !== undefined;
-    const isOversold = hasResult && result <= 0.2;
-    const isOverbought = hasResult && result >= 0.8;
+    const isOversold = hasResult && result <= this.#oversold;
+    const isOverbought = hasResult && result >= this.#overbought;
 
     switch (true) {
       case !hasResult:

--- a/packages/trading-signals/src/momentum/WILLR/WilliamsR.test.ts
+++ b/packages/trading-signals/src/momentum/WILLR/WilliamsR.test.ts
@@ -68,7 +68,7 @@ describe('WilliamsR', () => {
        * Therefore: Williams %R = Stochastic %K - 100
        */
       const willR = new WilliamsR(5);
-      const stoch = new StochasticOscillator(5, 1, 1);
+      const stoch = new StochasticOscillator({dPeriod: 1, kPeriod: 5, kSlowingPeriod: 1});
 
       candles.forEach(candle => {
         const willRResult = willR.add(candle);

--- a/packages/trading-signals/src/momentum/WILLR/WilliamsR.test.ts
+++ b/packages/trading-signals/src/momentum/WILLR/WilliamsR.test.ts
@@ -132,6 +132,16 @@ describe('WilliamsR', () => {
       expect(signal).toBe(TradingSignal.UNKNOWN);
     });
 
+    it('respects custom overbought and oversold thresholds', () => {
+      const willR = new WilliamsR(14, {overbought: -10, oversold: -90});
+      const calculateSignalState = willR['calculateSignalState'].bind(willR);
+
+      expect(calculateSignalState(-20)).toBe(TradingSignal.SIDEWAYS);
+      expect(calculateSignalState(-10)).toBe(TradingSignal.BULLISH);
+      expect(calculateSignalState(-80)).toBe(TradingSignal.SIDEWAYS);
+      expect(calculateSignalState(-90)).toBe(TradingSignal.BEARISH);
+    });
+
     it('returns OVERBOUGHT when Williams %R >= -20', () => {
       const willR = new WilliamsR(14);
       const calculateSignalState = willR['calculateSignalState'].bind(willR);

--- a/packages/trading-signals/src/momentum/WILLR/WilliamsR.ts
+++ b/packages/trading-signals/src/momentum/WILLR/WilliamsR.ts
@@ -1,5 +1,6 @@
 import {TradingSignal, TrendIndicatorSeries} from '../../base/Indicator.js';
 import type {HighLowClose} from '../../base/Candle.type.js';
+import type {SignalThresholds} from '../../base/SignalThresholds.type.js';
 import {pushUpdate} from '../../util/pushUpdate.js';
 
 /**
@@ -22,10 +23,14 @@ export class WilliamsR extends TrendIndicatorSeries<HighLowClose<number>> {
   public readonly candles: HighLowClose<number>[] = [];
 
   public readonly interval: number;
+  readonly #overbought: number;
+  readonly #oversold: number;
 
-  constructor(interval: number) {
+  constructor(interval: number, {overbought = -20, oversold = -80}: SignalThresholds = {}) {
     super();
     this.interval = interval;
+    this.#overbought = overbought;
+    this.#oversold = oversold;
   }
 
   override getRequiredInputs() {
@@ -64,8 +69,8 @@ export class WilliamsR extends TrendIndicatorSeries<HighLowClose<number>> {
 
   protected calculateSignalState(result?: number | null | undefined) {
     const hasResult = result !== null && result !== undefined;
-    const isOverbought = hasResult && result >= -20;
-    const isOversold = hasResult && result <= -80;
+    const isOverbought = hasResult && result >= this.#overbought;
+    const isOversold = hasResult && result <= this.#oversold;
 
     switch (true) {
       case !hasResult:


### PR DESCRIPTION
## Summary

Follow-up to #1214: every oscillator with an arbitrary overbought/oversold territory now accepts custom thresholds, and StochasticOscillator's constructor becomes self-documenting.

### Configurable signal thresholds

New shared `SignalThresholds` type in `base/` (`{overbought?, oversold?}`), threaded through as an optional constructor parameter with the literature defaults preserved:

| Indicator | Defaults |
|---|---|
| RSI | 70 / 30 |
| STOCH | 80 / 20 |
| STOCHRSI | 0.8 / 0.2 |
| WILLR | −20 / −80 |
| CCI | +100 / −100 |
| REI | +60 / −60 |
| MFI | 80 / 20 (migrated from its own `MFIThresholds`) |
| ER | `ERThresholds` with single `trending` threshold (0.5) |

Thresholds are constructor-level rather than `getSignal()` arguments: `TrendIndicatorSeries` caches the previous signal state at `setResult()` time, so per-call thresholds would make `hasChanged` compare states computed under different rules.

Not touched (deliberately): zero-cross indicators (AO, AC, ROC, MOM, CMF, EMV, VROC), direction-vs-previous (OBV, AD, PVT), signal-line crossovers (CG, VWMA, MACD) — their thresholds are mathematically meaningful, not tunable territory.

### ⚠️ BREAKING: StochasticOscillator config object

```ts
// Before
new StochasticOscillator(5, 3, 3);

// After
new StochasticOscillator({dPeriod: 3, kPeriod: 5, kSlowingPeriod: 3}, {overbought: 90}); // thresholds optional
```

The cryptic `n/m/p` parameters (inherited from George Lane's notation) are replaced with self-documenting names in a `StochasticOscillatorConfig` object.

### Also

- Fixes the MFI class JSDoc, which had been accidentally attached to the `MFIThresholds` type instead of the class

## Tests

- One custom-threshold test per indicator (7 new tests), asserting exact results where deterministic (e.g. CCI 111.11, stochK 44.44, ER 0.75)
- 473/473 pass, coverage stays at 100%, tsc + ESLint clean
- All existing tests pass unchanged except STOCH call-site migration — defaults are fully backward compatible