### PR TITLE
fix(exchange): remove console noise and dotenv-defaults from consumer install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15682,10 +15682,12 @@
         "axios": "^1.18.1",
         "axios-retry": "^4.5.0",
         "big.js": "^7.0.1",
-        "dotenv-defaults": "^6.0.0",
         "ms": "4.0.0-nightly.202508271359",
         "ts-retry-promise": "^0.8.1",
         "zod": "^4.4.3"
+      },
+      "devDependencies": {
+        "dotenv-defaults": "^6.0.0"
       }
     },
     "packages/exchange/node_modules/ms": {

--- a/packages/exchange/package.json
+++ b/packages/exchange/package.json
@@ -48,9 +48,11 @@
     "axios": "^1.18.1",
     "axios-retry": "^4.5.0",
     "big.js": "^7.0.1",
-    "dotenv-defaults": "^6.0.0",
     "ms": "4.0.0-nightly.202508271359",
     "ts-retry-promise": "^0.8.1",
     "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "dotenv-defaults": "^6.0.0"
   }
 }

--- a/packages/exchange/src/broker/alpaca/getAlpacaClient.ts
+++ b/packages/exchange/src/broker/alpaca/getAlpacaClient.ts
@@ -39,8 +39,6 @@ export function getAlpacaClient(options: {
    */
   marketData?: MarketDataSource;
 }) {
-  console.log('Initializing Alpaca client', {usePaperTrading: options.usePaperTrading});
-
   const ownedMarketData = options.marketData ? null : new AlpacaMarketData(options);
   const marketData = options.marketData ?? ownedMarketData!;
   const broker = new AlpacaBroker({...options, marketData});

--- a/packages/exchange/src/broker/alpaca/getAlpacaMarketData.ts
+++ b/packages/exchange/src/broker/alpaca/getAlpacaMarketData.ts
@@ -1,8 +1,6 @@
 import {AlpacaMarketData, type AlpacaMarketDataOptions} from './AlpacaMarketData.js';
 
 export function getAlpacaMarketData(options: AlpacaMarketDataOptions) {
-  console.log('Initializing Alpaca market data');
-
   const marketData = new AlpacaMarketData(options);
 
   process.on('SIGINT', () => {

--- a/packages/exchange/src/broker/trading212/getTrading212Client.ts
+++ b/packages/exchange/src/broker/trading212/getTrading212Client.ts
@@ -7,6 +7,5 @@ export function getTrading212Client(options: {
   usePaperTrading: boolean;
   marketData: MarketDataSource;
 }): Trading212Broker {
-  console.log('Initializing Trading212 client', {usePaperTrading: options.usePaperTrading});
   return new Trading212Broker(options);
 }


### PR DESCRIPTION
## Problem

Consuming `@typedtrader/exchange` as a third party has two rough edges (found while building a consumer-side test bed against the published 0.3.0):

1. `getTrading212Client`, `getAlpacaClient`, and `getAlpacaMarketData` log `Initializing ...` on construction. A library must not write to a consumer's stdout — this pollutes every consumer's test output and application logs with no way to silence it.
2. `dotenv-defaults` ships as a runtime dependency, so every consumer installs it transitively — even though it is only imported by the demo scripts under `src/**/demo`, which are already excluded from the published build (`tsconfig.build.json` excludes them; `dist` contains no reference to it).

## Changes

- Remove the three `Initializing ...` `console.log` calls from the exported client factories (Trading212 + Alpaca). Diagnostic `console.error`/`console.warn` in the WebSocket layer is untouched.
- Move `dotenv-defaults` from `dependencies` to `devDependencies` — the demo scripts run via `tsx` inside the workspace, where devDependencies are available.

## Verification

- `npm test` in `packages/exchange`: 89 tests pass, type-check clean
- `oxlint` clean
- `grep -r dotenv packages/exchange/dist` → no matches (nothing shipped imports it)