### PR TITLE
feat(trading-signals-docs): add SuperTrend and Volatility Stop demos

### DIFF
--- a/packages/trading-signals-docs/indicator-demos/trend/SuperTrend.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/SuperTrend.demo.tsx
@@ -1,0 +1,150 @@
+import {Chart as HighchartsChart} from '@highcharts/react';
+import {SuperTrend as SuperTrendClass, TradingSignal} from 'trading-signals';
+import type {ReactNode} from 'react';
+import type {Candle} from '@typedtrader/exchange';
+import type {ChartDataPoint} from '../../components/Chart';
+import {NotAvailable} from '../../components/NotAvailable';
+import PriceChart, {type PriceData} from '../../components/PriceChart';
+import {formatDate} from '../../utils/formatDate';
+import {collectPriceData} from '../../utils/renderUtils';
+import type {IndicatorConfig} from '../../utils/types';
+
+const renderSuperTrend = (config: IndicatorConfig, selectedCandles: Candle[]) => {
+  const st = new SuperTrendClass();
+  const chartDataClose: ChartDataPoint[] = [];
+  const chartDataUptrend: ChartDataPoint[] = [];
+  const chartDataDowntrend: ChartDataPoint[] = [];
+  const priceData: PriceData[] = [];
+  const sampleValues: {period: number; date: string; close: number; supertrend: ReactNode; trend: ReactNode}[] = [];
+
+  selectedCandles.forEach((candle, idx) => {
+    const result = st.add({close: Number(candle.close), high: Number(candle.high), low: Number(candle.low)});
+    chartDataClose.push({x: idx + 1, y: Number(candle.close)});
+    chartDataUptrend.push({x: idx + 1, y: result?.trend === TradingSignal.BULLISH ? result.supertrend : null});
+    chartDataDowntrend.push({x: idx + 1, y: result?.trend === TradingSignal.BEARISH ? result.supertrend : null});
+
+    priceData.push(collectPriceData(candle, idx));
+
+    sampleValues.push({
+      close: Number(candle.close),
+      date: formatDate(candle.openTimeInISO),
+      period: idx + 1,
+      supertrend: result ? result.supertrend.toFixed(2) : <NotAvailable />,
+      trend: result ? result.trend : <NotAvailable />,
+    });
+  });
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold text-white mb-2 select-text">
+          SuperTrend({st.interval}, {st.multiplier}) / Required Inputs: {st.getRequiredInputs()}
+        </h2>
+        <p className="text-slate-300 select-text">{config.description}</p>
+        {config.details && <p className="text-slate-400 text-sm mt-2 select-text">{config.details}</p>}
+      </div>
+
+      <div className="bg-slate-800/50 border border-slate-700 rounded-lg p-4">
+        <HighchartsChart
+          options={{
+            chart: {backgroundColor: 'transparent', height: 300, type: 'line'},
+            credits: {enabled: false},
+            legend: {enabled: true, itemStyle: {color: '#e2e8f0'}},
+            plotOptions: {line: {lineWidth: 2, marker: {enabled: true, radius: 3}}},
+            series: [
+              {
+                color: '#94a3b8',
+                data: chartDataClose.map(point => [point.x, point.y]),
+                marker: {fillColor: '#94a3b8'},
+                name: 'Close',
+                type: 'line',
+              },
+              {
+                color: '#10b981',
+                data: chartDataUptrend.map(point => [point.x, point.y]),
+                marker: {fillColor: '#10b981'},
+                name: 'Uptrend (support)',
+                type: 'line',
+              },
+              {
+                color: '#ef4444',
+                data: chartDataDowntrend.map(point => [point.x, point.y]),
+                marker: {fillColor: '#ef4444'},
+                name: 'Downtrend (resistance)',
+                type: 'line',
+              },
+            ],
+            title: {style: {color: '#e2e8f0', fontSize: '16px', fontWeight: '600'}, text: 'SuperTrend (10, 3)'},
+            tooltip: {
+              backgroundColor: '#1e293b',
+              borderColor: '#475569',
+              formatter: function () {
+                let s: string = `<b>Period ${(this as any).x}</b><br/>`;
+                ((this as any).points as any[])?.forEach((point: any) => {
+                  const yValue = typeof point.y === 'number' ? point.y.toFixed(2) : 'N/A';
+                  s += `${point.series.name}: ${yValue}<br/>`;
+                });
+                return s;
+              },
+              shared: true,
+              style: {color: '#e2e8f0'},
+            },
+            xAxis: {
+              gridLineColor: '#334155',
+              labels: {style: {color: '#94a3b8'}},
+              title: {style: {color: '#94a3b8'}, text: 'Period'},
+            },
+            yAxis: {
+              gridLineColor: '#334155',
+              labels: {style: {color: '#94a3b8'}},
+              title: {style: {color: '#94a3b8'}, text: 'Price'},
+            },
+          }}
+        />
+      </div>
+
+      <PriceChart title="Input Prices" data={priceData} />
+
+      <div className="bg-slate-800/50 border border-slate-700 rounded-lg p-4">
+        <h3 className="text-lg font-semibold text-white mb-3">All Sample Values</h3>
+        <div className="overflow-x-auto">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-slate-600">
+                <th className="text-left py-2 px-3 text-slate-400 font-medium">Period</th>
+                <th className="text-left py-2 px-3 text-slate-400 font-medium">Date</th>
+                <th className="text-left py-2 px-3 text-slate-400 font-medium">Close</th>
+                <th className="text-left py-2 px-3 text-slate-400 font-medium">SuperTrend</th>
+                <th className="text-left py-2 px-3 text-slate-400 font-medium">Trend</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sampleValues.map((row, idx) => (
+                <tr key={idx} className="border-b border-slate-700/50">
+                  <td className="py-2 px-3 text-white font-mono">{row.period}</td>
+                  <td className="py-2 px-3 text-slate-300">{row.date}</td>
+                  <td className="py-2 px-3 text-slate-300">${row.close.toFixed(2)}</td>
+                  <td className="py-2 px-3 text-white font-mono">{row.supertrend}</td>
+                  <td className="py-2 px-3 text-white font-mono">{row.trend}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const SuperTrend: IndicatorConfig = {
+  color: '#10b981',
+  createIndicator: () => new SuperTrendClass(),
+  customRender: renderSuperTrend,
+  description: 'SuperTrend',
+  details:
+    'Answers the one question a trend follower keeps asking: which side of the market to be on right now. It plots a single ATR-based band that trails below price in an uptrend and above it in a downtrend, and because the band only ratchets in the direction of the trend, it doubles as a volatility-adjusted trailing stop. The line flips sides only when the close breaks through the active band, so a flip marks a potential trend reversal.',
+  id: 'supertrend',
+  name: 'SuperTrend',
+  requiredInputs: 10,
+  type: 'custom',
+};

--- a/packages/trading-signals-docs/indicator-demos/trend/VolatilityStop.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/VolatilityStop.demo.tsx
@@ -1,0 +1,150 @@
+import {Chart as HighchartsChart} from '@highcharts/react';
+import {TradingSignal, VolatilityStop as VolatilityStopClass} from 'trading-signals';
+import type {ReactNode} from 'react';
+import type {Candle} from '@typedtrader/exchange';
+import type {ChartDataPoint} from '../../components/Chart';
+import {NotAvailable} from '../../components/NotAvailable';
+import PriceChart, {type PriceData} from '../../components/PriceChart';
+import {formatDate} from '../../utils/formatDate';
+import {collectPriceData} from '../../utils/renderUtils';
+import type {IndicatorConfig} from '../../utils/types';
+
+const renderVolatilityStop = (config: IndicatorConfig, selectedCandles: Candle[]) => {
+  const vstop = new VolatilityStopClass();
+  const chartDataClose: ChartDataPoint[] = [];
+  const chartDataSupport: ChartDataPoint[] = [];
+  const chartDataResistance: ChartDataPoint[] = [];
+  const priceData: PriceData[] = [];
+  const sampleValues: {period: number; date: string; close: number; stop: ReactNode; side: ReactNode}[] = [];
+
+  selectedCandles.forEach((candle, idx) => {
+    const result = vstop.add({close: Number(candle.close), high: Number(candle.high), low: Number(candle.low)});
+    chartDataClose.push({x: idx + 1, y: Number(candle.close)});
+    chartDataSupport.push({x: idx + 1, y: result?.signal === TradingSignal.BULLISH ? result.stop : null});
+    chartDataResistance.push({x: idx + 1, y: result?.signal === TradingSignal.BEARISH ? result.stop : null});
+
+    priceData.push(collectPriceData(candle, idx));
+
+    sampleValues.push({
+      close: Number(candle.close),
+      date: formatDate(candle.openTimeInISO),
+      period: idx + 1,
+      side: result ? result.signal : <NotAvailable />,
+      stop: result ? result.stop.toFixed(2) : <NotAvailable />,
+    });
+  });
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold text-white mb-2 select-text">
+          VolatilityStop({vstop.interval}, {vstop.multiplier}) / Required Inputs: {vstop.getRequiredInputs()}
+        </h2>
+        <p className="text-slate-300 select-text">{config.description}</p>
+        {config.details && <p className="text-slate-400 text-sm mt-2 select-text">{config.details}</p>}
+      </div>
+
+      <div className="bg-slate-800/50 border border-slate-700 rounded-lg p-4">
+        <HighchartsChart
+          options={{
+            chart: {backgroundColor: 'transparent', height: 300, type: 'line'},
+            credits: {enabled: false},
+            legend: {enabled: true, itemStyle: {color: '#e2e8f0'}},
+            plotOptions: {line: {lineWidth: 2, marker: {enabled: true, radius: 3}}},
+            series: [
+              {
+                color: '#94a3b8',
+                data: chartDataClose.map(point => [point.x, point.y]),
+                marker: {fillColor: '#94a3b8'},
+                name: 'Close',
+                type: 'line',
+              },
+              {
+                color: '#10b981',
+                data: chartDataSupport.map(point => [point.x, point.y]),
+                marker: {fillColor: '#10b981'},
+                name: 'Stop (support)',
+                type: 'line',
+              },
+              {
+                color: '#ef4444',
+                data: chartDataResistance.map(point => [point.x, point.y]),
+                marker: {fillColor: '#ef4444'},
+                name: 'Stop (resistance)',
+                type: 'line',
+              },
+            ],
+            title: {style: {color: '#e2e8f0', fontSize: '16px', fontWeight: '600'}, text: 'Volatility Stop (5, 3.5)'},
+            tooltip: {
+              backgroundColor: '#1e293b',
+              borderColor: '#475569',
+              formatter: function () {
+                let s: string = `<b>Period ${(this as any).x}</b><br/>`;
+                ((this as any).points as any[])?.forEach((point: any) => {
+                  const yValue = typeof point.y === 'number' ? point.y.toFixed(2) : 'N/A';
+                  s += `${point.series.name}: ${yValue}<br/>`;
+                });
+                return s;
+              },
+              shared: true,
+              style: {color: '#e2e8f0'},
+            },
+            xAxis: {
+              gridLineColor: '#334155',
+              labels: {style: {color: '#94a3b8'}},
+              title: {style: {color: '#94a3b8'}, text: 'Period'},
+            },
+            yAxis: {
+              gridLineColor: '#334155',
+              labels: {style: {color: '#94a3b8'}},
+              title: {style: {color: '#94a3b8'}, text: 'Price'},
+            },
+          }}
+        />
+      </div>
+
+      <PriceChart title="Input Prices" data={priceData} />
+
+      <div className="bg-slate-800/50 border border-slate-700 rounded-lg p-4">
+        <h3 className="text-lg font-semibold text-white mb-3">All Sample Values</h3>
+        <div className="overflow-x-auto">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-slate-600">
+                <th className="text-left py-2 px-3 text-slate-400 font-medium">Period</th>
+                <th className="text-left py-2 px-3 text-slate-400 font-medium">Date</th>
+                <th className="text-left py-2 px-3 text-slate-400 font-medium">Close</th>
+                <th className="text-left py-2 px-3 text-slate-400 font-medium">Stop</th>
+                <th className="text-left py-2 px-3 text-slate-400 font-medium">Side</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sampleValues.map((row, idx) => (
+                <tr key={idx} className="border-b border-slate-700/50">
+                  <td className="py-2 px-3 text-white font-mono">{row.period}</td>
+                  <td className="py-2 px-3 text-slate-300">{row.date}</td>
+                  <td className="py-2 px-3 text-slate-300">${row.close.toFixed(2)}</td>
+                  <td className="py-2 px-3 text-white font-mono">{row.stop}</td>
+                  <td className="py-2 px-3 text-white font-mono">{row.side}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const VolatilityStop: IndicatorConfig = {
+  color: '#10b981',
+  createIndicator: () => new VolatilityStopClass(),
+  customRender: renderVolatilityStop,
+  description: 'Volatility Stop',
+  details:
+    "Trails a stop a multiple of the Average True Range behind the closing price, so the stop only ratchets in the trade's favor: it rises (never falls) below price in an uptrend and falls (never rises) above price in a downtrend. A close beyond the stop flips it to the other side of the price — the stop switches from acting as support to acting as resistance (or back), signaling a trend change rather than mere noise.",
+  id: 'volatility-stop',
+  name: 'Volatility Stop',
+  requiredInputs: 5,
+  type: 'custom',
+};

--- a/packages/trading-signals-docs/indicator-demos/trend/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/index.tsx
@@ -15,8 +15,10 @@ import {PSAR} from './PSAR.demo';
 import {RMA} from './RMA.demo';
 import {SMA} from './SMA.demo';
 import {SMA15} from './SMA15.demo';
+import {SuperTrend} from './SuperTrend.demo';
 import {SwingHigh} from './SwingHigh.demo';
 import {SwingLow} from './SwingLow.demo';
+import {VolatilityStop} from './VolatilityStop.demo';
 import {VWAP} from './VWAP.demo';
 import {WMA} from './WMA.demo';
 import {WSMA} from './WSMA.demo';
@@ -47,4 +49,6 @@ export const indicators: IndicatorConfig[] = [
   SwingHigh,
   HigherLowTrail,
   BreakoutBarLow,
+  SuperTrend,
+  VolatilityStop,
 ];


### PR DESCRIPTION
## What

Exposes the two recently merged indicators on the docs site (Trend category):

- **SuperTrend** (`id: supertrend`) — demo for `SuperTrend` with defaults (interval 10, multiplier 3), added in #1237
- **Volatility Stop** (`id: volatility-stop`) — demo for `VolatilityStop` with defaults (interval 5, multiplier 3.5), added in #1238

Both follow the `ChandelierExit.demo.tsx` template: `customRender` with a Highcharts chart, `PriceChart` input prices, and a full sample-values table.

## How the flip is visualized

Each indicator produces a single line that jumps from one side of price to the other on a trend change. To make the flip visible, the line is split into **two chart series** keyed on the result's `trend`/`signal`:

- Green (`#10b981`): value while `BULLISH` — the stop/band acting as support below price (null elsewhere)
- Red (`#ef4444`): value while `BEARISH` — acting as resistance above price (null elsewhere)

plus the Close line in slate (`#94a3b8`). The tables show Period / Date / Close plus SuperTrend + Trend (or Stop + Side), with `<NotAvailable />` during warm-up.

## Verification

- `npm run test:types` (tsc --noEmit): pass
- `npm run lint` (oxlint + oxfmt): pass
- `npm run build` (Next.js static export): pass
- Unit suite: no test files in this package; Playwright e2e not run (no browser install)