### PR TITLE
fix(trading-signals): recalculate Bollinger Bands on replace()

### DIFF
--- a/packages/trading-signals/src/volatility/BBANDS/BollingerBands.test.ts
+++ b/packages/trading-signals/src/volatility/BBANDS/BollingerBands.test.ts
@@ -161,6 +161,20 @@ describe('BollingerBands', () => {
       expect(restoredResult?.middle, 'replacing back restores the original bands').toBe(originalResult.middle);
     });
 
+    it('changes nothing when the latest price is replaced with the same value', () => {
+      const bb = new BollingerBands(5, 2);
+      const prices = [81.59, 81.06, 82.87, 83.0, 83.61, 83.15] as const;
+
+      prices.forEach(price => bb.add(price));
+
+      const resultBefore = bb.getResultOrThrow();
+
+      bb.replace(83.15);
+
+      expect(bb.getResultOrThrow(), 'replacing a price with itself is a no-op').toEqual(resultBefore);
+      expect(bb.isStable, 'and it stays stable').toBe(true);
+    });
+
     it('keeps calculating when a price of zero drops out of the window', () => {
       const bb = new BollingerBands(3, 2);
 

--- a/packages/trading-signals/src/volatility/BBANDS/BollingerBands.test.ts
+++ b/packages/trading-signals/src/volatility/BBANDS/BollingerBands.test.ts
@@ -144,6 +144,32 @@ describe('BollingerBands', () => {
     });
   });
 
+  describe('update', () => {
+    it('recalculates the bands when replacing the latest price', () => {
+      const bb = new BollingerBands(5, 2);
+      const prices = [81.59, 81.06, 82.87, 83.0, 83.61, 83.15] as const;
+
+      prices.forEach(price => bb.add(price));
+
+      const originalResult = bb.getResultOrThrow();
+      const replacedResult = bb.replace(90);
+
+      expect(replacedResult?.middle, 'a replacement recalculates the bands').not.toBe(originalResult.middle);
+
+      const restoredResult = bb.replace(83.15);
+
+      expect(restoredResult?.middle, 'replacing back restores the original bands').toBe(originalResult.middle);
+    });
+
+    it('keeps calculating when a price of zero drops out of the window', () => {
+      const bb = new BollingerBands(3, 2);
+
+      [0, 1, 2, 3].forEach(price => bb.add(price));
+
+      expect(bb.getResultOrThrow().middle, 'a zero drop-out must not suppress the calculation').toBe(2);
+    });
+  });
+
   describe('getSignal', () => {
     it('returns UNKNOWN when there is no result', () => {
       const bb = new BollingerBands(10);

--- a/packages/trading-signals/src/volatility/BBANDS/BollingerBands.ts
+++ b/packages/trading-signals/src/volatility/BBANDS/BollingerBands.ts
@@ -18,6 +18,11 @@ export class BollingerBands extends TechnicalIndicator<BandsResult, number> {
   #twoPreviousResult?: BandsResult;
   #lastPrice?: number;
   #previousPrice?: number;
+  /**
+   * Latches on the first evicted price. Only an `add()` evicts, so reading the eviction directly
+   * made every `replace()` fall through and drop the result.
+   */
+  #hasEvictedPrice: boolean = false;
 
   public readonly interval: number;
   public readonly deviationMultiplier: number;
@@ -35,6 +40,10 @@ export class BollingerBands extends TechnicalIndicator<BandsResult, number> {
   update(price: number, replace: boolean) {
     const dropOut = pushUpdate(this.prices, replace, price, this.interval);
 
+    if (dropOut !== null) {
+      this.#hasEvictedPrice = true;
+    }
+
     if (replace) {
       this.result = this.#previousResult;
       this.#previousResult = this.#twoPreviousResult;
@@ -46,7 +55,7 @@ export class BollingerBands extends TechnicalIndicator<BandsResult, number> {
     this.#previousPrice = this.#lastPrice;
     this.#lastPrice = price;
 
-    if (dropOut) {
+    if (this.#hasEvictedPrice) {
       const middle = getAverage(this.prices);
       const standardDeviation = getStandardDeviation(this.prices, middle);
 


### PR DESCRIPTION
## Problem

`BollingerBands.update()` gated its calculation on `dropOut` — the price evicted by `pushUpdate()`:

```ts
const dropOut = pushUpdate(this.prices, replace, price, this.interval);
if (dropOut) {
  // calculate bands
}
```

Only an `add()` evicts a price. A `replace()` swaps the last element without changing the array length, so nothing is evicted, `dropOut` is `null`, and the method returns `null` — after the `if (replace)` block has already rewound `this.result`. Replacing the latest price of a warmed-up indicator therefore **erases the result**:

```ts
const bb = new BollingerBands(5, 2);
[10, 11, 12, 13, 14, 15].forEach(p => bb.add(p));
bb.getResult()?.middle; // 13
bb.replace(999);
bb.getResult()?.middle; // undefined  ❌
```

The same gate checks the evicted price for *truthiness*, so a dropped-out price of `0` also suppresses the calculation:

```ts
const bb = new BollingerBands(3, 2);
[0, 1, 2, 3].forEach(p => bb.add(p));
bb.getResult(); // null  ❌ expected middle 2
```

`BollingerBandsWidth` wraps `BollingerBands` and inherited both bugs.

## Fix

Latch a private `#hasEvictedPrice` flag on the first eviction and gate the calculation on that. The flag survives a `replace()`, so a replacement recalculates over the current window, and the latch is set by an explicit `!== null` check rather than truthiness.

## Scope

Warm-up timing is deliberately unchanged here. `BollingerBands` still emits its first band one bar later than its own reference fixture expects (`middle[19]` in `src/fixtures/BB/data.json` is `74.3 = avg(prices[0..19])`, but the indicator is not stable until the 21st price). That is a separate behavior change and gets its own PR.

## Tests

Two regression tests, both verified to fail on `main` and pass here:
- a bidirectional replace test — replace changes the bands, replacing back restores them
- a zero drop-out test

Full suite passes (543 tests), coverage stays at 100%, `npm run lint` and `tsc --noEmit` clean.