### PR TITLE
feat(trading-signals): add Triple Smoothed EMA Rate of Change (TRIX)

### DIFF
--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -217,6 +217,7 @@ console.log(signal.hasChanged); // true if the signal state changed from the pre
 1. Stochastic RSI (STOCHRSI)
 1. Tom Demark's Sequential Indicator (TDS)
 1. Triple Exponential Moving Average (TEMA)
+1. Triple Smoothed EMA Rate of Change (TRIX)
 1. True Range (TR)
 1. Ultimate Oscillator (ULTOSC)
 1. Volume Rate of Change (VROC)

--- a/packages/trading-signals/src/momentum/TRIX/TRIX.test.ts
+++ b/packages/trading-signals/src/momentum/TRIX/TRIX.test.ts
@@ -4,19 +4,13 @@ import {TradingSignal} from '../../base/index.js';
 
 describe('TRIX', () => {
   /*
-   * Input data taken from the Tulip Indicators test suite:
+   * Test data verified with:
    * https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt#L422-L424
-   *
-   * The expected values differ from Tulip's (0.492, 0.512) because Tulip divides the change by the
-   * CURRENT triple EMA while the textbook definition (TA-Lib, TradingView, StockCharts) divides by
-   * the PREVIOUS one:
-   * https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/indicators/trix.c#L69
-   * This implementation follows the textbook definition.
    */
   const prices = [
     81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84, 83.99, 84.55, 84.36, 85.53, 86.54, 86.89, 87.77, 87.29,
   ] as const;
-  const expectations = ['0.495', '0.515'] as const;
+  const expectations = ['0.492', '0.512'] as const;
 
   describe('replace', () => {
     it('replaces the most recently added value', () => {
@@ -29,7 +23,7 @@ describe('TRIX', () => {
 
       const originalResult = trix.add(originalValue);
 
-      expect(originalResult?.toFixed(3)).toBe('0.609');
+      expect(originalResult?.toFixed(3)).toBe('0.605');
 
       const replacedResult = trix.replace(replacedValue);
 
@@ -43,7 +37,7 @@ describe('TRIX', () => {
   });
 
   describe('getResultOrThrow', () => {
-    it('calculates the percent change of the triple smoothed EMA', () => {
+    it('is compatible with results from Tulip Indicators (TI)', {tags: ['tulipindicators']}, () => {
       const interval = 5;
       const trix = new TRIX(interval);
       const offset = trix.getRequiredInputs() - 1;
@@ -60,7 +54,7 @@ describe('TRIX', () => {
       expect(trix.getRequiredInputs()).toBe(14);
     });
 
-    it('never produces a result when the triple EMA has no value to change from', () => {
+    it('never produces a result when the triple EMA is zero', () => {
       const trix = new TRIX(5);
 
       for (let i = 0; i < 14; i++) {

--- a/packages/trading-signals/src/momentum/TRIX/TRIX.test.ts
+++ b/packages/trading-signals/src/momentum/TRIX/TRIX.test.ts
@@ -1,0 +1,130 @@
+import {TRIX} from './TRIX.js';
+import {NotEnoughDataError} from '../../error/index.js';
+import {TradingSignal} from '../../base/index.js';
+
+describe('TRIX', () => {
+  /*
+   * Input data taken from the Tulip Indicators test suite:
+   * https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt#L422-L424
+   *
+   * The expected values differ from Tulip's (0.492, 0.512) because Tulip divides the change by the
+   * CURRENT triple EMA while the textbook definition (TA-Lib, TradingView, StockCharts) divides by
+   * the PREVIOUS one:
+   * https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/indicators/trix.c#L69
+   * This implementation follows the textbook definition.
+   */
+  const prices = [
+    81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84, 83.99, 84.55, 84.36, 85.53, 86.54, 86.89, 87.77, 87.29,
+  ] as const;
+  const expectations = ['0.495', '0.515'] as const;
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const trix = new TRIX(5);
+
+      trix.updates(prices, false);
+
+      const originalValue = 90;
+      const replacedValue = 83;
+
+      const originalResult = trix.add(originalValue);
+
+      expect(originalResult?.toFixed(3)).toBe('0.609');
+
+      const replacedResult = trix.replace(replacedValue);
+
+      expect(replacedResult?.toFixed(3)).toBe('0.303');
+      expect(replacedResult).not.toBe(originalResult);
+
+      const restoredResult = trix.replace(originalValue);
+
+      expect(restoredResult).toBe(originalResult);
+    });
+  });
+
+  describe('getResultOrThrow', () => {
+    it('calculates the percent change of the triple smoothed EMA', () => {
+      const interval = 5;
+      const trix = new TRIX(interval);
+      const offset = trix.getRequiredInputs() - 1;
+
+      prices.forEach((price, i) => {
+        const result = trix.add(price);
+
+        if (result) {
+          expect(result.toFixed(3)).toBe(expectations[i - offset]);
+        }
+      });
+
+      expect(trix.isStable).toBe(true);
+      expect(trix.getRequiredInputs()).toBe(14);
+    });
+
+    it('never produces a result when the triple EMA has no value to change from', () => {
+      const trix = new TRIX(5);
+
+      for (let i = 0; i < 14; i++) {
+        trix.add(0);
+      }
+
+      try {
+        trix.getResultOrThrow();
+        throw new Error('Expected error');
+      } catch (error) {
+        expect(error).toBeInstanceOf(NotEnoughDataError);
+      }
+    });
+
+    it('throws an error when there is not enough input data', () => {
+      const trix = new TRIX(5);
+
+      try {
+        trix.getResultOrThrow();
+        throw new Error('Expected error');
+      } catch (error) {
+        expect(error).toBeInstanceOf(NotEnoughDataError);
+      }
+    });
+  });
+
+  describe('getSignal', () => {
+    it('returns UNKNOWN when there is no result', () => {
+      const trix = new TRIX(5);
+
+      expect(trix.getSignal().state).toBe(TradingSignal.UNKNOWN);
+    });
+
+    it('returns BULLISH when the triple EMA is rising', () => {
+      const trix = new TRIX(5);
+
+      for (let i = 0; i < 14; i++) {
+        trix.add(100 + i);
+      }
+
+      expect(trix.getResultOrThrow()).toBeGreaterThan(0);
+      expect(trix.getSignal().state).toBe(TradingSignal.BULLISH);
+    });
+
+    it('returns BEARISH when the triple EMA is falling', () => {
+      const trix = new TRIX(5);
+
+      for (let i = 0; i < 14; i++) {
+        trix.add(100 - i);
+      }
+
+      expect(trix.getResultOrThrow()).toBeLessThan(0);
+      expect(trix.getSignal().state).toBe(TradingSignal.BEARISH);
+    });
+
+    it('returns SIDEWAYS when the triple EMA is unchanged', () => {
+      const trix = new TRIX(5);
+
+      for (let i = 0; i < 14; i++) {
+        trix.add(100);
+      }
+
+      expect(trix.getResultOrThrow()).toBe(0);
+      expect(trix.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+    });
+  });
+});

--- a/packages/trading-signals/src/momentum/TRIX/TRIX.ts
+++ b/packages/trading-signals/src/momentum/TRIX/TRIX.ts
@@ -1,0 +1,85 @@
+import {TradingSignal, TrendIndicatorSeries} from '../../base/Indicator.js';
+import {EMA} from '../../trend/EMA/EMA.js';
+
+/**
+ * Triple Smoothed EMA Rate of Change (TRIX)
+ * Type: Momentum
+ *
+ * TRIX was developed by Jack Hutson and reports the percent change of a triple smoothed EMA from one candle to the
+ * next. The triple smoothing filters out moves shorter than the interval, so TRIX only reacts to changes it
+ * considers significant — its zero-line crossings are used as trend-change signals with less whipsaw than raw
+ * momentum oscillators.
+ *
+ * The percent change divides by the previous triple EMA (the textbook definition, as used by TA-Lib and most
+ * charting platforms). Note: Tulip Indicators divides by the current value instead, so its reference values differ
+ * slightly.
+ *
+ * @see https://www.investopedia.com/terms/t/trix.asp
+ * @see https://tulipindicators.org/trix
+ */
+export class TRIX extends TrendIndicatorSeries {
+  readonly #single: EMA;
+  readonly #double: EMA;
+  readonly #triple: EMA;
+  #previousTripleEma?: number;
+  #penultimateTripleEma?: number;
+
+  public readonly interval: number;
+
+  constructor(interval: number) {
+    super();
+    this.interval = interval;
+    this.#single = new EMA(interval);
+    this.#double = new EMA(interval);
+    this.#triple = new EMA(interval);
+  }
+
+  override getRequiredInputs() {
+    return 3 * (this.interval - 1) + 2;
+  }
+
+  update(price: number, replace: boolean) {
+    const single = this.#single.update(price, replace);
+
+    if (this.#single.isStable) {
+      const double = this.#double.update(single, replace);
+
+      if (this.#double.isStable) {
+        const triple = this.#triple.update(double, replace);
+
+        if (this.#triple.isStable) {
+          const previous = replace ? this.#penultimateTripleEma : this.#previousTripleEma;
+
+          if (!replace) {
+            this.#penultimateTripleEma = this.#previousTripleEma;
+          }
+
+          this.#previousTripleEma = triple;
+
+          if (previous !== undefined && previous !== 0) {
+            return this.setResult((100 * (triple - previous)) / previous, replace);
+          }
+        }
+      }
+    }
+
+    return null;
+  }
+
+  protected calculateSignalState(result: number | null | undefined) {
+    const hasResult = result !== null && result !== undefined;
+    const isBullish = hasResult && result > 0;
+    const isBearish = hasResult && result < 0;
+
+    switch (true) {
+      case !hasResult:
+        return TradingSignal.UNKNOWN;
+      case isBullish:
+        return TradingSignal.BULLISH;
+      case isBearish:
+        return TradingSignal.BEARISH;
+      default:
+        return TradingSignal.SIDEWAYS;
+    }
+  }
+}

--- a/packages/trading-signals/src/momentum/TRIX/TRIX.ts
+++ b/packages/trading-signals/src/momentum/TRIX/TRIX.ts
@@ -10,9 +10,8 @@ import {EMA} from '../../trend/EMA/EMA.js';
  * considers significant — its zero-line crossings are used as trend-change signals with less whipsaw than raw
  * momentum oscillators.
  *
- * The percent change divides by the previous triple EMA (the textbook definition, as used by TA-Lib and most
- * charting platforms). Note: Tulip Indicators divides by the current value instead, so its reference values differ
- * slightly.
+ * The percent change divides by the current triple EMA, matching Tulip Indicators. Note: TA-Lib and most charting
+ * platforms divide by the previous value instead, so their readings differ slightly.
  *
  * @see https://www.investopedia.com/terms/t/trix.asp
  * @see https://tulipindicators.org/trix
@@ -56,8 +55,8 @@ export class TRIX extends TrendIndicatorSeries {
 
           this.#previousTripleEma = triple;
 
-          if (previous !== undefined && previous !== 0) {
-            return this.setResult((100 * (triple - previous)) / previous, replace);
+          if (previous !== undefined && triple !== 0) {
+            return this.setResult((100 * (triple - previous)) / triple, replace);
           }
         }
       }

--- a/packages/trading-signals/src/momentum/index.ts
+++ b/packages/trading-signals/src/momentum/index.ts
@@ -15,5 +15,6 @@ export * from './RSI/RSI.js';
 export * from './STOCH/StochasticOscillator.js';
 export * from './STOCHRSI/StochasticRSI.js';
 export * from './TDS/TDS.js';
+export * from './TRIX/TRIX.js';
 export * from './ULTOSC/UltimateOscillator.js';
 export * from './WILLR/WilliamsR.js';


### PR DESCRIPTION
## Summary

Implements [Jack Hutson's TRIX](https://www.investopedia.com/terms/t/trix.asp) — the percent change of a triple smoothed EMA. The smoothing filters out moves shorter than the interval, so zero-line crossings whipsaw less than raw momentum oscillators.

- `TRIX` in `src/momentum/TRIX/` extending `TrendIndicatorSeries`, staged triple EMA chain (same staging as TEMA in #1222)
- Zero-cross signal; warm-up `3(n−1)+2`
- Replace support tracks the penultimate triple EMA so restore stays exact
- **Follows strict Tulip Indicators semantics**: the change is divided by the *current* triple EMA ([trix.c#L69](https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/indicators/trix.c#L69)). TA-Lib/TradingView divide by the previous value instead — this deviation is documented in the JSDoc.

## Tests (8)

- Verified against [Tulip `trix 5`](https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt#L422-L424) (0.492/0.512, exact at 3 decimals), tagged `tulipindicators`, independently reproduced first
- Exact-value bidirectional replace (0.605 → 0.303 → restored), zero-price guard, `NotEnoughDataError`, all four signal states
- 491/491 tests, 100% coverage

Part of the indicator batch (CMO #1218 → KAMA #1219 → NATR #1220 → PPO #1221 → TEMA #1222 → TRIX → ADOSC #1224). Note: TEMA (#1222) and TRIX insert adjacent README lines — whichever merges second may need a trivial rebase.