### PR TITLE
fix(trading-signals): hold the ROC comparand inside the price window

### DIFF
--- a/packages/trading-signals/src/momentum/ROC/ROC.test.ts
+++ b/packages/trading-signals/src/momentum/ROC/ROC.test.ts
@@ -144,18 +144,30 @@ describe('ROC', () => {
 
   describe('update', () => {
     it('returns a valid result when replacing values', () => {
-      const prices = [81.59, 81.06, 82.87, 83.0, 83.61] as const;
-      const updatePrice = 82.84;
-      const expectation = 0.01911999019;
+      const prices = [81.59, 81.06, 82.87, 83.0, 83.61, 83.15] as const;
 
-      const interval = 5;
-      const roc = new ROC(interval);
+      const roc = new ROC(5);
 
       prices.forEach(price => roc.add(price));
 
-      roc.replace(updatePrice);
+      const originalResult = roc.getResultOrThrow();
+      const replacedResult = roc.replace(82.84);
 
-      expect(roc.getResultOrThrow().toFixed(2)).toEqual(expectation.toFixed(2));
+      expect(replacedResult, 'a replacement recalculates against the same comparand').not.toBe(originalResult);
+
+      const restoredResult = roc.replace(83.15);
+
+      expect(restoredResult, 'replacing back restores the original result').toBe(originalResult);
+    });
+
+    it('stays unstable when replacing before the window is full', () => {
+      const roc = new ROC(3);
+
+      [10, 11, 12].forEach(price => roc.add(price));
+
+      expect(roc.isStable, 'three prices do not fill a ROC(3) comparison window').toBe(false);
+      expect(roc.replace(12.5), 'a replacement adds no bar, so there is still nothing to compare').toBeNull();
+      expect(roc.isStable, 'a replacement must never make an unstable indicator stable').toBe(false);
     });
 
     it('keeps the correct comparand when replacing after the window has advanced', () => {

--- a/packages/trading-signals/src/momentum/ROC/ROC.test.ts
+++ b/packages/trading-signals/src/momentum/ROC/ROC.test.ts
@@ -160,6 +160,25 @@ describe('ROC', () => {
       expect(restoredResult, 'replacing back restores the original result').toBe(originalResult);
     });
 
+    it('changes nothing when the latest price is replaced with the same value', () => {
+      const prices = [81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84] as const;
+
+      // Swept over every length because the comparand only goes wrong at the boundary.
+      for (let length = 1; length <= prices.length; length++) {
+        const roc = new ROC(5);
+
+        prices.slice(0, length).forEach(price => roc.add(price));
+
+        const resultBefore = roc.getResult();
+        const stableBefore = roc.isStable;
+
+        roc.replace(prices[length - 1]);
+
+        expect(roc.getResult(), `replacing price ${length} with itself is a no-op`).toBe(resultBefore);
+        expect(roc.isStable, `and does not change stability at ${length} prices`).toBe(stableBefore);
+      }
+    });
+
     it('stays unstable when replacing before the window is full', () => {
       const roc = new ROC(3);
 

--- a/packages/trading-signals/src/momentum/ROC/ROC.ts
+++ b/packages/trading-signals/src/momentum/ROC/ROC.ts
@@ -15,8 +15,6 @@ export class ROC extends TrendIndicatorSeries {
 
   public readonly interval: number;
 
-  #comparePrice: number | null = null;
-
   constructor(interval: number) {
     super();
     this.interval = interval;
@@ -28,13 +26,15 @@ export class ROC extends TrendIndicatorSeries {
   }
 
   update(price: number, replace: boolean) {
-    if (!replace || this.#comparePrice === null) {
-      this.#comparePrice = this.prices.length === this.interval ? this.prices[0] : null;
-    }
-    pushUpdate(this.prices, replace, price, this.interval);
+    /*
+     * Keeping the comparand inside the window makes `replace()` correct for free: the window is the
+     * only state, so re-running the latest bar cannot read anything the previous bar left behind.
+     */
+    pushUpdate(this.prices, replace, price, this.getRequiredInputs());
 
-    if (this.#comparePrice !== null) {
-      return this.setResult((price - this.#comparePrice) / this.#comparePrice, replace);
+    if (this.prices.length === this.getRequiredInputs()) {
+      const comparePrice = this.prices[0];
+      return this.setResult((price - comparePrice) / comparePrice, replace);
     }
 
     return null;


### PR DESCRIPTION
> Stacked on #1259 — review that one first. Base will retarget to `main` once it merges.

## Problem

ROC kept only `interval` prices, so the bar it compares against had already been evicted from the window by the time it was needed. #1242 worked around that by caching it in `#comparePrice`, refreshed only on an `add()`.

That left one boundary case wrong. Replacing the `interval`-th bar re-reads a comparand that does not exist yet, fabricating a result and turning an unstable indicator stable:

```ts
const roc = new ROC(3);
[10, 11, 12].forEach(p => roc.add(p));
roc.isStable;      // false — correct, ROC(3) needs 4 prices
roc.replace(12.5);
roc.isStable;      // true  ❌ result 0.25 out of thin air
```

A `replace()` does not add a bar, so it can never move an indicator from unstable to stable.

## Fix

Size the window to `interval + 1` and read `prices[0]`, the way `MOM` and `VROC` already do for the same arithmetic. The window becomes the only state ROC carries, so `pushUpdate()` makes `replace()` correct on its own and the cache disappears.

This is what `packages/trading-signals/CLAUDE.md` prescribes: *"if the result is a pure function of the candle window, `pushUpdate()` handles it"*. ROC's result is a pure function of the last `interval + 1` prices.

## Verification

**Values are unchanged.** Checked every emission against the textbook definition `(p[k] - p[k-interval]) / p[k-interval]` — 2322 emitted values across intervals 1 to 12, zero mismatches.

**`replace()` now always matches an add-only series.** Across 84 scenarios (intervals 1–6 × every series length), comparing `add(decoy) + replace(real)` against adding the real series:

| | mismatches |
|---|---|
| before (cached comparand) | **6 of 84** — one per interval, each at the boundary |
| after | **0 of 84** |

## Rewritten test

`returns a valid result when replacing values` fed 5 prices into a `ROC(5)` and asserted a result — it was pinning this very bug as expected behaviour. It only passed because `toFixed(2)` rounded the actual `0.0153` and the expected `0.01912` to the same `"0.02"`. It is now a bidirectional replace test on a warmed-up indicator, asserting exact values.

Added a test for the boundary case itself, which fails on `main`.

Full suite passes (543 tests), `trading-strategies` passes unchanged (259 tests), coverage stays at 100%, lint and `tsc --noEmit` clean.