### PR TITLE
docs(trading-signals): use canonical Alan Hull reference URL in HMA

### DIFF
--- a/packages/trading-signals/src/trend/HMA/HMA.ts
+++ b/packages/trading-signals/src/trend/HMA/HMA.ts
@@ -12,7 +12,7 @@ import {WMA} from '../WMA/WMA.js';
  *
  * The half and square-root periods are truncated to integers, matching Tulip Indicators.
  *
- * @see https://alanhull.com/hull-moving-average
+ * @see https://alanhull.com/the-hull-moving-average/
  * @see https://tulipindicators.org/hma
  */
 export class HMA extends MovingAverage {


### PR DESCRIPTION
One-liner: `alanhull.com/hull-moving-average` 301-redirects to `alanhull.com/the-hull-moving-average/` — use the canonical target directly.

Found while sweeping all reference URLs introduced today: Tulip, ChartSchool and CFI links all return 200; Investopedia returns 403 to any automated client (bot-blocking, pages are fine in a browser); this was the only redirect.