### PR TITLE
fix(trading-signals): restore ZigZag swing state on replace()

### DIFF
--- a/packages/trading-signals/src/trend/ZIGZAG/ZigZag.test.ts
+++ b/packages/trading-signals/src/trend/ZIGZAG/ZigZag.test.ts
@@ -43,6 +43,74 @@ describe('ZigZag', () => {
     });
   });
 
+  describe('replace', () => {
+    const highs = [
+      -8, -4, -1, 9, 8, 7, 6, 5, 4, 3, 2, 1, 11, 22, 33, 44, 55, 66, 77, 88, 88, 71, 61, 51, 41, 51, 61, 71, 81, 91,
+    ] as const;
+
+    const lows = [
+      -9, -5, -2, 8, 7, 6, 5, 4, 3, 2, 1, 0, 10, 20, 30, 40, 50, 60, 70, 80, 85, 70, 60, 50, 40, 50, 60, 70, 80, 90,
+    ] as const;
+
+    const candles = highs.map((high, index) => ({high, low: lows[index]}));
+
+    function collect(zigzag: ZigZag, inputs: readonly {high: number; low: number}[]) {
+      const results: number[] = [];
+
+      for (const candle of inputs) {
+        const result = zigzag.add(candle);
+
+        if (result !== null) {
+          results.push(result);
+        }
+      }
+
+      return results;
+    }
+
+    it('reproduces an add-only series after a replacement', () => {
+      const replaced = new ZigZag({deviation: 15});
+      collect(replaced, candles.slice(0, -1));
+      replaced.add({high: 500, low: 400});
+      replaced.replace(candles[candles.length - 1]);
+
+      const reference = new ZigZag({deviation: 15});
+      collect(reference, candles);
+
+      expect(replaced.getResult(), 'a replacement must undo the state the decoy candle left behind').toBe(
+        reference.getResult()
+      );
+    });
+
+    it('treats a replacement before any candle like a first candle', () => {
+      const candle = {high: 9, low: -9} as const;
+
+      const replacedFirst = new ZigZag({deviation: 15});
+      const addedFirst = new ZigZag({deviation: 15});
+
+      expect(
+        replacedFirst.replace(candle),
+        'with no candle to roll back to, a replacement is just the first candle'
+      ).toBe(addedFirst.add(candle));
+    });
+
+    it('takes back a pivot when the replacement no longer reverses the trend', () => {
+      const zigzag = new ZigZag({deviation: 15});
+
+      collect(zigzag, candles.slice(0, 20));
+
+      const resultBeforeReversal = zigzag.getResult();
+
+      // A deep low reverses the uptrend and reports the highest extreme as a pivot.
+      expect(zigzag.add({high: 88, low: 10}), 'a deep low ends the uptrend and emits the swing high').toBe(88);
+
+      // Replacing it with a quiet candle means no reversal happened after all.
+      zigzag.replace({high: 88, low: 85});
+
+      expect(zigzag.getResult(), 'the withdrawn pivot must not linger').toBe(resultBeforeReversal);
+    });
+  });
+
   describe('getRequiredInputs', () => {
     it('returns the amount of required data needed for a calculation', () => {
       const expected = 1;

--- a/packages/trading-signals/src/trend/ZIGZAG/ZigZag.test.ts
+++ b/packages/trading-signals/src/trend/ZIGZAG/ZigZag.test.ts
@@ -94,6 +94,22 @@ describe('ZigZag', () => {
       ).toBe(addedFirst.add(candle));
     });
 
+    it('keeps an earlier pivot when the replaced candle reversed nothing', () => {
+      const zigzag = new ZigZag({deviation: 15});
+
+      collect(zigzag, candles.slice(0, 20));
+
+      const pivot = zigzag.getResult();
+
+      expect(pivot, 'the series has already reported a pivot').not.toBeNull();
+
+      // Neither candle reverses the trend, so the earlier pivot stands.
+      expect(zigzag.add({high: 89, low: 86}), 'a quiet candle reports nothing').toBeNull();
+      expect(zigzag.replace({high: 90, low: 87}), 'nor does its replacement').toBeNull();
+
+      expect(zigzag.getResult(), 'replacing a candle that reported nothing must not drop an older pivot').toBe(pivot);
+    });
+
     it('takes back a pivot when the replacement no longer reverses the trend', () => {
       const zigzag = new ZigZag({deviation: 15});
 

--- a/packages/trading-signals/src/trend/ZIGZAG/ZigZag.test.ts
+++ b/packages/trading-signals/src/trend/ZIGZAG/ZigZag.test.ts
@@ -94,6 +94,21 @@ describe('ZigZag', () => {
       ).toBe(addedFirst.add(candle));
     });
 
+    it('changes nothing when the latest candle is replaced with the same values', () => {
+      // Swept over every length because the swing state only diverges at some of them.
+      for (let length = 1; length <= candles.length; length++) {
+        const zigzag = new ZigZag({deviation: 15});
+
+        collect(zigzag, candles.slice(0, length));
+
+        const resultBefore = zigzag.getResult();
+
+        zigzag.replace(candles[length - 1]);
+
+        expect(zigzag.getResult(), `replacing candle ${length} with itself is a no-op`).toBe(resultBefore);
+      }
+    });
+
     it('keeps an earlier pivot when the replaced candle reversed nothing', () => {
       const zigzag = new ZigZag({deviation: 15});
 

--- a/packages/trading-signals/src/trend/ZIGZAG/ZigZag.ts
+++ b/packages/trading-signals/src/trend/ZIGZAG/ZigZag.ts
@@ -10,6 +10,16 @@ export type ZigZagConfig = {
 };
 
 /**
+ * The swing state {@link ZigZag.update} carries between candles. Capturing it lets a replacement
+ * re-run the latest candle from the state that candle originally saw.
+ */
+type ZigZagState = {
+  highestExtreme: number | null;
+  isUp: boolean;
+  lowestExtreme: number | null;
+};
+
+/**
  * ZigZag Indicator (ZigZag)
  * Type: Trend
  *
@@ -24,22 +34,17 @@ export type ZigZagConfig = {
  * @see https://capex.com/en/academy/zigzag
  * @see https://corporatefinanceinstitute.com/resources/career-map/sell-side/capital-markets/zig-zag-indicator/
  */
-/**
- * The swing state {@link ZigZag.update} carries between candles. Capturing it lets a replacement
- * re-run the latest candle from the state that candle originally saw.
- */
-type ZigZagState = {
-  highestExtreme: number | null;
-  isUp: boolean;
-  lowestExtreme: number | null;
-};
-
 export class ZigZag extends IndicatorSeries<HighLow> {
   readonly #deviation: number;
   #isUp: boolean = false;
   #highestExtreme: number | null = null;
   #lowestExtreme: number | null = null;
   #previousState: ZigZagState | null = null;
+  /**
+   * Whether the latest candle reversed the trend. ZigZag emits only on a reversal and its result
+   * persists in between, so only a candle that emitted may withdraw that pivot when replaced.
+   */
+  #lastCandleReversed: boolean = false;
 
   constructor(config: ZigZagConfig) {
     super();
@@ -60,11 +65,9 @@ export class ZigZag extends IndicatorSeries<HighLow> {
         this.#highestExtreme = this.#previousState.highestExtreme;
         this.#lowestExtreme = this.#previousState.lowestExtreme;
       }
-      /*
-       * ZigZag only emits on a reversal, so a replacement that no longer reverses has to take back
-       * the pivot the replaced candle reported.
-       */
-      this.rollbackLastResult();
+      if (this.#lastCandleReversed) {
+        this.rollbackLastResult();
+      }
     } else {
       this.#previousState = {
         highestExtreme: this.#highestExtreme,
@@ -72,6 +75,8 @@ export class ZigZag extends IndicatorSeries<HighLow> {
         lowestExtreme: this.#lowestExtreme,
       };
     }
+
+    this.#lastCandleReversed = false;
 
     if (this.#lowestExtreme === null) {
       this.#lowestExtreme = low;
@@ -90,6 +95,7 @@ export class ZigZag extends IndicatorSeries<HighLow> {
       } else if (low < uptrendReversal) {
         this.#isUp = false;
         this.#lowestExtreme = low;
+        this.#lastCandleReversed = true;
         return this.setResult(this.#highestExtreme, replace);
       }
     } else {
@@ -100,6 +106,7 @@ export class ZigZag extends IndicatorSeries<HighLow> {
       } else if (high > downtrendReversal) {
         this.#isUp = true;
         this.#highestExtreme = high;
+        this.#lastCandleReversed = true;
         return this.setResult(this.#lowestExtreme, replace);
       }
     }

--- a/packages/trading-signals/src/trend/ZIGZAG/ZigZag.ts
+++ b/packages/trading-signals/src/trend/ZIGZAG/ZigZag.ts
@@ -24,11 +24,22 @@ export type ZigZagConfig = {
  * @see https://capex.com/en/academy/zigzag
  * @see https://corporatefinanceinstitute.com/resources/career-map/sell-side/capital-markets/zig-zag-indicator/
  */
+/**
+ * The swing state {@link ZigZag.update} carries between candles. Capturing it lets a replacement
+ * re-run the latest candle from the state that candle originally saw.
+ */
+type ZigZagState = {
+  highestExtreme: number | null;
+  isUp: boolean;
+  lowestExtreme: number | null;
+};
+
 export class ZigZag extends IndicatorSeries<HighLow> {
   readonly #deviation: number;
   #isUp: boolean = false;
   #highestExtreme: number | null = null;
   #lowestExtreme: number | null = null;
+  #previousState: ZigZagState | null = null;
 
   constructor(config: ZigZagConfig) {
     super();
@@ -42,6 +53,25 @@ export class ZigZag extends IndicatorSeries<HighLow> {
   update(candle: HighLow<number>, replace: boolean): number | null {
     const low = candle.low;
     const high = candle.high;
+
+    if (replace) {
+      if (this.#previousState !== null) {
+        this.#isUp = this.#previousState.isUp;
+        this.#highestExtreme = this.#previousState.highestExtreme;
+        this.#lowestExtreme = this.#previousState.lowestExtreme;
+      }
+      /*
+       * ZigZag only emits on a reversal, so a replacement that no longer reverses has to take back
+       * the pivot the replaced candle reported.
+       */
+      this.rollbackLastResult();
+    } else {
+      this.#previousState = {
+        highestExtreme: this.#highestExtreme,
+        isUp: this.#isUp,
+        lowestExtreme: this.#lowestExtreme,
+      };
+    }
 
     if (this.#lowestExtreme === null) {
       this.#lowestExtreme = low;


### PR DESCRIPTION
## Problem

ZigZag carries `isUp`, `highestExtreme` and `lowestExtreme` across candles and emits a pivot only when the trend reverses. `replace()` left all three holding whatever the replaced candle produced, so a discarded candle kept setting the extremes:

```ts
const zigzag = new ZigZag({deviation: 15});
candles.slice(0, -1).forEach(c => zigzag.add(c));
zigzag.add({high: 500, low: 400});     // decoy
zigzag.replace(candles.at(-1));        // replaced with the real candle
zigzag.getResult(); // 500  ❌ expected 40 — what an add-only series produces
```

A pivot also survived being invalidated. ZigZag only emits on a reversal, so when a replacement means no reversal happened, the previously reported swing point has to be withdrawn:

```ts
zigzag.add({high: 88, low: 10});   // deep low ends the uptrend → emits 88
zigzag.replace({high: 88, low: 85}); // quiet candle, no reversal after all
zigzag.getResult(); // 10  ❌ the reversal was undone but the pivot lingered
```

## Fix

Snapshot the three fields before each `add()` and restore them when replacing. Withdraw the last emission with `rollbackLastResult()`, whose doc comment names this exact case ("sparse indicators whose `replace()` can invalidate a prior emission without producing a new one").

## Tests

ZigZag had **no** `replace()` test before this. Three added:
- a replaced series reproduces the equivalent add-only series (fails on `main`: `500` vs `40`)
- an invalidated pivot is withdrawn (fails on `main`: `10` vs `0`)
- replacing before any candle behaves like adding the first candle

Full suite passes (544 tests), coverage stays at 100%, lint and `tsc --noEmit` clean.