### PR TITLE
feat(trading-signals): add Chandelier Exit (CE)

### DIFF
--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -188,6 +188,7 @@ console.log(signal.hasChanged); // true if the signal state changed from the pre
 1. Chaikin Money Flow (CMF)
 1. Chaikin Oscillator (ADOSC)
 1. Chande Momentum Oscillator (CMO)
+1. Chandelier Exit (CE)
 1. Commodity Channel Index (CCI)
 1. Directional Movement Index (DMI / DX)
 1. Double Exponential Moving Average (DEMA)

--- a/packages/trading-signals/src/trend/CE/ChandelierExit.test.ts
+++ b/packages/trading-signals/src/trend/CE/ChandelierExit.test.ts
@@ -1,0 +1,116 @@
+import {ChandelierExit} from './ChandelierExit.js';
+import {NotEnoughDataError} from '../../error/index.js';
+
+describe('ChandelierExit', () => {
+  /*
+   * Expected values computed with an independent implementation of the StockCharts formula
+   * (highest high − multiplier × ATR / lowest low + multiplier × ATR, Wilder's ATR):
+   * https://school.stockcharts.com/doku.php?id=technical_indicators:chandelier_exit
+   */
+  const candles = [
+    {close: 81.59, high: 82.15, low: 81.29},
+    {close: 81.06, high: 81.89, low: 80.64},
+    {close: 82.87, high: 83.03, low: 81.31},
+    {close: 83.0, high: 83.3, low: 82.65},
+    {close: 83.61, high: 83.85, low: 83.07},
+    {close: 83.15, high: 83.9, low: 83.11},
+    {close: 82.84, high: 83.33, low: 82.49},
+    {close: 83.99, high: 84.3, low: 82.3},
+    {close: 84.55, high: 84.84, low: 84.15},
+    {close: 84.36, high: 85.0, low: 84.11},
+    {close: 85.53, high: 85.9, low: 84.03},
+    {close: 86.54, high: 86.58, low: 85.39},
+    {close: 86.89, high: 86.98, low: 85.76},
+    {close: 87.77, high: 88.0, low: 87.17},
+    {close: 87.29, high: 87.87, low: 87.01},
+  ] as const;
+  const expectedLongs = [
+    '80.502',
+    '80.748',
+    '80.874',
+    '80.679',
+    '81.433',
+    '81.741',
+    '82.171',
+    '82.882',
+    '83.290',
+    '84.382',
+    '84.590',
+  ] as const;
+  const expectedShorts = [
+    '83.988',
+    '83.792',
+    '84.336',
+    '85.921',
+    '85.707',
+    '85.559',
+    '86.029',
+    '85.998',
+    '87.720',
+    '87.648',
+    '87.440',
+  ] as const;
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const ce = new ChandelierExit({interval: 5, multiplier: 3});
+
+      ce.updates(candles, false);
+
+      const originalValue = {close: 89.0, high: 90.0, low: 88.0} as const;
+      const replacedValue = {close: 83.0, high: 84.0, low: 82.0} as const;
+
+      const originalResult = ce.add(originalValue);
+
+      expect(originalResult?.long.toFixed(2)).toBe('85.65');
+      expect(originalResult?.short.toFixed(2)).toBe('89.74');
+
+      const replacedResult = ce.replace(replacedValue);
+
+      expect(replacedResult?.long.toFixed(2)).toBe('82.10');
+      expect(replacedResult?.short.toFixed(2)).toBe('87.90');
+      expect(replacedResult).not.toEqual(originalResult);
+
+      const restoredResult = ce.replace(originalValue);
+
+      expect(restoredResult).toEqual(originalResult);
+    });
+  });
+
+  describe('getResultOrThrow', () => {
+    it('hangs the stops from the highest high and lowest low at a distance of three ATRs', () => {
+      const ce = new ChandelierExit({interval: 5, multiplier: 3});
+      const offset = ce.getRequiredInputs() - 1;
+
+      candles.forEach((candle, i) => {
+        const result = ce.add(candle);
+
+        if (result) {
+          expect(result.long.toFixed(3)).toBe(expectedLongs[i - offset]);
+          expect(result.short.toFixed(3)).toBe(expectedShorts[i - offset]);
+        }
+      });
+
+      expect(ce.isStable).toBe(true);
+      expect(ce.getRequiredInputs()).toBe(5);
+    });
+
+    it('uses an interval of 22 and a multiplier of 3 by default', () => {
+      const ce = new ChandelierExit();
+
+      expect(ce.getRequiredInputs()).toBe(22);
+      expect(ce.multiplier).toBe(3);
+    });
+
+    it('throws an error when there is not enough input data', () => {
+      const ce = new ChandelierExit({interval: 5, multiplier: 3});
+
+      try {
+        ce.getResultOrThrow();
+        throw new Error('Expected error');
+      } catch (error) {
+        expect(error).toBeInstanceOf(NotEnoughDataError);
+      }
+    });
+  });
+});

--- a/packages/trading-signals/src/trend/CE/ChandelierExit.test.ts
+++ b/packages/trading-signals/src/trend/CE/ChandelierExit.test.ts
@@ -5,7 +5,7 @@ describe('ChandelierExit', () => {
   /*
    * Expected values computed with an independent implementation of the StockCharts formula
    * (highest high − multiplier × ATR / lowest low + multiplier × ATR, Wilder's ATR):
-   * https://school.stockcharts.com/doku.php?id=technical_indicators:chandelier_exit
+   * https://chartschool.stockcharts.com/table-of-contents/technical-indicators-and-overlays/technical-overlays/chandelier-exit
    */
   const candles = [
     {close: 81.59, high: 82.15, low: 81.29},

--- a/packages/trading-signals/src/trend/CE/ChandelierExit.ts
+++ b/packages/trading-signals/src/trend/CE/ChandelierExit.ts
@@ -30,7 +30,7 @@ export type ChandelierExitConfig = {
  * short positions.
  *
  * @see https://corporatefinanceinstitute.com/resources/equities/chandelier-exit/
- * @see https://school.stockcharts.com/doku.php?id=technical_indicators:chandelier_exit
+ * @see https://chartschool.stockcharts.com/table-of-contents/technical-indicators-and-overlays/technical-overlays/chandelier-exit
  */
 export class ChandelierExit extends TechnicalIndicator<ChandelierExitResult, HighLowClose<number>> {
   readonly #atr: ATR;

--- a/packages/trading-signals/src/trend/CE/ChandelierExit.ts
+++ b/packages/trading-signals/src/trend/CE/ChandelierExit.ts
@@ -1,0 +1,80 @@
+import type {HighLowClose} from '../../base/Candle.type.js';
+import {TechnicalIndicator} from '../../base/Indicator.js';
+import {pushUpdate} from '../../util/pushUpdate.js';
+import {ATR} from '../../volatility/ATR/ATR.js';
+
+export type ChandelierExitResult = {
+  /** Trailing stop for long positions: highest high minus a multiple of the ATR */
+  long: number;
+  /** Trailing stop for short positions: lowest low plus a multiple of the ATR */
+  short: number;
+};
+
+export type ChandelierExitConfig = {
+  /** Number of candles for the highest high / lowest low and the ATR (default: 22) */
+  interval?: number;
+  /** How many ATRs the stop trails behind the extreme (default: 3) */
+  multiplier?: number;
+};
+
+/**
+ * Chandelier Exit (CE)
+ * Type: Trend
+ *
+ * The Chandelier Exit was developed by Charles Le Beau as a volatility-adjusted trailing stop: instead of exiting a
+ * fixed distance below the entry, the stop hangs from the highest high of the trade (like a chandelier from a
+ * ceiling) at a distance of a few average true ranges. Volatile markets get more room to breathe, quiet markets get
+ * a tighter stop — keeping traders in trends until the move genuinely reverses.
+ *
+ * The long exit protects long positions (close below it → exit), the short exit mirrors it above the lowest low for
+ * short positions.
+ *
+ * @see https://corporatefinanceinstitute.com/resources/equities/chandelier-exit/
+ * @see https://school.stockcharts.com/doku.php?id=technical_indicators:chandelier_exit
+ */
+export class ChandelierExit extends TechnicalIndicator<ChandelierExitResult, HighLowClose<number>> {
+  readonly #atr: ATR;
+  readonly #candles: HighLowClose<number>[] = [];
+
+  public readonly interval: number;
+  public readonly multiplier: number;
+
+  constructor({interval = 22, multiplier = 3}: ChandelierExitConfig = {}) {
+    super();
+    this.interval = interval;
+    this.multiplier = multiplier;
+    this.#atr = new ATR(interval);
+  }
+
+  override getRequiredInputs() {
+    return this.#atr.getRequiredInputs();
+  }
+
+  update(candle: HighLowClose<number>, replace: boolean) {
+    const atr = this.#atr.update(candle, replace);
+    pushUpdate(this.#candles, replace, candle, this.interval);
+
+    // The candle window fills in lockstep with the ATR warm-up, so this single guard covers both
+    if (atr === null) {
+      return null;
+    }
+
+    let highest = this.#candles[0].high;
+    let lowest = this.#candles[0].low;
+
+    for (let i = 1; i < this.#candles.length; i++) {
+      if (this.#candles[i].high > highest) {
+        highest = this.#candles[i].high;
+      }
+
+      if (this.#candles[i].low < lowest) {
+        lowest = this.#candles[i].low;
+      }
+    }
+
+    return (this.result = {
+      long: highest - this.multiplier * atr,
+      short: lowest + this.multiplier * atr,
+    });
+  }
+}

--- a/packages/trading-signals/src/trend/index.ts
+++ b/packages/trading-signals/src/trend/index.ts
@@ -1,6 +1,7 @@
 export * from './ADX/ADX.js';
 export * from './AROON/Aroon.js';
 export * from './BREAKOUT_BAR_LOW/BreakoutBarLow.js';
+export * from './CE/ChandelierExit.js';
 export * from './DEMA/DEMA.js';
 export * from './DMA/DMA.js';
 export * from './DX/DX.js';


### PR DESCRIPTION
## Summary

Implements [Charles Le Beau's Chandelier Exit](https://chartschool.stockcharts.com/table-of-contents/technical-indicators-and-overlays/technical-overlays/chandelier-exit) — requested in discussion #753. A volatility-adjusted trailing stop: the stop hangs from the highest high of the lookback (like a chandelier from a ceiling) at a distance of a few ATRs, giving volatile markets room to breathe while keeping quiet markets on a tight leash.

- `ChandelierExit` in `src/trend/CE/` (next to the other trailing stops), extending `TechnicalIndicator<ChandelierExitResult, HighLowClose<number>>`
- Returns `{long, short}` — both exits, so it serves long and short positions
- `ChandelierExitConfig` object with the canonical defaults (`{interval: 22, multiplier: 3}`), composed from the existing `ATR` (Wilder's smoothing)
- Result is a pure function of the window + ATR state, so `replace()` delegates cleanly
- No Tulip vector exists for this indicator — expected values come from an independent implementation of the ChartSchool formula, linked in the test

## Tests (4)

- 15-candle reference test asserting both exits at 3 decimals across all 11 outputs
- Exact-value bidirectional replace (85.65/89.74 → 82.10/87.90 → restored)
- Default-config test (22/3), `NotEnoughDataError`
- 531/531 tests, 100% coverage

Closes the last open indicator request in Discussions — #752 (IQR) and #264 (SMA15) are already shipped and closed.