### PR TITLE
feat(trading-signals): add Volatility Stop indicator (VSTOP)

### DIFF
--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -72,6 +72,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Triple Smoothed EMA Rate of Change (TRIX)
 1. True Range (TR)
 1. Ultimate Oscillator (ULTOSC)
+1. Volatility Stop (VSTOP)
 1. Volume Rate of Change (VROC)
 1. Volume-Weighted Average Price (VWAP)
 1. Volume Weighted Moving Average (VWMA)

--- a/packages/trading-signals/src/trend/VSTOP/VolatilityStop.test.ts
+++ b/packages/trading-signals/src/trend/VSTOP/VolatilityStop.test.ts
@@ -1,0 +1,111 @@
+import {VolatilityStop} from './VolatilityStop.js';
+import {NotEnoughDataError} from '../../error/index.js';
+
+describe('VolatilityStop', () => {
+  /*
+   * Expected values computed with an independent throwaway Node.js script implementing Vervoort's published logic
+   * directly (loss = multiplier × Wilder ATR(interval); stop ratchets via max/min while both the current and the
+   * previous close stay on the trend's side, flips to close ∓ loss otherwise; first stable bar = close − loss):
+   * https://traders.com/Documentation/FEEDbk_docs/2009/06/Vervoort.html
+   * https://traders.com/Documentation/FEEDbk_docs/2009/06/TradersTips.html
+   *
+   * The sequence exercises every branch: initialization (bar 5), uptrend ratchet moving up (bar 6), uptrend ratchet
+   * holding (bar 7), flip to downtrend (bar 8), downtrend ratchet moving down (bar 9), downtrend ratchet holding
+   * (bar 10), flip back to uptrend (bar 11) and another uptrend ratchet (bar 12).
+   */
+  const candles = [
+    {close: 10, high: 11, low: 9},
+    {close: 11, high: 12, low: 10},
+    {close: 12, high: 13, low: 11},
+    {close: 13, high: 14, low: 12},
+    {close: 14, high: 15, low: 13},
+    {close: 15, high: 16, low: 14},
+    {close: 14.5, high: 15.5, low: 13.5},
+    {close: 10, high: 15, low: 9.5},
+    {close: 9, high: 10, low: 8},
+    {close: 9.5, high: 10.5, low: 8.5},
+    {close: 13, high: 13.5, low: 9},
+    {close: 14, high: 15, low: 13},
+  ] as const;
+  const expectedStops = [
+    '12.0000',
+    '13.0000',
+    '13.0000',
+    '12.7000',
+    '11.5600',
+    '11.5600',
+    '10.1416',
+    '11.3133',
+  ] as const;
+  const expectedSignals = [
+    'BULLISH',
+    'BULLISH',
+    'BULLISH',
+    'BEARISH',
+    'BEARISH',
+    'BEARISH',
+    'BULLISH',
+    'BULLISH',
+  ] as const;
+
+  describe('replace', () => {
+    it('replaces the most recently added value and flips the side back and forth', () => {
+      const vstop = new VolatilityStop({interval: 5, multiplier: 1});
+
+      vstop.updates(candles, false);
+
+      const originalValue = {close: 15, high: 16, low: 14} as const;
+      const replacedValue = {close: 8, high: 14.5, low: 7.5} as const;
+
+      const originalResult = vstop.add(originalValue);
+
+      expect(originalResult?.stop.toFixed(4)).toBe('12.4506');
+      expect(originalResult?.signal).toBe('BULLISH');
+
+      const replacedResult = vstop.replace(replacedValue);
+
+      expect(replacedResult?.stop.toFixed(4)).toBe('11.5494');
+      expect(replacedResult?.signal).toBe('BEARISH');
+
+      const restoredResult = vstop.replace(originalValue);
+
+      expect(restoredResult).toEqual(originalResult);
+    });
+  });
+
+  describe('getResultOrThrow', () => {
+    it('ratchets the stop in the trade direction and flips the side when the close breaches it', () => {
+      const vstop = new VolatilityStop({interval: 5, multiplier: 1});
+      const offset = vstop.getRequiredInputs() - 1;
+
+      candles.forEach((candle, i) => {
+        const result = vstop.add(candle);
+
+        if (result) {
+          expect(result.stop.toFixed(4)).toBe(expectedStops[i - offset]);
+          expect(result.signal).toBe(expectedSignals[i - offset]);
+        }
+      });
+
+      expect(vstop.isStable).toBe(true);
+    });
+
+    it('uses an interval of 5 and a multiplier of 3.5 by default', () => {
+      const vstop = new VolatilityStop();
+
+      expect(vstop.getRequiredInputs()).toBe(5);
+      expect(vstop.multiplier).toBe(3.5);
+    });
+
+    it('throws an error when there is not enough input data', () => {
+      const vstop = new VolatilityStop({interval: 5, multiplier: 1});
+
+      try {
+        vstop.getResultOrThrow();
+        throw new Error('Expected error');
+      } catch (error) {
+        expect(error).toBeInstanceOf(NotEnoughDataError);
+      }
+    });
+  });
+});

--- a/packages/trading-signals/src/trend/VSTOP/VolatilityStop.ts
+++ b/packages/trading-signals/src/trend/VSTOP/VolatilityStop.ts
@@ -1,0 +1,99 @@
+import type {HighLowClose} from '../../base/Candle.type.js';
+import {TechnicalIndicator, TradingSignal} from '../../base/Indicator.js';
+import {ATR} from '../../volatility/ATR/ATR.js';
+
+export type VolatilityStopResult = {
+  /**
+   * Which side of the price the stop currently sits on. At the exact flip bar the stop value alone is ambiguous, so
+   * the side is reported explicitly: BULLISH = stop below price (support), BEARISH = stop above price (resistance).
+   */
+  signal: typeof TradingSignal.BULLISH | typeof TradingSignal.BEARISH;
+  /** Trailing stop level */
+  stop: number;
+};
+
+export type VolatilityStopConfig = {
+  /** Number of candles for the ATR (default: 5) */
+  interval?: number;
+  /** How many ATRs the stop trails behind the close (default: 3.5) */
+  multiplier?: number;
+};
+
+/**
+ * Volatility Stop (VSTOP)
+ * Type: Trend
+ *
+ * Published by Sylvain Vervoort as "Average True Range Trailing Stops" (Technical Analysis of Stocks & Commodities,
+ * June 2009). It trails a stop a multiple of the Average True Range behind the closing price, so the stop only
+ * ratchets in the trade's favor: it rises (never falls) below price in an uptrend and falls (never rises) above
+ * price in a downtrend. Because the distance adapts to volatility, a whippy market gets more room before the stop is
+ * hit, while a quiet market keeps the stop tight.
+ *
+ * Interpretation:
+ * A close beyond the stop flips it to the other side of the price — the stop switches from acting as support to
+ * acting as resistance (or back), signaling a trend change rather than mere noise.
+ *
+ * @see https://traders.com/Documentation/FEEDbk_docs/2009/06/Vervoort.html
+ * @see https://traders.com/Documentation/FEEDbk_docs/2009/06/TradersTips.html
+ * @see https://toslc.thinkorswim.com/center/reference/Tech-Indicators/studies-library/A-B/ATRTrailingStop
+ */
+export class VolatilityStop extends TechnicalIndicator<VolatilityStopResult, HighLowClose<number>> {
+  readonly #atr: ATR;
+  #previous: {close: number; stop: number} | null = null;
+  #previousSnapshot: {close: number; stop: number} | null = null;
+
+  public readonly interval: number;
+  public readonly multiplier: number;
+
+  constructor({interval = 5, multiplier = 3.5}: VolatilityStopConfig = {}) {
+    super();
+    this.interval = interval;
+    this.multiplier = multiplier;
+    this.#atr = new ATR(interval);
+  }
+
+  override getRequiredInputs() {
+    return this.#atr.getRequiredInputs();
+  }
+
+  update(candle: HighLowClose<number>, replace: boolean) {
+    if (replace) {
+      this.#previous = this.#previousSnapshot;
+    } else {
+      this.#previousSnapshot = this.#previous;
+    }
+
+    const atr = this.#atr.update(candle, replace);
+
+    if (atr === null) {
+      return null;
+    }
+
+    const {close} = candle;
+    const loss = this.multiplier * atr;
+    const previous = this.#previous;
+
+    let result: VolatilityStopResult;
+
+    /*
+     * Vervoort's published logic: while both the current and the previous close stay on the trend's side of the
+     * stop, the stop only ratchets in the trend's direction; a close on the other side flips the stop over. The
+     * first stable bar starts as an uptrend stop, matching the original MetaStock formula where PREV starts at 0.
+     */
+    if (previous === null) {
+      result = {signal: TradingSignal.BULLISH, stop: close - loss};
+    } else if (close > previous.stop && previous.close > previous.stop) {
+      result = {signal: TradingSignal.BULLISH, stop: Math.max(previous.stop, close - loss)};
+    } else if (close < previous.stop && previous.close < previous.stop) {
+      result = {signal: TradingSignal.BEARISH, stop: Math.min(previous.stop, close + loss)};
+    } else if (close > previous.stop) {
+      result = {signal: TradingSignal.BULLISH, stop: close - loss};
+    } else {
+      result = {signal: TradingSignal.BEARISH, stop: close + loss};
+    }
+
+    this.#previous = {close, stop: result.stop};
+
+    return (this.result = result);
+  }
+}

--- a/packages/trading-signals/src/trend/index.ts
+++ b/packages/trading-signals/src/trend/index.ts
@@ -19,6 +19,7 @@ export * from './SWING_HIGH/SwingHigh.js';
 export * from './SWING_LOW/SwingLookback.js';
 export * from './SWING_LOW/SwingLow.js';
 export * from './TEMA/TEMA.js';
+export * from './VSTOP/VolatilityStop.js';
 export * from './VWAP/VWAP.js';
 export * from './WMA/WMA.js';
 export * from './WSMA/WSMA.js';


### PR DESCRIPTION
## What

Adds `VolatilityStop` (`src/trend/VSTOP/VolatilityStop.ts`) — Sylvain Vervoort's **"Average True Range Trailing Stops"**, published in *Technical Analysis of Stocks & Commodities*, June 2009 (V. 27:6, pp. 34–40).

Sources:
- Original article: https://traders.com/Documentation/FEEDbk_docs/2009/06/Vervoort.html
- Traders' Tips (June 2009) with the platform code listings the logic was verified against: https://traders.com/Documentation/FEEDbk_docs/2009/06/TradersTips.html
- thinkorswim `ATRTrailingStop` reference (cites Vervoort): https://toslc.thinkorswim.com/center/reference/Tech-Indicators/studies-library/A-B/ATRTrailingStop

## Formula & defaults

`loss = multiplier × ATR(interval)` with Wilder ATR (existing `ATR` composed with default WSMA smoothing). Defaults per the article: **interval 5, multiplier 3.5**. Per bar (close-based):

- close > prev stop AND prev close > prev stop → `max(prev stop, close − loss)` (uptrend, stop only ratchets up)
- close < prev stop AND prev close < prev stop → `min(prev stop, close + loss)` (downtrend, stop only ratchets down)
- close > prev stop → `close − loss` (flip to uptrend)
- else → `close + loss` (flip to downtrend)

First stable bar initializes as `close − loss` (matches MetaStock's `PREV` starting at 0 and thinkScript's long `firstTrade`). The result exposes both the stop and the current side — `signal: BULLISH` (stop below price, support) / `BEARISH` (stop above price, resistance) via the `TradingSignal` const — since the stop value alone is ambiguous on the exact flip bar.

## Replace handling

The recursive state (previous close + previous stop) is kept as a single nullable pair with a one-deep snapshot: `add()` saves the pre-update state, `replace()` restores it before recomputing, so replace is fully bidirectional (original → replaced → restored yields exact equality). The composed `ATR` handles its own replace internally.

## Test data provenance

Expected values were computed with an independent throwaway Node.js script implementing the published logic directly from the Traders' Tips listing (not by running the indicator class); the script was deleted after generating the values. The 12-candle sequence exercises every branch: initialization, uptrend ratchet moving/holding, flip to downtrend, downtrend ratchet moving/holding, and flip back to uptrend. The replace test also flips the side (BULLISH → BEARISH → restored).

## Verification

- `npx vitest run src/trend/VSTOP` — 4/4 passing
- `npm test` — full suite passing, coverage 100% statements/branches/functions/lines
- `npm run test:types` — clean
- `npm run lint` — clean