### PR TITLE
fix(trading-signals): report the correct number of required inputs for ROC

### DIFF
--- a/packages/trading-signals/src/momentum/ROC/ROC.test.ts
+++ b/packages/trading-signals/src/momentum/ROC/ROC.test.ts
@@ -20,7 +20,7 @@ describe('ROC', () => {
 
       const interval = 5;
       const roc = new ROC(interval);
-      const offset = roc.getRequiredInputs();
+      const offset = roc.getRequiredInputs() - 1;
 
       prices.forEach((price, i) => {
         roc.add(price);
@@ -31,7 +31,7 @@ describe('ROC', () => {
         }
       });
 
-      expect(roc.getRequiredInputs()).toBe(interval);
+      expect(roc.getRequiredInputs(), 'a comparison needs one bar more than the interval').toBe(interval + 1);
       expect(roc.getSignal()).toEqual({
         hasChanged: false,
         state: TradingSignal.BULLISH,
@@ -75,6 +75,20 @@ describe('ROC', () => {
       const mockedPrices = [0.0001904, 0.00019071, 0.00019198, 0.0001922, 0.00019214, 0.00019205];
       mockedPrices.forEach(price => indicator.add(price));
       expect(indicator.isStable).toBe(true);
+    });
+
+    it('becomes stable after exactly the number of inputs it reports as required', () => {
+      const roc = new ROC(3);
+      const required = roc.getRequiredInputs();
+
+      for (let i = 1; i < required; i++) {
+        roc.add(10 + i);
+        expect(roc.isStable, `${i} of ${required} inputs is not enough`).toBe(false);
+      }
+
+      roc.add(20);
+
+      expect(roc.isStable, 'the reported number of inputs produces a result').toBe(true);
     });
   });
 

--- a/packages/trading-signals/src/momentum/ROC/ROC.ts
+++ b/packages/trading-signals/src/momentum/ROC/ROC.ts
@@ -23,7 +23,8 @@ export class ROC extends TrendIndicatorSeries {
   }
 
   override getRequiredInputs() {
-    return this.interval;
+    // Comparing against the price `interval` bars back needs that bar on top of the interval itself.
+    return this.interval + 1;
   }
 
   update(price: number, replace: boolean) {


### PR DESCRIPTION
## Problem

ROC compares the current price against the price `interval` bars back, so it needs `interval + 1` inputs before it can produce anything. `getRequiredInputs()` returned just the interval:

```ts
const roc = new ROC(5);
roc.getRequiredInputs(); // 5

[1, 2, 3, 4, 5].forEach(p => roc.add(p));
roc.isStable;            // false  ❌ it said 5 was enough
```

`NotEnoughDataError` is constructed from the same value, so it also quoted the wrong minimum (`A minimum of "5" inputs is required` when six are needed).

## Precedent

`MOM` and `VROC` do the same "value n periods ago" arithmetic and both already size their history to `interval + 1` and report it:

```ts
// VROC
this.#historyLength = interval + 1;
override getRequiredInputs() {
  return this.#historyLength;
}
```

ROC was the odd one out of the three.

## Scope

Only the reported number was wrong — ROC's actual behavior (first result on the `interval + 1`th input) is correct and unchanged. No values move.

## Tests

- The Tulip test's offset moves to the repo's usual `getRequiredInputs() - 1`, so it asserts the same expectations against the same bars as before. With the old return value it now fails (`'0.02'` vs `'0.01'`), so it pins the number rather than absorbing it.
- New test asserting the indicator becomes stable after exactly the number of inputs it reports, which fails on `main`.

Full suite passes (542 tests), `trading-strategies` passes unchanged (259 tests), coverage stays at 100%, lint and `tsc --noEmit` clean.

## Still open

Separate from this: replacing the 5th bar of a `ROC(5)` still flips it from unstable to stable with a fabricated result. That needs the window-sizing change (holding `interval + 1` prices like MOM/VROC), not a warm-up count fix.