### PR TITLE
feat(trading-signals-docs): add demos for the eleven new indicators

### DIFF
--- a/packages/trading-signals-docs/indicator-demos/momentum/CMO.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/CMO.demo.tsx
@@ -1,0 +1,20 @@
+import {CMO as CMOClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const CMO: IndicatorConfig = {
+  chartTitle: 'CMO (14)',
+  color: '#84cc16',
+  createIndicator: () => new CMOClass(14),
+  description: 'Chande Momentum Oscillator',
+  details:
+    'Relates the sum of gains to the sum of losses over the interval — faster and more symmetric than the RSI, oscillating between -100 and +100. Values above +50 indicate overbought, below -50 indicate oversold.',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
+  id: 'cmo',
+  name: 'CMO',
+  processData: makeProcessData({rowInputs: ['close']}),
+  requiredInputs: 15,
+  type: 'single',
+  yAxisLabel: 'CMO',
+};

--- a/packages/trading-signals-docs/indicator-demos/momentum/MFI.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/MFI.demo.tsx
@@ -1,0 +1,20 @@
+import {MFI as MFIClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const MFI: IndicatorConfig = {
+  chartTitle: 'MFI (14)',
+  color: '#10b981',
+  createIndicator: () => new MFIClass(14),
+  description: 'Money Flow Index',
+  details:
+    "A volume-weighted RSI: each candle's typical price is weighted by trading volume, so moves backed by heavy volume shift the index more than moves on thin volume. Values above 80 indicate overbought, below 20 indicate oversold.",
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close', 'volume']}),
+  id: 'mfi',
+  name: 'MFI',
+  processData: makeProcessData({addInputs: ['close', 'high', 'low', 'volume'], rowInputs: ['close', 'volume']}),
+  requiredInputs: 15,
+  type: 'single',
+  yAxisLabel: 'MFI',
+};

--- a/packages/trading-signals-docs/indicator-demos/momentum/PPO.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/PPO.demo.tsx
@@ -1,0 +1,20 @@
+import {PPO as PPOClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const PPO: IndicatorConfig = {
+  chartTitle: 'PPO (12, 26)',
+  color: '#06b6d4',
+  createIndicator: () => new PPOClass(),
+  description: 'Percentage Price Oscillator',
+  details:
+    "The MACD's percentage sibling: divides the spread between the fast and slow EMA by the slow EMA, making momentum readings comparable across differently priced instruments. Crossings of the zero line signal trend changes.",
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
+  id: 'ppo',
+  name: 'PPO',
+  processData: makeProcessData({rowInputs: ['close']}),
+  requiredInputs: 26,
+  type: 'single',
+  yAxisLabel: 'PPO (%)',
+};

--- a/packages/trading-signals-docs/indicator-demos/momentum/TRIX.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/TRIX.demo.tsx
@@ -1,0 +1,20 @@
+import {TRIX as TRIXClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const TRIX: IndicatorConfig = {
+  chartTitle: 'TRIX (9)',
+  color: '#a855f7',
+  createIndicator: () => new TRIXClass(9),
+  description: 'Triple Smoothed EMA Rate of Change',
+  details:
+    'The percent change of a triple smoothed EMA. The smoothing filters out moves shorter than the interval, so zero-line crossings whipsaw less than raw momentum oscillators.',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
+  id: 'trix',
+  name: 'TRIX',
+  processData: makeProcessData({rowInputs: ['close']}),
+  requiredInputs: 26,
+  type: 'single',
+  yAxisLabel: 'TRIX (%)',
+};

--- a/packages/trading-signals-docs/indicator-demos/momentum/UltimateOscillator.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/UltimateOscillator.demo.tsx
@@ -1,0 +1,20 @@
+import {UltimateOscillator as UltimateOscillatorClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const UltimateOscillator: IndicatorConfig = {
+  chartTitle: 'Ultimate Oscillator (7, 14, 28)',
+  color: '#f43f5e',
+  createIndicator: () => new UltimateOscillatorClass(),
+  description: 'Ultimate Oscillator',
+  details:
+    'Blends buying pressure across three timeframes (7/14/28, weighted 4:2:1) to avoid the false divergences single-period oscillators produce. Values above 70 indicate overbought, below 30 indicate oversold.',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
+  id: 'ultosc',
+  name: 'ULTOSC',
+  processData: makeProcessData({addInputs: ['close', 'high', 'low'], rowInputs: ['close']}),
+  requiredInputs: 29,
+  type: 'single',
+  yAxisLabel: 'ULTOSC',
+};

--- a/packages/trading-signals-docs/indicator-demos/momentum/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/index.tsx
@@ -2,16 +2,21 @@ import {AC} from './AC.demo';
 import {AO} from './AO.demo';
 import {CCI} from './CCI.demo';
 import {CG} from './CG.demo';
+import {CMO} from './CMO.demo';
 import {ER} from './ER.demo';
 import {MACD} from './MACD.demo';
+import {MFI} from './MFI.demo';
 import {MOM} from './MOM.demo';
 import {OBV} from './OBV.demo';
+import {PPO} from './PPO.demo';
 import {REI} from './REI.demo';
 import {ROC} from './ROC.demo';
 import {RSI} from './RSI.demo';
 import {StochasticOscillator} from './StochasticOscillator.demo';
 import {StochasticRSI} from './StochasticRSI.demo';
 import {TDS} from './TDS.demo';
+import {TRIX} from './TRIX.demo';
+import {UltimateOscillator} from './UltimateOscillator.demo';
 import {WilliamsR} from './WilliamsR.demo';
 import type {IndicatorConfig} from '../../utils/types';
 
@@ -31,4 +36,9 @@ export const indicators: IndicatorConfig[] = [
   TDS,
   WilliamsR,
   ER,
+  MFI,
+  UltimateOscillator,
+  CMO,
+  PPO,
+  TRIX,
 ];

--- a/packages/trading-signals-docs/indicator-demos/trend/Aroon.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/Aroon.demo.tsx
@@ -1,0 +1,143 @@
+import {Chart as HighchartsChart} from '@highcharts/react';
+import {Aroon as AroonClass} from 'trading-signals';
+import type {ReactNode} from 'react';
+import type {Candle} from '@typedtrader/exchange';
+import type {ChartDataPoint} from '../../components/Chart';
+import {NotAvailable} from '../../components/NotAvailable';
+import PriceChart, {type PriceData} from '../../components/PriceChart';
+import {formatDate} from '../../utils/formatDate';
+import {collectPriceData} from '../../utils/renderUtils';
+import type {IndicatorConfig} from '../../utils/types';
+
+const renderAroon = (config: IndicatorConfig, selectedCandles: Candle[]) => {
+  const aroon = new AroonClass(14);
+  const chartDataUp: ChartDataPoint[] = [];
+  const chartDataDown: ChartDataPoint[] = [];
+  const priceData: PriceData[] = [];
+  const sampleValues: {period: number; date: string; close: number; up: ReactNode; down: ReactNode}[] = [];
+
+  selectedCandles.forEach((candle, idx) => {
+    const result = aroon.add({high: Number(candle.high), low: Number(candle.low)});
+    chartDataUp.push({x: idx + 1, y: result?.aroonUp ?? null});
+    chartDataDown.push({x: idx + 1, y: result?.aroonDown ?? null});
+
+    priceData.push(collectPriceData(candle, idx));
+
+    sampleValues.push({
+      close: Number(candle.close),
+      date: formatDate(candle.openTimeInISO),
+      down: result ? result.aroonDown.toFixed(2) : <NotAvailable />,
+      period: idx + 1,
+      up: result ? result.aroonUp.toFixed(2) : <NotAvailable />,
+    });
+  });
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold text-white mb-2 select-text">
+          Aroon({aroon.interval}) / Required Inputs: {aroon.getRequiredInputs()}
+        </h2>
+        <p className="text-slate-300 select-text">{config.description}</p>
+        {config.details && <p className="text-slate-400 text-sm mt-2 select-text">{config.details}</p>}
+      </div>
+
+      <div className="bg-slate-800/50 border border-slate-700 rounded-lg p-4">
+        <HighchartsChart
+          options={{
+            chart: {backgroundColor: 'transparent', height: 300, type: 'line'},
+            credits: {enabled: false},
+            legend: {enabled: true, itemStyle: {color: '#e2e8f0'}},
+            plotOptions: {line: {lineWidth: 2, marker: {enabled: true, radius: 3}}},
+            series: [
+              {
+                color: '#10b981',
+                data: chartDataUp.map(point => [point.x, point.y]),
+                marker: {fillColor: '#10b981'},
+                name: 'Aroon Up',
+                type: 'line',
+              },
+              {
+                color: '#ef4444',
+                data: chartDataDown.map(point => [point.x, point.y]),
+                marker: {fillColor: '#ef4444'},
+                name: 'Aroon Down',
+                type: 'line',
+              },
+            ],
+            title: {style: {color: '#e2e8f0', fontSize: '16px', fontWeight: '600'}, text: 'Aroon (14)'},
+            tooltip: {
+              backgroundColor: '#1e293b',
+              borderColor: '#475569',
+              formatter: function () {
+                let s: string = `<b>Period ${(this as any).x}</b><br/>`;
+                ((this as any).points as any[])?.forEach((point: any) => {
+                  const yValue = typeof point.y === 'number' ? point.y.toFixed(2) : 'N/A';
+                  s += `${point.series.name}: ${yValue}<br/>`;
+                });
+                return s;
+              },
+              shared: true,
+              style: {color: '#e2e8f0'},
+            },
+            xAxis: {
+              gridLineColor: '#334155',
+              labels: {style: {color: '#94a3b8'}},
+              title: {style: {color: '#94a3b8'}, text: 'Period'},
+            },
+            yAxis: {
+              gridLineColor: '#334155',
+              labels: {style: {color: '#94a3b8'}},
+              max: 100,
+              min: 0,
+              title: {style: {color: '#94a3b8'}, text: 'Aroon'},
+            },
+          }}
+        />
+      </div>
+
+      <PriceChart title="Input Prices" data={priceData} />
+
+      <div className="bg-slate-800/50 border border-slate-700 rounded-lg p-4">
+        <h3 className="text-lg font-semibold text-white mb-3">All Sample Values</h3>
+        <div className="overflow-x-auto">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-slate-600">
+                <th className="text-left py-2 px-3 text-slate-400 font-medium">Period</th>
+                <th className="text-left py-2 px-3 text-slate-400 font-medium">Date</th>
+                <th className="text-left py-2 px-3 text-slate-400 font-medium">Close</th>
+                <th className="text-left py-2 px-3 text-slate-400 font-medium">Aroon Up</th>
+                <th className="text-left py-2 px-3 text-slate-400 font-medium">Aroon Down</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sampleValues.map((row, idx) => (
+                <tr key={idx} className="border-b border-slate-700/50">
+                  <td className="py-2 px-3 text-white font-mono">{row.period}</td>
+                  <td className="py-2 px-3 text-slate-300">{row.date}</td>
+                  <td className="py-2 px-3 text-slate-300">${row.close.toFixed(2)}</td>
+                  <td className="py-2 px-3 text-white font-mono">{row.up}</td>
+                  <td className="py-2 px-3 text-white font-mono">{row.down}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const Aroon: IndicatorConfig = {
+  color: '#10b981',
+  createIndicator: () => new AroonClass(14),
+  customRender: renderAroon,
+  description: 'Aroon',
+  details:
+    'Identifies emerging trends by measuring how recently the highest high and lowest low occurred within the interval. An Aroon Up above 70 with an Aroon Down below 30 indicates a strong uptrend; crossovers of the two lines can signal trend changes.',
+  id: 'aroon',
+  name: 'Aroon',
+  requiredInputs: 15,
+  type: 'custom',
+};

--- a/packages/trading-signals-docs/indicator-demos/trend/HMA.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/HMA.demo.tsx
@@ -1,0 +1,20 @@
+import {HMA as HMAClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const HMA: IndicatorConfig = {
+  chartTitle: 'HMA (14)',
+  color: '#14b8a6',
+  createIndicator: () => new HMAClass(14),
+  description: 'Hull Moving Average',
+  details:
+    'Solves the classic moving average dilemma: smoothing adds lag, and lag-reduction adds noise. The HMA amplifies recent price action and smooths the result over the square root of the interval — tracking price nearly in real time while staying smooth.',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
+  id: 'hma',
+  name: 'HMA',
+  processData: makeProcessData({rowInputs: ['close']}),
+  requiredInputs: 16,
+  type: 'single',
+  yAxisLabel: 'Price',
+};

--- a/packages/trading-signals-docs/indicator-demos/trend/KAMA.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/KAMA.demo.tsx
@@ -1,0 +1,20 @@
+import {KAMA as KAMAClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const KAMA: IndicatorConfig = {
+  chartTitle: 'KAMA (10)',
+  color: '#f97316',
+  createIndicator: () => new KAMAClass(10),
+  description: "Kaufman's Adaptive Moving Average",
+  details:
+    'Adapts its smoothing based on how efficiently price traveled over the interval: fast in clean trends, slow in noise. Hugs trending prices closely while staying flat through choppy sideways markets.',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
+  id: 'kama',
+  name: 'KAMA',
+  processData: makeProcessData({rowInputs: ['close']}),
+  requiredInputs: 10,
+  type: 'single',
+  yAxisLabel: 'Price',
+};

--- a/packages/trading-signals-docs/indicator-demos/trend/TEMA.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/TEMA.demo.tsx
@@ -1,0 +1,20 @@
+import {TEMA as TEMAClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const TEMA: IndicatorConfig = {
+  chartTitle: 'TEMA (9)',
+  color: '#eab308',
+  createIndicator: () => new TEMAClass(9),
+  description: 'Triple Exponential Moving Average',
+  details:
+    'Combines a single, double and triple smoothed EMA (3×EMA − 3×EMA² + EMA³) to cancel out the lag that stacking EMAs would normally add — hugging price more closely than both EMA and DEMA.',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
+  id: 'tema',
+  name: 'TEMA',
+  processData: makeProcessData({rowInputs: ['close']}),
+  requiredInputs: 25,
+  type: 'single',
+  yAxisLabel: 'Price',
+};

--- a/packages/trading-signals-docs/indicator-demos/trend/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/index.tsx
@@ -1,6 +1,10 @@
 import {ADX} from './ADX.demo';
+import {Aroon} from './Aroon.demo';
 import {BreakoutBarLow} from './BreakoutBarLow.demo';
 import {DEMA} from './DEMA.demo';
+import {HMA} from './HMA.demo';
+import {KAMA} from './KAMA.demo';
+import {TEMA} from './TEMA.demo';
 import {DMA} from './DMA.demo';
 import {DX} from './DX.demo';
 import {EMA} from './EMA.demo';
@@ -22,6 +26,10 @@ export const indicators: IndicatorConfig[] = [
   SMA,
   EMA,
   DEMA,
+  TEMA,
+  HMA,
+  KAMA,
+  Aroon,
   WMA,
   RMA,
   WSMA,

--- a/packages/trading-signals-docs/indicator-demos/volatility/NATR.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volatility/NATR.demo.tsx
@@ -1,0 +1,20 @@
+import {NATR as NATRClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const NATR: IndicatorConfig = {
+  chartTitle: 'NATR (14)',
+  color: '#38bdf8',
+  createIndicator: () => new NATRClass(14),
+  description: 'Normalized Average True Range',
+  details:
+    'Expresses the ATR as a percentage of the closing price, making volatility comparable across differently priced instruments — a raw $5 ATR is huge for a $50 stock and noise for a $5,000 one.',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
+  id: 'natr',
+  name: 'NATR',
+  processData: makeProcessData({addInputs: ['close', 'high', 'low'], rowInputs: ['close']}),
+  requiredInputs: 14,
+  type: 'single',
+  yAxisLabel: 'NATR (%)',
+};

--- a/packages/trading-signals-docs/indicator-demos/volatility/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volatility/index.tsx
@@ -4,6 +4,7 @@ import {BollingerBands} from './BollingerBands.demo';
 import {BollingerBandsWidth} from './BollingerBandsWidth.demo';
 import {IQR} from './IQR.demo';
 import {MAD} from './MAD.demo';
+import {NATR} from './NATR.demo';
 import {TR} from './TR.demo';
 import type {IndicatorConfig} from '../../utils/types';
 
@@ -11,6 +12,7 @@ export const indicators: IndicatorConfig[] = [
   BollingerBands,
   AccelerationBands,
   ATR,
+  NATR,
   TR,
   BollingerBandsWidth,
   IQR,

--- a/packages/trading-signals-docs/indicator-demos/volume/ADOSC.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volume/ADOSC.demo.tsx
@@ -1,0 +1,20 @@
+import {ADOSC as ADOSCClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const ADOSC: IndicatorConfig = {
+  chartTitle: 'Chaikin Oscillator (3, 10)',
+  color: '#6366f1',
+  createIndicator: () => new ADOSCClass(),
+  description: 'Chaikin Oscillator',
+  details:
+    'Applies the MACD principle to the Accumulation/Distribution line: the spread between a fast and slow EMA of A/D measures the momentum of money flow, flagging accumulation or distribution before price shows it.',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close', 'volume']}),
+  id: 'adosc',
+  name: 'ADOSC',
+  processData: makeProcessData({addInputs: ['close', 'high', 'low', 'volume'], rowInputs: ['close', 'volume']}),
+  requiredInputs: 10,
+  type: 'single',
+  yAxisLabel: 'ADOSC',
+};

--- a/packages/trading-signals-docs/indicator-demos/volume/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volume/index.tsx
@@ -1,4 +1,5 @@
 import {AD} from './AD.demo';
+import {ADOSC} from './ADOSC.demo';
 import {CMF} from './CMF.demo';
 import {EMV} from './EMV.demo';
 import {PVT} from './PVT.demo';
@@ -6,4 +7,4 @@ import {VROC} from './VROC.demo';
 import {VWMA} from './VWMA.demo';
 import type {IndicatorConfig} from '../../utils/types';
 
-export const indicators: IndicatorConfig[] = [AD, CMF, PVT, EMV, VROC, VWMA];
+export const indicators: IndicatorConfig[] = [AD, ADOSC, CMF, PVT, EMV, VROC, VWMA];


### PR DESCRIPTION
## Summary

Wires up all eleven indicators shipped today on the docs pages:

| Page | New demos |
|---|---|
| momentum | MFI (14), Ultimate Oscillator (7/14/28), CMO (14), PPO (12/26), TRIX (9) |
| trend | TEMA (9), HMA (14), KAMA (10), Aroon (14) |
| volatility | NATR (14) |
| volume | Chaikin Oscillator (3/10) |

- Ten use the standard `type: 'single'` config (`makeProcessData` + `buildTableColumns`); Aroon gets a custom two-line render (Aroon Up green / Aroon Down red, 0–100 axis) following the DMA/STOCH pattern
- Demo intervals chosen so warm-ups fit the 40-candle synthetic datasets (longest: ULTOSC at 29)
- Candle-input indicators wire `addInputs` correctly (HLC for ULTOSC/NATR, HLCV for MFI/ADOSC)

## Checks

- `tsc --noEmit` clean, ESLint clean
- `next build` succeeds (static export, all pages generated)
- Playwright E2E suite passes (3/3)