### PR TITLE
feat(trading-signals): add SuperTrend indicator (SUPERTREND)

### DIFF
--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -67,6 +67,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Spencer's 15-Point Moving Average (SMA15)
 1. Stochastic Oscillator (STOCH)
 1. Stochastic RSI (STOCHRSI)
+1. SuperTrend (SUPERTREND)
 1. Tom Demark's Sequential Indicator (TDS)
 1. Triple Exponential Moving Average (TEMA)
 1. Triple Smoothed EMA Rate of Change (TRIX)

--- a/packages/trading-signals/src/trend/SUPERTREND/SuperTrend.test.ts
+++ b/packages/trading-signals/src/trend/SUPERTREND/SuperTrend.test.ts
@@ -1,0 +1,128 @@
+import {SuperTrend} from './SuperTrend.js';
+import {NotEnoughDataError} from '../../error/index.js';
+
+describe('SuperTrend', () => {
+  /*
+   * Expected values computed with an independent throwaway Node.js script implementing the
+   * TradingView formula (hl2 ± multiplier × ATR basic bands, ratcheting final bands,
+   * close-through-band trend flips, Wilder's ATR):
+   * https://www.tradingview.com/support/solutions/43000634738-supertrend/
+   *
+   * The sequence covers an uptrend breakout (flip to BULLISH), a crash (flip to BEARISH),
+   * a grind lower (upper band ratcheting down) and a rally (second flip to BULLISH).
+   */
+  const candles = [
+    {close: 81, high: 82, low: 80},
+    {close: 82, high: 83, low: 81},
+    {close: 83, high: 84, low: 82},
+    {close: 84, high: 85, low: 83},
+    {close: 85, high: 86, low: 84},
+    {close: 86, high: 87, low: 85},
+    {close: 87, high: 88, low: 86},
+    {close: 90.5, high: 91, low: 87},
+    {close: 91, high: 92, low: 89},
+    {close: 92, high: 93, low: 90},
+    {close: 82, high: 92, low: 81},
+    {close: 77, high: 83, low: 76},
+    {close: 75, high: 78, low: 74},
+    {close: 74, high: 76, low: 73},
+    {close: 73, high: 75, low: 72},
+    {close: 79, high: 80, low: 72},
+    {close: 85.5, high: 86, low: 79},
+    {close: 86, high: 87, low: 84},
+    {close: 87, high: 88, low: 85},
+    {close: 88, high: 89, low: 86},
+  ] as const;
+  const expectations = [
+    ['89.0000', 'BEARISH'],
+    ['89.0000', 'BEARISH'],
+    ['89.0000', 'BEARISH'],
+    ['84.2000', 'BULLISH'],
+    ['85.4600', 'BULLISH'],
+    ['86.2680', 'BULLISH'],
+    ['95.0856', 'BEARISH'],
+    ['89.1685', 'BEARISH'],
+    ['85.3348', 'BEARISH'],
+    ['83.1678', 'BEARISH'],
+    ['81.6343', 'BEARISH'],
+    ['81.6343', 'BEARISH'],
+    ['71.9341', 'BULLISH'],
+    ['75.8473', 'BULLISH'],
+    ['77.5778', 'BULLISH'],
+    ['79.1622', 'BULLISH'],
+  ] as const;
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const supertrend = new SuperTrend({interval: 5, multiplier: 2});
+
+      supertrend.updates(candles, false);
+
+      const originalValue = {close: 88, high: 89, low: 86} as const;
+      const replacedValue = {close: 61, high: 87, low: 60} as const;
+
+      const originalResult = supertrend.add(originalValue);
+
+      expect(originalResult?.supertrend.toFixed(4)).toBe('79.6298');
+      expect(originalResult?.trend).toBe('BULLISH');
+
+      const replacedResult = supertrend.replace(replacedValue);
+
+      expect(replacedResult?.supertrend.toFixed(4)).toBe('91.3702');
+      expect(replacedResult?.trend).toBe('BEARISH');
+
+      const restoredResult = supertrend.replace(originalValue);
+
+      expect(restoredResult).toEqual(originalResult);
+    });
+  });
+
+  describe('getResultOrThrow', () => {
+    it('rides the active band and flips the trend when the close breaks through it', () => {
+      const supertrend = new SuperTrend({interval: 5, multiplier: 2});
+      const offset = supertrend.getRequiredInputs() - 1;
+
+      candles.forEach((candle, i) => {
+        const result = supertrend.add(candle);
+
+        if (result) {
+          const [expectedValue, expectedTrend] = expectations[i - offset];
+          expect(result.supertrend.toFixed(4)).toBe(expectedValue);
+          expect(result.trend).toBe(expectedTrend);
+        }
+      });
+
+      expect(supertrend.isStable).toBe(true);
+      expect(supertrend.getRequiredInputs()).toBe(5);
+    });
+
+    it('uses an interval of 10 and a multiplier of 3 by default', () => {
+      const supertrend = new SuperTrend();
+
+      expect(supertrend.getRequiredInputs()).toBe(10);
+      expect(supertrend.multiplier).toBe(3);
+    });
+
+    it('starts in an uptrend when the first stable close clears the upper band', () => {
+      const supertrend = new SuperTrend({interval: 2, multiplier: 0.5});
+
+      supertrend.add({close: 10, high: 11, low: 9});
+
+      const result = supertrend.add({close: 15, high: 15.1, low: 9});
+
+      expect(result?.supertrend.toFixed(3)).toBe('10.025');
+      expect(result?.trend).toBe('BULLISH');
+    });
+
+    it('throws an error when there is not enough input data', () => {
+      const supertrend = new SuperTrend({interval: 5, multiplier: 2});
+
+      try {
+        supertrend.getResultOrThrow();
+        throw new Error('Expected error');
+      } catch (error) {
+        expect(error).toBeInstanceOf(NotEnoughDataError);
+      }
+    });
+  });
+});

--- a/packages/trading-signals/src/trend/SUPERTREND/SuperTrend.ts
+++ b/packages/trading-signals/src/trend/SUPERTREND/SuperTrend.ts
@@ -1,0 +1,107 @@
+import type {HighLowClose} from '../../base/Candle.type.js';
+import {TechnicalIndicator, TradingSignal} from '../../base/Indicator.js';
+import {ATR} from '../../volatility/ATR/ATR.js';
+
+export type SuperTrendResult = {
+  /** The active band price trails against: support below price in an uptrend, resistance above it in a downtrend */
+  supertrend: number;
+  /** BULLISH while the line rides below price, BEARISH while it caps price from above */
+  trend: typeof TradingSignal.BULLISH | typeof TradingSignal.BEARISH;
+};
+
+export type SuperTrendConfig = {
+  /** Number of candles for the ATR that sets the band distance (default: 10) */
+  interval?: number;
+  /** How many ATRs the band sits away from the candle midpoint (default: 3) */
+  multiplier?: number;
+};
+
+type SuperTrendState = {
+  close: number;
+  finalLowerBand: number;
+  finalUpperBand: number;
+  isUp: boolean;
+};
+
+/**
+ * SuperTrend (SUPERTREND)
+ * Type: Trend
+ *
+ * Popularized by Olivier Seban, the SuperTrend answers the one question a trend follower keeps asking: which side of
+ * the market to be on right now. It plots a single ATR-based band that trails below price in an uptrend and above it
+ * in a downtrend, and because the band only ratchets in the direction of the trend (it never loosens), it doubles as
+ * a volatility-adjusted trailing stop — wide in turbulent markets, tight in quiet ones.
+ *
+ * Interpretation:
+ * The trend is BULLISH while price closes above the line and BEARISH while price closes below it. The line flips
+ * sides only when the close breaks through the active band, so a flip marks a potential trend reversal. Like most
+ * trend followers, it whipsaws in sideways markets and shines in trending ones.
+ *
+ * @see https://www.tradingview.com/support/solutions/43000634738-supertrend/
+ * @see https://trendspider.com/learning-center/supertrend-indicator-a-comprehensive-guide/
+ */
+export class SuperTrend extends TechnicalIndicator<SuperTrendResult, HighLowClose<number>> {
+  readonly #atr: ATR;
+  #state?: SuperTrendState;
+  /** One-deep undo snapshot so `replace()` can rewind the recursive band/trend state */
+  #previousState?: SuperTrendState;
+
+  public readonly interval: number;
+  public readonly multiplier: number;
+
+  constructor({interval = 10, multiplier = 3}: SuperTrendConfig = {}) {
+    super();
+    this.interval = interval;
+    this.multiplier = multiplier;
+    this.#atr = new ATR(interval);
+  }
+
+  override getRequiredInputs() {
+    return this.#atr.getRequiredInputs();
+  }
+
+  update(candle: HighLowClose<number>, replace: boolean) {
+    if (replace) {
+      this.#state = this.#previousState;
+    }
+
+    const atr = this.#atr.update(candle, replace);
+
+    if (atr === null) {
+      return null;
+    }
+
+    const hl2 = (candle.high + candle.low) / 2;
+    const basicUpperBand = hl2 + this.multiplier * atr;
+    const basicLowerBand = hl2 - this.multiplier * atr;
+
+    const previous = this.#state;
+    let finalUpperBand: number;
+    let finalLowerBand: number;
+    let isUp: boolean;
+
+    if (previous === undefined) {
+      finalUpperBand = basicUpperBand;
+      finalLowerBand = basicLowerBand;
+      isUp = candle.close > finalUpperBand;
+    } else {
+      finalUpperBand =
+        basicUpperBand < previous.finalUpperBand || previous.close > previous.finalUpperBand
+          ? basicUpperBand
+          : previous.finalUpperBand;
+      finalLowerBand =
+        basicLowerBand > previous.finalLowerBand || previous.close < previous.finalLowerBand
+          ? basicLowerBand
+          : previous.finalLowerBand;
+      isUp = previous.isUp ? candle.close >= finalLowerBand : candle.close > finalUpperBand;
+    }
+
+    this.#previousState = previous;
+    this.#state = {close: candle.close, finalLowerBand, finalUpperBand, isUp};
+
+    return (this.result = {
+      supertrend: isUp ? finalLowerBand : finalUpperBand,
+      trend: isUp ? TradingSignal.BULLISH : TradingSignal.BEARISH,
+    });
+  }
+}

--- a/packages/trading-signals/src/trend/index.ts
+++ b/packages/trading-signals/src/trend/index.ts
@@ -15,6 +15,7 @@ export * from './PSAR/PSAR.js';
 export * from './RMA/RMA.js';
 export * from './SMA/SMA.js';
 export * from './SMA15/SMA15.js';
+export * from './SUPERTREND/SuperTrend.js';
 export * from './SWING_HIGH/SwingHigh.js';
 export * from './SWING_LOW/SwingLookback.js';
 export * from './SWING_LOW/SwingLow.js';


### PR DESCRIPTION
## What

Adds the **SuperTrend** indicator (popularized by Olivier Seban) as a new public `TechnicalIndicator` in `src/trend/SUPERTREND/SuperTrend.ts`. It plots a single ATR-based band that trails below price in an uptrend and above it in a downtrend, and exposes the trend direction (`BULLISH`/`BEARISH` via `TradingSignal`) alongside the line in the result.

## Formula & defaults

Verified against the TradingView reference (linked in the JSDoc together with TrendSpider's guide):

- `hl2 = (high + low) / 2`
- basic upper/lower band = `hl2 ± multiplier × ATR(interval)`
- final upper band ratchets: basic upper if it is below the previous final upper or the previous close broke above it, else the previous final upper (mirrored for the lower band)
- trend flips only when the close breaks through the active band; the first stable bar follows close vs. upper band (canonical initialization → effectively starts bearish)
- Defaults: `interval: 10`, `multiplier: 3`, reusing the existing `ATR` class with Wilder smoothing (WSMA ≡ RMA, matching TradingView's `ta.atr`)

Sources:
- https://www.tradingview.com/support/solutions/43000634738-supertrend/
- https://trendspider.com/learning-center/supertrend-indicator-a-comprehensive-guide/

## replace() handling

The recursive state (previous final bands, previous close, trend direction) is kept in a single state object with a one-deep undo snapshot: `update(candle, true)` first rewinds to the snapshot, then recomputes. The ATR handles its own replace internally. The test suite asserts bidirectional replacement (original → replaced → restored with exact equality), including a replace that flips the trend from BULLISH to BEARISH.

## Test data provenance

Tulip Indicators has no supertrend, so expected values were computed with an independent throwaway Node.js script implementing the published TradingView formula directly (not by running the indicator class); the script was deleted afterwards. The 20-candle sequence exercises both trend flips (up→down and down→up) and all band-ratcheting branches (hold, reset via basic band, reset via previous close). A separate case covers the rare bullish initialization where the first stable close clears the upper band.

## Verification

- `npm test`: 76 files / 536 tests passed, coverage 100% statements / 100% branches / 100% functions / 100% lines
- `npm run test:types`: clean
- `npm run lint`: clean (oxlint + oxfmt)