### PR TITLE
fix(trading-signals): restore PSAR state on replace()

### DIFF
--- a/packages/trading-signals/src/trend/PSAR/PSAR.test.ts
+++ b/packages/trading-signals/src/trend/PSAR/PSAR.test.ts
@@ -48,17 +48,23 @@ describe('PSAR', () => {
     });
   });
 
-  it('handles replace correctly', () => {
-    const psar = new PSAR({accelerationMax: 0.2, accelerationStep: 0.02});
+  it('changes nothing when the latest candle is replaced with the same values', () => {
+    const candles = testData.map(({high, low}) => ({high, low}));
 
-    // Add first two candles
-    psar.add({high: testData[0].high, low: testData[0].low});
-    const initialResult = psar.add({high: testData[1].high, low: testData[1].low});
+    // Swept over every length because the carried state only diverges at some of them.
+    for (let length = 1; length <= candles.length; length++) {
+      const psar = new PSAR({accelerationMax: 0.2, accelerationStep: 0.02});
 
-    // Replace the second candle
-    const replacedResult = psar.replace({high: testData[1].high, low: testData[1].low});
+      candles.slice(0, length).forEach(candle => psar.add(candle));
 
-    expect(replacedResult, 'replacing a candle with itself reproduces the result exactly').toBe(initialResult);
+      const resultBefore = psar.getResult();
+      const stableBefore = psar.isStable;
+
+      psar.replace(candles[length - 1]);
+
+      expect(psar.getResult(), `replacing candle ${length} with itself is a no-op`).toBe(resultBefore);
+      expect(psar.isStable, `and does not change stability at ${length} candles`).toBe(stableBefore);
+    }
   });
 
   it('reproduces an add-only series after a replacement', () => {

--- a/packages/trading-signals/src/trend/PSAR/PSAR.test.ts
+++ b/packages/trading-signals/src/trend/PSAR/PSAR.test.ts
@@ -58,11 +58,44 @@ describe('PSAR', () => {
     // Replace the second candle
     const replacedResult = psar.replace({high: testData[1].high, low: testData[1].low});
 
-    // Allow small differences due to floating point arithmetic
-    const diff = Math.abs((initialResult || 0) - (replacedResult || 0));
-    // Use a reasonable tolerance - 1% or 0.1 absolute
-    const tolerance = Math.max((initialResult || 0) * 0.01, 0.1);
-    expect(diff).toBeLessThanOrEqual(tolerance);
+    expect(replacedResult, 'replacing a candle with itself reproduces the result exactly').toBe(initialResult);
+  });
+
+  it('reproduces an add-only series after a replacement', () => {
+    const candles = testData.slice(0, 20).map(({high, low}) => ({high, low}));
+    const decoy = {high: 999, low: 1};
+
+    const replaced = new PSAR({accelerationMax: 0.2, accelerationStep: 0.02});
+    candles.slice(0, -1).forEach(candle => replaced.add(candle));
+    replaced.add(decoy);
+    const replacedResult = replaced.replace(candles[candles.length - 1]);
+
+    const reference = new PSAR({accelerationMax: 0.2, accelerationStep: 0.02});
+    let referenceResult: number | null = null;
+    candles.forEach(candle => {
+      referenceResult = reference.add(candle);
+    });
+
+    expect(replacedResult, 'a replacement must undo the state the decoy candle left behind').toBe(referenceResult);
+  });
+
+  it('reproduces an add-only series when the decoy candle reversed the trend', () => {
+    const candles = testData.slice(0, 12).map(({high, low}) => ({high, low}));
+    // A deep low forces a long-to-short reversal, which resets acceleration and the extreme point.
+    const reversingDecoy = {high: 84, low: 40};
+
+    const replaced = new PSAR({accelerationMax: 0.2, accelerationStep: 0.02});
+    candles.slice(0, -1).forEach(candle => replaced.add(candle));
+    replaced.add(reversingDecoy);
+    const replacedResult = replaced.replace(candles[candles.length - 1]);
+
+    const reference = new PSAR({accelerationMax: 0.2, accelerationStep: 0.02});
+    let referenceResult: number | null = null;
+    candles.forEach(candle => {
+      referenceResult = reference.add(candle);
+    });
+
+    expect(replacedResult, 'a reversal caused by the replaced candle must be undone too').toBe(referenceResult);
   });
 
   it('returns null when replacing without enough data', () => {

--- a/packages/trading-signals/src/trend/PSAR/PSAR.ts
+++ b/packages/trading-signals/src/trend/PSAR/PSAR.ts
@@ -27,6 +27,19 @@ export type PSARConfig = {
  * It's particularly useful in trending markets, but less reliable in sideways or choppy markets.
  *
  */
+/**
+ * Everything {@link PSAR.update} reads before it decides on the next SAR. Capturing it lets a
+ * replacement re-run the latest candle from the state that candle originally saw.
+ */
+type PSARState = {
+  acceleration: number;
+  extreme: number | null;
+  isLong: boolean | null;
+  lastSar: number | null;
+  prePreviousCandle: HighLow<number> | null;
+  previousCandle: HighLow<number> | null;
+};
+
 export class PSAR extends IndicatorSeries<HighLow<number>> {
   private readonly accelerationStep: number;
   private readonly accelerationMax: number;
@@ -36,6 +49,7 @@ export class PSAR extends IndicatorSeries<HighLow<number>> {
   private isLong: boolean | null = null;
   private previousCandle: HighLow<number> | null = null;
   private prePreviousCandle: HighLow<number> | null = null;
+  private previousState: PSARState | null = null;
 
   constructor(config: PSARConfig) {
     super();
@@ -58,14 +72,35 @@ export class PSAR extends IndicatorSeries<HighLow<number>> {
     return 2;
   }
 
+  private captureState(): PSARState {
+    return {
+      acceleration: this.acceleration,
+      extreme: this.extreme,
+      isLong: this.isLong,
+      lastSar: this.lastSar,
+      prePreviousCandle: this.prePreviousCandle,
+      previousCandle: this.previousCandle,
+    };
+  }
+
+  private restoreState(state: PSARState) {
+    this.acceleration = state.acceleration;
+    this.extreme = state.extreme;
+    this.isLong = state.isLong;
+    this.lastSar = state.lastSar;
+    this.prePreviousCandle = state.prePreviousCandle;
+    this.previousCandle = state.previousCandle;
+  }
+
   update(candle: HighLow<number>, replace: boolean): number | null {
     const {high, low} = candle;
 
-    // If replacing the last candle and we haven't processed enough data yet
-    const notEnoughData = !this.previousCandle || this.lastSar === null;
-    if (replace && notEnoughData) {
-      this.previousCandle = candle;
-      return null;
+    if (replace) {
+      if (this.previousState !== null) {
+        this.restoreState(this.previousState);
+      }
+    } else {
+      this.previousState = this.captureState();
     }
 
     // First candle, just store it and return null

--- a/packages/trading-signals/src/trend/PSAR/PSAR.ts
+++ b/packages/trading-signals/src/trend/PSAR/PSAR.ts
@@ -15,19 +15,6 @@ export type PSARConfig = {
 };
 
 /**
- * Parabolic SAR
- * Type: Trend
- *
- * The Parabolic SAR (Stop and Reverse) is a technical indicator used in trading to determine the direction of an asset's price and potential points of trend reversal. It was developed by J. Welles Wilder Jr., who also created indicators like the RSI.
- *
- * Interpretation:
- * The indicator places dots above or below the price. If the dots are below the price, it signals an uptrend. If the dots are above the price it signals a downtrend. It "stops and reverses" when the trend is likely to change, hence the name. Its logic says to stay in a trend as long as the dots stay on the same side of the price. Exit or reverse positions when the dots flip to the opposite side.
- *
- * Note:
- * It's particularly useful in trending markets, but less reliable in sideways or choppy markets.
- *
- */
-/**
  * Everything {@link PSAR.update} reads before it decides on the next SAR. Capturing it lets a
  * replacement re-run the latest candle from the state that candle originally saw.
  */
@@ -40,6 +27,19 @@ type PSARState = {
   previousCandle: HighLow<number> | null;
 };
 
+/**
+ * Parabolic SAR
+ * Type: Trend
+ *
+ * The Parabolic SAR (Stop and Reverse) is a technical indicator used in trading to determine the direction of an asset's price and potential points of trend reversal. It was developed by J. Welles Wilder Jr., who also created indicators like the RSI.
+ *
+ * Interpretation:
+ * The indicator places dots above or below the price. If the dots are below the price, it signals an uptrend. If the dots are above the price it signals a downtrend. It "stops and reverses" when the trend is likely to change, hence the name. Its logic says to stay in a trend as long as the dots stay on the same side of the price. Exit or reverse positions when the dots flip to the opposite side.
+ *
+ * Note:
+ * It's particularly useful in trending markets, but less reliable in sideways or choppy markets.
+ *
+ */
 export class PSAR extends IndicatorSeries<HighLow<number>> {
   private readonly accelerationStep: number;
   private readonly accelerationMax: number;


### PR DESCRIPTION
## Problem

PSAR carries six mutable fields from bar to bar — `acceleration`, `extreme`, `lastSar`, `isLong`, `previousCandle` and `prePreviousCandle`. `replace()` overwrote none of them, so every value the discarded candle produced stayed in the indicator and kept influencing later bars.

The discarded candle stays visible in the result:

```ts
const psar = new PSAR({accelerationMax: 0.2, accelerationStep: 0.02});
candles.slice(0, -1).forEach(c => psar.add(c));
psar.add({high: 999, low: 1});          // decoy
psar.replace(candles.at(-1));           // replaced with the real candle
// result: 999  ❌ expected 85.07 — the value an add-only series produces
```

Even replacing a candle with **itself** shifted the result, because the second-candle branch re-ran against already-advanced state:

```ts
psar.add(candles[0]);
psar.add(candles[1]);                   // 82.15
psar.replace(candles[1]);               // 82.1198  ❌ same input, different output
```

## Fix

Snapshot the six fields before each `add()` and restore them when replacing, so the replacement re-runs from the state the original candle saw. Those six are the complete set `update()` reads before deciding the next SAR, so the snapshot fully determines the transition.

## Removed early return

```ts
const notEnoughData = !this.previousCandle || this.lastSar === null;
if (replace && notEnoughData) {
  this.previousCandle = candle;
  return null;
}
```

This existed to stop `replace()` reading corrupted state, and it had a side effect: replacing the **second** candle returned `null` instead of the first SAR, because `lastSar` was still `null` at that point in the original bar. With the state restored, the ordinary first-candle branch covers the genuine not-enough-data case, so the special case is gone. Both existing tests that pin this behavior (`handles replace flag for second candle`, `handles replace flag with notEnoughData`) still pass unchanged.

## Tests

Three tests, all verified to fail on `main`:
- replacing a candle with itself is now exact (tightened from a 1% tolerance to `toBe`)
- a replaced series reproduces the equivalent add-only series
- the same, with a decoy that forces a long-to-short **reversal**, which resets acceleration and the extreme point

Full suite passes (543 tests), coverage stays at 100%, lint and `tsc --noEmit` clean.