### PR TITLE
fix(trading-signals): roll back TDS setup state on replace()

### DIFF
--- a/packages/trading-signals/src/momentum/TDS/TDS.test.ts
+++ b/packages/trading-signals/src/momentum/TDS/TDS.test.ts
@@ -111,6 +111,23 @@ describe('TDS', () => {
       expect(result).toBeNull();
     });
 
+    it('changes nothing when the latest close is replaced with the same value', () => {
+      const tds = new TDS();
+      const closes = [10, 10, 10, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19] as const;
+
+      closes.forEach(close => tds.add(close));
+
+      const resultBefore = tds.getResult();
+      const countBefore = tds['setupCount'];
+      const directionBefore = tds['setupDirection'];
+
+      tds.replace(19);
+
+      expect(tds.getResult(), 'replacing a close with itself is a no-op').toBe(resultBefore);
+      expect(tds['setupCount'], 'and leaves the setup count alone').toBe(countBefore);
+      expect(tds['setupDirection'], 'and the setup direction').toBe(directionBefore);
+    });
+
     it('does not advance the setup count twice for the same bar', () => {
       const tds = new TDS();
 

--- a/packages/trading-signals/src/momentum/TDS/TDS.test.ts
+++ b/packages/trading-signals/src/momentum/TDS/TDS.test.ts
@@ -110,6 +110,75 @@ describe('TDS', () => {
       const result = tds.replace(20);
       expect(result).toBeNull();
     });
+
+    it('does not advance the setup count twice for the same bar', () => {
+      const tds = new TDS();
+
+      for (let i = 0; i < 4; i++) {
+        tds.add(10);
+      }
+
+      tds.add(15);
+      tds.add(16);
+
+      expect(tds['setupCount'], 'two bars closed above the close four bars earlier').toBe(2);
+
+      tds.replace(17);
+
+      expect(tds['setupCount'], 'replacing the second bar must not count it again').toBe(2);
+      expect(tds['setupDirection']).toBe('bullish');
+    });
+
+    it('restores the setup direction when a replacement reverses the bar', () => {
+      const tds = new TDS();
+
+      for (let i = 0; i < 4; i++) {
+        tds.add(10);
+      }
+
+      tds.add(15);
+      tds.add(16);
+      tds.replace(5);
+
+      expect(tds['setupCount'], 'a bearish bar restarts the count').toBe(1);
+      expect(tds['setupDirection'], 'the direction flips with the replaced bar').toBe('bearish');
+    });
+
+    it('matches an equivalent series that never used replace', () => {
+      const closes = [10, 10, 10, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19] as const;
+
+      const replaced = new TDS();
+      closes.slice(0, -1).forEach(close => replaced.add(close));
+      replaced.add(99);
+      replaced.replace(closes[closes.length - 1]);
+
+      const reference = new TDS();
+      closes.forEach(close => reference.add(close));
+
+      expect(replaced.getResult(), 'a replacement must reproduce the add-only series').toBe(reference.getResult());
+      expect(replaced['setupCount']).toBe(reference['setupCount']);
+      expect(replaced['setupDirection']).toBe(reference['setupDirection']);
+    });
+
+    it('withdraws a completed setup when the replacement breaks it', () => {
+      const tds = new TDS();
+
+      for (let i = 0; i < 4; i++) {
+        tds.add(10);
+      }
+
+      for (let i = 0; i < 8; i++) {
+        tds.add(11 + i);
+      }
+
+      expect(tds.getResult(), 'eight bars are one short of a completed setup').toBeNull();
+
+      expect(tds.add(19), 'the ninth consecutive bar completes the bullish setup').toBe(1);
+
+      tds.replace(5);
+
+      expect(tds.getResult(), 'the setup no longer completes, so the emission is withdrawn').toBeNull();
+    });
   });
 
   describe('getSignal', () => {

--- a/packages/trading-signals/src/momentum/TDS/TDS.test.ts
+++ b/packages/trading-signals/src/momentum/TDS/TDS.test.ts
@@ -160,6 +160,26 @@ describe('TDS', () => {
       expect(replaced['setupDirection']).toBe(reference['setupDirection']);
     });
 
+    it('keeps an earlier setup when the replaced bar completed nothing', () => {
+      const tds = new TDS();
+
+      for (let i = 0; i < 4; i++) {
+        tds.add(10);
+      }
+
+      for (let i = 0; i < 9; i++) {
+        tds.add(11 + i);
+      }
+
+      expect(tds.getResult(), 'nine rising bars complete a bullish setup').toBe(1);
+
+      // Neither of these bars completes a setup, so the earlier result stands.
+      tds.add(5);
+      tds.replace(6);
+
+      expect(tds.getResult(), 'replacing a bar that emitted nothing must not withdraw an older setup').toBe(1);
+    });
+
     it('withdraws a completed setup when the replacement breaks it', () => {
       const tds = new TDS();
 

--- a/packages/trading-signals/src/momentum/TDS/TDS.ts
+++ b/packages/trading-signals/src/momentum/TDS/TDS.ts
@@ -25,6 +25,11 @@ export class TDS extends TrendIndicatorSeries {
    */
   private previousSetupCount: number = 0;
   private previousSetupDirection: 'bullish' | 'bearish' | null = null;
+  /*
+   * Whether the latest bar completed a setup. TDS emits sparsely and its result persists between
+   * setups, so only a bar that emitted may withdraw that emission when it gets replaced.
+   */
+  private lastBarCompletedSetup: boolean = false;
 
   override getRequiredInputs() {
     return 9;
@@ -35,14 +40,18 @@ export class TDS extends TrendIndicatorSeries {
       this.closes.pop();
       this.setupCount = this.previousSetupCount;
       this.setupDirection = this.previousSetupDirection;
-      // A replaced bar may no longer complete a setup, so any emission it caused has to be undone.
-      this.rollbackLastResult();
+
+      if (this.lastBarCompletedSetup) {
+        this.rollbackLastResult();
+      }
     } else {
       this.previousSetupCount = this.setupCount;
       this.previousSetupDirection = this.setupDirection;
     }
 
     this.closes.push(close);
+    this.lastBarCompletedSetup = false;
+
     if (this.closes.length < 5) {
       return null;
     }
@@ -74,6 +83,7 @@ export class TDS extends TrendIndicatorSeries {
       const result = this.setupDirection === 'bullish' ? 1 : -1;
       this.setupCount = 0;
       this.setupDirection = null;
+      this.lastBarCompletedSetup = true;
       return this.setResult(result, replace);
     }
     return null;

--- a/packages/trading-signals/src/momentum/TDS/TDS.ts
+++ b/packages/trading-signals/src/momentum/TDS/TDS.ts
@@ -19,6 +19,12 @@ export class TDS extends TrendIndicatorSeries {
   private readonly closes: number[] = [];
   private setupCount: number = 0;
   private setupDirection: 'bullish' | 'bearish' | null = null;
+  /*
+   * The setup state as of the bar before the current one. A replacement re-runs the latest bar, so
+   * the count has to start again from what that bar originally found, not from what it left behind.
+   */
+  private previousSetupCount: number = 0;
+  private previousSetupDirection: 'bullish' | 'bearish' | null = null;
 
   override getRequiredInputs() {
     return 9;
@@ -27,7 +33,15 @@ export class TDS extends TrendIndicatorSeries {
   update(close: number, replace: boolean): number | null {
     if (replace) {
       this.closes.pop();
+      this.setupCount = this.previousSetupCount;
+      this.setupDirection = this.previousSetupDirection;
+      // A replaced bar may no longer complete a setup, so any emission it caused has to be undone.
+      this.rollbackLastResult();
+    } else {
+      this.previousSetupCount = this.setupCount;
+      this.previousSetupDirection = this.setupDirection;
     }
+
     this.closes.push(close);
     if (this.closes.length < 5) {
       return null;


### PR DESCRIPTION
## Problem

TDS tracks a running `setupCount` and `setupDirection`, advancing them on every update and resetting them once a 9-bar setup completes. `replace()` popped the last close but left those mutations in place, so the replaced bar was counted a second time.

**The count runs away:**

```ts
const tds = new TDS();
[10, 10, 10, 10].forEach(c => tds.add(c));
tds.add(15);
tds.add(16);
tds['setupCount']; // 2

tds.replace(17);
tds['setupCount']; // 3  ❌ still two bars, counted three times
```

Because a replacement can push the count past the 9-bar threshold, it could fabricate a completed setup on an indicator that was not stable before the call.

**A broken setup stays emitted:**

```ts
// ... 9 consecutive rising closes complete a bullish setup
tds.getResult(); // 1

tds.replace(5);  // the last bar is now a big down bar
tds.getResult(); // 1  ❌ the setup no longer completes
```

## Fix

Snapshot `setupCount`/`setupDirection` before each `add()` and restore them when replacing, so the replaced bar re-runs from the state it originally found.

A replacement that no longer completes a setup also has to withdraw the value it previously emitted. That is what `rollbackLastResult()` on `IndicatorSeries` is for — its doc comment names exactly this case ("sparse indicators whose `replace()` can invalidate a prior emission without producing a new one").

## Tests

Four new tests. Three fail on `main` and pass here:
- setup count not advanced twice (`3` vs `2`)
- a replaced series matches the equivalent add-only series
- a completed setup is withdrawn when the replacement breaks it

The fourth pins the direction-reversal path, which the rollback could plausibly regress.

Full suite passes (545 tests), coverage stays at 100%, lint and `tsc --noEmit` clean.