### PR TITLE
feat(trading-signals): add Normalized Average True Range (NATR)

### DIFF
--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -199,6 +199,7 @@ console.log(signal.hasChanged); // true if the signal state changed from the pre
 1. Momentum (MOM / MTM)
 1. Money Flow Index (MFI)
 1. Moving Average Convergence Divergence (MACD)
+1. Normalized Average True Range (NATR)
 1. On-Balance Volume (OBV)
 1. Parabolic SAR (PSAR)
 1. Price Volume Trend (PVT)

--- a/packages/trading-signals/src/volatility/NATR/NATR.test.ts
+++ b/packages/trading-signals/src/volatility/NATR/NATR.test.ts
@@ -1,0 +1,93 @@
+import {NATR} from './NATR.js';
+import {NotEnoughDataError} from '../../error/index.js';
+
+describe('NATR', () => {
+  /*
+   * Test data verified with:
+   * https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt#L297-L301
+   */
+  const candles = [
+    {close: 81.59, high: 82.15, low: 81.29},
+    {close: 81.06, high: 81.89, low: 80.64},
+    {close: 82.87, high: 83.03, low: 81.31},
+    {close: 83.0, high: 83.3, low: 82.65},
+    {close: 83.61, high: 83.85, low: 83.07},
+    {close: 83.15, high: 83.9, low: 83.11},
+    {close: 82.84, high: 83.33, low: 82.49},
+    {close: 83.99, high: 84.3, low: 82.3},
+    {close: 84.55, high: 84.84, low: 84.15},
+    {close: 84.36, high: 85.0, low: 84.11},
+    {close: 85.53, high: 85.9, low: 84.03},
+    {close: 86.54, high: 86.58, low: 85.39},
+    {close: 86.89, high: 86.98, low: 85.76},
+    {close: 87.77, high: 88.0, low: 87.17},
+    {close: 87.29, high: 87.87, low: 87.01},
+  ] as const;
+  const expectations = [
+    '1.335',
+    '1.264',
+    '1.218',
+    '1.437',
+    '1.343',
+    '1.288',
+    '1.453',
+    '1.424',
+    '1.416',
+    '1.374',
+    '1.302',
+  ] as const;
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const natr = new NATR(5);
+
+      natr.updates(candles, false);
+
+      const originalValue = {close: 89.0, high: 90.0, low: 88.0} as const;
+      const replacedValue = {close: 83.0, high: 84.0, low: 82.0} as const;
+
+      const originalResult = natr.add(originalValue);
+
+      expect(originalResult?.toFixed(2)).toBe('1.63');
+
+      const replacedResult = natr.replace(replacedValue);
+
+      expect(replacedResult?.toFixed(2)).toBe('2.37');
+      expect(replacedResult).not.toBe(originalResult);
+
+      const restoredResult = natr.replace(originalValue);
+
+      expect(restoredResult).toBe(originalResult);
+    });
+  });
+
+  describe('getResultOrThrow', () => {
+    it('is compatible with results from Tulip Indicators (TI)', {tags: ['tulipindicators']}, () => {
+      const interval = 5;
+      const natr = new NATR(interval);
+      const offset = natr.getRequiredInputs() - 1;
+
+      candles.forEach((candle, i) => {
+        const result = natr.add(candle);
+
+        if (result) {
+          expect(result.toFixed(3)).toBe(expectations[i - offset]);
+        }
+      });
+
+      expect(natr.isStable).toBe(true);
+      expect(natr.getRequiredInputs()).toBe(interval);
+    });
+
+    it('throws an error when there is not enough input data', () => {
+      const natr = new NATR(5);
+
+      try {
+        natr.getResultOrThrow();
+        throw new Error('Expected error');
+      } catch (error) {
+        expect(error).toBeInstanceOf(NotEnoughDataError);
+      }
+    });
+  });
+});

--- a/packages/trading-signals/src/volatility/NATR/NATR.ts
+++ b/packages/trading-signals/src/volatility/NATR/NATR.ts
@@ -1,0 +1,42 @@
+import type {HighLowClose} from '../../base/Candle.type.js';
+import {IndicatorSeries} from '../../base/Indicator.js';
+import type {MovingAverageTypes} from '../../trend/MA/MovingAverageTypes.js';
+import {WSMA} from '../../trend/WSMA/WSMA.js';
+import {ATR} from '../ATR/ATR.js';
+
+/**
+ * Normalized Average True Range (NATR)
+ * Type: Volatility
+ *
+ * Makes volatility comparable across instruments: a raw $5 ATR means nothing without the price level — it's huge for
+ * a $50 stock and noise for a $5,000 one. The NATR expresses the ATR as a percentage of the closing price, so
+ * readings compare directly between differently priced assets and across long time ranges of the same asset.
+ *
+ * @see https://www.investopedia.com/terms/a/atr.asp
+ * @see https://tulipindicators.org/natr
+ */
+export class NATR extends IndicatorSeries<HighLowClose<number>> {
+  readonly #atr: ATR;
+
+  public readonly interval: number;
+
+  constructor(interval: number, SmoothingIndicator: MovingAverageTypes = WSMA) {
+    super();
+    this.interval = interval;
+    this.#atr = new ATR(interval, SmoothingIndicator);
+  }
+
+  override getRequiredInputs() {
+    return this.#atr.getRequiredInputs();
+  }
+
+  update(candle: HighLowClose<number>, replace: boolean) {
+    const atr = this.#atr.update(candle, replace);
+
+    if (atr === null) {
+      return null;
+    }
+
+    return this.setResult((100 * atr) / candle.close, replace);
+  }
+}

--- a/packages/trading-signals/src/volatility/index.ts
+++ b/packages/trading-signals/src/volatility/index.ts
@@ -4,4 +4,5 @@ export * from './BBANDS/BollingerBands.js';
 export * from './BBW/BollingerBandsWidth.js';
 export * from './IQR/IQR.js';
 export * from './MAD/MAD.js';
+export * from './NATR/NATR.js';
 export * from './TR/TR.js';


### PR DESCRIPTION
## Summary

Implements the Normalized ATR — the ATR expressed as a percentage of the closing price, so volatility compares directly between a $7 and a $700 instrument.

- `NATR` in `src/volatility/NATR/` extending `IndicatorSeries<HighLowClose<number>>`, composed from the existing `ATR` (default Wilder's smoothing, `MovingAverageTypes`-customizable like ATR)
- Overlay-style volatility measure — no signal logic
- `replace()` delegates to ATR's existing replace handling

## Tests (3)

- Verified against [Tulip `natr 5`](https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt#L297-L301) (15 candles → 11 outputs, exact at 3 decimals), tagged `tulipindicators`, independently reproduced first
- Exact-value bidirectional replace (1.63 → 2.37 → restored), `NotEnoughDataError`
- 486/486 tests, 100% coverage

Part of the indicator batch (CMO → KAMA → NATR → PPO → TEMA → TRIX → ADOSC), each as its own PR off `main`.