### PR TITLE
fix(trading-signals): keep PVT from counting a replaced candle twice

### DIFF
--- a/packages/trading-signals/src/volume/PVT/PVT.test.ts
+++ b/packages/trading-signals/src/volume/PVT/PVT.test.ts
@@ -106,6 +106,25 @@ describe('PVT', () => {
   });
 
   describe('replace', () => {
+    it('accumulates onto the total from before the replaced candle', () => {
+      const candle = (close: number) => ({close, high: close, low: close, volume: 1000}) as const;
+
+      const replaced = new PVT();
+      replaced.add(candle(100));
+      replaced.add(candle(110));
+      replaced.add(candle(120));
+      replaced.replace(candle(130));
+
+      const reference = new PVT();
+      reference.add(candle(100));
+      reference.add(candle(110));
+      reference.add(candle(130));
+
+      expect(replaced.getResultOrThrow(), 'a replacement must not count the replaced candle twice').toBe(
+        reference.getResultOrThrow()
+      );
+    });
+
     it('replaces the most recently added value', () => {
       const pvt = new PVT();
       pvt.add({close: 10, high: 10, low: 9, volume: 25000});

--- a/packages/trading-signals/src/volume/PVT/PVT.test.ts
+++ b/packages/trading-signals/src/volume/PVT/PVT.test.ts
@@ -125,6 +125,21 @@ describe('PVT', () => {
       );
     });
 
+    it('changes nothing when the latest candle is replaced with the same values', () => {
+      const candle = (close: number) => ({close, high: close, low: close, volume: 1000}) as const;
+      const pvt = new PVT();
+
+      pvt.add(candle(100));
+      pvt.add(candle(110));
+      pvt.add(candle(120));
+
+      const resultBefore = pvt.getResultOrThrow();
+
+      pvt.replace(candle(120));
+
+      expect(pvt.getResultOrThrow(), 'replacing a candle with itself is a no-op').toBe(resultBefore);
+    });
+
     it('replaces the most recently added value', () => {
       const pvt = new PVT();
       pvt.add({close: 10, high: 10, low: 9, volume: 25000});

--- a/packages/trading-signals/src/volume/PVT/PVT.ts
+++ b/packages/trading-signals/src/volume/PVT/PVT.ts
@@ -30,7 +30,12 @@ export class PVT extends TrendIndicatorSeries<HighLowCloseVolume> {
     }
 
     const previousClose = this.#candles[0].close;
-    const previousPVT = this.result ?? 0;
+    /*
+     * PVT accumulates onto the running total, so a replacement has to build on the total from
+     * before the replaced candle. `this.result` still carries that candle's contribution until
+     * `setResult()` unwinds it, which would count the bar twice.
+     */
+    const previousPVT = (replace ? this.previousResult : this.result) ?? 0;
 
     if (previousClose === 0) {
       return this.setResult(previousPVT, replace);


### PR DESCRIPTION
## Problem

PVT is cumulative — each bar adds to a running total. `update()` read that total from `this.result`:

```ts
const previousPVT = this.result ?? 0;
```

On a `replace()`, `this.result` still includes the contribution of the candle being replaced. `setResult()` only unwinds it *afterwards*, so the replaced bar gets counted twice:

```ts
const candle = (close: number) => ({close, high: close, low: close, volume: 1000});

const pvt = new PVT();
pvt.add(candle(100));
pvt.add(candle(110));
pvt.add(candle(120));
pvt.replace(candle(130));
pvt.getResultOrThrow(); // 372.72  ❌

// the equivalent series without a replacement
const reference = new PVT();
reference.add(candle(100));
reference.add(candle(110));
reference.add(candle(130));
reference.getResultOrThrow(); // 281.81  ✅
```

## Fix

Read `this.previousResult` when replacing — the total from before the replaced candle.

## Why the existing test missed it

`replaces the most recently added value` uses only two candles. There the inflated total (`1500` instead of `0`) was exactly cancelled by the replacement subtracting the same amount, so the restored result still matched the original. The bug only shows once a third candle makes the running total non-trivial.

## Tests

A regression test comparing a replaced series against the equivalent add-only series, verified to fail on `main` (`372.72 !== 281.81`) and pass here.

Full suite passes (542 tests), coverage stays at 100%, lint and `tsc --noEmit` clean.