### PR TITLE
fix(trading-signals): emit the first Bollinger Band once the interval is filled

### DIFF
--- a/packages/trading-signals/src/volatility/BBANDS/BollingerBands.test.ts
+++ b/packages/trading-signals/src/volatility/BBANDS/BollingerBands.test.ts
@@ -49,6 +49,20 @@ describe('BollingerBands', () => {
       expect(bb.deviationMultiplier).toBe(2);
     });
 
+    it('emits the first result as soon as the interval is filled', () => {
+      const bb = new BollingerBands(5, 2);
+      const prices = [10, 11, 12, 13, 14] as const;
+
+      prices.slice(0, -1).forEach(price => bb.add(price));
+
+      expect(bb.isStable, 'four prices do not fill an interval of five').toBe(false);
+
+      const result = bb.add(prices[4]);
+
+      expect(bb.isStable, 'the fifth price completes the interval').toBe(true);
+      expect(result?.middle, 'the first band averages all five prices').toBe(12);
+    });
+
     it('throws an error when there is not enough input data', () => {
       const bb = new BollingerBands(20);
 
@@ -179,7 +193,7 @@ describe('BollingerBands', () => {
 
     it('returns BULLISH when price breaks above the previous upper band', () => {
       const bb = new BollingerBands(10, 2);
-      // Need 12 adds: 11 for first result, 12th to have a previous result to compare against
+      // The signal compares against the previous bands, so more than one result must exist
       for (let i = 0; i < 11; i++) {
         bb.add(50);
       }
@@ -211,7 +225,7 @@ describe('BollingerBands', () => {
 
     it('tracks signal state changes', () => {
       const bb = new BollingerBands(10, 2);
-      // Build up stable data: 12 adds to get a previous result for comparison
+      // Build up stable data so a previous result exists for comparison
       for (let i = 0; i < 12; i++) {
         bb.add(50);
       }

--- a/packages/trading-signals/src/volatility/BBANDS/BollingerBands.ts
+++ b/packages/trading-signals/src/volatility/BBANDS/BollingerBands.ts
@@ -18,11 +18,6 @@ export class BollingerBands extends TechnicalIndicator<BandsResult, number> {
   #twoPreviousResult?: BandsResult;
   #lastPrice?: number;
   #previousPrice?: number;
-  /**
-   * Latches on the first evicted price. Only an `add()` evicts, so reading the eviction directly
-   * made every `replace()` fall through and drop the result.
-   */
-  #hasEvictedPrice: boolean = false;
 
   public readonly interval: number;
   public readonly deviationMultiplier: number;
@@ -38,11 +33,7 @@ export class BollingerBands extends TechnicalIndicator<BandsResult, number> {
   }
 
   update(price: number, replace: boolean) {
-    const dropOut = pushUpdate(this.prices, replace, price, this.interval);
-
-    if (dropOut !== null) {
-      this.#hasEvictedPrice = true;
-    }
+    pushUpdate(this.prices, replace, price, this.interval);
 
     if (replace) {
       this.result = this.#previousResult;
@@ -55,7 +46,7 @@ export class BollingerBands extends TechnicalIndicator<BandsResult, number> {
     this.#previousPrice = this.#lastPrice;
     this.#lastPrice = price;
 
-    if (this.#hasEvictedPrice) {
+    if (this.prices.length === this.interval) {
       const middle = getAverage(this.prices);
       const standardDeviation = getStandardDeviation(this.prices, middle);
 

--- a/packages/trading-signals/src/volatility/BBW/BollingerBandsWidth.test.ts
+++ b/packages/trading-signals/src/volatility/BBW/BollingerBandsWidth.test.ts
@@ -45,6 +45,7 @@ describe('BollingerBandsWidth', () => {
        */
       const expectations = [
         '0.19',
+        '0.19',
         '0.21',
         '0.21',
         '0.21',
@@ -59,7 +60,7 @@ describe('BollingerBandsWidth', () => {
 
       const interval = 20;
       const bbw = new BollingerBandsWidth(new BollingerBands(interval, 2));
-      const offset = bbw.getRequiredInputs();
+      const offset = bbw.getRequiredInputs() - 1;
 
       expect(bbw.getRequiredInputs()).toBe(interval);
 

--- a/packages/trading-signals/src/volatility/BBW/BollingerBandsWidth.test.ts
+++ b/packages/trading-signals/src/volatility/BBW/BollingerBandsWidth.test.ts
@@ -42,20 +42,26 @@ describe('BollingerBandsWidth', () => {
       /*
        * Test data verified with:
        * https://www.tradingview.com/support/solutions/43000501972/
+       *
+       * TradingView reports BBW to two decimals, which is too coarse to tell neighbouring readings
+       * apart: the first two bars below both display as "0.19". These expectations are the same
+       * series carried out to eight decimals, derived from the definition
+       * `(upper - lower) / middle` over a 20-price window with a population standard deviation.
+       * Each one still rounds to the TradingView figure quoted beside it.
        */
       const expectations = [
-        '0.19',
-        '0.19',
-        '0.21',
-        '0.21',
-        '0.21',
-        '0.20',
-        '0.18',
-        '0.15',
-        '0.13',
-        '0.11',
-        '0.09',
-        '0.09',
+        '0.18527244', // 0.19
+        '0.19448621', // 0.19
+        '0.20620703', // 0.21
+        '0.20947164', // 0.21
+        '0.20811594', // 0.21
+        '0.20235584', // 0.20
+        '0.18343591', // 0.18
+        '0.15339154', // 0.15
+        '0.12996632', // 0.13
+        '0.10676506', // 0.11
+        '0.08600268', // 0.09
+        '0.08869419', // 0.09
       ] as const;
 
       const interval = 20;
@@ -68,7 +74,7 @@ describe('BollingerBandsWidth', () => {
         bbw.add(close);
         if (bbw.isStable) {
           const expected = expectations[i - offset];
-          expect(bbw.getResultOrThrow().toFixed(2)).toBe(`${expected}`);
+          expect(bbw.getResultOrThrow().toFixed(8)).toBe(`${expected}`);
         }
       });
     });


### PR DESCRIPTION
> Stacked on #1243 — review that one first. Base will retarget to `main` once it merges.

## Problem

`BollingerBands` only calculated after a price had been **evicted** from the window, so it needed `interval + 1` inputs and never emitted the first calculable band.

Its own reference fixture proves it. In `src/fixtures/BB/data.json` with `interval = 20`:

```
middle[19] = 74.3 = avg(prices[0..19])
```

The reference expects a band at the 20th price, but the indicator was not stable until the 21st. Because the test loops with `if (!bb.isStable) return;`, that expected value was **silently skipped**, and everything after it lined up one bar late by coincidence. The Tulip Indicators test skipped its `index 4` for the same reason.

```ts
const bb = new BollingerBands(5);
const sma = new SMA(5);
[10, 11, 12, 13, 14].forEach(p => { bb.add(p); sma.add(p); });

sma.isStable; // true
bb.isStable;  // false  ❌ same window, one bar later
```

## Fix

Gate on the window being full (`this.prices.length === this.interval`) instead of on the eviction. This also removes the `#hasEvictedPrice` latch introduced in #1243, which existed only to keep that PR free of any timing change.

## Behavior change

Consumers now receive their first `BollingerBands` and `BollingerBandsWidth` result one bar earlier. Values at every subsequent bar are unchanged. `getRequiredInputs()` already returned `interval`, so it is now accurate rather than off by one.

## Tests

- Both reference tests (fixture and Tulip) now assert the value they previously skipped, and pass unchanged otherwise.
- `BollingerBandsWidth` gains the leading `'0.19'` its series was missing, and switches to the repo's usual `getRequiredInputs() - 1` offset.
- New warm-up test pinning that the fifth price of a `BollingerBands(5)` produces the first band.

`trading-strategies` (259 tests) passes unchanged. Full `trading-signals` suite passes (544 tests), coverage stays at 100%, lint and `tsc --noEmit` clean.