### PR TITLE
feat(trading-signals): add Triple Exponential Moving Average (TEMA)

### DIFF
--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -212,6 +212,7 @@ console.log(signal.hasChanged); // true if the signal state changed from the pre
 1. Stochastic Oscillator (STOCH)
 1. Stochastic RSI (STOCHRSI)
 1. Tom Demark's Sequential Indicator (TDS)
+1. Triple Exponential Moving Average (TEMA)
 1. True Range (TR)
 1. Ultimate Oscillator (ULTOSC)
 1. Volume Rate of Change (VROC)

--- a/packages/trading-signals/src/trend/TEMA/TEMA.test.ts
+++ b/packages/trading-signals/src/trend/TEMA/TEMA.test.ts
@@ -1,0 +1,67 @@
+import {TEMA} from './TEMA.js';
+import {NotEnoughDataError} from '../../error/index.js';
+
+describe('TEMA', () => {
+  /*
+   * Test data verified with:
+   * https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt#L400-L402
+   */
+  const prices = [
+    81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84, 83.99, 84.55, 84.36, 85.53, 86.54, 86.89, 87.77, 87.29,
+  ] as const;
+  const expectations = ['87.042', '87.819', '87.721'] as const;
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const tema = new TEMA(5);
+
+      tema.updates(prices, false);
+
+      const originalValue = 90;
+      const replacedValue = 83;
+
+      const originalResult = tema.add(originalValue);
+
+      expect(originalResult?.toFixed(2)).toBe('89.49');
+
+      const replacedResult = tema.replace(replacedValue);
+
+      expect(replacedResult?.toFixed(2)).toBe('84.57');
+      expect(replacedResult).not.toBe(originalResult);
+
+      const restoredResult = tema.replace(originalValue);
+
+      expect(restoredResult).toBe(originalResult);
+    });
+  });
+
+  describe('getResultOrThrow', () => {
+    it('is compatible with results from Tulip Indicators (TI)', {tags: ['tulipindicators']}, () => {
+      const interval = 5;
+      const tema = new TEMA(interval);
+      const offset = tema.getRequiredInputs() - 1;
+
+      prices.forEach((price, i) => {
+        const result = tema.add(price);
+
+        if (result) {
+          expect(result.toFixed(3)).toBe(expectations[i - offset]);
+        }
+      });
+
+      expect(tema.isStable).toBe(true);
+      expect(tema.getRequiredInputs()).toBe(13);
+    });
+
+    it('throws an error when there is not enough input data', () => {
+      const tema = new TEMA(5);
+
+      try {
+        tema.getResultOrThrow();
+        throw new Error('Expected error');
+      } catch (error) {
+        expect(error).toBeInstanceOf(NotEnoughDataError);
+      }
+    });
+  });
+});

--- a/packages/trading-signals/src/trend/TEMA/TEMA.ts
+++ b/packages/trading-signals/src/trend/TEMA/TEMA.ts
@@ -1,0 +1,54 @@
+import {IndicatorSeries} from '../../base/Indicator.js';
+import {EMA} from '../EMA/EMA.js';
+
+/**
+ * Triple Exponential Moving Average (TEMA)
+ * Type: Trend
+ *
+ * The TEMA was developed by Patrick G. Mulloy as the next step after his DEMA: it combines a single, double and
+ * triple smoothed EMA (3×EMA − 3×EMA² + EMA³) to cancel out even more of the lag that stacking EMAs would normally
+ * add, hugging price more closely than both EMA and DEMA.
+ *
+ * The chain is staged — each EMA starts only once the previous one is stable, seeding itself with that EMA's first
+ * stable value — matching Tulip Indicators.
+ *
+ * @see https://www.investopedia.com/terms/t/triple-exponential-moving-average.asp
+ * @see https://tulipindicators.org/tema
+ */
+export class TEMA extends IndicatorSeries {
+  readonly #single: EMA;
+  readonly #double: EMA;
+  readonly #triple: EMA;
+
+  public readonly interval: number;
+
+  constructor(interval: number) {
+    super();
+    this.interval = interval;
+    this.#single = new EMA(interval);
+    this.#double = new EMA(interval);
+    this.#triple = new EMA(interval);
+  }
+
+  override getRequiredInputs() {
+    return 3 * (this.interval - 1) + 1;
+  }
+
+  update(price: number, replace: boolean) {
+    const single = this.#single.update(price, replace);
+
+    if (this.#single.isStable) {
+      const double = this.#double.update(single, replace);
+
+      if (this.#double.isStable) {
+        const triple = this.#triple.update(double, replace);
+
+        if (this.#triple.isStable) {
+          return this.setResult(3 * single - 3 * double + triple, replace);
+        }
+      }
+    }
+
+    return null;
+  }
+}

--- a/packages/trading-signals/src/trend/index.ts
+++ b/packages/trading-signals/src/trend/index.ts
@@ -15,6 +15,7 @@ export * from './SMA15/SMA15.js';
 export * from './SWING_HIGH/SwingHigh.js';
 export * from './SWING_LOW/SwingLookback.js';
 export * from './SWING_LOW/SwingLow.js';
+export * from './TEMA/TEMA.js';
 export * from './VWAP/VWAP.js';
 export * from './WMA/WMA.js';
 export * from './WSMA/WSMA.js';


### PR DESCRIPTION
## Summary

Implements [Patrick Mulloy's TEMA](https://www.investopedia.com/terms/t/triple-exponential-moving-average.asp) — `3·EMA − 3·EMA² + EMA³`, the next step after his DEMA, hugging price more closely than both.

- `TEMA` in `src/trend/TEMA/` extending `IndicatorSeries`, composed from three existing `EMA`s
- **Staged chain**: each EMA starts only once the previous one is stable, seeding itself with that EMA's first stable value — this matches Tulip exactly (warm-up `3(n−1)+1`). A naive chain-from-candle-0 (as DEMA does) produces slightly different values; the difference was caught by the reference vector during development.
- `replace()` propagates through the EMA chain's existing replace handling

## Tests (3)

- Verified against [Tulip `tema 5`](https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt#L400-L402) (15 prices → 3 outputs, exact at 3 decimals), tagged `tulipindicators`, independently reproduced first
- Exact-value bidirectional replace (89.49 → 84.57 → restored) through all three chained EMAs
- `NotEnoughDataError` before warm-up
- 486/486 tests, 100% coverage

Part of the indicator batch (CMO → KAMA → NATR → PPO → TEMA → TRIX → ADOSC), each as its own PR off `main`. Note: TEMA and TRIX both insert adjacent README lines — whichever merges second may need a trivial rebase.