### PR TITLE
fix(trading-signals): use correct comparand when replacing ROC values

### DIFF
--- a/packages/trading-signals/src/momentum/ROC/ROC.test.ts
+++ b/packages/trading-signals/src/momentum/ROC/ROC.test.ts
@@ -143,5 +143,19 @@ describe('ROC', () => {
 
       expect(roc.getResultOrThrow().toFixed(2)).toEqual(expectation.toFixed(2));
     });
+
+    it('keeps the correct comparand when replacing after the window has advanced', () => {
+      const interval = 3;
+
+      const withReplace = new ROC(interval);
+      [10, 11, 12, 13].forEach(price => withReplace.add(price));
+      withReplace.replace(13);
+
+      const withoutReplace = new ROC(interval);
+      [10, 11, 12, 13].forEach(price => withoutReplace.add(price));
+
+      expect(withReplace.getResultOrThrow().toFixed(4)).toBe('0.3000');
+      expect(withReplace.getResultOrThrow().toFixed(5)).toBe(withoutReplace.getResultOrThrow().toFixed(5));
+    });
   });
 });

--- a/packages/trading-signals/src/momentum/ROC/ROC.ts
+++ b/packages/trading-signals/src/momentum/ROC/ROC.ts
@@ -15,6 +15,8 @@ export class ROC extends TrendIndicatorSeries {
 
   public readonly interval: number;
 
+  #comparePrice: number | null = null;
+
   constructor(interval: number) {
     super();
     this.interval = interval;
@@ -25,11 +27,13 @@ export class ROC extends TrendIndicatorSeries {
   }
 
   update(price: number, replace: boolean) {
-    const comparePrice = this.prices.length === this.interval ? this.prices[0] : null;
+    if (!replace || this.#comparePrice === null) {
+      this.#comparePrice = this.prices.length === this.interval ? this.prices[0] : null;
+    }
     pushUpdate(this.prices, replace, price, this.interval);
 
-    if (comparePrice !== null) {
-      return this.setResult((price - comparePrice) / comparePrice, replace);
+    if (this.#comparePrice !== null) {
+      return this.setResult((price - this.#comparePrice) / this.#comparePrice, replace);
     }
 
     return null;


### PR DESCRIPTION
## Problem

`ROC` recomputes its comparand (the price `interval` bars ago) from the current window head on every `update()`. Once more than `interval` prices have been added, the oldest price has already been evicted from the rolling window, so on a `replace()` `prices[0]` points one bar too recent. Replacing the latest bar — even with the same value — therefore changes the result.

### Reproduction

```ts
const roc = new ROC(3);
[10, 11, 12, 13].forEach(p => roc.add(p));
roc.getResultOrThrow(); // 0.3        (13 - 10) / 10  ✅
roc.replace(13);        // same value
roc.getResultOrThrow(); // 0.18181…   ❌ expected 0.3
```

The existing `replace()` test only replaces the first stable bar (before any eviction), where `prices[0]` still happens to be the correct comparand — which is why this went unnoticed.

## Fix

Persist the comparand captured when a bar is first added (`#comparePrice`) and reuse it on `replace()` instead of re-reading the window head.

## Tests

- Added a regression test that replaces a bar after the window has advanced and asserts the result matches the equivalent non-replaced series.
- Full `trading-signals` suite passes (541 tests) and `tsc --noEmit` is clean.