### PR TITLE
feat(trading-signals): add Percentage Price Oscillator (PPO)

### DIFF
--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -201,6 +201,7 @@ console.log(signal.hasChanged); // true if the signal state changed from the pre
 1. Moving Average Convergence Divergence (MACD)
 1. On-Balance Volume (OBV)
 1. Parabolic SAR (PSAR)
+1. Percentage Price Oscillator (PPO)
 1. Price Volume Trend (PVT)
 1. Range Expansion Index (REI)
 1. Rate-of-Change (ROC)

--- a/packages/trading-signals/src/momentum/PPO/PPO.test.ts
+++ b/packages/trading-signals/src/momentum/PPO/PPO.test.ts
@@ -1,0 +1,123 @@
+import {PPO} from './PPO.js';
+import {NotEnoughDataError} from '../../error/index.js';
+import {TradingSignal} from '../../base/index.js';
+
+describe('PPO', () => {
+  /*
+   * Test data verified with:
+   * https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt#L313-L315
+   *
+   * Tulip emits results from the 2nd candle onward; this implementation waits until the slow
+   * EMA is stable, so the first three Tulip values are skipped and the remaining ones match.
+   */
+  const prices = [
+    81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84, 83.99, 84.55, 84.36, 85.53, 86.54, 86.89, 87.77, 87.29,
+  ] as const;
+  const expectations = [
+    '0.747',
+    '0.424',
+    '0.134',
+    '0.500',
+    '0.691',
+    '0.503',
+    '0.810',
+    '1.088',
+    '1.040',
+    '1.133',
+    '0.716',
+  ] as const;
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const ppo = new PPO({fastPeriod: 2, slowPeriod: 5});
+
+      ppo.updates(prices, false);
+
+      const originalValue = 90;
+      const replacedValue = 83;
+
+      const originalResult = ppo.add(originalValue);
+
+      expect(originalResult?.toFixed(2)).toBe('1.49');
+
+      const replacedResult = ppo.replace(replacedValue);
+
+      expect(replacedResult?.toFixed(2)).toBe('-1.20');
+      expect(replacedResult).not.toBe(originalResult);
+
+      const restoredResult = ppo.replace(originalValue);
+
+      expect(restoredResult).toBe(originalResult);
+    });
+  });
+
+  describe('getResultOrThrow', () => {
+    it('is compatible with results from Tulip Indicators (TI)', {tags: ['tulipindicators']}, () => {
+      const ppo = new PPO({fastPeriod: 2, slowPeriod: 5});
+      const offset = ppo.getRequiredInputs() - 1;
+
+      prices.forEach((price, i) => {
+        const result = ppo.add(price);
+
+        if (result) {
+          expect(result.toFixed(3)).toBe(expectations[i - offset]);
+        }
+      });
+
+      expect(ppo.isStable).toBe(true);
+      expect(ppo.getRequiredInputs()).toBe(5);
+    });
+
+    it('throws an error when there is not enough input data', () => {
+      const ppo = new PPO();
+
+      try {
+        ppo.getResultOrThrow();
+        throw new Error('Expected error');
+      } catch (error) {
+        expect(error).toBeInstanceOf(NotEnoughDataError);
+      }
+    });
+  });
+
+  describe('getSignal', () => {
+    it('returns UNKNOWN when there is no result', () => {
+      const ppo = new PPO();
+
+      expect(ppo.getSignal().state).toBe(TradingSignal.UNKNOWN);
+    });
+
+    it('returns BULLISH when the fast EMA is above the slow EMA', () => {
+      const ppo = new PPO({fastPeriod: 2, slowPeriod: 5});
+
+      for (let i = 0; i < 6; i++) {
+        ppo.add(100 + i);
+      }
+
+      expect(ppo.getResultOrThrow()).toBeGreaterThan(0);
+      expect(ppo.getSignal().state).toBe(TradingSignal.BULLISH);
+    });
+
+    it('returns BEARISH when the fast EMA is below the slow EMA', () => {
+      const ppo = new PPO({fastPeriod: 2, slowPeriod: 5});
+
+      for (let i = 0; i < 6; i++) {
+        ppo.add(100 - i);
+      }
+
+      expect(ppo.getResultOrThrow()).toBeLessThan(0);
+      expect(ppo.getSignal().state).toBe(TradingSignal.BEARISH);
+    });
+
+    it('returns SIDEWAYS when the fast and slow EMA are equal', () => {
+      const ppo = new PPO({fastPeriod: 2, slowPeriod: 5});
+
+      for (let i = 0; i < 6; i++) {
+        ppo.add(100);
+      }
+
+      expect(ppo.getResultOrThrow()).toBe(0);
+      expect(ppo.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+    });
+  });
+});

--- a/packages/trading-signals/src/momentum/PPO/PPO.ts
+++ b/packages/trading-signals/src/momentum/PPO/PPO.ts
@@ -1,0 +1,69 @@
+import {TradingSignal, TrendIndicatorSeries} from '../../base/Indicator.js';
+import {EMA} from '../../trend/EMA/EMA.js';
+
+export type PPOConfig = {
+  /** Number of candles for the fast EMA (default: 12) */
+  fastPeriod?: number;
+  /** Number of candles for the slow EMA (default: 26) */
+  slowPeriod?: number;
+};
+
+/**
+ * Percentage Price Oscillator (PPO)
+ * Type: Momentum
+ *
+ * The PPO is the MACD's percentage sibling: it divides the spread between the fast and slow EMA by the slow EMA
+ * instead of reporting it in absolute price units. That makes readings comparable across differently priced
+ * instruments and across long time ranges of the same instrument — a $2 MACD spread means something entirely
+ * different at a $20 price than at a $2,000 price, while a 1% PPO reads the same everywhere.
+ *
+ * @see https://www.investopedia.com/terms/p/ppo.asp
+ * @see https://tulipindicators.org/ppo
+ */
+export class PPO extends TrendIndicatorSeries {
+  readonly #fast: EMA;
+  readonly #slow: EMA;
+
+  public readonly fastPeriod: number;
+  public readonly slowPeriod: number;
+
+  constructor({fastPeriod = 12, slowPeriod = 26}: PPOConfig = {}) {
+    super();
+    this.fastPeriod = fastPeriod;
+    this.slowPeriod = slowPeriod;
+    this.#fast = new EMA(fastPeriod);
+    this.#slow = new EMA(slowPeriod);
+  }
+
+  override getRequiredInputs() {
+    return this.#slow.getRequiredInputs();
+  }
+
+  update(price: number, replace: boolean) {
+    const fast = this.#fast.update(price, replace);
+    const slow = this.#slow.update(price, replace);
+
+    if (this.#slow.isStable) {
+      return this.setResult((100 * (fast - slow)) / slow, replace);
+    }
+
+    return null;
+  }
+
+  protected calculateSignalState(result: number | null | undefined) {
+    const hasResult = result !== null && result !== undefined;
+    const isBullish = hasResult && result > 0;
+    const isBearish = hasResult && result < 0;
+
+    switch (true) {
+      case !hasResult:
+        return TradingSignal.UNKNOWN;
+      case isBullish:
+        return TradingSignal.BULLISH;
+      case isBearish:
+        return TradingSignal.BEARISH;
+      default:
+        return TradingSignal.SIDEWAYS;
+    }
+  }
+}

--- a/packages/trading-signals/src/momentum/index.ts
+++ b/packages/trading-signals/src/momentum/index.ts
@@ -7,6 +7,7 @@ export * from './MACD/MACD.js';
 export * from './MFI/MFI.js';
 export * from './MOM/MOM.js';
 export * from './OBV/OBV.js';
+export * from './PPO/PPO.js';
 export * from './REI/REI.js';
 export * from './ROC/ROC.js';
 export * from './RSI/RSI.js';


### PR DESCRIPTION
## Summary

Implements the [Percentage Price Oscillator](https://www.investopedia.com/terms/p/ppo.asp) — the MACD expressed as a percentage of the slow EMA, so momentum reads the same on a $20 and a $2,000 instrument.

- `PPO` in `src/momentum/PPO/` extending `TrendIndicatorSeries`, composed from two existing `EMA`s
- `PPOConfig` object (`{fastPeriod: 12, slowPeriod: 26}` defaults, both optional)
- Zero-cross signal (BULLISH above 0, BEARISH below, SIDEWAYS at 0)
- Emits once the slow EMA is stable; Tulip emits from the 2nd candle, so the test skips Tulip's first three warm-up values and matches every remaining one exactly (documented in the test)

## Tests (7)

- Verified against [Tulip `ppo 2 5`](https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt#L313-L315) (11 matched outputs, exact at 3 decimals), tagged `tulipindicators`, independently reproduced first
- Exact-value bidirectional replace (1.49 → −1.20 → restored), `NotEnoughDataError`, all four signal states
- 490/490 tests, 100% coverage

Part of the indicator batch (CMO → KAMA → NATR → PPO → TEMA → TRIX → ADOSC), each as its own PR off `main`.