### PR TITLE
docs(exchange): make README end-user focused, move design decisions to CLAUDE.md

### DIFF
--- a/packages/exchange/CLAUDE.md
+++ b/packages/exchange/CLAUDE.md
@@ -2,6 +2,16 @@
 
 For the full architectural template (layering, outer composition root, mapper layer, streaming manager, neutral `Exchange` base, etc.), see [BROKER_TEMPLATE.md](./BROKER_TEMPLATE.md). The notes below are a condensed checklist.
 
+## Design Decisions
+
+The `Broker` interface is intentionally kept generic so that any broker can implement it:
+
+- **Bring your own broker.** Alpaca and Trading212 are first-class, but the package is built to be extended.
+- **Extending the abstract `Broker` class** makes an integration plug straight into the `trading-strategies` package's `TradingSession` for live strategies and `BacktestExecutor` for backtesting — both for free, with no extra wiring.
+- **Execution and market data are deliberately separated.** `Broker` handles order execution; `MarketDataSource` handles candles. This lets any data provider be paired with any broker — essential for brokers without a market-data API (e.g. Trading212, which exposes no historical bars and no WebSocket, so `Trading212Broker` requires an external `MarketDataSource`).
+
+The README is written for end users (installation, quick starts, broker trade-offs) — keep architectural rationale here or in BROKER_TEMPLATE.md, not there.
+
 ## Exchange Implementation Patterns
 
 When implementing an exchange integration, follow these patterns:

--- a/packages/exchange/README.md
+++ b/packages/exchange/README.md
@@ -1,67 +1,56 @@
 # @typedtrader/exchange
 
-Utilities for handling trading exchange data with proper type safety and aggregation.
+Typed broker clients for algorithmic trading in TypeScript. Trade through [Alpaca](https://alpaca.markets/) or [Trading212](https://www.trading212.com/) with one consistent API — every response validated at runtime (zod), all money math in arbitrary precision (big.js), live candles streamed over WebSocket.
+
+## Installation
+
+```sh
+npm install @typedtrader/exchange
+```
+
+The package is ESM-only and targets the latest Node.js LTS.
 
 ## Features
 
-- **Candle Batching:** Aggregates multiple exchange candles into larger timeframes
-- **Type Safety:** Zod schemas for runtime validation of exchange data
-- **High Precision:** Uses `big.js` for arbitrary-precision decimal arithmetic
-- **Event-Driven:** Built-in EventEmitter for streaming candle updates
-- **Flexible Intervals:** Timeframes using human-readable strings (e.g., "1h", "5m")
+- **One broker API for every broker:** place market/limit orders, list balances, watch fills and candles — identical methods whether you trade through Alpaca or Trading212
+- **Paper trading:** both brokers support a sandbox environment via a single `usePaperTrading` flag
+- **Runtime validation:** every API response is parsed with zod schemas — malformed data fails loudly instead of corrupting your strategy
+- **High precision:** `big.js` for order sizes, prices, and fees — no floating-point drift
+- **Streaming candles:** WebSocket-fed minute bars, batched into larger timeframes using human-readable intervals (e.g. `"5m"`, `"1h"`)
+- **Fee awareness:** `getFeeRates()` / `estimateFee()` let strategies subtract round-trip costs before entering a position
 
-## Design Decisions
-
-The `Broker` interface is intentionally kept generic so that any broker can implement it. This means:
-
-- **Bring your own broker.** Alpaca and Trading212 are first-class, but the package is built to be extended.
-- **Extend the abstract `Broker` class** and your integration plugs straight into the `trading-strategies` package's `TradingSession` for live strategies and `BacktestExecutor` for backtesting — both for free, with no extra wiring. See [`BROKER_TEMPLATE.md`](./BROKER_TEMPLATE.md) for the conventions every integration follows.
-- **Extend `MarketDataSource`** to add live-streaming candles for your strategies. If your broker has no market-data API, plug in an existing source (e.g. Alpaca) instead — execution and market data are deliberately separated so they can be mixed and matched.
-
-## Alpaca
-
-This package includes a first-class [Alpaca](https://alpaca.markets/) implementation.
+## Quick Start: Alpaca
 
 ```ts
-import {getAlpacaClient} from '@typedtrader/exchange';
+import {getAlpacaClient, TradingPair} from '@typedtrader/exchange';
 
-const exchange = getAlpacaClient({
-  apiKey: process.env.ALPACA_API_KEY,
-  apiSecret: process.env.ALPACA_API_SECRET,
+const broker = getAlpacaClient({
+  apiKey: 'ALPACA_API_KEY',
+  apiSecret: 'ALPACA_API_SECRET',
   usePaperTrading: true,
 });
+
+await broker.verifyCredentials();
+
+const pair = new TradingPair('AAPL', 'USD');
+const latest = await broker.getLatestCandle(pair, 60_000);
+await broker.placeLimitOrder(pair, {side: 'BUY', size: '1', price: latest.close});
 ```
 
 **Why Alpaca:**
 
 - **Commission-free** US stocks and ETFs, with fractional shares.
-- **Add funds commission-free** with [Revolut](https://www.revolut.com/), avoiding the transfer fees most banks charge.
 - **Free paper trading** that mirrors the live API, so strategies can be validated without risking capital.
 - **Free market data** via the IEX feed, including WebSocket-streamed minute bars (the source this package pairs with other brokers).
 - **Crypto** trades 24/7 alongside equities.
 - **[24/5 trading](https://docs.alpaca.markets/us/docs/245-trading)** of US stocks via an overnight session, so positions can be opened or closed from Sunday evening through Friday evening.
+- **Add funds commission-free** with [Revolut](https://www.revolut.com/), avoiding the transfer fees most banks charge.
 
-**Resources:**
+**Resources:** [API Reference](https://docs.alpaca.markets/reference/) · [OpenAPI Files](https://docs.alpaca.markets/openapi) · [24/5 Trading](https://docs.alpaca.markets/us/docs/245-trading)
 
-- [Alpaca API Reference](https://docs.alpaca.markets/reference/)
-- [Alpaca OpenAPI Files](https://docs.alpaca.markets/openapi)
-- [24/5 Trading](https://docs.alpaca.markets/us/docs/245-trading)
+## Quick Start: Trading212
 
-## Trading212
-
-[Trading212](https://www.trading212.com/) is supported as a broker.
-
-**Why Trading212:**
-
-- **Commission-free** investing in 13,000+ stocks and ETFs, with fractional shares from £1/€1.
-- **Broad UK, European, and US coverage.**
-- **Multi-currency accounts** for depositing and investing in 13 currencies.
-- **Tax-advantaged Stocks & Shares ISA** (and Cash ISA) for UK residents, with no account fees.
-- **Daily [interest](https://www.trading212.com/interest-on-cash)** paid on uninvested cash.
-
-Its API has **no historical bars and no WebSocket**, so `Trading212Broker` requires an external `MarketDataSource` for candle methods.
-
-The package separates **execution** (`Broker`) from **market data** (`MarketDataSource`) so any data provider can be paired with any broker. For US equities, Alpaca's market-data feed is the natural pairing as it is free, works with a paper account, and supports WebSocket-streamed minute bars:
+Trading212's API has **no historical bars and no WebSocket**, so the broker is paired with an external market-data source. For US equities, Alpaca's feed is the natural choice — it is free, works with a paper account, and streams minute bars over WebSocket:
 
 ```ts
 import {AlpacaMarketData, getTrading212Client, TradingPair} from '@typedtrader/exchange';
@@ -88,13 +77,47 @@ const latest = await broker.getLatestCandle(pair, 60_000); // → from Alpaca's 
 await broker.placeLimitOrder(pair, {side: 'BUY', size: '1', price: latest.close}); // → Trading212
 ```
 
-**Caveats:**
+**Why Trading212:**
 
-- **Coverage mismatch.** Alpaca's free IEX feed covers US equities (and crypto). Trading212's universe includes European and UK instruments that Alpaca doesn't have data for; those tickers will fail at `getCandles` even though Trading212 can trade them. Pair with a different data source (Bloomberg, Polygon, EODHD, Twelve Data) for non-US coverage.
-- **Cross-currency fees.** Trading212 debits a currency-conversion fee on cross-currency trades (e.g. a EUR account buying USD instruments) at ~0.15% per leg. `Trading212Broker.getFeeRates()` surfaces this as `CURRENCY_CONVERSION_FEE`; `estimateFee()` includes it in the total so strategies can subtract round-trip costs before deciding to enter.
-- **No order-stream WebSocket.** `watchOrders` is implemented by polling `/api/v0/equity/history/orders` once per minute (matching Trading212's documented rate limit). Latency therefore equals the poll interval; fills arrive within ~60 seconds rather than push-style.
+- **Commission-free** investing in 13,000+ stocks and ETFs, with fractional shares from £1/€1.
+- **Broad UK, European, and US coverage.**
+- **Multi-currency accounts** for depositing and investing in 13 currencies.
+- **Tax-advantaged Stocks & Shares ISA** (and Cash ISA) for UK residents, with no account fees.
+- **Daily [interest](https://www.trading212.com/interest-on-cash)** paid on uninvested cash.
 
-**Resources:**
+**Good to know:**
 
-- [Trading212 API Documentation](https://docs.trading212.com/api)
-- [Trading212 Help Centre — Fees](https://helpcentre.trading212.com/hc/en-us/articles/11471996799517)
+- **Coverage mismatch.** Alpaca's free IEX feed covers US equities (and crypto). Trading212's universe includes European and UK instruments that Alpaca has no data for; those tickers will fail at `getCandles` even though Trading212 can trade them. Pair with a different data source (Bloomberg, Polygon, EODHD, Twelve Data) for non-US coverage.
+- **Cross-currency fees.** Trading212 debits a currency-conversion fee on cross-currency trades (e.g. a EUR account buying USD instruments) at ~0.15% per leg. `getFeeRates()` surfaces this as `CURRENCY_CONVERSION_FEE`; `estimateFee()` includes it in the total.
+- **Order updates are polled.** Trading212 has no order-stream WebSocket, so `watchOrders` polls once per minute (matching Trading212's documented rate limit). Fills arrive within ~60 seconds rather than push-style.
+
+**Resources:** [API Documentation](https://docs.trading212.com/api) · [Fees](https://helpcentre.trading212.com/hc/en-us/articles/11471996799517)
+
+## Raw API Access
+
+Prefer direct REST calls over the broker abstraction? The low-level clients are exported too, with zod-validated responses and rate-limit-aware retries built in:
+
+```ts
+import {Trading212API} from '@typedtrader/exchange';
+
+const api = new Trading212API({
+  apiKey: 'TRADING212_API_KEY',
+  apiSecret: 'TRADING212_API_SECRET',
+  usePaperTrading: true,
+});
+
+const cash = await api.getAccountCash();
+const positions = await api.getPositions();
+const orders = await api.getHistoryOrders(); // auto-paginates
+```
+
+`AlpacaAPI` offers the same for Alpaca.
+
+## Bring Your Own Broker
+
+Alpaca and Trading212 are first-class, but any broker can be integrated:
+
+- **Extend the abstract `Broker` class** and your integration plugs straight into the `trading-strategies` package's `TradingSession` (live trading) and `BacktestExecutor` (backtesting) — no extra wiring.
+- **Extend `MarketDataSource`** to stream candles from your own data provider. Execution and market data are deliberately separated, so any data source can be paired with any broker.
+
+See [`BROKER_TEMPLATE.md`](https://github.com/bennycode/trading-signals/blob/main/packages/exchange/BROKER_TEMPLATE.md) for the conventions every integration follows.

--- a/packages/exchange/README.md
+++ b/packages/exchange/README.md
@@ -1,6 +1,10 @@
 # @typedtrader/exchange
 
+[![npm](https://img.shields.io/npm/v/@typedtrader/exchange.svg)](https://www.npmjs.com/package/@typedtrader/exchange) [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT) [![TypeScript](https://img.shields.io/badge/types-included-blue.svg)](https://www.typescriptlang.org/)
+
 Typed broker clients for algorithmic trading in TypeScript. Trade through [Alpaca](https://alpaca.markets/) or [Trading212](https://www.trading212.com/) with one consistent API — every response validated at runtime (zod), all money math in arbitrary precision (big.js), live candles streamed over WebSocket.
+
+### [Install](#installation) · [Brokers](#supported-brokers) · [Quick Start](#quick-start-alpaca) · [Raw API](#raw-api-access) · [Rate Limits](#rate-limiting) · [Extend](#bring-your-own-broker) · [Disclaimer](#disclaimer)
 
 ## Installation
 
@@ -18,6 +22,15 @@ The package is ESM-only and targets the latest Node.js LTS.
 - **High precision:** `big.js` for order sizes, prices, and fees — no floating-point drift
 - **Streaming candles:** WebSocket-fed minute bars, batched into larger timeframes using human-readable intervals (e.g. `"5m"`, `"1h"`)
 - **Fee awareness:** `getFeeRates()` / `estimateFee()` let strategies subtract round-trip costs before entering a position
+
+## Supported Brokers
+
+| id | name | markets | paper trading | market data | order updates | API docs |
+| --- | --- | --- | :-: | --- | --- | --- |
+| `alpaca` | [Alpaca](https://alpaca.markets/) | US stocks, ETFs, crypto | ✅ | ✅ IEX feed, WebSocket streamed | ✅ WebSocket stream | [docs.alpaca.markets](https://docs.alpaca.markets/reference/) |
+| `trading212` | [Trading212](https://www.trading212.com/) | 13,000+ US/UK/EU stocks and ETFs | ✅ | ❌ bring your own source | 🔁 polled (~60s) | [docs.trading212.com](https://docs.trading212.com/api) |
+
+You need to create the API keys yourself in each broker's dashboard — this package talks to the brokers with your credentials but never creates accounts or keys for you: [Alpaca API keys](https://docs.alpaca.markets/us/docs/getting-started) · [Trading212 API keys](https://helpcentre.trading212.com/hc/en-us/articles/14584770928157-Trading-212-API-key)
 
 ## Quick Start: Alpaca
 
@@ -113,6 +126,14 @@ const orders = await api.getHistoryOrders(); // auto-paginates
 
 `AlpacaAPI` offers the same for Alpaca.
 
+## Rate Limiting
+
+Brokers enforce rate limits, and this package respects them so you don't have to:
+
+- **Automatic retries with broker-aware delays.** Both clients use `axios-retry` under the hood. Trading212's retry delays are calibrated per endpoint to its documented limits (e.g. account cash: 1 req / 2s, order history: 1 req / 60s), so a rate-limited request waits exactly as long as it must — no longer.
+- **Polling matches documented limits.** Where the package polls (Trading212's `watchOrders`), the interval defaults to the broker's documented rate limit rather than hammering the API.
+- **Transient network errors** (`EAI_AGAIN`, HTTP 429/5xx) are retried transparently; non-retryable errors (401, 403, validation failures) surface immediately.
+
 ## Bring Your Own Broker
 
 Alpaca and Trading212 are first-class, but any broker can be integrated:
@@ -121,3 +142,12 @@ Alpaca and Trading212 are first-class, but any broker can be integrated:
 - **Extend `MarketDataSource`** to stream candles from your own data provider. Execution and market data are deliberately separated, so any data source can be paired with any broker.
 
 See [`BROKER_TEMPLATE.md`](https://github.com/bennycode/trading-signals/blob/main/packages/exchange/BROKER_TEMPLATE.md) for the conventions every integration follows.
+
+## Disclaimer
+
+`@typedtrader/exchange` is software, not a financial service. It is **free, open-source, non-custodial broker-client software under the MIT license**:
+
+- **Non-custodial** — the package never holds your money. It talks to your broker's API directly, with API keys you create and control.
+- **Not financial advice** — nothing in this package or its documentation is a recommendation to buy or sell any instrument. The broker comparisons describe API capabilities, not investment suitability.
+- **MIT license** — use it for any purpose, at your own risk, without warranty of any kind.
+- **Trading involves risk of loss.** Validate every strategy against a paper-trading environment (`usePaperTrading: true`) before committing real capital.

--- a/packages/exchange/README.md
+++ b/packages/exchange/README.md
@@ -4,7 +4,13 @@
 
 Typed broker clients for algorithmic trading in TypeScript. Trade through [Alpaca](https://alpaca.markets/) or [Trading212](https://www.trading212.com/) with one consistent API — every response validated at runtime (zod), all money math in arbitrary precision (big.js), live candles streamed over WebSocket.
 
-### [Install](#installation) · [Brokers](#supported-brokers) · [Quick Start](#quick-start-alpaca) · [Raw API](#raw-api-access) · [Rate Limits](#rate-limiting) · [Extend](#bring-your-own-broker) · [Disclaimer](#disclaimer)
+### [Install](#installation) · [Brokers](#supported-brokers) · [Quick Start](#quick-start-alpaca) · [Raw API](#raw-api-access) · [Rate Limits](#rate-limiting) · [Extend](#bring-your-own-broker)
+
+## Motivation
+
+Libraries like [CCXT](https://github.com/ccxt/ccxt) prove how powerful a unified trading API is — but they stop at crypto exchanges. This package brings the same idea to traditional brokers: one typed API that connects stock brokers like Alpaca and Trading212 the way CCXT connects crypto exchanges.
+
+It also aims beyond the basic paths most trading APIs cover. Long **and** short positions, market **and** limit orders, fills, fee estimation, and trading rules are all part of one `Broker` contract — the full spectrum of trading, not just "place a buy order".
 
 ## Installation
 
@@ -142,12 +148,3 @@ Alpaca and Trading212 are first-class, but any broker can be integrated:
 - **Extend `MarketDataSource`** to stream candles from your own data provider. Execution and market data are deliberately separated, so any data source can be paired with any broker.
 
 See [`BROKER_TEMPLATE.md`](https://github.com/bennycode/trading-signals/blob/main/packages/exchange/BROKER_TEMPLATE.md) for the conventions every integration follows.
-
-## Disclaimer
-
-`@typedtrader/exchange` is software, not a financial service. It is **free, open-source, non-custodial broker-client software under the MIT license**:
-
-- **Non-custodial** — the package never holds your money. It talks to your broker's API directly, with API keys you create and control.
-- **Not financial advice** — nothing in this package or its documentation is a recommendation to buy or sell any instrument. The broker comparisons describe API capabilities, not investment suitability.
-- **MIT license** — use it for any purpose, at your own risk, without warranty of any kind.
-- **Trading involves risk of loss.** Validate every strategy against a paper-trading environment (`usePaperTrading: true`) before committing real capital.

--- a/packages/exchange/README.md
+++ b/packages/exchange/README.md
@@ -1,7 +1,5 @@
 # @typedtrader/exchange
 
-[![npm](https://img.shields.io/npm/v/@typedtrader/exchange.svg)](https://www.npmjs.com/package/@typedtrader/exchange) [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT) [![TypeScript](https://img.shields.io/badge/types-included-blue.svg)](https://www.typescriptlang.org/)
-
 Typed broker clients for algorithmic trading in TypeScript. Trade through [Alpaca](https://alpaca.markets/) or [Trading212](https://www.trading212.com/) with one consistent API — every response validated at runtime (zod), all money math in arbitrary precision (big.js), live candles streamed over WebSocket.
 
 ### [Install](#installation) · [Brokers](#supported-brokers) · [Quick Start](#quick-start-alpaca) · [Raw API](#raw-api-access) · [Rate Limits](#rate-limiting) · [Extend](#bring-your-own-broker)

--- a/packages/exchange/README.md
+++ b/packages/exchange/README.md
@@ -106,7 +106,6 @@ await broker.placeLimitOrder(pair, {side: 'BUY', size: '1', price: latest.close}
 
 **Good to know:**
 
-- **Coverage mismatch.** Alpaca's free IEX feed covers US equities (and crypto). Trading212's universe includes European and UK instruments that Alpaca has no data for; those tickers will fail at `getCandles` even though Trading212 can trade them. Pair with a different data source (Bloomberg, Polygon, EODHD, Twelve Data) for non-US coverage.
 - **Cross-currency fees.** Trading212 debits a currency-conversion fee on cross-currency trades (e.g. a EUR account buying USD instruments) at ~0.15% per leg. `getFeeRates()` surfaces this as `CURRENCY_CONVERSION_FEE`; `estimateFee()` includes it in the total.
 - **Order updates are polled.** Trading212 has no order-stream WebSocket, so `watchOrders` polls once per minute (matching Trading212's documented rate limit). Fills arrive within ~60 seconds rather than push-style.
 

--- a/packages/exchange/README.md
+++ b/packages/exchange/README.md
@@ -1,14 +1,14 @@
 # @typedtrader/exchange
 
-Typed broker clients for algorithmic trading in TypeScript. Trade through [Alpaca](https://alpaca.markets/) or [Trading212](https://www.trading212.com/) with one consistent API — every response validated at runtime (zod), all money math in arbitrary precision (big.js), live candles streamed over WebSocket.
+Typed broker clients for algorithmic trading in TypeScript. Trade through brokers like [Alpaca](https://alpaca.markets/) and [Trading212](https://www.trading212.com/) with one consistent API: every response validated at runtime (zod), all money math in arbitrary precision (big.js), live candles streamed over WebSocket.
 
 ### [Install](#installation) · [Brokers](#supported-brokers) · [Quick Start](#quick-start-alpaca) · [Raw API](#raw-api-access) · [Rate Limits](#rate-limiting) · [Extend](#bring-your-own-broker)
 
 ## Motivation
 
-Libraries like [CCXT](https://github.com/ccxt/ccxt) prove how powerful a unified trading API is — but they stop at crypto exchanges. This package brings the same idea to traditional brokers: one typed API that connects stock brokers like Alpaca and Trading212 the way CCXT connects crypto exchanges.
+[CCXT](https://github.com/ccxt/ccxt) proved how much a unified trading API is worth, but it stops at crypto exchanges. This package brings the same idea to traditional brokers: one typed API for stock brokers like Alpaca and Trading212.
 
-It also aims beyond the basic paths most trading APIs cover. Long **and** short positions, market **and** limit orders, fills, fee estimation, and trading rules are all part of one `Broker` contract — the full spectrum of trading, not just "place a buy order".
+It also covers more of trading than the basic paths most broker APIs wrap. Long and short positions, market and limit orders, fills, fee estimation, and trading rules are all part of one `Broker` contract.
 
 ## Installation
 
@@ -20,10 +20,10 @@ The package is ESM-only and targets the latest Node.js LTS.
 
 ## Features
 
-- **One broker API for every broker:** place market/limit orders, list balances, watch fills and candles — identical methods whether you trade through Alpaca or Trading212
-- **Paper trading:** both brokers support a sandbox environment via a single `usePaperTrading` flag
-- **Runtime validation:** every API response is parsed with zod schemas — malformed data fails loudly instead of corrupting your strategy
-- **High precision:** `big.js` for order sizes, prices, and fees — no floating-point drift
+- **One API for every broker:** place market/limit orders, list balances, watch fills and candles with the same methods on every supported broker
+- **Paper trading:** a single `usePaperTrading` flag switches a broker to its sandbox environment
+- **Runtime validation:** every API response is parsed with zod schemas, so malformed data fails loudly instead of corrupting your strategy
+- **High precision:** `big.js` for order sizes, prices, and fees, with no floating-point drift
 - **Streaming candles:** WebSocket-fed minute bars, batched into larger timeframes using human-readable intervals (e.g. `"5m"`, `"1h"`)
 - **Fee awareness:** `getFeeRates()` / `estimateFee()` let strategies subtract round-trip costs before entering a position
 
@@ -34,7 +34,9 @@ The package is ESM-only and targets the latest Node.js LTS.
 | `alpaca` | [Alpaca](https://alpaca.markets/) | US stocks, ETFs, crypto | ✅ | ✅ IEX feed, WebSocket streamed | ✅ WebSocket stream | [docs.alpaca.markets](https://docs.alpaca.markets/reference/) |
 | `trading212` | [Trading212](https://www.trading212.com/) | 13,000+ US/UK/EU stocks and ETFs | ✅ | ❌ bring your own source | 🔁 polled (~60s) | [docs.trading212.com](https://docs.trading212.com/api) |
 
-You need to create the API keys yourself in each broker's dashboard — this package talks to the brokers with your credentials but never creates accounts or keys for you: [Alpaca API keys](https://docs.alpaca.markets/us/docs/getting-started) · [Trading212 API keys](https://helpcentre.trading212.com/hc/en-us/articles/14584770928157-Trading-212-API-key)
+More brokers are planned, and the `Broker` abstraction is built for it (see [Bring Your Own Broker](#bring-your-own-broker)).
+
+You create the API keys yourself in each broker's dashboard. The package uses your credentials but never creates accounts or keys for you: [Alpaca API keys](https://docs.alpaca.markets/us/docs/getting-started) · [Trading212 API keys](https://helpcentre.trading212.com/hc/en-us/articles/14584770928157-Trading-212-API-key)
 
 ## Quick Start: Alpaca
 
@@ -67,7 +69,7 @@ await broker.placeLimitOrder(pair, {side: 'BUY', size: '1', price: latest.close}
 
 ## Quick Start: Trading212
 
-Trading212's API has **no historical bars and no WebSocket**, so the broker is paired with an external market-data source. For US equities, Alpaca's feed is the natural choice — it is free, works with a paper account, and streams minute bars over WebSocket:
+Trading212's API has no historical bars and no WebSocket, so the broker is paired with an external market-data source. For US equities, Alpaca's feed is the natural choice: it is free, works with a paper account, and streams minute bars over WebSocket.
 
 ```ts
 import {AlpacaMarketData, getTrading212Client, TradingPair} from '@typedtrader/exchange';
@@ -84,7 +86,7 @@ const broker = getTrading212Client({
   apiKey: 'TRADING212_API_KEY',
   apiSecret: 'TRADING212_API_SECRET',
   usePaperTrading: true,
-  marketData, // required — Trading212 has no candles of its own
+  marketData, // required: Trading212 has no candles of its own
 });
 
 // 3. Use the broker as if it provided everything natively. Symbol mapping is automatic:
@@ -112,7 +114,7 @@ await broker.placeLimitOrder(pair, {side: 'BUY', size: '1', price: latest.close}
 
 ## Raw API Access
 
-Prefer direct REST calls over the broker abstraction? The low-level clients are exported too, with zod-validated responses and rate-limit-aware retries built in:
+The low-level REST clients are exported too, for direct calls without the broker abstraction. They keep the zod-validated responses and rate-limit-aware retries:
 
 ```ts
 import {Trading212API} from '@typedtrader/exchange';
@@ -128,21 +130,21 @@ const positions = await api.getPositions();
 const orders = await api.getHistoryOrders(); // auto-paginates
 ```
 
-`AlpacaAPI` offers the same for Alpaca.
+Every broker integration exports its raw client the same way (`AlpacaAPI`, `Trading212API`, ...).
 
 ## Rate Limiting
 
-Brokers enforce rate limits, and this package respects them so you don't have to:
+Brokers enforce rate limits. The package respects them automatically:
 
-- **Automatic retries with broker-aware delays.** Both clients use `axios-retry` under the hood. Trading212's retry delays are calibrated per endpoint to its documented limits (e.g. account cash: 1 req / 2s, order history: 1 req / 60s), so a rate-limited request waits exactly as long as it must — no longer.
+- **Automatic retries with broker-aware delays.** Every client uses `axios-retry`, with retry delays calibrated per endpoint to the broker's documented limits (e.g. Trading212 account cash: 1 req / 2s, order history: 1 req / 60s), so a rate-limited request waits exactly as long as it must.
 - **Polling matches documented limits.** Where the package polls (Trading212's `watchOrders`), the interval defaults to the broker's documented rate limit rather than hammering the API.
 - **Transient network errors** (`EAI_AGAIN`, HTTP 429/5xx) are retried transparently; non-retryable errors (401, 403, validation failures) surface immediately.
 
 ## Bring Your Own Broker
 
-Alpaca and Trading212 are first-class, but any broker can be integrated:
+The built-in integrations are first-class, but any broker can be added:
 
-- **Extend the abstract `Broker` class** and your integration plugs straight into the `trading-strategies` package's `TradingSession` (live trading) and `BacktestExecutor` (backtesting) — no extra wiring.
+- **Extend the abstract `Broker` class** and your integration plugs straight into the `trading-strategies` package's `TradingSession` (live trading) and `BacktestExecutor` (backtesting) with no extra wiring.
 - **Extend `MarketDataSource`** to stream candles from your own data provider. Execution and market data are deliberately separated, so any data source can be paired with any broker.
 
 See [`BROKER_TEMPLATE.md`](https://github.com/bennycode/trading-signals/blob/main/packages/exchange/BROKER_TEMPLATE.md) for the conventions every integration follows.

--- a/packages/exchange/README.md
+++ b/packages/exchange/README.md
@@ -6,9 +6,9 @@ Typed broker clients for algorithmic trading in TypeScript. Trade through broker
 
 ## Motivation
 
-[CCXT](https://github.com/ccxt/ccxt) proved how much a unified trading API is worth, but it stops at crypto exchanges. This package brings the same idea to traditional brokers: one typed API for stock brokers like Alpaca and Trading212.
+This package provides a unified trading API for traditional brokers like Alpaca and Trading212. Write your strategy against one typed `Broker` contract and it runs on any supported broker, the way [CCXT](https://github.com/ccxt/ccxt) does it for crypto exchanges.
 
-It also covers more of trading than the basic paths most broker APIs wrap. Long and short positions, market and limit orders, fills, fee estimation, and trading rules are all part of one `Broker` contract.
+It also covers more of trading than the basic paths most broker APIs wrap: long and short positions, market and limit orders, fills, fee estimation, and trading rules.
 
 ## Installation
 


### PR DESCRIPTION
## Problem

The `@typedtrader/exchange` README mixed end-user documentation with internal architecture rationale. A consumer landing on npmjs.com got "Design Decisions" before any install instructions or runnable example.

## Changes

**README** — rewritten end-user first, with sections inspired by [ccxt](https://github.com/ccxt/ccxt):

- **Motivation** — positions the package as CCXT's unified-API idea applied to traditional brokers, covering the full trading spectrum (long/short, market/limit) rather than just crypto exchanges and basic buy paths
- ccxt-style quick-nav link line under the pitch
- Leads with installation (`npm install @typedtrader/exchange`, ESM-only note) and features phrased as user benefits
- **Supported Brokers** — ccxt-style comparison table (markets, paper trading, market data, order updates, API docs) plus links for creating API keys at each broker
- **Quick Start: Alpaca** — new runnable example covering the full credentials → candle → order flow (previously only client construction)
- **Quick Start: Trading212** — existing pairing example kept, caveats reframed as "Good to know"
- **Raw API Access** — new section documenting `Trading212API`/`AlpacaAPI` for consumers who want direct REST calls without the broker abstraction
- **Rate Limiting** — documents the broker-aware retry delays and polling intervals
- **Bring Your Own Broker** — short end-user-facing extension section; the architectural *why* moved out
- `BROKER_TEMPLATE.md` link is now absolute — the file isn't published to npm, so the relative link was broken on npmjs.com
- No badges — visual noise

**CLAUDE.md** — gained a "Design Decisions" section: generic `Broker` interface rationale, the `trading-strategies` integration contract, and the execution/market-data separation. Plus a note that the README is end-user territory so the split stays intact.

## Verification

- `oxfmt` clean (pre-commit hook)
- API-key documentation links verified to resolve (canonical URLs, no redirects)