### PR TITLE
feat(trading-signals): add Chande Momentum Oscillator (CMO)

### DIFF
--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -193,6 +193,7 @@ console.log(signal.hasChanged); // true if the signal state changed from the pre
 1. Ease of Movement (EMV)
 1. Exponential Moving Average (EMA)
 1. Efficiency Ratio (ER)
+1. Hull Moving Average (HMA)
 1. Interquartile Range (IQR)
 1. Linear Regression (LINREG)
 1. Mean Absolute Deviation (MAD)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -186,6 +186,7 @@ console.log(signal.hasChanged); // true if the signal state changed from the pre
 1. Bollinger Bands Width (BBW)
 1. Center of Gravity (CG)
 1. Chaikin Money Flow (CMF)
+1. Chande Momentum Oscillator (CMO)
 1. Commodity Channel Index (CCI)
 1. Directional Movement Index (DMI / DX)
 1. Double Exponential Moving Average (DEMA)

--- a/packages/trading-signals/src/momentum/CMO/CMO.test.ts
+++ b/packages/trading-signals/src/momentum/CMO/CMO.test.ts
@@ -1,0 +1,143 @@
+import {CMO} from './CMO.js';
+import {NotEnoughDataError} from '../../error/index.js';
+import {TradingSignal} from '../../base/index.js';
+
+describe('CMO', () => {
+  /*
+   * Test data verified with:
+   * https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt#L109-L111
+   */
+  const prices = [
+    81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84, 83.99, 84.55, 84.36, 85.53, 86.54, 86.89, 87.77, 87.29,
+  ] as const;
+  const expectations = [
+    '44.068',
+    '53.614',
+    '42.105',
+    '50.162',
+    '28.090',
+    '70.414',
+    '90.686',
+    '88.415',
+    '89.444',
+    '75.321',
+  ] as const;
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const cmo = new CMO(5);
+
+      cmo.updates(prices, false);
+
+      const originalValue = 90;
+      const replacedValue = 83;
+
+      const originalResult = cmo.add(originalValue);
+
+      expect(originalResult?.toFixed(2)).toBe('82.32');
+
+      const replacedResult = cmo.replace(replacedValue);
+
+      expect(replacedResult?.toFixed(2)).toBe('-36.09');
+      expect(replacedResult).not.toBe(originalResult);
+
+      const restoredResult = cmo.replace(originalValue);
+
+      expect(restoredResult).toBe(originalResult);
+    });
+  });
+
+  describe('getResultOrThrow', () => {
+    it('is compatible with results from Tulip Indicators (TI)', {tags: ['tulipindicators']}, () => {
+      const interval = 5;
+      const cmo = new CMO(interval);
+      const offset = cmo.getRequiredInputs() - 1;
+
+      prices.forEach((price, i) => {
+        const result = cmo.add(price);
+
+        if (result) {
+          expect(result.toFixed(3)).toBe(expectations[i - offset]);
+        }
+      });
+
+      expect(cmo.isStable).toBe(true);
+      expect(cmo.getRequiredInputs()).toBe(interval + 1);
+    });
+
+    it('returns zero when the market has no momentum in either direction', () => {
+      const cmo = new CMO(5);
+
+      for (let i = 0; i < 6; i++) {
+        cmo.add(100);
+      }
+
+      expect(cmo.getResultOrThrow()).toBe(0);
+    });
+
+    it('throws an error when there is not enough input data', () => {
+      const cmo = new CMO(5);
+
+      try {
+        cmo.getResultOrThrow();
+        throw new Error('Expected error');
+      } catch (error) {
+        expect(error).toBeInstanceOf(NotEnoughDataError);
+      }
+    });
+  });
+
+  describe('getSignal', () => {
+    it('returns UNKNOWN when there is no result', () => {
+      const cmo = new CMO(5);
+
+      expect(cmo.getSignal().state).toBe(TradingSignal.UNKNOWN);
+    });
+
+    it('returns BULLISH when all price changes are gains', () => {
+      const cmo = new CMO(5);
+
+      for (let i = 0; i < 6; i++) {
+        cmo.add(100 + i);
+      }
+
+      expect(cmo.getResultOrThrow()).toBe(100);
+      expect(cmo.getSignal().state).toBe(TradingSignal.BULLISH);
+    });
+
+    it('returns BEARISH when all price changes are losses', () => {
+      const cmo = new CMO(5);
+
+      for (let i = 0; i < 6; i++) {
+        cmo.add(100 - i);
+      }
+
+      expect(cmo.getResultOrThrow()).toBe(-100);
+      expect(cmo.getSignal().state).toBe(TradingSignal.BEARISH);
+    });
+
+    it('returns SIDEWAYS when the CMO is between the oversold and overbought thresholds', () => {
+      const cmo = new CMO(5);
+
+      for (let i = 0; i < 6; i++) {
+        cmo.add(100);
+      }
+
+      expect(cmo.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+    });
+
+    it('respects custom overbought and oversold thresholds', () => {
+      const sensitiveBull = new CMO(5, {overbought: 0});
+      const sensitiveBear = new CMO(5, {oversold: 0});
+
+      for (let i = 0; i < 6; i++) {
+        sensitiveBull.add(100);
+        sensitiveBear.add(100);
+      }
+
+      expect(sensitiveBull.getResultOrThrow()).toBe(0);
+      expect(sensitiveBull.getSignal().state).toBe(TradingSignal.BULLISH);
+      expect(sensitiveBear.getSignal().state).toBe(TradingSignal.BEARISH);
+    });
+  });
+});

--- a/packages/trading-signals/src/momentum/CMO/CMO.ts
+++ b/packages/trading-signals/src/momentum/CMO/CMO.ts
@@ -1,0 +1,85 @@
+import {TradingSignal, TrendIndicatorSeries} from '../../base/Indicator.js';
+import type {SignalThresholds} from '../../base/SignalThresholds.type.js';
+import {pushUpdate} from '../../util/pushUpdate.js';
+
+/**
+ * Chande Momentum Oscillator (CMO)
+ * Type: Momentum
+ *
+ * The Chande Momentum Oscillator was developed by Tushar Chande and relates the sum of gains to the sum of losses
+ * over the interval. Unlike the RSI, which smooths both sides, the CMO uses the raw sums and keeps losses in the
+ * denominator alongside gains — making it react faster and swing symmetrically between -100 and +100.
+ *
+ * Interpretation:
+ * A value of +50 or above indicates an overbought condition, -50 or below indicates an oversold condition (both
+ * thresholds can be customized via the constructor). Chande also used the absolute CMO level as a trend-strength
+ * filter: the further from zero, the stronger the trend.
+ *
+ * @see https://www.investopedia.com/terms/c/chandemomentumoscillator.asp
+ * @see https://tulipindicators.org/cmo
+ */
+export class CMO extends TrendIndicatorSeries {
+  readonly #prices: number[] = [];
+  readonly #overbought: number;
+  readonly #oversold: number;
+
+  public readonly interval: number;
+
+  constructor(interval: number, {overbought = 50, oversold = -50}: SignalThresholds = {}) {
+    super();
+    this.interval = interval;
+    this.#overbought = overbought;
+    this.#oversold = oversold;
+  }
+
+  override getRequiredInputs() {
+    return this.interval + 1;
+  }
+
+  update(price: number, replace: boolean) {
+    pushUpdate(this.#prices, replace, price, this.getRequiredInputs());
+
+    if (this.#prices.length < this.getRequiredInputs()) {
+      return null;
+    }
+
+    let gains = 0;
+    let losses = 0;
+
+    for (let i = 1; i < this.#prices.length; i++) {
+      const change = this.#prices[i] - this.#prices[i - 1];
+
+      if (change > 0) {
+        gains += change;
+      } else {
+        losses -= change;
+      }
+    }
+
+    const total = gains + losses;
+
+    // A completely flat market has no momentum in either direction
+    if (total === 0) {
+      return this.setResult(0, replace);
+    }
+
+    return this.setResult((100 * (gains - losses)) / total, replace);
+  }
+
+  protected calculateSignalState(result: number | null | undefined) {
+    const hasResult = result !== null && result !== undefined;
+    const isOversold = hasResult && result <= this.#oversold;
+    const isOverbought = hasResult && result >= this.#overbought;
+
+    switch (true) {
+      case !hasResult:
+        return TradingSignal.UNKNOWN;
+      case isOversold:
+        return TradingSignal.BEARISH;
+      case isOverbought:
+        return TradingSignal.BULLISH;
+      default:
+        return TradingSignal.SIDEWAYS;
+    }
+  }
+}

--- a/packages/trading-signals/src/momentum/index.ts
+++ b/packages/trading-signals/src/momentum/index.ts
@@ -2,6 +2,7 @@ export * from './AC/AC.js';
 export * from './AO/AO.js';
 export * from './CCI/CCI.js';
 export * from './CG/CG.js';
+export * from './CMO/CMO.js';
 export * from './ER/ER.js';
 export * from './MACD/MACD.js';
 export * from './MFI/MFI.js';

--- a/packages/trading-signals/src/trend/HMA/HMA.test.ts
+++ b/packages/trading-signals/src/trend/HMA/HMA.test.ts
@@ -1,0 +1,78 @@
+import {HMA} from './HMA.js';
+import {NotEnoughDataError} from '../../error/index.js';
+
+describe('HMA', () => {
+  /*
+   * Test data verified with:
+   * https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt#L203-L205
+   */
+  const prices = [
+    81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84, 83.99, 84.55, 84.36, 85.53, 86.54, 86.89, 87.77, 87.29,
+  ] as const;
+  const expectations = [
+    '83.690',
+    '83.038',
+    '83.472',
+    '84.550',
+    '84.835',
+    '85.360',
+    '86.552',
+    '87.346',
+    '87.965',
+    '87.916',
+  ] as const;
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const hma = new HMA(5);
+
+      hma.updates(prices, false);
+
+      const originalValue = 90;
+      const replacedValue = 83;
+
+      const originalResult = hma.add(originalValue);
+
+      expect(originalResult?.toFixed(2)).toBe('89.26');
+
+      const replacedResult = hma.replace(replacedValue);
+
+      expect(replacedResult?.toFixed(2)).toBe('84.60');
+      expect(replacedResult).not.toBe(originalResult);
+
+      const restoredResult = hma.replace(originalValue);
+
+      expect(restoredResult).toBe(originalResult);
+    });
+  });
+
+  describe('getResultOrThrow', () => {
+    it('is compatible with results from Tulip Indicators (TI)', {tags: ['tulipindicators']}, () => {
+      const interval = 5;
+      const hma = new HMA(interval);
+      const offset = hma.getRequiredInputs() - 1;
+
+      prices.forEach((price, i) => {
+        const result = hma.add(price);
+
+        if (result) {
+          expect(result.toFixed(3)).toBe(expectations[i - offset]);
+        }
+      });
+
+      expect(hma.isStable).toBe(true);
+      expect(hma.getRequiredInputs()).toBe(6);
+    });
+
+    it('throws an error when there is not enough input data', () => {
+      const hma = new HMA(5);
+
+      try {
+        hma.getResultOrThrow();
+        throw new Error('Expected error');
+      } catch (error) {
+        expect(error).toBeInstanceOf(NotEnoughDataError);
+      }
+    });
+  });
+});

--- a/packages/trading-signals/src/trend/HMA/HMA.ts
+++ b/packages/trading-signals/src/trend/HMA/HMA.ts
@@ -1,0 +1,49 @@
+import {MovingAverage} from '../MA/MovingAverage.js';
+import {WMA} from '../WMA/WMA.js';
+
+/**
+ * Hull Moving Average (HMA)
+ * Type: Trend
+ *
+ * The Hull Moving Average was developed by Alan Hull to solve the classic moving average dilemma: smoothing out
+ * noise always adds lag, and reducing lag always adds noise. The HMA amplifies recent price action by subtracting a
+ * full-period WMA from a doubled half-period WMA, then smooths the result with a WMA over the square root of the
+ * interval — tracking price nearly in real time while staying smooth.
+ *
+ * The half and square-root periods are truncated to integers, matching Tulip Indicators.
+ *
+ * @see https://alanhull.com/hull-moving-average
+ * @see https://tulipindicators.org/hma
+ */
+export class HMA extends MovingAverage {
+  readonly #wmaHalf: WMA;
+  readonly #wmaFull: WMA;
+  readonly #wmaSqrt: WMA;
+
+  constructor(interval: number) {
+    super(interval);
+    this.#wmaHalf = new WMA(Math.floor(interval / 2));
+    this.#wmaFull = new WMA(interval);
+    this.#wmaSqrt = new WMA(Math.floor(Math.sqrt(interval)));
+  }
+
+  override getRequiredInputs() {
+    return this.#wmaFull.getRequiredInputs() + this.#wmaSqrt.getRequiredInputs() - 1;
+  }
+
+  update(price: number, replace: boolean) {
+    const half = this.#wmaHalf.update(price, replace);
+    const full = this.#wmaFull.update(price, replace);
+
+    if (half !== null && full !== null) {
+      const lagReduced = 2 * half - full;
+      const result = this.#wmaSqrt.update(lagReduced, replace);
+
+      if (result !== null) {
+        return this.setResult(result, replace);
+      }
+    }
+
+    return null;
+  }
+}

--- a/packages/trading-signals/src/trend/MA/MovingAverageTypes.ts
+++ b/packages/trading-signals/src/trend/MA/MovingAverageTypes.ts
@@ -1,7 +1,8 @@
 import type {EMA} from '../EMA/EMA.js';
+import type {HMA} from '../HMA/HMA.js';
 import type {RMA} from '../RMA/RMA.js';
 import type {SMA} from '../SMA/SMA.js';
 import type {WMA} from '../WMA/WMA.js';
 import type {WSMA} from '../WSMA/WSMA.js';
 
-export type MovingAverageTypes = typeof EMA | typeof RMA | typeof SMA | typeof WMA | typeof WSMA;
+export type MovingAverageTypes = typeof EMA | typeof HMA | typeof RMA | typeof SMA | typeof WMA | typeof WSMA;

--- a/packages/trading-signals/src/trend/index.ts
+++ b/packages/trading-signals/src/trend/index.ts
@@ -6,6 +6,7 @@ export * from './DMA/DMA.js';
 export * from './DX/DX.js';
 export * from './EMA/EMA.js';
 export * from './HIGHER_LOW_TRAIL/HigherLowTrail.js';
+export * from './HMA/HMA.js';
 export * from './LINREG/LinearRegression.js';
 export * from './MA/MovingAverage.js';
 export * from './PSAR/PSAR.js';


### PR DESCRIPTION
## Summary

Implements [Tushar Chande's Momentum Oscillator](https://www.investopedia.com/terms/c/chandemomentumoscillator.asp) — the sum of gains related to the sum of losses over the interval. Unlike the RSI it uses raw sums and keeps both sides in the denominator, making it faster and symmetric between −100 and +100.

- `CMO` in `src/momentum/CMO/` extending `TrendIndicatorSeries`, shared `SignalThresholds` (±50)
- Pure function of the price window (warm-up `interval + 1`) — `replace()` via `pushUpdate`
- Flat-market guard: zero total movement → 0

## Tests (8)

- Verified against [Tulip `cmo 5`](https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt#L109-L111) (15 prices → 10 outputs, exact at 3 decimals), tagged `tulipindicators`, independently reproduced before testing the class
- Exact-value bidirectional replace (82.32 → −36.09 → restored), flat-market zero, `NotEnoughDataError`, all four signal states (±100 extremes asserted exactly), custom thresholds
- 495/495 tests, 100% coverage

Part of the indicator batch (CMO → KAMA → NATR → PPO → TEMA → TRIX → ADOSC), each as its own PR off `main`.