### PR TITLE
feat(trading-signals): add Hull Moving Average (HMA)

### DIFF
--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -193,6 +193,7 @@ console.log(signal.hasChanged); // true if the signal state changed from the pre
 1. Ease of Movement (EMV)
 1. Exponential Moving Average (EMA)
 1. Efficiency Ratio (ER)
+1. Hull Moving Average (HMA)
 1. Interquartile Range (IQR)
 1. Linear Regression (LINREG)
 1. Mean Absolute Deviation (MAD)

--- a/packages/trading-signals/src/trend/HMA/HMA.test.ts
+++ b/packages/trading-signals/src/trend/HMA/HMA.test.ts
@@ -1,0 +1,78 @@
+import {HMA} from './HMA.js';
+import {NotEnoughDataError} from '../../error/index.js';
+
+describe('HMA', () => {
+  /*
+   * Test data verified with:
+   * https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt#L203-L205
+   */
+  const prices = [
+    81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84, 83.99, 84.55, 84.36, 85.53, 86.54, 86.89, 87.77, 87.29,
+  ] as const;
+  const expectations = [
+    '83.690',
+    '83.038',
+    '83.472',
+    '84.550',
+    '84.835',
+    '85.360',
+    '86.552',
+    '87.346',
+    '87.965',
+    '87.916',
+  ] as const;
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const hma = new HMA(5);
+
+      hma.updates(prices, false);
+
+      const originalValue = 90;
+      const replacedValue = 83;
+
+      const originalResult = hma.add(originalValue);
+
+      expect(originalResult?.toFixed(2)).toBe('89.26');
+
+      const replacedResult = hma.replace(replacedValue);
+
+      expect(replacedResult?.toFixed(2)).toBe('84.60');
+      expect(replacedResult).not.toBe(originalResult);
+
+      const restoredResult = hma.replace(originalValue);
+
+      expect(restoredResult).toBe(originalResult);
+    });
+  });
+
+  describe('getResultOrThrow', () => {
+    it('is compatible with results from Tulip Indicators (TI)', {tags: ['tulipindicators']}, () => {
+      const interval = 5;
+      const hma = new HMA(interval);
+      const offset = hma.getRequiredInputs() - 1;
+
+      prices.forEach((price, i) => {
+        const result = hma.add(price);
+
+        if (result) {
+          expect(result.toFixed(3)).toBe(expectations[i - offset]);
+        }
+      });
+
+      expect(hma.isStable).toBe(true);
+      expect(hma.getRequiredInputs()).toBe(6);
+    });
+
+    it('throws an error when there is not enough input data', () => {
+      const hma = new HMA(5);
+
+      try {
+        hma.getResultOrThrow();
+        throw new Error('Expected error');
+      } catch (error) {
+        expect(error).toBeInstanceOf(NotEnoughDataError);
+      }
+    });
+  });
+});

--- a/packages/trading-signals/src/trend/HMA/HMA.ts
+++ b/packages/trading-signals/src/trend/HMA/HMA.ts
@@ -1,0 +1,49 @@
+import {MovingAverage} from '../MA/MovingAverage.js';
+import {WMA} from '../WMA/WMA.js';
+
+/**
+ * Hull Moving Average (HMA)
+ * Type: Trend
+ *
+ * The Hull Moving Average was developed by Alan Hull to solve the classic moving average dilemma: smoothing out
+ * noise always adds lag, and reducing lag always adds noise. The HMA amplifies recent price action by subtracting a
+ * full-period WMA from a doubled half-period WMA, then smooths the result with a WMA over the square root of the
+ * interval — tracking price nearly in real time while staying smooth.
+ *
+ * The half and square-root periods are truncated to integers, matching Tulip Indicators.
+ *
+ * @see https://alanhull.com/hull-moving-average
+ * @see https://tulipindicators.org/hma
+ */
+export class HMA extends MovingAverage {
+  readonly #wmaHalf: WMA;
+  readonly #wmaFull: WMA;
+  readonly #wmaSqrt: WMA;
+
+  constructor(interval: number) {
+    super(interval);
+    this.#wmaHalf = new WMA(Math.floor(interval / 2));
+    this.#wmaFull = new WMA(interval);
+    this.#wmaSqrt = new WMA(Math.floor(Math.sqrt(interval)));
+  }
+
+  override getRequiredInputs() {
+    return this.#wmaFull.getRequiredInputs() + this.#wmaSqrt.getRequiredInputs() - 1;
+  }
+
+  update(price: number, replace: boolean) {
+    const half = this.#wmaHalf.update(price, replace);
+    const full = this.#wmaFull.update(price, replace);
+
+    if (half !== null && full !== null) {
+      const lagReduced = 2 * half - full;
+      const result = this.#wmaSqrt.update(lagReduced, replace);
+
+      if (result !== null) {
+        return this.setResult(result, replace);
+      }
+    }
+
+    return null;
+  }
+}

--- a/packages/trading-signals/src/trend/MA/MovingAverageTypes.ts
+++ b/packages/trading-signals/src/trend/MA/MovingAverageTypes.ts
@@ -1,7 +1,8 @@
 import type {EMA} from '../EMA/EMA.js';
+import type {HMA} from '../HMA/HMA.js';
 import type {RMA} from '../RMA/RMA.js';
 import type {SMA} from '../SMA/SMA.js';
 import type {WMA} from '../WMA/WMA.js';
 import type {WSMA} from '../WSMA/WSMA.js';
 
-export type MovingAverageTypes = typeof EMA | typeof RMA | typeof SMA | typeof WMA | typeof WSMA;
+export type MovingAverageTypes = typeof EMA | typeof HMA | typeof RMA | typeof SMA | typeof WMA | typeof WSMA;

--- a/packages/trading-signals/src/trend/index.ts
+++ b/packages/trading-signals/src/trend/index.ts
@@ -6,6 +6,7 @@ export * from './DMA/DMA.js';
 export * from './DX/DX.js';
 export * from './EMA/EMA.js';
 export * from './HIGHER_LOW_TRAIL/HigherLowTrail.js';
+export * from './HMA/HMA.js';
 export * from './LINREG/LinearRegression.js';
 export * from './MA/MovingAverage.js';
 export * from './PSAR/PSAR.js';


### PR DESCRIPTION
## Summary

Implements [Alan Hull's Hull Moving Average](https://alanhull.com/hull-moving-average) — the answer to the moving-average dilemma that smoothing adds lag and lag-reduction adds noise: `WMA(√n)` applied to `2·WMA(⌊n/2⌋) − WMA(n)`.

- `HMA` in `src/trend/HMA/` extending `MovingAverage`, composed entirely from the existing `WMA` class — no bespoke math
- Integer conventions (`⌊n/2⌋`, `⌊√n⌋`) match Tulip Indicators and are locked in by the reference vector
- Warm-up: `n + ⌊√n⌋ − 1` candles; `replace()` propagates naturally through the windowed WMA chain
- Added to `MovingAverageTypes`, so it can be plugged in as a smoothing indicator anywhere the MA family is accepted (e.g. `new RSI(14, HMA)`)
- Overlay, not an oscillator — deliberately no signal logic

## Tests

- Verified against [Tulip's `hma 5` reference vector](https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt#L203-L205) (15 prices → 10 outputs, exact at 3 decimals), tagged `tulipindicators` — an independent reimplementation reproduced the vector before the class was tested against it
- Exact-value bidirectional replace (89.26 → 84.60 → restored) exercising replace propagation through all three chained WMAs
- `NotEnoughDataError` before warm-up
- 486/486 tests, coverage stays at 100%