### PR TITLE
feat(trading-signals): add Kaufman's Adaptive Moving Average (KAMA)

### DIFF
--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -196,6 +196,7 @@ console.log(signal.hasChanged); // true if the signal state changed from the pre
 1. Efficiency Ratio (ER)
 1. Hull Moving Average (HMA)
 1. Interquartile Range (IQR)
+1. Kaufman's Adaptive Moving Average (KAMA)
 1. Linear Regression (LINREG)
 1. Mean Absolute Deviation (MAD)
 1. Momentum (MOM / MTM)

--- a/packages/trading-signals/src/trend/KAMA/KAMA.test.ts
+++ b/packages/trading-signals/src/trend/KAMA/KAMA.test.ts
@@ -1,0 +1,89 @@
+import {KAMA} from './KAMA.js';
+import {NotEnoughDataError} from '../../error/index.js';
+
+describe('KAMA', () => {
+  /*
+   * Test data verified with:
+   * https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt#L207-L209
+   */
+  const prices = [
+    81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84, 83.99, 84.55, 84.36, 85.53, 86.54, 86.89, 87.77, 87.29,
+  ] as const;
+  const expectations = [
+    '83.610',
+    '83.560',
+    '83.452',
+    '83.506',
+    '83.647',
+    '83.686',
+    '84.126',
+    '85.026',
+    '85.690',
+    '86.447',
+    '86.673',
+  ] as const;
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const kama = new KAMA(5);
+
+      kama.updates(prices, false);
+
+      const originalValue = 90;
+      const replacedValue = 83;
+
+      const originalResult = kama.add(originalValue);
+
+      expect(originalResult?.toFixed(2)).toBe('87.72');
+
+      const replacedResult = kama.replace(replacedValue);
+
+      expect(replacedResult?.toFixed(2)).toBe('86.38');
+      expect(replacedResult).not.toBe(originalResult);
+
+      const restoredResult = kama.replace(originalValue);
+
+      expect(restoredResult).toBe(originalResult);
+    });
+  });
+
+  describe('getResultOrThrow', () => {
+    it('is compatible with results from Tulip Indicators (TI)', {tags: ['tulipindicators']}, () => {
+      const interval = 5;
+      const kama = new KAMA(interval);
+      const offset = kama.getRequiredInputs() - 1;
+
+      prices.forEach((price, i) => {
+        const result = kama.add(price);
+
+        if (result) {
+          expect(result.toFixed(3)).toBe(expectations[i - offset]);
+        }
+      });
+
+      expect(kama.isStable).toBe(true);
+      expect(kama.getRequiredInputs()).toBe(interval);
+    });
+
+    it('stays on the price level when the market is completely flat', () => {
+      const kama = new KAMA(5);
+
+      for (let i = 0; i < 8; i++) {
+        kama.add(100);
+      }
+
+      expect(kama.getResultOrThrow()).toBe(100);
+    });
+
+    it('throws an error when there is not enough input data', () => {
+      const kama = new KAMA(5);
+
+      try {
+        kama.getResultOrThrow();
+        throw new Error('Expected error');
+      } catch (error) {
+        expect(error).toBeInstanceOf(NotEnoughDataError);
+      }
+    });
+  });
+});

--- a/packages/trading-signals/src/trend/KAMA/KAMA.ts
+++ b/packages/trading-signals/src/trend/KAMA/KAMA.ts
@@ -1,0 +1,54 @@
+import {MovingAverage} from '../MA/MovingAverage.js';
+import {pushUpdate} from '../../util/pushUpdate.js';
+
+/**
+ * Kaufman's Adaptive Moving Average (KAMA)
+ * Type: Trend
+ *
+ * KAMA was developed by Perry Kaufman to solve the fixed-speed problem of ordinary moving averages: a fast MA whipsaws
+ * in sideways markets, a slow MA lags in trends. KAMA measures how efficiently price traveled over the interval
+ * (net change relative to the sum of all interim moves) and adapts its smoothing between a fast EMA constant (2
+ * periods) in clean trends and a slow one (30 periods) in noise.
+ *
+ * The first result seeds with the closing price of the first full window, matching Tulip Indicators.
+ *
+ * @see https://www.investopedia.com/terms/k/kaufmansadaptivemovingaverage.asp
+ * @see https://tulipindicators.org/kama
+ */
+export class KAMA extends MovingAverage {
+  static readonly #FAST = 2 / (2 + 1);
+  static readonly #SLOW = 2 / (30 + 1);
+
+  readonly #prices: number[] = [];
+
+  override getRequiredInputs() {
+    return this.interval;
+  }
+
+  update(price: number, replace: boolean) {
+    pushUpdate(this.#prices, replace, price, this.interval + 1);
+
+    if (this.#prices.length < this.interval) {
+      return null;
+    }
+
+    if (this.#prices.length === this.interval) {
+      return this.setResult(price, replace);
+    }
+
+    let volatility = 0;
+
+    for (let i = 1; i < this.#prices.length; i++) {
+      volatility += Math.abs(this.#prices[i] - this.#prices[i - 1]);
+    }
+
+    const netChange = Math.abs(price - this.#prices[0]);
+    // A flat window is perfectly efficient: there was no noise to smooth out
+    const efficiencyRatio = volatility === 0 ? 1 : netChange / volatility;
+    const smoothing = (efficiencyRatio * (KAMA.#FAST - KAMA.#SLOW) + KAMA.#SLOW) ** 2;
+    // Guaranteed to exist: the seed result was set as soon as the first window filled up
+    const previous = (replace ? this.previousResult : this.result) as number;
+
+    return this.setResult(previous + smoothing * (price - previous), replace);
+  }
+}

--- a/packages/trading-signals/src/trend/index.ts
+++ b/packages/trading-signals/src/trend/index.ts
@@ -7,6 +7,7 @@ export * from './DX/DX.js';
 export * from './EMA/EMA.js';
 export * from './HIGHER_LOW_TRAIL/HigherLowTrail.js';
 export * from './HMA/HMA.js';
+export * from './KAMA/KAMA.js';
 export * from './LINREG/LinearRegression.js';
 export * from './MA/MovingAverage.js';
 export * from './PSAR/PSAR.js';


### PR DESCRIPTION
## Summary

Implements [Perry Kaufman's Adaptive Moving Average](https://www.investopedia.com/terms/k/kaufmansadaptivemovingaverage.asp) — the answer to the fixed-speed MA problem: it measures how efficiently price traveled over the interval (net change ÷ sum of interim moves) and adapts smoothing between a fast EMA constant (2) in clean trends and a slow one (30) in noise.

- `KAMA` in `src/trend/KAMA/` extending `MovingAverage`
- Seeds with the first full window's closing price, matching Tulip
- Recursive with replace support via `previousResult` (same mechanism as EMA)
- Flat-market edge: zero volatility counts as perfectly efficient (ER = 1), so KAMA stays glued to the price
- Note: KAMA's efficiency ratio is close-to-close based — deliberately distinct from the library's range-based `ER` indicator

## Tests (4)

- Verified against [Tulip `kama 5`](https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt#L207-L209) (15 prices → 11 outputs incl. the seed, exact at 3 decimals), tagged `tulipindicators`, independently reproduced first
- Exact-value bidirectional replace (87.72 → 86.38 → restored) through the recursive state
- Flat-market test (covers the zero-volatility branch), `NotEnoughDataError`
- 487/487 tests, 100% coverage

Part of the indicator batch (CMO → KAMA → NATR → PPO → TEMA → TRIX → ADOSC), each as its own PR off `main`.