### PR TITLE
feat(trading-signals): add AtrTrail indicator (ATR_TRAIL)

### DIFF
--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -28,6 +28,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Accelerator Oscillator (AC)
 1. Accumulation/Distribution (AD)
 1. Aroon (AROON)
+1. ATR Trail (ATR_TRAIL)
 1. Average Directional Index (ADX)
 1. Average True Range (ATR)
 1. Awesome Oscillator (AO)

--- a/packages/trading-signals/src/trend/ATR_TRAIL/AtrTrail.test.ts
+++ b/packages/trading-signals/src/trend/ATR_TRAIL/AtrTrail.test.ts
@@ -1,0 +1,150 @@
+import {AtrTrail, AtrTrailMode} from './AtrTrail.js';
+import {NotEnoughDataError} from '../../error/index.js';
+
+describe('AtrTrail', () => {
+  /*
+   * Five identical candles with a steady true range of 10 around a close of 100 warm the
+   * Wilder-smoothed ATR(5) up to exactly 10, i.e. an ATR% of 10. With a multiplier of 2 the
+   * trail width is therefore 20% and the first stop hangs 20% below the peak of 105.
+   */
+  const warmupCandles = [
+    {close: 100, high: 105, low: 95},
+    {close: 100, high: 105, low: 95},
+    {close: 100, high: 105, low: 95},
+    {close: 100, high: 105, low: 95},
+    {close: 100, high: 105, low: 95},
+  ] as const;
+
+  const followUpCandles = [
+    {close: 195, high: 200, low: 190},
+    {close: 245, high: 250, low: 240},
+    {close: 150, high: 240, low: 140},
+  ] as const;
+
+  describe('getResultOrThrow', () => {
+    it('freezes the trail width at warm-up and trails a ratcheting peak', () => {
+      const candles = [...warmupCandles, ...followUpCandles] as const;
+      /*
+       * The width stays 20% although the last candle's volatility explodes, and the peak of 250
+       * never falls back although the last candle prints far below it.
+       */
+      const expectations = ['84.00', '160.00', '200.00', '200.00'] as const;
+      const trail = new AtrTrail({interval: 5, multiplier: 2});
+      const offset = trail.getRequiredInputs() - 1;
+
+      candles.forEach((candle, i) => {
+        const result = trail.add(candle);
+
+        if (result) {
+          expect(result.toFixed(2)).toBe(expectations[i - offset]);
+        }
+      });
+
+      expect(trail.isStable).toBe(true);
+      expect(trail.getRequiredInputs()).toBe(5);
+    });
+
+    it('re-sizes the trail from the live ATR in ROLLING mode without loosening the stop', () => {
+      const candles = [...warmupCandles, ...followUpCandles] as const;
+      /*
+       * The width widens as the ATR picks up, but the volatility spike of the last candle only
+       * lowers the candidate stop — the emitted stop never decreases.
+       */
+      const expectations = ['84.00', '142.56', '181.84', '181.84'] as const;
+      const trail = new AtrTrail({interval: 5, mode: AtrTrailMode.ROLLING, multiplier: 2});
+      const offset = trail.getRequiredInputs() - 1;
+
+      candles.forEach((candle, i) => {
+        const result = trail.add(candle);
+
+        if (result) {
+          expect(result.toFixed(2)).toBe(expectations[i - offset]);
+        }
+      });
+
+      expect(trail.isStable).toBe(true);
+    });
+
+    it('gives a volatile instrument a wider trail than a calm one', () => {
+      const volatile = new AtrTrail({interval: 5, multiplier: 2});
+      const calm = new AtrTrail({interval: 5, multiplier: 2});
+
+      for (const candle of warmupCandles) {
+        volatile.add(candle);
+        calm.add({close: 100, high: 100.5, low: 99.5});
+      }
+
+      // Volatile: 10% ATR -> stop 20% below the peak of 105. Calm: 1% ATR -> stop 2% below 100.5.
+      expect(volatile.getResultOrThrow().toFixed(2)).toBe('84.00');
+      expect(calm.getResultOrThrow().toFixed(2)).toBe('98.49');
+    });
+
+    it('uses an interval of 14, a multiplier of 3 and the FROZEN mode by default', () => {
+      const trail = new AtrTrail();
+
+      expect(trail.getRequiredInputs()).toBe(14);
+      expect(trail.interval).toBe(14);
+      expect(trail.mode).toBe(AtrTrailMode.FROZEN);
+      expect(trail.multiplier).toBe(3);
+    });
+
+    it('throws an error when there is not enough input data', () => {
+      const trail = new AtrTrail({interval: 5, multiplier: 2});
+
+      try {
+        trail.getResultOrThrow();
+        throw new Error('Expected error');
+      } catch (error) {
+        expect(error).toBeInstanceOf(NotEnoughDataError);
+      }
+    });
+  });
+
+  describe('replace', () => {
+    it('replaces the most recently added value in FROZEN mode', () => {
+      const trail = new AtrTrail({interval: 5, multiplier: 2});
+
+      trail.updates(warmupCandles, false);
+
+      const originalValue = {close: 195, high: 200, low: 190} as const;
+      const replacedValue = {close: 100, high: 110, low: 90} as const;
+
+      const originalResult = trail.add(originalValue);
+
+      expect(originalResult?.toFixed(2)).toBe('160.00');
+
+      const replacedResult = trail.replace(replacedValue);
+
+      expect(replacedResult?.toFixed(2)).toBe('88.00');
+
+      const restoredResult = trail.replace(originalValue);
+
+      expect(restoredResult).toBe(originalResult);
+    });
+
+    it('replaces the most recently added value in ROLLING mode', () => {
+      const trail = new AtrTrail({interval: 5, mode: AtrTrailMode.ROLLING, multiplier: 2});
+
+      trail.updates(warmupCandles, false);
+
+      const originalValue = {close: 195, high: 200, low: 190} as const;
+      const replacedValue = {close: 100, high: 110, low: 90} as const;
+
+      const originalResult = trail.add(originalValue);
+
+      expect(originalResult?.toFixed(2)).toBe('142.56');
+
+      /*
+       * The replaced candle's stop candidate (83.60) sits below the already committed stop of
+       * 84.00, so the ratchet keeps the prior stop in place.
+       */
+      const replacedResult = trail.replace(replacedValue);
+
+      expect(replacedResult?.toFixed(2)).toBe('84.00');
+
+      const restoredResult = trail.replace(originalValue);
+
+      expect(restoredResult).toBe(originalResult);
+    });
+  });
+});

--- a/packages/trading-signals/src/trend/ATR_TRAIL/AtrTrail.test.ts
+++ b/packages/trading-signals/src/trend/ATR_TRAIL/AtrTrail.test.ts
@@ -28,7 +28,12 @@ describe('AtrTrail', () => {
        * The width stays 20% although the last candle's volatility explodes, and the peak of 250
        * never falls back although the last candle prints far below it.
        */
-      const expectations = ['84.00', '160.00', '200.00', '200.00'] as const;
+      const expectations = [
+        {peak: 105, stop: '84.00', trail: '84.00', trailPct: '20.00'},
+        {peak: 200, stop: '160.00', trail: '160.00', trailPct: '20.00'},
+        {peak: 250, stop: '200.00', trail: '200.00', trailPct: '20.00'},
+        {peak: 250, stop: '200.00', trail: '200.00', trailPct: '20.00'},
+      ] as const;
       const trail = new AtrTrail({interval: 5, multiplier: 2});
       const offset = trail.getRequiredInputs() - 1;
 
@@ -36,7 +41,11 @@ describe('AtrTrail', () => {
         const result = trail.add(candle);
 
         if (result) {
-          expect(result.toFixed(2)).toBe(expectations[i - offset]);
+          const expected = expectations[i - offset];
+          expect(result.peak).toBe(expected.peak);
+          expect(result.stop.toFixed(2)).toBe(expected.stop);
+          expect(result.trail.toFixed(2)).toBe(expected.trail);
+          expect(result.trailPct.toFixed(2)).toBe(expected.trailPct);
         }
       });
 
@@ -47,10 +56,16 @@ describe('AtrTrail', () => {
     it('re-sizes the trail from the live ATR in ROLLING mode without loosening the stop', () => {
       const candles = [...warmupCandles, ...followUpCandles] as const;
       /*
-       * The width widens as the ATR picks up, but the volatility spike of the last candle only
-       * lowers the candidate stop — the emitted stop never decreases.
+       * The width widens as the ATR picks up. On the last candle the volatility spike pushes the
+       * raw trail candidate far below the committed stop — both values are exposed and diverge,
+       * while the stop itself never decreases.
        */
-      const expectations = ['84.00', '142.56', '181.84', '181.84'] as const;
+      const expectations = [
+        {peak: 105, stop: '84.00', trail: '84.00', trailPct: '20.00'},
+        {peak: 200, stop: '142.56', trail: '142.56', trailPct: '28.72'},
+        {peak: 250, stop: '181.84', trail: '181.84', trailPct: '27.27'},
+        {peak: 250, stop: '181.84', trail: '90.93', trailPct: '63.63'},
+      ] as const;
       const trail = new AtrTrail({interval: 5, mode: AtrTrailMode.ROLLING, multiplier: 2});
       const offset = trail.getRequiredInputs() - 1;
 
@@ -58,7 +73,11 @@ describe('AtrTrail', () => {
         const result = trail.add(candle);
 
         if (result) {
-          expect(result.toFixed(2)).toBe(expectations[i - offset]);
+          const expected = expectations[i - offset];
+          expect(result.peak).toBe(expected.peak);
+          expect(result.stop.toFixed(2)).toBe(expected.stop);
+          expect(result.trail.toFixed(2)).toBe(expected.trail);
+          expect(result.trailPct.toFixed(2)).toBe(expected.trailPct);
         }
       });
 
@@ -75,8 +94,10 @@ describe('AtrTrail', () => {
       }
 
       // Volatile: 10% ATR -> stop 20% below the peak of 105. Calm: 1% ATR -> stop 2% below 100.5.
-      expect(volatile.getResultOrThrow().toFixed(2)).toBe('84.00');
-      expect(calm.getResultOrThrow().toFixed(2)).toBe('98.49');
+      expect(volatile.getResultOrThrow().trailPct).toBe(20);
+      expect(volatile.getResultOrThrow().stop.toFixed(2)).toBe('84.00');
+      expect(calm.getResultOrThrow().trailPct).toBe(2);
+      expect(calm.getResultOrThrow().stop.toFixed(2)).toBe('98.49');
     });
 
     it('uses an interval of 14, a multiplier of 3 and the FROZEN mode by default', () => {
@@ -111,15 +132,16 @@ describe('AtrTrail', () => {
 
       const originalResult = trail.add(originalValue);
 
-      expect(originalResult?.toFixed(2)).toBe('160.00');
+      expect(originalResult?.stop.toFixed(2)).toBe('160.00');
 
       const replacedResult = trail.replace(replacedValue);
 
-      expect(replacedResult?.toFixed(2)).toBe('88.00');
+      expect(replacedResult?.peak).toBe(110);
+      expect(replacedResult?.stop.toFixed(2)).toBe('88.00');
 
       const restoredResult = trail.replace(originalValue);
 
-      expect(restoredResult).toBe(originalResult);
+      expect(restoredResult).toEqual(originalResult);
     });
 
     it('replaces the most recently added value in ROLLING mode', () => {
@@ -132,19 +154,20 @@ describe('AtrTrail', () => {
 
       const originalResult = trail.add(originalValue);
 
-      expect(originalResult?.toFixed(2)).toBe('142.56');
+      expect(originalResult?.stop.toFixed(2)).toBe('142.56');
 
       /*
-       * The replaced candle's stop candidate (83.60) sits below the already committed stop of
-       * 84.00, so the ratchet keeps the prior stop in place.
+       * The replaced candle's trail candidate (83.60) sits below the already committed stop of
+       * 84.00, so the ratchet keeps the prior stop while the raw trail exposes the candidate.
        */
       const replacedResult = trail.replace(replacedValue);
 
-      expect(replacedResult?.toFixed(2)).toBe('84.00');
+      expect(replacedResult?.trail.toFixed(2)).toBe('83.60');
+      expect(replacedResult?.stop.toFixed(2)).toBe('84.00');
 
       const restoredResult = trail.replace(originalValue);
 
-      expect(restoredResult).toBe(originalResult);
+      expect(restoredResult).toEqual(originalResult);
     });
   });
 });

--- a/packages/trading-signals/src/trend/ATR_TRAIL/AtrTrail.ts
+++ b/packages/trading-signals/src/trend/ATR_TRAIL/AtrTrail.ts
@@ -1,0 +1,89 @@
+import type {HighLowClose} from '../../base/Candle.type.js';
+import {IndicatorSeries} from '../../base/Indicator.js';
+import {NATR} from '../../volatility/NATR/NATR.js';
+
+export const AtrTrailMode = {
+  /** Size the trail width once when the ATR warms up, then leave it alone. */
+  FROZEN: 'FROZEN',
+  /** Re-size the trail width from the live ATR on every candle. */
+  ROLLING: 'ROLLING',
+} as const;
+
+export type AtrTrailModes = (typeof AtrTrailMode)[keyof typeof AtrTrailMode];
+
+export type AtrTrailConfig = {
+  /** ATR lookback used to measure the instrument's volatility (default: 14) */
+  interval?: number;
+  /** Sizing behavior of the trail width (default: FROZEN) */
+  mode?: AtrTrailModes;
+  /** How many ATR% the trail sits below the peak (default: 3, Chandelier convention) */
+  multiplier?: number;
+};
+
+/**
+ * ATR Trail (ATR_TRAIL)
+ * Type: Trend
+ *
+ * A trailing stop for long positions whose width is sized from the instrument's own volatility
+ * instead of a hand-tuned percentage: the trail sits `multiplier` ATR% below the highest high, so a
+ * volatile name automatically gets room to breathe while a calm one gets a tight stop. A close
+ * below the trail means the uptrend has given back more than its usual range → exit.
+ *
+ * Unlike the Chandelier Exit, whose highest high rolls out of a fixed window and whose stop can
+ * therefore drop again, the peak here ratchets upward only and the emitted stop never decreases.
+ * In `FROZEN` mode (default) the width is measured once when the ATR warms up and stays fixed —
+ * a plain percentage trail sized sensibly from recent history. In `ROLLING` mode the width keeps
+ * adapting to the live ATR, but a volatility spike can only widen the trail for future peaks —
+ * it never loosens a stop that is already in place.
+ */
+export class AtrTrail extends IndicatorSeries<HighLowClose<number>> {
+  readonly #natr: NATR;
+  #peak?: number;
+  #previousPeak?: number;
+  #widthPct?: number;
+  #previousWidthPct?: number;
+
+  public readonly interval: number;
+  public readonly mode: AtrTrailModes;
+  public readonly multiplier: number;
+
+  constructor({interval = 14, mode = AtrTrailMode.FROZEN, multiplier = 3}: AtrTrailConfig = {}) {
+    super();
+    this.interval = interval;
+    this.mode = mode;
+    this.multiplier = multiplier;
+    this.#natr = new NATR(interval);
+  }
+
+  override getRequiredInputs() {
+    return this.#natr.getRequiredInputs();
+  }
+
+  update(candle: HighLowClose<number>, replace: boolean) {
+    if (replace) {
+      this.#peak = this.#previousPeak;
+      this.#widthPct = this.#previousWidthPct;
+    } else {
+      this.#previousPeak = this.#peak;
+      this.#previousWidthPct = this.#widthPct;
+    }
+
+    const natr = this.#natr.update(candle, replace);
+
+    if (natr === null) {
+      return null;
+    }
+
+    if (this.#widthPct === undefined || this.mode === AtrTrailMode.ROLLING) {
+      this.#widthPct = this.multiplier * natr;
+    }
+
+    this.#peak = this.#peak === undefined ? candle.high : Math.max(this.#peak, candle.high);
+
+    const candidate = this.#peak * (1 - this.#widthPct / 100);
+    const previousStop = replace ? this.previousResult : this.result;
+    const stop = previousStop === undefined ? candidate : Math.max(previousStop, candidate);
+
+    return this.setResult(stop, replace);
+  }
+}

--- a/packages/trading-signals/src/trend/ATR_TRAIL/AtrTrail.ts
+++ b/packages/trading-signals/src/trend/ATR_TRAIL/AtrTrail.ts
@@ -1,5 +1,5 @@
 import type {HighLowClose} from '../../base/Candle.type.js';
-import {IndicatorSeries} from '../../base/Indicator.js';
+import {TechnicalIndicator} from '../../base/Indicator.js';
 import {NATR} from '../../volatility/NATR/NATR.js';
 
 export const AtrTrailMode = {
@@ -11,6 +11,17 @@ export const AtrTrailMode = {
 
 export type AtrTrailModes = (typeof AtrTrailMode)[keyof typeof AtrTrailMode];
 
+export type AtrTrailResult = {
+  /** Highest high since the ATR warmed up, ratcheting upward only. */
+  peak: number;
+  /** Actionable stop level: the highest `trail` seen so far, so it never decreases. */
+  stop: number;
+  /** Raw trail candidate, `peak * (1 - trailPct / 100)`. In ROLLING mode a volatility spike can push it below `stop`. */
+  trail: number;
+  /** Trail width in percent, `multiplier * ATR%`. */
+  trailPct: number;
+};
+
 export type AtrTrailConfig = {
   /** ATR lookback used to measure the instrument's volatility (default: 14) */
   interval?: number;
@@ -20,6 +31,12 @@ export type AtrTrailConfig = {
   multiplier?: number;
 };
 
+type AtrTrailState = {
+  peak: number;
+  stop: number;
+  trailPct: number;
+};
+
 /**
  * ATR Trail (ATR_TRAIL)
  * Type: Trend
@@ -27,21 +44,21 @@ export type AtrTrailConfig = {
  * A trailing stop for long positions whose width is sized from the instrument's own volatility
  * instead of a hand-tuned percentage: the trail sits `multiplier` ATR% below the highest high, so a
  * volatile name automatically gets room to breathe while a calm one gets a tight stop. A close
- * below the trail means the uptrend has given back more than its usual range → exit.
+ * below the stop means the uptrend has given back more than its usual range → exit.
  *
  * Unlike the Chandelier Exit, whose highest high rolls out of a fixed window and whose stop can
- * therefore drop again, the peak here ratchets upward only and the emitted stop never decreases.
+ * therefore drop again, the peak here ratchets upward only and the emitted `stop` never decreases.
  * In `FROZEN` mode (default) the width is measured once when the ATR warms up and stays fixed —
  * a plain percentage trail sized sensibly from recent history. In `ROLLING` mode the width keeps
  * adapting to the live ATR, but a volatility spike can only widen the trail for future peaks —
- * it never loosens a stop that is already in place.
+ * it never loosens a stop that is already in place. The raw `trail` candidate is exposed alongside
+ * `stop` so a consumer can see when the two diverge.
  */
-export class AtrTrail extends IndicatorSeries<HighLowClose<number>> {
+export class AtrTrail extends TechnicalIndicator<AtrTrailResult, HighLowClose<number>> {
   readonly #natr: NATR;
-  #peak?: number;
-  #previousPeak?: number;
-  #widthPct?: number;
-  #previousWidthPct?: number;
+  #state?: AtrTrailState;
+  /** One-deep undo snapshot so `replace()` can rewind the recursive peak/stop/width state. */
+  #previousState?: AtrTrailState;
 
   public readonly interval: number;
   public readonly mode: AtrTrailModes;
@@ -61,11 +78,9 @@ export class AtrTrail extends IndicatorSeries<HighLowClose<number>> {
 
   update(candle: HighLowClose<number>, replace: boolean) {
     if (replace) {
-      this.#peak = this.#previousPeak;
-      this.#widthPct = this.#previousWidthPct;
+      this.#state = this.#previousState;
     } else {
-      this.#previousPeak = this.#peak;
-      this.#previousWidthPct = this.#widthPct;
+      this.#previousState = this.#state;
     }
 
     const natr = this.#natr.update(candle, replace);
@@ -74,16 +89,15 @@ export class AtrTrail extends IndicatorSeries<HighLowClose<number>> {
       return null;
     }
 
-    if (this.#widthPct === undefined || this.mode === AtrTrailMode.ROLLING) {
-      this.#widthPct = this.multiplier * natr;
-    }
+    const previous = this.#state;
+    const trailPct =
+      previous === undefined || this.mode === AtrTrailMode.ROLLING ? this.multiplier * natr : previous.trailPct;
+    const peak = previous === undefined ? candle.high : Math.max(previous.peak, candle.high);
+    const trail = peak * (1 - trailPct / 100);
+    const stop = previous === undefined ? trail : Math.max(previous.stop, trail);
 
-    this.#peak = this.#peak === undefined ? candle.high : Math.max(this.#peak, candle.high);
+    this.#state = {peak, stop, trailPct};
 
-    const candidate = this.#peak * (1 - this.#widthPct / 100);
-    const previousStop = replace ? this.previousResult : this.result;
-    const stop = previousStop === undefined ? candidate : Math.max(previousStop, candidate);
-
-    return this.setResult(stop, replace);
+    return (this.result = {peak, stop, trail, trailPct});
   }
 }

--- a/packages/trading-signals/src/trend/index.ts
+++ b/packages/trading-signals/src/trend/index.ts
@@ -1,5 +1,6 @@
 export * from './ADX/ADX.js';
 export * from './AROON/Aroon.js';
+export * from './ATR_TRAIL/AtrTrail.js';
 export * from './BREAKOUT_BAR_LOW/BreakoutBarLow.js';
 export * from './CE/ChandelierExit.js';
 export * from './DEMA/DEMA.js';


### PR DESCRIPTION
The feature at the heart of #1131 — a trailing stop whose width is sized from the instrument's own volatility — extracted as a standalone, publicly exported indicator in the `trading-signals` library.

## What it does
- Trail width = `multiplier × ATR%` (via `NATR`), so a volatile name automatically gets room to breathe while a calm one gets a tight stop — no hand-tuned percentage.
- The peak **ratchets upward only** and the emitted stop **never decreases** — unlike `ChandelierExit`, whose highest high rolls out of a fixed window and whose stop can drop again.
- Two modes:
  - **`FROZEN`** (default): the width is measured once when the ATR warms up and stays fixed — a plain percentage trail sized sensibly from recent history.
  - **`ROLLING`**: the width keeps adapting to the live ATR, but a volatility spike only widens the trail for future peaks — it never loosens a stop already in place.

## Usage
```ts
const trail = new AtrTrail({interval: 14, multiplier: 2, mode: AtrTrailMode.ROLLING});

const result = trail.add({high: 200, low: 190, close: 195});
// => {
//   peak: 200,      // ratcheting highest high
//   stop: 160,      // never-decreasing stop
//   trail: 160,     // raw candidate: peak * (1 - trailPct/100)
//   trailPct: 20,   // width from multiplier x ATR%
// }
// null during warm-up
```

`trail` and `stop` diverge in `ROLLING` mode when a volatility spike pushes the raw candidate below the committed stop — both are exposed so consumers see the ratchet at work.

## Notes
- Extends `TechnicalIndicator<AtrTrailResult, HighLowClose<number>>` (multi-value result, like `ChandelierExit`/`SuperTrend`), correct bidirectional `replace()` via a one-deep state snapshot, `getRequiredInputs()` delegated to the internal `NATR`.
- 7 unit tests: exact-value sequences for both modes (including the `trail`/`stop` divergence), volatile-vs-calm width comparison, defaults, `NotEnoughDataError`, and bidirectional replace per mode. 100% coverage maintained.
- #1131 (`AtrTrailStrategy`) can adopt this indicator later instead of carrying the trail logic inline.