### PR TITLE
fix(trading-signals): correct replace() across six indicators

### DIFF
--- a/packages/trading-signals/CLAUDE.md
+++ b/packages/trading-signals/CLAUDE.md
@@ -21,6 +21,18 @@ Reference implementation: [PR #1214 (MFI)](https://github.com/bennycode/trading-
 
 # Coding Conventions
 
+Comments explain domain intent in plain language and must not reference concrete code constructs — method names, field names, or types rot the moment the code changes.
+
+```ts
+// ❌ Bad: names `this.result` and `setResult()`, which ties the comment to the implementation
+// PVT accumulates onto the running total. `this.result` still carries that candle's
+// contribution until `setResult()` unwinds it, which would count the bar twice.
+
+// ✅ Good: states the domain rule only
+// PVT accumulates onto the running total, so a replacement has to build on the total
+// from before the replaced candle.
+```
+
 Wrap variables in quotes for log clarity.
 
 ```ts

--- a/packages/trading-signals/src/base/Indicator.ts
+++ b/packages/trading-signals/src/base/Indicator.ts
@@ -25,10 +25,40 @@ export type TradingSignals = (typeof TradingSignal)[keyof typeof TradingSignal];
 /**
  * Implements common update behaviour among indicators.
  */
-export abstract class TechnicalIndicator<Result, Input> implements Indicator<Result, Input> {
+export abstract class TechnicalIndicator<
+  Result,
+  Input,
+  State extends object = Record<string, never>,
+> implements Indicator<Result, Input> {
   protected result: Result | undefined;
+  /**
+   * Single container for every mutable field (beyond the result) that `update()` may change.
+   * Keeping such fields here instead of in loose class fields lets the base class rewind them
+   * generically on `replace()` (see {@link trackState}) and makes two indicator instances
+   * comparable via {@link getState}.
+   */
+  protected state: State = {} as State;
+  #previousState?: State;
 
   abstract getRequiredInputs(): number;
+
+  protected trackState(replace: boolean) {
+    if (replace) {
+      if (this.#previousState !== undefined) {
+        this.state = structuredClone(this.#previousState);
+      }
+    } else {
+      this.#previousState = structuredClone(this.state);
+    }
+  }
+
+  /**
+   * Snapshot of the result and the mutable state, so two indicator instances fed the same
+   * inputs can be compared.
+   */
+  getState() {
+    return structuredClone({...this.state, result: this.result});
+  }
 
   getResult() {
     try {
@@ -68,7 +98,10 @@ export abstract class TechnicalIndicator<Result, Input> implements Indicator<Res
 /**
  * Tracks results of an indicator over time.
  */
-export abstract class IndicatorSeries<Input = number> extends TechnicalIndicator<number, Input> {
+export abstract class IndicatorSeries<
+  Input = number,
+  State extends object = Record<string, never>,
+> extends TechnicalIndicator<number, Input, State> {
   protected previousResult?: number;
 
   protected setResult(value: number, replace: boolean) {
@@ -101,7 +134,8 @@ export abstract class IndicatorSeries<Input = number> extends TechnicalIndicator
 export abstract class TrendIndicatorSeries<
   Input = number,
   SignalState = TradingSignals,
-> extends IndicatorSeries<Input> {
+  State extends object = Record<string, never>,
+> extends IndicatorSeries<Input, State> {
   protected abstract calculateSignalState(result?: number | null | undefined): SignalState;
   #previousSignalState?: SignalState;
 

--- a/packages/trading-signals/src/base/Indicator.ts
+++ b/packages/trading-signals/src/base/Indicator.ts
@@ -44,7 +44,13 @@ export abstract class TechnicalIndicator<
 
   protected trackState(replace: boolean) {
     if (replace) {
-      if (this.#previousState !== undefined) {
+      if (this.#previousState === undefined) {
+        /*
+         * A replacement before any input still needs a rollback baseline, so repeated
+         * replacements of the first logical input remain replacements.
+         */
+        this.#previousState = structuredClone(this.state);
+      } else {
         this.state = structuredClone(this.#previousState);
       }
     } else {

--- a/packages/trading-signals/src/base/Indicator.ts
+++ b/packages/trading-signals/src/base/Indicator.ts
@@ -31,12 +31,6 @@ export abstract class TechnicalIndicator<
   State extends object = Record<string, never>,
 > implements Indicator<Result, Input> {
   protected result: Result | undefined;
-  /**
-   * Single container for every mutable field (beyond the result) that `update()` may change.
-   * Keeping such fields here instead of in loose class fields lets the base class rewind them
-   * generically on `replace()` (see {@link trackState}) and makes two indicator instances
-   * comparable via {@link getState}.
-   */
   protected state: State = {} as State;
   #previousState?: State;
 

--- a/packages/trading-signals/src/base/Period.ts
+++ b/packages/trading-signals/src/base/Period.ts
@@ -34,7 +34,7 @@ export class Period extends TechnicalIndicator<PeriodResult, number> {
   }
 
   update(value: number, replace: boolean) {
-    pushUpdate(this.values, replace, value, this.interval);
+    pushUpdate({array: this.values, item: value, maxLength: this.interval, replace: replace});
 
     if (this.values.length === this.interval) {
       this.#lowest = Math.min(...this.values);

--- a/packages/trading-signals/src/fixtures/testIndicatorContract.ts
+++ b/packages/trading-signals/src/fixtures/testIndicatorContract.ts
@@ -1,17 +1,10 @@
 import {describe, expect, it} from 'vitest';
+import type {TechnicalIndicator} from '../base/Indicator.js';
 import {NotEnoughDataError} from '../error/NotEnoughDataError.js';
 
 type IndicatorContractOptions<Input> = {
   /** Creates a fresh instance of the indicator under test */
-  create: () => {
-    add(input: Input): unknown;
-    getRequiredInputs(): number;
-    getResult(): unknown;
-    getResultOrThrow(): unknown;
-    getState(): object;
-    isStable: boolean;
-    replace(input: Input): unknown;
-  };
+  create: () => TechnicalIndicator<unknown, Input, object>;
   /** Input that must lead the indicator into a different state than the last of `inputs` */
   divergentInput: Input;
   /** Input series fed before exercising replace(); the last input is the one being replaced */
@@ -46,6 +39,18 @@ export function testIndicatorContract<Input>({create, divergentInput, inputs}: I
         indicator.add(input);
         expectNoResult(index + 1);
       });
+    });
+
+    it('yields a result once the warm-up is complete', () => {
+      const indicator = create();
+
+      for (const input of inputs) {
+        indicator.add(input);
+      }
+
+      expect(indicator.isStable, 'the contract inputs leave the indicator stable').toBe(true);
+      expect(indicator.getResult(), 'a warmed-up indicator never yields undefined').not.toBeUndefined();
+      expect(indicator.getResultOrThrow(), 'a stable indicator yields an actual result').not.toBeNull();
     });
   });
 

--- a/packages/trading-signals/src/fixtures/testIndicatorContract.ts
+++ b/packages/trading-signals/src/fixtures/testIndicatorContract.ts
@@ -1,10 +1,15 @@
 import {describe, expect, it} from 'vitest';
+import {NotEnoughDataError} from '../error/NotEnoughDataError.js';
 
-type ReplaceContractOptions<Input> = {
+type IndicatorContractOptions<Input> = {
   /** Creates a fresh instance of the indicator under test */
   create: () => {
     add(input: Input): unknown;
+    getRequiredInputs(): number;
+    getResult(): unknown;
+    getResultOrThrow(): unknown;
     getState(): object;
+    isStable: boolean;
     replace(input: Input): unknown;
   };
   /** Input that must lead the indicator into a different state than the last of `inputs` */
@@ -14,11 +19,36 @@ type ReplaceContractOptions<Input> = {
 };
 
 /**
- * Registers the replace() contract every indicator must fulfil: replacing the latest input
- * with itself changes nothing, and replacing a divergent input restores the exact state of
- * an add-only series.
+ * Registers the contracts every indicator must fulfil. Warm-up: below the declared number of
+ * required inputs there is no result, only a `NotEnoughDataError`. Replace: replacing the
+ * latest input with itself changes nothing, and replacing a divergent input restores the
+ * exact state of an add-only series.
  */
-export function testReplaceContract<Input>({create, divergentInput, inputs}: ReplaceContractOptions<Input>) {
+export function testIndicatorContract<Input>({create, divergentInput, inputs}: IndicatorContractOptions<Input>) {
+  describe('warm-up contract', () => {
+    it('stays unstable and yields no result before the declared warm-up', () => {
+      const indicator = create();
+      const requiredInputs = indicator.getRequiredInputs();
+
+      expect(inputs.length, 'the contract inputs must cover the declared warm-up').toBeGreaterThanOrEqual(
+        requiredInputs
+      );
+
+      const expectNoResult = (count: number) => {
+        expect(indicator.isStable, `unstable after ${count} of ${requiredInputs} required inputs`).toBe(false);
+        expect(indicator.getResult(), `no result after ${count} of ${requiredInputs} required inputs`).toBeNull();
+        expect(() => indicator.getResultOrThrow()).toThrow(NotEnoughDataError);
+      };
+
+      expectNoResult(0);
+
+      inputs.slice(0, requiredInputs - 1).forEach((input, index) => {
+        indicator.add(input);
+        expectNoResult(index + 1);
+      });
+    });
+  });
+
   describe('replace() contract', () => {
     it('changes nothing when the latest input is replaced with itself', () => {
       const indicator = create();

--- a/packages/trading-signals/src/fixtures/testReplaceContract.ts
+++ b/packages/trading-signals/src/fixtures/testReplaceContract.ts
@@ -1,0 +1,58 @@
+import {describe, expect, it} from 'vitest';
+
+type ReplaceContractOptions<Input> = {
+  /** Creates a fresh instance of the indicator under test */
+  create: () => {
+    add(input: Input): unknown;
+    getState(): object;
+    replace(input: Input): unknown;
+  };
+  /** Input that must lead the indicator into a different state than the last of `inputs` */
+  divergentInput: Input;
+  /** Input series fed before exercising replace(); the last input is the one being replaced */
+  inputs: readonly Input[];
+};
+
+/**
+ * Registers the replace() contract every indicator must fulfil: replacing the latest input
+ * with itself changes nothing, and replacing a divergent input restores the exact state of
+ * an add-only series.
+ */
+export function testReplaceContract<Input>({create, divergentInput, inputs}: ReplaceContractOptions<Input>) {
+  describe('replace() contract', () => {
+    it('changes nothing when the latest input is replaced with itself', () => {
+      const indicator = create();
+
+      for (const input of inputs) {
+        indicator.add(input);
+      }
+
+      const stateBefore = indicator.getState();
+      indicator.replace(inputs[inputs.length - 1]);
+
+      expect(indicator.getState(), 'replacing the latest input with itself is a no-op').toEqual(stateBefore);
+    });
+
+    it('reproduces the state of an add-only series after replacing a divergent input', () => {
+      const reference = create();
+
+      for (const input of inputs) {
+        reference.add(input);
+      }
+
+      const replaced = create();
+
+      for (const input of inputs.slice(0, -1)) {
+        replaced.add(input);
+      }
+
+      replaced.add(divergentInput);
+
+      expect(replaced.getState(), 'the divergent input leads to a different state').not.toEqual(reference.getState());
+
+      replaced.replace(inputs[inputs.length - 1]);
+
+      expect(replaced.getState(), 'a replacement reproduces the add-only series').toEqual(reference.getState());
+    });
+  });
+}

--- a/packages/trading-signals/src/momentum/AC/AC.test.ts
+++ b/packages/trading-signals/src/momentum/AC/AC.test.ts
@@ -1,5 +1,4 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
-import {NotEnoughDataError} from '../../error/index.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {TradingSignal} from '../../base/Indicator.js';
 import {AC} from './AC.js';
 
@@ -295,20 +294,9 @@ describe('AC', () => {
        * https://github.com/jesse-ai/jesse/blob/53297462d48ebf43f9df46ab5005076d25073e5e/tests/test_indicators.py#L14
        */
       expect(ac.isStable).toBe(true);
-      expect(ac.getRequiredInputs()).toBe(39);
+      expect(ac.getRequiredInputs()).toBe(38);
       expect(ac.getResultOrThrow().toFixed(2)).toBe('-21.97');
       expect(ac.momentum.getResultOrThrow().toFixed(2)).toBe('-9.22');
-    });
-
-    it('throws an error when there is not enough input data', () => {
-      const ac = new AC(5, 34, 5);
-
-      try {
-        ac.getResultOrThrow();
-        throw new Error('Expected error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotEnoughDataError);
-      }
     });
   });
 
@@ -385,7 +373,7 @@ describe('AC', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new AC(5, 10, 5),
   divergentInput: {high: 1_000, low: 998},
   inputs: [

--- a/packages/trading-signals/src/momentum/AC/AC.test.ts
+++ b/packages/trading-signals/src/momentum/AC/AC.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {NotEnoughDataError} from '../../error/index.js';
 import {TradingSignal} from '../../base/Indicator.js';
 import {AC} from './AC.js';
@@ -382,4 +383,27 @@ describe('AC', () => {
       expect(signal.hasChanged).toBe(false);
     });
   });
+});
+
+testReplaceContract({
+  create: () => new AC(5, 10, 5),
+  divergentInput: {high: 1_000, low: 998},
+  inputs: [
+    {high: 101, low: 99},
+    {high: 103, low: 101},
+    {high: 106, low: 104},
+    {high: 109, low: 107},
+    {high: 113, low: 111},
+    {high: 117, low: 115},
+    {high: 121, low: 119},
+    {high: 126, low: 124},
+    {high: 131, low: 129},
+    {high: 136, low: 134},
+    {high: 141, low: 139},
+    {high: 146, low: 144},
+    {high: 151, low: 149},
+    {high: 156, low: 154},
+    {high: 161, low: 159},
+    {high: 166, low: 164},
+  ],
 });

--- a/packages/trading-signals/src/momentum/AC/AC.ts
+++ b/packages/trading-signals/src/momentum/AC/AC.ts
@@ -32,7 +32,8 @@ export class AC extends TrendIndicatorSeries<HighLow<number>> {
   }
 
   override getRequiredInputs() {
-    return this.ao.getRequiredInputs() + this.signal.getRequiredInputs();
+    // The bar that yields the first AO result is also the signal SMA's first input.
+    return this.ao.getRequiredInputs() + this.signal.getRequiredInputs() - 1;
   }
 
   update(input: HighLow<number>, replace: boolean) {

--- a/packages/trading-signals/src/momentum/AO/AO.test.ts
+++ b/packages/trading-signals/src/momentum/AO/AO.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {NotEnoughDataError} from '../../error/index.js';
 import {TradingSignal} from '../../base/Indicator.js';
 import {AO} from './AO.js';
@@ -157,4 +158,17 @@ describe('AO', () => {
       expect(signal.state).toBe(TradingSignal.SIDEWAYS);
     });
   });
+});
+
+testReplaceContract({
+  create: () => new AO(2, 5),
+  divergentInput: {high: 1_000, low: 900},
+  inputs: [
+    {high: 32.11, low: 25.69},
+    {high: 27.62, low: 25.57},
+    {high: 28.26, low: 25.73},
+    {high: 28.02, low: 25.69},
+    {high: 26.93, low: 25.69},
+    {high: 26.65, low: 26.17},
+  ],
 });

--- a/packages/trading-signals/src/momentum/AO/AO.test.ts
+++ b/packages/trading-signals/src/momentum/AO/AO.test.ts
@@ -1,5 +1,4 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
-import {NotEnoughDataError} from '../../error/index.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {TradingSignal} from '../../base/Indicator.js';
 import {AO} from './AO.js';
 
@@ -59,17 +58,6 @@ describe('AO', () => {
         hasChanged: false,
         state: TradingSignal.BEARISH,
       });
-    });
-
-    it('throws an error when there is not enough input data', () => {
-      const ao = new AO(5, 34);
-
-      try {
-        ao.getResultOrThrow();
-        throw new Error('Expected error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotEnoughDataError);
-      }
     });
   });
 
@@ -160,7 +148,7 @@ describe('AO', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new AO(2, 5),
   divergentInput: {high: 1_000, low: 900},
   inputs: [

--- a/packages/trading-signals/src/momentum/CCI/CCI.test.ts
+++ b/packages/trading-signals/src/momentum/CCI/CCI.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {NotEnoughDataError} from '../../error/index.js';
 import {TradingSignal} from '../../base/Indicator.js';
 import {CCI} from './CCI.js';
@@ -183,4 +184,17 @@ describe('CCI', () => {
       expect(signal.state).toBe(TradingSignal.SIDEWAYS);
     });
   });
+});
+
+testReplaceContract({
+  create: () => new CCI(5),
+  divergentInput: {close: 1_000, high: 1_100, low: 900},
+  inputs: [
+    {close: 81.59, high: 82.15, low: 81.29},
+    {close: 81.06, high: 81.89, low: 80.64},
+    {close: 82.87, high: 83.03, low: 81.31},
+    {close: 83.0, high: 83.3, low: 82.65},
+    {close: 83.61, high: 83.85, low: 83.07},
+    {close: 83.15, high: 83.9, low: 83.11},
+  ],
 });

--- a/packages/trading-signals/src/momentum/CCI/CCI.test.ts
+++ b/packages/trading-signals/src/momentum/CCI/CCI.test.ts
@@ -1,5 +1,4 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
-import {NotEnoughDataError} from '../../error/index.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {TradingSignal} from '../../base/Indicator.js';
 import {CCI} from './CCI.js';
 
@@ -80,16 +79,6 @@ describe('CCI', () => {
 
       const actual = cci.getResultOrThrow().toFixed(2);
       expect(actual).toBe('71.93');
-    });
-
-    it('throws an error when there is not enough input data', () => {
-      const cci = new CCI(5);
-      try {
-        cci.getResultOrThrow();
-        throw new Error('Expected error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotEnoughDataError);
-      }
     });
   });
 
@@ -186,7 +175,7 @@ describe('CCI', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new CCI(5),
   divergentInput: {close: 1_000, high: 1_100, low: 900},
   inputs: [

--- a/packages/trading-signals/src/momentum/CCI/CCI.ts
+++ b/packages/trading-signals/src/momentum/CCI/CCI.ts
@@ -66,7 +66,7 @@ export class CCI extends TrendIndicatorSeries<HighLowClose<number>> {
 
   #cacheTypicalPrice(candle: HighLowClose<number>, replace: boolean) {
     const typicalPrice = getTypicalPrice(candle);
-    pushUpdate(this.#typicalPrices, replace, typicalPrice, this.interval);
+    pushUpdate({array: this.#typicalPrices, item: typicalPrice, maxLength: this.interval, replace});
     return typicalPrice;
   }
 

--- a/packages/trading-signals/src/momentum/CG/CG.test.ts
+++ b/packages/trading-signals/src/momentum/CG/CG.test.ts
@@ -1,5 +1,4 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
-import {NotEnoughDataError} from '../../error/index.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {TradingSignal} from '../../base/Indicator.js';
 import {CG} from './CG.js';
 
@@ -91,17 +90,6 @@ describe('CG', () => {
       expect(cg.getResultOrThrow().toFixed(4)).toBe('2.7059');
     });
 
-    it('throws an error when there is not enough input data', () => {
-      const cg = new CG(10, 20);
-
-      try {
-        cg.getResultOrThrow();
-        throw new Error('Expected error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotEnoughDataError);
-      }
-    });
-
     it('is protected against division by zero errors', () => {
       const cg = new CG(1, 1);
       cg.add(0);
@@ -156,7 +144,7 @@ describe('CG', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new CG(5, 10),
   divergentInput: 1_000,
   inputs: [100, 110, 120, 130, 140, 150, 160, 170, 180, 190, 200],

--- a/packages/trading-signals/src/momentum/CG/CG.test.ts
+++ b/packages/trading-signals/src/momentum/CG/CG.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {NotEnoughDataError} from '../../error/index.js';
 import {TradingSignal} from '../../base/Indicator.js';
 import {CG} from './CG.js';
@@ -153,4 +154,10 @@ describe('CG', () => {
       expect(cg.getResultOrThrow()).toBe(cg.signal.getResultOrThrow());
     });
   });
+});
+
+testReplaceContract({
+  create: () => new CG(5, 10),
+  divergentInput: 1_000,
+  inputs: [100, 110, 120, 130, 140, 150, 160, 170, 180, 190, 200],
 });

--- a/packages/trading-signals/src/momentum/CG/CG.ts
+++ b/packages/trading-signals/src/momentum/CG/CG.ts
@@ -60,7 +60,7 @@ export class CG extends TrendIndicatorSeries {
   }
 
   update(price: number, replace: boolean) {
-    pushUpdate(this.prices, replace, price, this.interval);
+    pushUpdate({array: this.prices, item: price, maxLength: this.interval, replace: replace});
 
     let nominator = 0;
     let denominator = 0;

--- a/packages/trading-signals/src/momentum/CMO/CMO.test.ts
+++ b/packages/trading-signals/src/momentum/CMO/CMO.test.ts
@@ -1,6 +1,5 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {CMO} from './CMO.js';
-import {NotEnoughDataError} from '../../error/index.js';
 import {TradingSignal} from '../../base/index.js';
 
 describe('CMO', () => {
@@ -75,17 +74,6 @@ describe('CMO', () => {
 
       expect(cmo.getResultOrThrow()).toBe(0);
     });
-
-    it('throws an error when there is not enough input data', () => {
-      const cmo = new CMO(5);
-
-      try {
-        cmo.getResultOrThrow();
-        throw new Error('Expected error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotEnoughDataError);
-      }
-    });
   });
 
   describe('getSignal', () => {
@@ -143,7 +131,7 @@ describe('CMO', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new CMO(5),
   divergentInput: 1_000,
   inputs: [81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84],

--- a/packages/trading-signals/src/momentum/CMO/CMO.test.ts
+++ b/packages/trading-signals/src/momentum/CMO/CMO.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {CMO} from './CMO.js';
 import {NotEnoughDataError} from '../../error/index.js';
 import {TradingSignal} from '../../base/index.js';
@@ -140,4 +141,10 @@ describe('CMO', () => {
       expect(sensitiveBear.getSignal().state).toBe(TradingSignal.BEARISH);
     });
   });
+});
+
+testReplaceContract({
+  create: () => new CMO(5),
+  divergentInput: 1_000,
+  inputs: [81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84],
 });

--- a/packages/trading-signals/src/momentum/CMO/CMO.ts
+++ b/packages/trading-signals/src/momentum/CMO/CMO.ts
@@ -37,7 +37,7 @@ export class CMO extends TrendIndicatorSeries {
   }
 
   update(price: number, replace: boolean) {
-    pushUpdate(this.#prices, replace, price, this.getRequiredInputs());
+    pushUpdate({array: this.#prices, item: price, maxLength: this.getRequiredInputs(), replace: replace});
 
     if (this.#prices.length < this.getRequiredInputs()) {
       return null;

--- a/packages/trading-signals/src/momentum/ER/ER.test.ts
+++ b/packages/trading-signals/src/momentum/ER/ER.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {ER} from './ER.js';
 import {NotEnoughDataError} from '../../error/index.js';
 import {TradingSignal} from '../../base/Indicator.js';
@@ -191,4 +192,15 @@ describe('ER', () => {
       expect(er.getRequiredInputs()).toBe(20);
     });
   });
+});
+
+testReplaceContract({
+  create: () => new ER(3),
+  divergentInput: {close: 1_000, high: 1_100, low: 900},
+  inputs: [
+    {close: 100, high: 101, low: 99},
+    {close: 102, high: 103, low: 101},
+    {close: 104, high: 105, low: 103},
+    {close: 106, high: 107, low: 105},
+  ],
 });

--- a/packages/trading-signals/src/momentum/ER/ER.test.ts
+++ b/packages/trading-signals/src/momentum/ER/ER.test.ts
@@ -1,6 +1,5 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {ER} from './ER.js';
-import {NotEnoughDataError} from '../../error/index.js';
 import {TradingSignal} from '../../base/Indicator.js';
 
 describe('ER', () => {
@@ -73,17 +72,6 @@ describe('ER', () => {
       }
 
       expect(er.getResultOrThrow()).toBe(0);
-    });
-
-    it('throws an error when there is not enough input data', () => {
-      const er = new ER(5);
-
-      try {
-        er.getResultOrThrow();
-        throw new Error('Expected error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotEnoughDataError);
-      }
     });
   });
 
@@ -194,7 +182,7 @@ describe('ER', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new ER(3),
   divergentInput: {close: 1_000, high: 1_100, low: 900},
   inputs: [

--- a/packages/trading-signals/src/momentum/ER/ER.ts
+++ b/packages/trading-signals/src/momentum/ER/ER.ts
@@ -41,9 +41,9 @@ export class ER extends TrendIndicatorSeries<HighLowClose> {
   }
 
   update(candle: HighLowClose, replace: boolean) {
-    pushUpdate(this.#closes, replace, candle.close, this.interval);
-    pushUpdate(this.#highs, replace, candle.high, this.interval);
-    pushUpdate(this.#lows, replace, candle.low, this.interval);
+    pushUpdate({array: this.#closes, item: candle.close, maxLength: this.interval, replace: replace});
+    pushUpdate({array: this.#highs, item: candle.high, maxLength: this.interval, replace: replace});
+    pushUpdate({array: this.#lows, item: candle.low, maxLength: this.interval, replace: replace});
 
     if (this.#closes.length < this.interval) {
       return null;

--- a/packages/trading-signals/src/momentum/MACD/MACD.test.ts
+++ b/packages/trading-signals/src/momentum/MACD/MACD.test.ts
@@ -1,7 +1,6 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {MACD} from './MACD.js';
 import {EMA} from '../../trend/EMA/EMA.js';
-import {NotEnoughDataError} from '../../error/index.js';
 import {TradingSignal} from '../../base/index.js';
 
 describe('MACD', () => {
@@ -129,17 +128,6 @@ describe('MACD', () => {
 
       expect(macd.isStable).toBe(true);
     });
-
-    it('throws an error when there is not enough input data', () => {
-      const macd = new MACD(new EMA(12), new EMA(26), new EMA(9));
-
-      try {
-        macd.getResultOrThrow();
-        throw new Error('Expected error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotEnoughDataError);
-      }
-    });
   });
 
   describe('isStable', () => {
@@ -204,7 +192,7 @@ describe('MACD', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new MACD(new EMA(2), new EMA(5), new EMA(9)),
   divergentInput: 1_000,
   inputs: [81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84],

--- a/packages/trading-signals/src/momentum/MACD/MACD.test.ts
+++ b/packages/trading-signals/src/momentum/MACD/MACD.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {MACD} from './MACD.js';
 import {EMA} from '../../trend/EMA/EMA.js';
 import {NotEnoughDataError} from '../../error/index.js';
@@ -201,4 +202,10 @@ describe('MACD', () => {
       expect(typeof signal.hasChanged).toBe('boolean');
     });
   });
+});
+
+testReplaceContract({
+  create: () => new MACD(new EMA(2), new EMA(5), new EMA(9)),
+  divergentInput: 1_000,
+  inputs: [81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84],
 });

--- a/packages/trading-signals/src/momentum/MACD/MACD.ts
+++ b/packages/trading-signals/src/momentum/MACD/MACD.ts
@@ -38,7 +38,7 @@ export class MACD extends TechnicalIndicator<MACDResult, number> {
   }
 
   update(price: number, replace: boolean) {
-    pushUpdate(this.prices, replace, price, this.long.interval);
+    pushUpdate({array: this.prices, item: price, maxLength: this.long.interval, replace: replace});
 
     const short = this.short.update(price, replace);
     const long = this.long.update(price, replace);

--- a/packages/trading-signals/src/momentum/MFI/MFI.test.ts
+++ b/packages/trading-signals/src/momentum/MFI/MFI.test.ts
@@ -1,6 +1,5 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {MFI} from './MFI.js';
-import {NotEnoughDataError} from '../../error/index.js';
 import {TradingSignal} from '../../base/index.js';
 
 describe('MFI', () => {
@@ -91,17 +90,6 @@ describe('MFI', () => {
 
       expect(mfi.getResultOrThrow()).toBe(50);
     });
-
-    it('throws an error when there is not enough input data', () => {
-      const mfi = new MFI(5);
-
-      try {
-        mfi.getResultOrThrow();
-        throw new Error('Expected error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotEnoughDataError);
-      }
-    });
   });
 
   describe('getSignal', () => {
@@ -163,7 +151,7 @@ describe('MFI', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new MFI(5),
   divergentInput: {close: 500, high: 500, low: 500, volume: 99_000},
   inputs: [

--- a/packages/trading-signals/src/momentum/MFI/MFI.test.ts
+++ b/packages/trading-signals/src/momentum/MFI/MFI.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {MFI} from './MFI.js';
 import {NotEnoughDataError} from '../../error/index.js';
 import {TradingSignal} from '../../base/index.js';
@@ -160,4 +161,18 @@ describe('MFI', () => {
       expect(mfi.getSignal().state).toBe(TradingSignal.SIDEWAYS);
     });
   });
+});
+
+testReplaceContract({
+  create: () => new MFI(5),
+  divergentInput: {close: 500, high: 500, low: 500, volume: 99_000},
+  inputs: [
+    {close: 81.59, high: 82.15, low: 81.29, volume: 5_653_100},
+    {close: 81.06, high: 81.89, low: 80.64, volume: 6_447_400},
+    {close: 82.87, high: 83.03, low: 81.31, volume: 7_690_900},
+    {close: 83.0, high: 83.3, low: 82.65, volume: 3_831_400},
+    {close: 83.61, high: 83.85, low: 83.07, volume: 4_455_100},
+    {close: 83.15, high: 83.9, low: 83.11, volume: 3_798_000},
+    {close: 82.84, high: 83.33, low: 82.49, volume: 3_936_200},
+  ],
 });

--- a/packages/trading-signals/src/momentum/MFI/MFI.ts
+++ b/packages/trading-signals/src/momentum/MFI/MFI.ts
@@ -39,7 +39,7 @@ export class MFI extends TrendIndicatorSeries<HighLowCloseVolume<number>> {
   }
 
   update(candle: HighLowCloseVolume<number>, replace: boolean) {
-    pushUpdate(this.#candles, replace, candle, this.getRequiredInputs());
+    pushUpdate({array: this.#candles, item: candle, maxLength: this.getRequiredInputs(), replace: replace});
 
     if (this.#candles.length < this.getRequiredInputs()) {
       return null;

--- a/packages/trading-signals/src/momentum/MOM/MOM.test.ts
+++ b/packages/trading-signals/src/momentum/MOM/MOM.test.ts
@@ -1,6 +1,5 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {MOM} from './MOM.js';
-import {NotEnoughDataError} from '../../error/index.js';
 import {TradingSignal} from '../../base/Indicator.js';
 
 describe('MOM', () => {
@@ -44,17 +43,6 @@ describe('MOM', () => {
 
       expect(momentum.isStable).toBe(true);
       expect(momentum.getRequiredInputs()).toBe(6);
-    });
-
-    it('throws an error when there is not enough input data', () => {
-      const momentum = new MOM(5);
-
-      try {
-        momentum.getResultOrThrow();
-        throw new Error('Expected error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotEnoughDataError);
-      }
     });
   });
 
@@ -117,7 +105,7 @@ describe('MOM', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new MOM(5),
   divergentInput: 1_000,
   inputs: [81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84],

--- a/packages/trading-signals/src/momentum/MOM/MOM.test.ts
+++ b/packages/trading-signals/src/momentum/MOM/MOM.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {MOM} from './MOM.js';
 import {NotEnoughDataError} from '../../error/index.js';
 import {TradingSignal} from '../../base/Indicator.js';
@@ -114,4 +115,10 @@ describe('MOM', () => {
       expect(signal.state).toBe(TradingSignal.SIDEWAYS);
     });
   });
+});
+
+testReplaceContract({
+  create: () => new MOM(5),
+  divergentInput: 1_000,
+  inputs: [81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84],
 });

--- a/packages/trading-signals/src/momentum/MOM/MOM.ts
+++ b/packages/trading-signals/src/momentum/MOM/MOM.ts
@@ -28,7 +28,7 @@ export class MOM extends TrendIndicatorSeries {
   }
 
   update(value: number, replace: boolean) {
-    pushUpdate(this.#history, replace, value, this.#historyLength);
+    pushUpdate({array: this.#history, item: value, maxLength: this.#historyLength, replace: replace});
 
     if (this.#history.length === this.#historyLength) {
       return this.setResult(value - this.#history[0], replace);

--- a/packages/trading-signals/src/momentum/OBV/OBV.test.ts
+++ b/packages/trading-signals/src/momentum/OBV/OBV.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {OBV} from './OBV.js';
 import {NotEnoughDataError} from '../../error/index.js';
 import {TradingSignal} from '../../base/index.js';
@@ -116,4 +117,15 @@ describe('OBV', () => {
       expect(signal.state).toBe(TradingSignal.SIDEWAYS);
     });
   });
+});
+
+testReplaceContract({
+  create: () => new OBV(2),
+  divergentInput: {close: 1, high: 500, low: 1, open: 500, volume: 99_000},
+  inputs: [
+    {close: 100, high: 100, low: 100, open: 100, volume: 1_000},
+    {close: 101, high: 101, low: 101, open: 101, volume: 1_500},
+    {close: 102, high: 102, low: 102, open: 102, volume: 2_000},
+    {close: 101, high: 102, low: 100, open: 102, volume: 1_800},
+  ],
 });

--- a/packages/trading-signals/src/momentum/OBV/OBV.test.ts
+++ b/packages/trading-signals/src/momentum/OBV/OBV.test.ts
@@ -1,6 +1,5 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {OBV} from './OBV.js';
-import {NotEnoughDataError} from '../../error/index.js';
 import {TradingSignal} from '../../base/index.js';
 
 describe('OBV', () => {
@@ -44,18 +43,6 @@ describe('OBV', () => {
       expect(obv.isStable).toBe(true);
       expect(obv.getRequiredInputs()).toBe(2);
       expect(obv.getResultOrThrow().toFixed(2)).toBe('72100.00');
-    });
-
-    it('throws an error when there is not enough input data', () => {
-      const obv = new OBV(2);
-      expect(obv.isStable).toBe(false);
-      try {
-        obv.getResultOrThrow();
-        throw new Error('Expected error');
-      } catch (error) {
-        expect(obv.isStable).toBe(false);
-        expect(error).toBeInstanceOf(NotEnoughDataError);
-      }
     });
   });
 
@@ -119,7 +106,7 @@ describe('OBV', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new OBV(2),
   divergentInput: {close: 1, high: 500, low: 1, open: 500, volume: 99_000},
   inputs: [

--- a/packages/trading-signals/src/momentum/OBV/OBV.ts
+++ b/packages/trading-signals/src/momentum/OBV/OBV.ts
@@ -35,8 +35,7 @@ export class OBV extends TrendIndicatorSeries<OpenHighLowCloseVolume<number>> {
     const prevPrice = prevCandle.close;
     /*
      * OBV accumulates onto the running total, so a replacement has to build on the total from
-     * before the replaced candle. `this.result` still carries that candle's contribution until
-     * `setResult()` unwinds it, which would count the bar twice.
+     * before the replaced candle.
      */
     const prevResult = (replace ? this.previousResult : this.result) ?? 0;
     const currentPrice = candle.close;

--- a/packages/trading-signals/src/momentum/OBV/OBV.ts
+++ b/packages/trading-signals/src/momentum/OBV/OBV.ts
@@ -25,7 +25,7 @@ export class OBV extends TrendIndicatorSeries<OpenHighLowCloseVolume<number>> {
   }
 
   update(candle: OpenHighLowCloseVolume<number>, replace: boolean) {
-    pushUpdate({array: this.candles, item: candle, maxLength: this.getRequiredInputs(), replace: replace});
+    pushUpdate({array: this.candles, item: candle, maxLength: this.getRequiredInputs(), replace});
 
     if (this.candles.length < this.getRequiredInputs()) {
       return null;
@@ -33,11 +33,16 @@ export class OBV extends TrendIndicatorSeries<OpenHighLowCloseVolume<number>> {
 
     const prevCandle = this.candles[this.candles.length - 2];
     const prevPrice = prevCandle.close;
-    const prevResult = this.result ?? 0;
+    /*
+     * OBV accumulates onto the running total, so a replacement has to build on the total from
+     * before the replaced candle. `this.result` still carries that candle's contribution until
+     * `setResult()` unwinds it, which would count the bar twice.
+     */
+    const prevResult = (replace ? this.previousResult : this.result) ?? 0;
     const currentPrice = candle.close;
     const nextResult = currentPrice > prevPrice ? candle.volume : currentPrice < prevPrice ? -candle.volume : 0;
 
-    return this.setResult(prevResult + nextResult, false);
+    return this.setResult(prevResult + nextResult, replace);
   }
 
   protected calculateSignalState(result: number | null | undefined) {

--- a/packages/trading-signals/src/momentum/OBV/OBV.ts
+++ b/packages/trading-signals/src/momentum/OBV/OBV.ts
@@ -25,7 +25,7 @@ export class OBV extends TrendIndicatorSeries<OpenHighLowCloseVolume<number>> {
   }
 
   update(candle: OpenHighLowCloseVolume<number>, replace: boolean) {
-    pushUpdate(this.candles, replace, candle, this.getRequiredInputs());
+    pushUpdate({array: this.candles, item: candle, maxLength: this.getRequiredInputs(), replace: replace});
 
     if (this.candles.length < this.getRequiredInputs()) {
       return null;

--- a/packages/trading-signals/src/momentum/PPO/PPO.test.ts
+++ b/packages/trading-signals/src/momentum/PPO/PPO.test.ts
@@ -1,6 +1,5 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {PPO} from './PPO.js';
-import {NotEnoughDataError} from '../../error/index.js';
 import {TradingSignal} from '../../base/index.js';
 
 describe('PPO', () => {
@@ -68,17 +67,6 @@ describe('PPO', () => {
       expect(ppo.isStable).toBe(true);
       expect(ppo.getRequiredInputs()).toBe(5);
     });
-
-    it('throws an error when there is not enough input data', () => {
-      const ppo = new PPO();
-
-      try {
-        ppo.getResultOrThrow();
-        throw new Error('Expected error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotEnoughDataError);
-      }
-    });
   });
 
   describe('getSignal', () => {
@@ -123,7 +111,7 @@ describe('PPO', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new PPO({fastPeriod: 2, slowPeriod: 5}),
   divergentInput: 1_000,
   inputs: [81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84],

--- a/packages/trading-signals/src/momentum/PPO/PPO.test.ts
+++ b/packages/trading-signals/src/momentum/PPO/PPO.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {PPO} from './PPO.js';
 import {NotEnoughDataError} from '../../error/index.js';
 import {TradingSignal} from '../../base/index.js';
@@ -120,4 +121,10 @@ describe('PPO', () => {
       expect(ppo.getSignal().state).toBe(TradingSignal.SIDEWAYS);
     });
   });
+});
+
+testReplaceContract({
+  create: () => new PPO({fastPeriod: 2, slowPeriod: 5}),
+  divergentInput: 1_000,
+  inputs: [81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84],
 });

--- a/packages/trading-signals/src/momentum/REI/REI.test.ts
+++ b/packages/trading-signals/src/momentum/REI/REI.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {REI} from './REI.js';
 import {TradingSignal} from '../../base/index.js';
 
@@ -254,4 +255,28 @@ describe('REI', () => {
       expect(signal.state).toBe(TradingSignal.SIDEWAYS);
     });
   });
+});
+
+testReplaceContract({
+  create: () => new REI(8),
+  divergentInput: {close: 3_000, high: 4_000, low: 2_000},
+  inputs: [
+    {close: 453.13, high: 456.19, low: 450.43},
+    {close: 454.27, high: 454.36, low: 448.73},
+    {close: 458.87, high: 459.58, low: 450.8},
+    {close: 458.17, high: 458.34, low: 454.32},
+    {close: 452.57, high: 457.78, low: 451.81},
+    {close: 454.86, high: 460.25, low: 453.9},
+    {close: 450.18, high: 453.69, low: 448.91},
+    {close: 460.69, high: 460.95, low: 456.11},
+    {close: 457.36, high: 462.52, low: 456.93},
+    {close: 458.68, high: 461.72, low: 455.31},
+    {close: 460.36, high: 461.68, low: 455.54},
+    {close: 461.97, high: 462.11, low: 456.89},
+    {close: 462.97, high: 464.14, low: 460.86},
+    {close: 463.87, high: 465.69, low: 463.02},
+    {close: 467.68, high: 469.65, low: 464.03},
+    {close: 470.38, high: 473.33, low: 468.78},
+    {close: 471.12, high: 473.5, low: 469.4},
+  ],
 });

--- a/packages/trading-signals/src/momentum/REI/REI.test.ts
+++ b/packages/trading-signals/src/momentum/REI/REI.test.ts
@@ -1,4 +1,4 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {REI} from './REI.js';
 import {TradingSignal} from '../../base/index.js';
 
@@ -199,17 +199,6 @@ describe('REI', () => {
 
       expect(rei.getResultOrThrow().toFixed(2)).toBe('-14.99');
     });
-
-    it('returns null until there are enough data points', () => {
-      const interval = 8;
-      const rei = new REI(interval);
-
-      for (let i = 0; i < 15; i++) {
-        rei.add({close: i, high: i, low: i});
-      }
-
-      expect(rei.getResult()).toBeNull();
-    });
   });
 
   describe('getSignal', () => {
@@ -257,7 +246,7 @@ describe('REI', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new REI(8),
   divergentInput: {close: 3_000, high: 4_000, low: 2_000},
   inputs: [

--- a/packages/trading-signals/src/momentum/ROC/ROC.test.ts
+++ b/packages/trading-signals/src/momentum/ROC/ROC.test.ts
@@ -31,7 +31,6 @@ describe('ROC', () => {
         }
       });
 
-      expect(roc.getRequiredInputs(), 'a comparison needs one bar more than the interval').toBe(interval + 1);
       expect(roc.getSignal()).toEqual({
         hasChanged: false,
         state: TradingSignal.BULLISH,
@@ -41,11 +40,9 @@ describe('ROC', () => {
     it('identifies a down-trending asset by a negative ROC', () => {
       const roc = new ROC(5);
 
-      const prices = [1000, 900, 800, 700, 600, 500, 400, 300, 200, 100];
+      const prices = [1000, 900, 800, 700, 600, 500, 400, 300, 200, 100] as const;
 
-      prices.forEach(price => {
-        roc.add(price);
-      });
+      roc.updates(prices);
 
       expect(roc.getResultOrThrow().toFixed(2)).toBe('-0.83');
       expect(roc.getSignal()).toEqual({
@@ -66,14 +63,23 @@ describe('ROC', () => {
     });
   });
 
+  describe('getRequiredInputs', () => {
+    it('returns one bar more than the interval because a comparison needs an older price', () => {
+      const interval = 5;
+      const roc = new ROC(interval);
+
+      expect(roc.getRequiredInputs()).toBe(interval + 1);
+    });
+  });
+
   describe('isStable', () => {
     it('returns true when it can return reliable data', () => {
       const interval = 5;
       const indicator = new ROC(interval);
       expect(indicator.isStable).toBe(false);
 
-      const mockedPrices = [0.0001904, 0.00019071, 0.00019198, 0.0001922, 0.00019214, 0.00019205];
-      mockedPrices.forEach(price => indicator.add(price));
+      const mockedPrices = [0.0001904, 0.00019071, 0.00019198, 0.0001922, 0.00019214, 0.00019205] as const;
+      indicator.updates(mockedPrices);
       expect(indicator.isStable).toBe(true);
     });
 
@@ -103,9 +109,7 @@ describe('ROC', () => {
       const roc = new ROC(5);
       const prices = [100, 101, 102, 103, 104, 105] as const;
 
-      for (const price of prices) {
-        roc.add(price);
-      }
+      roc.updates(prices);
 
       const signal = roc.getSignal();
 
@@ -117,9 +121,7 @@ describe('ROC', () => {
       const roc = new ROC(5);
       const prices = [105, 104, 103, 102, 101, 100] as const;
 
-      for (const price of prices) {
-        roc.add(price);
-      }
+      roc.updates(prices);
 
       const signal = roc.getSignal();
 
@@ -131,9 +133,7 @@ describe('ROC', () => {
       const roc = new ROC(5);
       const prices = [100, 100, 100, 100, 100, 100] as const;
 
-      for (const price of prices) {
-        roc.add(price);
-      }
+      roc.updates(prices);
 
       const signal = roc.getSignal();
 
@@ -148,7 +148,7 @@ describe('ROC', () => {
 
       const roc = new ROC(5);
 
-      prices.forEach(price => roc.add(price));
+      roc.updates(prices);
 
       const originalResult = roc.getResultOrThrow();
       const replacedResult = roc.replace(82.84);
@@ -167,7 +167,7 @@ describe('ROC', () => {
       for (let length = 1; length <= prices.length; length++) {
         const roc = new ROC(5);
 
-        prices.slice(0, length).forEach(price => roc.add(price));
+        roc.updates(prices.slice(0, length));
 
         const resultBefore = roc.getResult();
         const stableBefore = roc.isStable;
@@ -182,7 +182,7 @@ describe('ROC', () => {
     it('stays unstable when replacing before the window is full', () => {
       const roc = new ROC(3);
 
-      [10, 11, 12].forEach(price => roc.add(price));
+      roc.updates([10, 11, 12]);
 
       expect(roc.isStable, 'three prices do not fill a ROC(3) comparison window').toBe(false);
       expect(roc.replace(12.5), 'a replacement adds no bar, so there is still nothing to compare').toBeNull();

--- a/packages/trading-signals/src/momentum/ROC/ROC.test.ts
+++ b/packages/trading-signals/src/momentum/ROC/ROC.test.ts
@@ -20,7 +20,7 @@ describe('ROC', () => {
 
       const interval = 5;
       const roc = new ROC(interval);
-      const offset = roc.getRequiredInputs();
+      const offset = roc.getRequiredInputs() - 1;
 
       prices.forEach((price, i) => {
         roc.add(price);
@@ -31,7 +31,7 @@ describe('ROC', () => {
         }
       });
 
-      expect(roc.getRequiredInputs()).toBe(interval);
+      expect(roc.getRequiredInputs(), 'a comparison needs one bar more than the interval').toBe(interval + 1);
       expect(roc.getSignal()).toEqual({
         hasChanged: false,
         state: TradingSignal.BULLISH,
@@ -75,6 +75,20 @@ describe('ROC', () => {
       const mockedPrices = [0.0001904, 0.00019071, 0.00019198, 0.0001922, 0.00019214, 0.00019205];
       mockedPrices.forEach(price => indicator.add(price));
       expect(indicator.isStable).toBe(true);
+    });
+
+    it('becomes stable after exactly the number of inputs it reports as required', () => {
+      const roc = new ROC(3);
+      const required = roc.getRequiredInputs();
+
+      for (let i = 1; i < required; i++) {
+        roc.add(10 + i);
+        expect(roc.isStable, `${i} of ${required} inputs is not enough`).toBe(false);
+      }
+
+      roc.add(20);
+
+      expect(roc.isStable, 'the reported number of inputs produces a result').toBe(true);
     });
   });
 

--- a/packages/trading-signals/src/momentum/ROC/ROC.test.ts
+++ b/packages/trading-signals/src/momentum/ROC/ROC.test.ts
@@ -1,6 +1,5 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {ROC} from './ROC.js';
-import {NotEnoughDataError} from '../../error/index.js';
 import {TradingSignal} from '../../base/Indicator.js';
 
 describe('ROC', () => {
@@ -50,17 +49,6 @@ describe('ROC', () => {
         hasChanged: false,
         state: TradingSignal.BEARISH,
       });
-    });
-
-    it('throws an error when there is not enough input data', () => {
-      const roc = new ROC(6);
-
-      try {
-        roc.getResultOrThrow();
-        throw new Error('Expected error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotEnoughDataError);
-      }
     });
   });
 
@@ -216,7 +204,7 @@ describe('ROC', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new ROC(5),
   divergentInput: 1_000,
   inputs: [81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84],

--- a/packages/trading-signals/src/momentum/ROC/ROC.test.ts
+++ b/packages/trading-signals/src/momentum/ROC/ROC.test.ts
@@ -144,18 +144,49 @@ describe('ROC', () => {
 
   describe('update', () => {
     it('returns a valid result when replacing values', () => {
-      const prices = [81.59, 81.06, 82.87, 83.0, 83.61] as const;
-      const updatePrice = 82.84;
-      const expectation = 0.01911999019;
+      const prices = [81.59, 81.06, 82.87, 83.0, 83.61, 83.15] as const;
 
-      const interval = 5;
-      const roc = new ROC(interval);
+      const roc = new ROC(5);
 
       prices.forEach(price => roc.add(price));
 
-      roc.replace(updatePrice);
+      const originalResult = roc.getResultOrThrow();
+      const replacedResult = roc.replace(82.84);
 
-      expect(roc.getResultOrThrow().toFixed(2)).toEqual(expectation.toFixed(2));
+      expect(replacedResult, 'a replacement recalculates against the same comparand').not.toBe(originalResult);
+
+      const restoredResult = roc.replace(83.15);
+
+      expect(restoredResult, 'replacing back restores the original result').toBe(originalResult);
+    });
+
+    it('changes nothing when the latest price is replaced with the same value', () => {
+      const prices = [81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84] as const;
+
+      // Swept over every length because the comparand only goes wrong at the boundary.
+      for (let length = 1; length <= prices.length; length++) {
+        const roc = new ROC(5);
+
+        prices.slice(0, length).forEach(price => roc.add(price));
+
+        const resultBefore = roc.getResult();
+        const stableBefore = roc.isStable;
+
+        roc.replace(prices[length - 1]);
+
+        expect(roc.getResult(), `replacing price ${length} with itself is a no-op`).toBe(resultBefore);
+        expect(roc.isStable, `and does not change stability at ${length} prices`).toBe(stableBefore);
+      }
+    });
+
+    it('stays unstable when replacing before the window is full', () => {
+      const roc = new ROC(3);
+
+      [10, 11, 12].forEach(price => roc.add(price));
+
+      expect(roc.isStable, 'three prices do not fill a ROC(3) comparison window').toBe(false);
+      expect(roc.replace(12.5), 'a replacement adds no bar, so there is still nothing to compare').toBeNull();
+      expect(roc.isStable, 'a replacement must never make an unstable indicator stable').toBe(false);
     });
 
     it('keeps the correct comparand when replacing after the window has advanced', {tags: ['regression']}, () => {

--- a/packages/trading-signals/src/momentum/ROC/ROC.test.ts
+++ b/packages/trading-signals/src/momentum/ROC/ROC.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {ROC} from './ROC.js';
 import {NotEnoughDataError} from '../../error/index.js';
 import {TradingSignal} from '../../base/Indicator.js';
@@ -213,4 +214,10 @@ describe('ROC', () => {
       ).toBe(original.getResultOrThrow().toFixed());
     });
   });
+});
+
+testReplaceContract({
+  create: () => new ROC(5),
+  divergentInput: 1_000,
+  inputs: [81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84],
 });

--- a/packages/trading-signals/src/momentum/ROC/ROC.ts
+++ b/packages/trading-signals/src/momentum/ROC/ROC.ts
@@ -30,7 +30,7 @@ export class ROC extends TrendIndicatorSeries {
      * Keeping the comparand inside the window makes `replace()` correct for free: the window is the
      * only state, so re-running the latest bar cannot read anything the previous bar left behind.
      */
-    pushUpdate(this.prices, replace, price, this.getRequiredInputs());
+    pushUpdate({array: this.prices, item: price, maxLength: this.getRequiredInputs(), replace: replace});
 
     if (this.prices.length === this.getRequiredInputs()) {
       const comparePrice = this.prices[0];

--- a/packages/trading-signals/src/momentum/ROC/ROC.ts
+++ b/packages/trading-signals/src/momentum/ROC/ROC.ts
@@ -15,8 +15,6 @@ export class ROC extends TrendIndicatorSeries {
 
   public readonly interval: number;
 
-  #comparePrice: number | null = null;
-
   constructor(interval: number) {
     super();
     this.interval = interval;
@@ -28,13 +26,15 @@ export class ROC extends TrendIndicatorSeries {
   }
 
   update(price: number, replace: boolean) {
-    if (!replace || this.#comparePrice === null) {
-      this.#comparePrice = this.prices.length === this.interval ? this.prices[0] : null;
-    }
-    pushUpdate(this.prices, replace, price, this.interval);
+    /*
+     * Keeping the comparand inside the window makes `replace()` correct for free: the window is the
+     * only state, so re-running the latest bar cannot read anything the previous bar left behind.
+     */
+    pushUpdate(this.prices, replace, price, this.getRequiredInputs());
 
-    if (this.#comparePrice !== null) {
-      return this.setResult((price - this.#comparePrice) / this.#comparePrice, replace);
+    if (this.prices.length === this.getRequiredInputs()) {
+      const comparePrice = this.prices[0];
+      return this.setResult((price - comparePrice) / comparePrice, replace);
     }
 
     return null;

--- a/packages/trading-signals/src/momentum/ROC/ROC.ts
+++ b/packages/trading-signals/src/momentum/ROC/ROC.ts
@@ -23,7 +23,8 @@ export class ROC extends TrendIndicatorSeries {
   }
 
   override getRequiredInputs() {
-    return this.interval;
+    // Comparing against the price `interval` bars back needs that bar on top of the interval itself.
+    return this.interval + 1;
   }
 
   update(price: number, replace: boolean) {

--- a/packages/trading-signals/src/momentum/RSI/RSI.test.ts
+++ b/packages/trading-signals/src/momentum/RSI/RSI.test.ts
@@ -1,6 +1,5 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {RSI} from './RSI.js';
-import {NotEnoughDataError} from '../../error/index.js';
 import {TradingSignal} from '../../base/index.js';
 import {WSMA} from '../../trend/WSMA/WSMA.js';
 
@@ -68,19 +67,6 @@ describe('RSI', () => {
       const rsi = new RSI(2);
       rsi.updates(updates, false);
       expect(rsi.getResultOrThrow()).toBe(100);
-    });
-
-    it('throws an error when there is not enough input data', () => {
-      const rsi = new RSI(2);
-      rsi.add(0);
-      expect(rsi.isStable).toBe(false);
-      try {
-        rsi.getResultOrThrow();
-        throw new Error('Expected error');
-      } catch (error) {
-        expect(rsi.isStable).toBe(false);
-        expect(error).toBeInstanceOf(NotEnoughDataError);
-      }
     });
   });
 
@@ -155,7 +141,7 @@ describe('RSI', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new RSI(5),
   divergentInput: 1_000,
   inputs: [81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84, 83.99],

--- a/packages/trading-signals/src/momentum/RSI/RSI.test.ts
+++ b/packages/trading-signals/src/momentum/RSI/RSI.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {RSI} from './RSI.js';
 import {NotEnoughDataError} from '../../error/index.js';
 import {TradingSignal} from '../../base/index.js';
@@ -152,4 +153,10 @@ describe('RSI', () => {
       expect(signal.state).toBe(TradingSignal.SIDEWAYS);
     });
   });
+});
+
+testReplaceContract({
+  create: () => new RSI(5),
+  divergentInput: 1_000,
+  inputs: [81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84, 83.99],
 });

--- a/packages/trading-signals/src/momentum/RSI/RSI.ts
+++ b/packages/trading-signals/src/momentum/RSI/RSI.ts
@@ -48,7 +48,7 @@ export class RSI extends TrendIndicatorSeries {
   }
 
   update(price: number, replace: boolean) {
-    pushUpdate(this.#previousPrices, replace, price, this.interval);
+    pushUpdate({array: this.#previousPrices, item: price, maxLength: this.interval, replace: replace});
 
     // Ensure at least 2 prices are available for calculation
     if (this.#previousPrices.length < 2) {

--- a/packages/trading-signals/src/momentum/STOCH/StochasticOscillator.test.ts
+++ b/packages/trading-signals/src/momentum/STOCH/StochasticOscillator.test.ts
@@ -1,6 +1,5 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {StochasticOscillator} from './StochasticOscillator.js';
-import {NotEnoughDataError} from '../../error/index.js';
 import {TradingSignal} from '../../base/index.js';
 import candles from '../../fixtures/STOCH/candles.json' with {type: 'json'};
 
@@ -62,24 +61,6 @@ describe('StochasticOscillator', () => {
   });
 
   describe('getResultOrThrow', () => {
-    it('throws an error when there is not enough input data', () => {
-      const stoch = new StochasticOscillator({dPeriod: 3, kPeriod: 5, kSlowingPeriod: 3});
-
-      stoch.add({close: 1, high: 1, low: 1});
-      stoch.add({close: 1, high: 2, low: 1});
-      stoch.add({close: 1, high: 3, low: 1});
-      stoch.add({close: 1, high: 4, low: 1});
-      stoch.add({close: 1, high: 5, low: 1}); // Emits 1st of 3 required values for %d period
-      stoch.add({close: 1, high: 6, low: 1}); // Emits 2nd of 3 required values for %d period
-
-      try {
-        stoch.getResultOrThrow();
-        throw new Error('Expected error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotEnoughDataError);
-      }
-    });
-
     it('prevents division by zero errors when highest high and lowest low have the same value', () => {
       const stoch = new StochasticOscillator({dPeriod: 3, kPeriod: 5, kSlowingPeriod: 3});
       stoch.updates(
@@ -159,7 +140,7 @@ describe('StochasticOscillator', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new StochasticOscillator({dPeriod: 3, kPeriod: 5, kSlowingPeriod: 3}),
   divergentInput: {close: 95, high: 100, low: 10},
   inputs: [

--- a/packages/trading-signals/src/momentum/STOCH/StochasticOscillator.test.ts
+++ b/packages/trading-signals/src/momentum/STOCH/StochasticOscillator.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {StochasticOscillator} from './StochasticOscillator.js';
 import {NotEnoughDataError} from '../../error/index.js';
 import {TradingSignal} from '../../base/index.js';
@@ -156,4 +157,21 @@ describe('StochasticOscillator', () => {
       expect(result.stochK).toBeLessThan(80);
     });
   });
+});
+
+testReplaceContract({
+  create: () => new StochasticOscillator({dPeriod: 3, kPeriod: 5, kSlowingPeriod: 3}),
+  divergentInput: {close: 95, high: 100, low: 10},
+  inputs: [
+    {close: 50, high: 100, low: 10},
+    {close: 51, high: 100, low: 10},
+    {close: 52, high: 100, low: 10},
+    {close: 53, high: 100, low: 10},
+    {close: 54, high: 100, low: 10},
+    {close: 55, high: 100, low: 10},
+    {close: 56, high: 100, low: 10},
+    {close: 57, high: 100, low: 10},
+    {close: 58, high: 100, low: 10},
+    {close: 59, high: 100, low: 10},
+  ],
 });

--- a/packages/trading-signals/src/momentum/STOCH/StochasticOscillator.ts
+++ b/packages/trading-signals/src/momentum/STOCH/StochasticOscillator.ts
@@ -69,7 +69,7 @@ export class StochasticOscillator extends TechnicalIndicator<StochasticResult, H
   }
 
   update(candle: HighLowClose<number>, replace: boolean) {
-    pushUpdate(this.candles, replace, candle, this.kPeriod);
+    pushUpdate({array: this.candles, item: candle, maxLength: this.kPeriod, replace: replace});
 
     if (this.candles.length === this.kPeriod) {
       const highest = Math.max(...this.candles.map(candle => candle.high));

--- a/packages/trading-signals/src/momentum/STOCHRSI/StochasticRSI.test.ts
+++ b/packages/trading-signals/src/momentum/STOCHRSI/StochasticRSI.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {SMA} from '../../trend/SMA/SMA.js';
 import {WSMA} from '../../trend/WSMA/WSMA.js';
 import {StochasticRSI} from './StochasticRSI.js';
@@ -186,4 +187,10 @@ describe('StochasticRSI', () => {
       expect(signal.state).toBe(TradingSignal.BULLISH);
     });
   });
+});
+
+testReplaceContract({
+  create: () => new StochasticRSI(5),
+  divergentInput: 1_000,
+  inputs: [81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84, 83.99, 84.55, 84.36, 85.53, 86.54, 86.89, 87.77, 87.29],
 });

--- a/packages/trading-signals/src/momentum/STOCHRSI/StochasticRSI.test.ts
+++ b/packages/trading-signals/src/momentum/STOCHRSI/StochasticRSI.test.ts
@@ -1,4 +1,4 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {SMA} from '../../trend/SMA/SMA.js';
 import {WSMA} from '../../trend/WSMA/WSMA.js';
 import {StochasticRSI} from './StochasticRSI.js';
@@ -189,7 +189,7 @@ describe('StochasticRSI', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new StochasticRSI(5),
   divergentInput: 1_000,
   inputs: [81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84, 83.99, 84.55, 84.36, 85.53, 86.54, 86.89, 87.77, 87.29],

--- a/packages/trading-signals/src/momentum/TDS/TDS.test.ts
+++ b/packages/trading-signals/src/momentum/TDS/TDS.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {TDS} from './TDS.js';
 import {TradingSignal} from '../../base/index.js';
 
@@ -258,4 +259,10 @@ describe('TDS', () => {
       expect(signal.state).toBe(TradingSignal.BEARISH);
     });
   });
+});
+
+testReplaceContract({
+  create: () => new TDS(),
+  divergentInput: 1_000,
+  inputs: [10, 10, 10, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19],
 });

--- a/packages/trading-signals/src/momentum/TDS/TDS.test.ts
+++ b/packages/trading-signals/src/momentum/TDS/TDS.test.ts
@@ -110,6 +110,112 @@ describe('TDS', () => {
       const result = tds.replace(20);
       expect(result).toBeNull();
     });
+
+    it('changes nothing when the latest close is replaced with the same value', () => {
+      const tds = new TDS();
+      const closes = [10, 10, 10, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19] as const;
+
+      closes.forEach(close => tds.add(close));
+
+      const resultBefore = tds.getResult();
+      const countBefore = tds['setupCount'];
+      const directionBefore = tds['setupDirection'];
+
+      tds.replace(19);
+
+      expect(tds.getResult(), 'replacing a close with itself is a no-op').toBe(resultBefore);
+      expect(tds['setupCount'], 'and leaves the setup count alone').toBe(countBefore);
+      expect(tds['setupDirection'], 'and the setup direction').toBe(directionBefore);
+    });
+
+    it('does not advance the setup count twice for the same bar', () => {
+      const tds = new TDS();
+
+      for (let i = 0; i < 4; i++) {
+        tds.add(10);
+      }
+
+      tds.add(15);
+      tds.add(16);
+
+      expect(tds['setupCount'], 'two bars closed above the close four bars earlier').toBe(2);
+
+      tds.replace(17);
+
+      expect(tds['setupCount'], 'replacing the second bar must not count it again').toBe(2);
+      expect(tds['setupDirection']).toBe('bullish');
+    });
+
+    it('restores the setup direction when a replacement reverses the bar', () => {
+      const tds = new TDS();
+
+      for (let i = 0; i < 4; i++) {
+        tds.add(10);
+      }
+
+      tds.add(15);
+      tds.add(16);
+      tds.replace(5);
+
+      expect(tds['setupCount'], 'a bearish bar restarts the count').toBe(1);
+      expect(tds['setupDirection'], 'the direction flips with the replaced bar').toBe('bearish');
+    });
+
+    it('matches an equivalent series that never used replace', () => {
+      const closes = [10, 10, 10, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19] as const;
+
+      const replaced = new TDS();
+      closes.slice(0, -1).forEach(close => replaced.add(close));
+      replaced.add(99);
+      replaced.replace(closes[closes.length - 1]);
+
+      const reference = new TDS();
+      closes.forEach(close => reference.add(close));
+
+      expect(replaced.getResult(), 'a replacement must reproduce the add-only series').toBe(reference.getResult());
+      expect(replaced['setupCount']).toBe(reference['setupCount']);
+      expect(replaced['setupDirection']).toBe(reference['setupDirection']);
+    });
+
+    it('keeps an earlier setup when the replaced bar completed nothing', () => {
+      const tds = new TDS();
+
+      for (let i = 0; i < 4; i++) {
+        tds.add(10);
+      }
+
+      for (let i = 0; i < 9; i++) {
+        tds.add(11 + i);
+      }
+
+      expect(tds.getResult(), 'nine rising bars complete a bullish setup').toBe(1);
+
+      // Neither of these bars completes a setup, so the earlier result stands.
+      tds.add(5);
+      tds.replace(6);
+
+      expect(tds.getResult(), 'replacing a bar that emitted nothing must not withdraw an older setup').toBe(1);
+    });
+
+    it('withdraws a completed setup when the replacement breaks it', () => {
+      const tds = new TDS();
+
+      for (let i = 0; i < 4; i++) {
+        tds.add(10);
+      }
+
+      for (let i = 0; i < 8; i++) {
+        tds.add(11 + i);
+      }
+
+      expect(tds.getResult(), 'eight bars are one short of a completed setup').toBeNull();
+
+      expect(tds.add(19), 'the ninth consecutive bar completes the bullish setup').toBe(1);
+
+      tds.replace(5);
+
+      expect(tds.getResult(), 'the setup no longer completes, so the emission is withdrawn').toBeNull();
+    });
   });
 
   describe('getSignal', () => {

--- a/packages/trading-signals/src/momentum/TDS/TDS.test.ts
+++ b/packages/trading-signals/src/momentum/TDS/TDS.test.ts
@@ -1,4 +1,4 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {TDS} from './TDS.js';
 import {TradingSignal} from '../../base/index.js';
 
@@ -261,7 +261,7 @@ describe('TDS', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new TDS(),
   divergentInput: 1_000,
   inputs: [10, 10, 10, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19],

--- a/packages/trading-signals/src/momentum/TDS/TDS.test.ts
+++ b/packages/trading-signals/src/momentum/TDS/TDS.test.ts
@@ -1,15 +1,6 @@
 import {TDS} from './TDS.js';
 import {TradingSignal} from '../../base/index.js';
 
-/** Captures everything a replacement could corrupt, so tests compare the whole setup state at once. */
-function getSetupState(tds: TDS) {
-  return {
-    result: tds.getResult(),
-    setupCount: tds['setupCount'],
-    setupDirection: tds['setupDirection'],
-  };
-}
-
 describe('TDS', () => {
   it('does not return a result for less than 9 prices', () => {
     const tds = new TDS();
@@ -54,7 +45,7 @@ describe('TDS', () => {
     for (let i = 0; i < 20; i++) {
       tds.add(i);
     }
-    expect(tds['closes'].length).toBeLessThanOrEqual(13);
+    expect(tds.getState().closes.length).toBeLessThanOrEqual(13);
   });
 
   it('detects a direction change from bearish to bullish', () => {
@@ -66,8 +57,8 @@ describe('TDS', () => {
     tds.add(4);
     tds.add(3);
     const result = tds.add(20);
-    expect(tds['setupCount']).toBe(1);
-    expect(tds['setupDirection']).toBe('bullish');
+    expect(tds.getState().setupCount).toBe(1);
+    expect(tds.getState().setupDirection).toBe('bullish');
     expect(result).toBeNull();
   });
 
@@ -80,8 +71,8 @@ describe('TDS', () => {
     tds.add(21);
     tds.add(22);
     const result = tds.add(5);
-    expect(tds['setupCount']).toBe(1);
-    expect(tds['setupDirection']).toBe('bearish');
+    expect(tds.getState().setupCount).toBe(1);
+    expect(tds.getState().setupDirection).toBe('bearish');
     expect(result).toBeNull();
   });
 
@@ -97,15 +88,15 @@ describe('TDS', () => {
     tds.add(16);
 
     // Current setup should be bullish with count 2
-    expect(tds['setupCount']).toBe(2);
-    expect(tds['setupDirection']).toBe('bullish');
+    expect(tds.getState().setupCount).toBe(2);
+    expect(tds.getState().setupDirection).toBe('bullish');
 
     // Add a close equal to "prev4" (10 === 10)
     const result = tds.add(prev4);
 
     // Setup count and direction should remain unchanged
-    expect(tds['setupCount']).toBe(2);
-    expect(tds['setupDirection']).toBe('bullish');
+    expect(tds.getState().setupCount).toBe(2);
+    expect(tds.getState().setupDirection).toBe('bullish');
     expect(result).toBeNull();
   });
 
@@ -126,11 +117,11 @@ describe('TDS', () => {
 
       tds.updates(closes);
 
-      const stateBefore = getSetupState(tds);
+      const stateBefore = tds.getState();
 
       tds.replace(19);
 
-      expect(getSetupState(tds), 'replacing a close with itself is a no-op').toEqual(stateBefore);
+      expect(tds.getState(), 'replacing a close with itself is a no-op').toEqual(stateBefore);
     });
 
     it('does not advance the setup count twice for the same bar', () => {
@@ -143,12 +134,12 @@ describe('TDS', () => {
       tds.add(15);
       tds.add(16);
 
-      expect(tds['setupCount'], 'two bars closed above the close four bars earlier').toBe(2);
+      expect(tds.getState().setupCount, 'two bars closed above the close four bars earlier').toBe(2);
 
       tds.replace(17);
 
-      expect(tds['setupCount'], 'replacing the second bar must not count it again').toBe(2);
-      expect(tds['setupDirection']).toBe('bullish');
+      expect(tds.getState().setupCount, 'replacing the second bar must not count it again').toBe(2);
+      expect(tds.getState().setupDirection).toBe('bullish');
     });
 
     it('restores the setup direction when a replacement reverses the bar', () => {
@@ -162,8 +153,8 @@ describe('TDS', () => {
       tds.add(16);
       tds.replace(5);
 
-      expect(tds['setupCount'], 'a bearish bar restarts the count').toBe(1);
-      expect(tds['setupDirection'], 'the direction flips with the replaced bar').toBe('bearish');
+      expect(tds.getState().setupCount, 'a bearish bar restarts the count').toBe(1);
+      expect(tds.getState().setupDirection, 'the direction flips with the replaced bar').toBe('bearish');
     });
 
     it('matches an equivalent series that never used replace', () => {
@@ -172,14 +163,17 @@ describe('TDS', () => {
       const replaced = new TDS();
       replaced.updates(closes.slice(0, -1));
       replaced.add(99);
-      replaced.replace(closes[closes.length - 1]);
 
       const reference = new TDS();
       reference.updates(closes);
 
-      expect(getSetupState(replaced), 'a replacement must reproduce the add-only series').toEqual(
-        getSetupState(reference)
+      expect(replaced.getState(), 'the decoy bar leaves the two indicators in different states').not.toEqual(
+        reference.getState()
       );
+
+      replaced.replace(closes[closes.length - 1]);
+
+      expect(replaced.getState(), 'a replacement must reproduce the add-only series').toEqual(reference.getState());
     });
 
     it('keeps an earlier setup when the replaced bar completed nothing', () => {

--- a/packages/trading-signals/src/momentum/TDS/TDS.test.ts
+++ b/packages/trading-signals/src/momentum/TDS/TDS.test.ts
@@ -1,6 +1,15 @@
 import {TDS} from './TDS.js';
 import {TradingSignal} from '../../base/index.js';
 
+/** Captures everything a replacement could corrupt, so tests compare the whole setup state at once. */
+function getSetupState(tds: TDS) {
+  return {
+    result: tds.getResult(),
+    setupCount: tds['setupCount'],
+    setupDirection: tds['setupDirection'],
+  };
+}
+
 describe('TDS', () => {
   it('does not return a result for less than 9 prices', () => {
     const tds = new TDS();
@@ -115,17 +124,13 @@ describe('TDS', () => {
       const tds = new TDS();
       const closes = [10, 10, 10, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19] as const;
 
-      closes.forEach(close => tds.add(close));
+      tds.updates(closes);
 
-      const resultBefore = tds.getResult();
-      const countBefore = tds['setupCount'];
-      const directionBefore = tds['setupDirection'];
+      const stateBefore = getSetupState(tds);
 
       tds.replace(19);
 
-      expect(tds.getResult(), 'replacing a close with itself is a no-op').toBe(resultBefore);
-      expect(tds['setupCount'], 'and leaves the setup count alone').toBe(countBefore);
-      expect(tds['setupDirection'], 'and the setup direction').toBe(directionBefore);
+      expect(getSetupState(tds), 'replacing a close with itself is a no-op').toEqual(stateBefore);
     });
 
     it('does not advance the setup count twice for the same bar', () => {
@@ -165,16 +170,16 @@ describe('TDS', () => {
       const closes = [10, 10, 10, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19] as const;
 
       const replaced = new TDS();
-      closes.slice(0, -1).forEach(close => replaced.add(close));
+      replaced.updates(closes.slice(0, -1));
       replaced.add(99);
       replaced.replace(closes[closes.length - 1]);
 
       const reference = new TDS();
-      closes.forEach(close => reference.add(close));
+      reference.updates(closes);
 
-      expect(replaced.getResult(), 'a replacement must reproduce the add-only series').toBe(reference.getResult());
-      expect(replaced['setupCount']).toBe(reference['setupCount']);
-      expect(replaced['setupDirection']).toBe(reference['setupDirection']);
+      expect(getSetupState(replaced), 'a replacement must reproduce the add-only series').toEqual(
+        getSetupState(reference)
+      );
     });
 
     it('keeps an earlier setup when the replaced bar completed nothing', () => {

--- a/packages/trading-signals/src/momentum/TDS/TDS.ts
+++ b/packages/trading-signals/src/momentum/TDS/TDS.ts
@@ -19,6 +19,17 @@ export class TDS extends TrendIndicatorSeries {
   private readonly closes: number[] = [];
   private setupCount: number = 0;
   private setupDirection: 'bullish' | 'bearish' | null = null;
+  /*
+   * The setup state as of the bar before the current one. A replacement re-runs the latest bar, so
+   * the count has to start again from what that bar originally found, not from what it left behind.
+   */
+  private previousSetupCount: number = 0;
+  private previousSetupDirection: 'bullish' | 'bearish' | null = null;
+  /*
+   * Whether the latest bar completed a setup. TDS emits sparsely and its result persists between
+   * setups, so only a bar that emitted may withdraw that emission when it gets replaced.
+   */
+  private lastBarCompletedSetup: boolean = false;
 
   override getRequiredInputs() {
     return 9;
@@ -27,8 +38,20 @@ export class TDS extends TrendIndicatorSeries {
   update(close: number, replace: boolean): number | null {
     if (replace) {
       this.closes.pop();
+      this.setupCount = this.previousSetupCount;
+      this.setupDirection = this.previousSetupDirection;
+
+      if (this.lastBarCompletedSetup) {
+        this.rollbackLastResult();
+      }
+    } else {
+      this.previousSetupCount = this.setupCount;
+      this.previousSetupDirection = this.setupDirection;
     }
+
     this.closes.push(close);
+    this.lastBarCompletedSetup = false;
+
     if (this.closes.length < 5) {
       return null;
     }
@@ -60,6 +83,7 @@ export class TDS extends TrendIndicatorSeries {
       const result = this.setupDirection === 'bullish' ? 1 : -1;
       this.setupCount = 0;
       this.setupDirection = null;
+      this.lastBarCompletedSetup = true;
       return this.setResult(result, replace);
     }
     return null;

--- a/packages/trading-signals/src/momentum/TDS/TDS.ts
+++ b/packages/trading-signals/src/momentum/TDS/TDS.ts
@@ -2,7 +2,7 @@ import {TradingSignal, TrendIndicatorSeries, type TradingSignals} from '../../ba
 
 type TDSState = {
   closes: number[];
-  /*
+  /**
    * Whether the latest bar completed a setup. TDS emits sparsely and its result persists between
    * setups, so only a bar that emitted may withdraw that emission when it gets replaced.
    */

--- a/packages/trading-signals/src/momentum/TDS/TDS.ts
+++ b/packages/trading-signals/src/momentum/TDS/TDS.ts
@@ -1,4 +1,15 @@
-import {TradingSignal, TrendIndicatorSeries} from '../../base/Indicator.js';
+import {TradingSignal, TrendIndicatorSeries, type TradingSignals} from '../../base/Indicator.js';
+
+type TDSState = {
+  closes: number[];
+  /*
+   * Whether the latest bar completed a setup. TDS emits sparsely and its result persists between
+   * setups, so only a bar that emitted may withdraw that emission when it gets replaced.
+   */
+  lastBarCompletedSetup: boolean;
+  setupCount: number;
+  setupDirection: 'bullish' | 'bearish' | null;
+};
 
 /**
  * Tom Demark's Sequential Indicator (TDS)
@@ -15,75 +26,63 @@ import {TradingSignal, TrendIndicatorSeries} from '../../base/Indicator.js';
  * @see https://hackernoon.com/how-to-buy-sell-cryptocurrency-with-number-indicator-td-sequential-5af46f0ebce1
  * @see https://practicaltechnicalanalysis.blogspot.com/2013/01/tom-demark-sequential.html
  */
-export class TDS extends TrendIndicatorSeries {
-  private readonly closes: number[] = [];
-  private setupCount: number = 0;
-  private setupDirection: 'bullish' | 'bearish' | null = null;
-  /*
-   * The setup state as of the bar before the current one. A replacement re-runs the latest bar, so
-   * the count has to start again from what that bar originally found, not from what it left behind.
-   */
-  private previousSetupCount: number = 0;
-  private previousSetupDirection: 'bullish' | 'bearish' | null = null;
-  /*
-   * Whether the latest bar completed a setup. TDS emits sparsely and its result persists between
-   * setups, so only a bar that emitted may withdraw that emission when it gets replaced.
-   */
-  private lastBarCompletedSetup: boolean = false;
+export class TDS extends TrendIndicatorSeries<number, TradingSignals, TDSState> {
+  protected override state: TDSState = {
+    closes: [],
+    lastBarCompletedSetup: false,
+    setupCount: 0,
+    setupDirection: null,
+  };
 
   override getRequiredInputs() {
     return 9;
   }
 
   update(close: number, replace: boolean): number | null {
-    if (replace) {
-      this.closes.pop();
-      this.setupCount = this.previousSetupCount;
-      this.setupDirection = this.previousSetupDirection;
-
-      if (this.lastBarCompletedSetup) {
-        this.rollbackLastResult();
-      }
-    } else {
-      this.previousSetupCount = this.setupCount;
-      this.previousSetupDirection = this.setupDirection;
+    // Read before trackState() rewinds the flag to what the bar before the replaced one found
+    if (replace && this.state.lastBarCompletedSetup) {
+      this.rollbackLastResult();
     }
 
-    this.closes.push(close);
-    this.lastBarCompletedSetup = false;
+    this.trackState(replace);
 
-    if (this.closes.length < 5) {
+    const state = this.state;
+
+    state.closes.push(close);
+    state.lastBarCompletedSetup = false;
+
+    if (state.closes.length < 5) {
       return null;
     }
     // Only keep the last 13 closes for memory efficiency
-    if (this.closes.length > 13) {
-      this.closes.shift();
+    if (state.closes.length > 13) {
+      state.closes.shift();
     }
-    const index = this.closes.length - 1;
-    const prev4 = this.closes[index - 4];
+    const index = state.closes.length - 1;
+    const prev4 = state.closes[index - 4];
     if (close > prev4) {
-      if (this.setupDirection === 'bearish') {
-        this.setupCount = 1;
-        this.setupDirection = 'bullish';
+      if (state.setupDirection === 'bearish') {
+        state.setupCount = 1;
+        state.setupDirection = 'bullish';
       } else {
-        this.setupCount++;
-        this.setupDirection = 'bullish';
+        state.setupCount++;
+        state.setupDirection = 'bullish';
       }
     } else if (close < prev4) {
-      if (this.setupDirection === 'bullish') {
-        this.setupCount = 1;
-        this.setupDirection = 'bearish';
+      if (state.setupDirection === 'bullish') {
+        state.setupCount = 1;
+        state.setupDirection = 'bearish';
       } else {
-        this.setupCount++;
-        this.setupDirection = 'bearish';
+        state.setupCount++;
+        state.setupDirection = 'bearish';
       }
     }
     // Setup completed
-    if (this.setupCount >= this.getRequiredInputs()) {
-      const result = this.setupDirection === 'bullish' ? 1 : -1;
-      this.setupCount = 0;
-      this.setupDirection = null;
-      this.lastBarCompletedSetup = true;
+    if (state.setupCount >= this.getRequiredInputs()) {
+      const result = state.setupDirection === 'bullish' ? 1 : -1;
+      state.setupCount = 0;
+      state.setupDirection = null;
+      state.lastBarCompletedSetup = true;
       return this.setResult(result, replace);
     }
     return null;

--- a/packages/trading-signals/src/momentum/TRIX/TRIX.test.ts
+++ b/packages/trading-signals/src/momentum/TRIX/TRIX.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {TRIX} from './TRIX.js';
 import {NotEnoughDataError} from '../../error/index.js';
 import {TradingSignal} from '../../base/index.js';
@@ -121,4 +122,10 @@ describe('TRIX', () => {
       expect(trix.getSignal().state).toBe(TradingSignal.SIDEWAYS);
     });
   });
+});
+
+testReplaceContract({
+  create: () => new TRIX(5),
+  divergentInput: 1_000,
+  inputs: [81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84, 83.99, 84.55, 84.36, 85.53, 86.54, 86.89, 87.77, 87.29],
 });

--- a/packages/trading-signals/src/momentum/TRIX/TRIX.test.ts
+++ b/packages/trading-signals/src/momentum/TRIX/TRIX.test.ts
@@ -1,4 +1,4 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {TRIX} from './TRIX.js';
 import {NotEnoughDataError} from '../../error/index.js';
 import {TradingSignal} from '../../base/index.js';
@@ -69,17 +69,6 @@ describe('TRIX', () => {
         expect(error).toBeInstanceOf(NotEnoughDataError);
       }
     });
-
-    it('throws an error when there is not enough input data', () => {
-      const trix = new TRIX(5);
-
-      try {
-        trix.getResultOrThrow();
-        throw new Error('Expected error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotEnoughDataError);
-      }
-    });
   });
 
   describe('getSignal', () => {
@@ -124,7 +113,7 @@ describe('TRIX', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new TRIX(5),
   divergentInput: 1_000,
   inputs: [81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84, 83.99, 84.55, 84.36, 85.53, 86.54, 86.89, 87.77, 87.29],

--- a/packages/trading-signals/src/momentum/ULTOSC/UltimateOscillator.test.ts
+++ b/packages/trading-signals/src/momentum/ULTOSC/UltimateOscillator.test.ts
@@ -1,6 +1,5 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {UltimateOscillator} from './UltimateOscillator.js';
-import {NotEnoughDataError} from '../../error/index.js';
 import {TradingSignal} from '../../base/index.js';
 
 describe('UltimateOscillator', () => {
@@ -143,17 +142,6 @@ describe('UltimateOscillator', () => {
 
       expect(ultosc.getResultOrThrow()).toBe(50);
     });
-
-    it('throws an error when there is not enough input data', () => {
-      const ultosc = new UltimateOscillator();
-
-      try {
-        ultosc.getResultOrThrow();
-        throw new Error('Expected error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotEnoughDataError);
-      }
-    });
   });
 
   describe('getSignal', () => {
@@ -214,7 +202,7 @@ describe('UltimateOscillator', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new UltimateOscillator({longPeriod: 5, mediumPeriod: 3, shortPeriod: 2}),
   divergentInput: {close: 1_000, high: 1_100, low: 900},
   inputs: [

--- a/packages/trading-signals/src/momentum/ULTOSC/UltimateOscillator.test.ts
+++ b/packages/trading-signals/src/momentum/ULTOSC/UltimateOscillator.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {UltimateOscillator} from './UltimateOscillator.js';
 import {NotEnoughDataError} from '../../error/index.js';
 import {TradingSignal} from '../../base/index.js';
@@ -211,4 +212,18 @@ describe('UltimateOscillator', () => {
       expect(sensitiveBear.getSignal().state).toBe(TradingSignal.BEARISH);
     });
   });
+});
+
+testReplaceContract({
+  create: () => new UltimateOscillator({longPeriod: 5, mediumPeriod: 3, shortPeriod: 2}),
+  divergentInput: {close: 1_000, high: 1_100, low: 900},
+  inputs: [
+    {close: 81.59, high: 82.15, low: 81.29},
+    {close: 81.06, high: 81.89, low: 80.64},
+    {close: 82.87, high: 83.03, low: 81.31},
+    {close: 83.0, high: 83.3, low: 82.65},
+    {close: 83.61, high: 83.85, low: 83.07},
+    {close: 83.15, high: 83.9, low: 83.11},
+    {close: 82.84, high: 83.33, low: 82.49},
+  ],
 });

--- a/packages/trading-signals/src/momentum/ULTOSC/UltimateOscillator.ts
+++ b/packages/trading-signals/src/momentum/ULTOSC/UltimateOscillator.ts
@@ -55,7 +55,7 @@ export class UltimateOscillator extends TrendIndicatorSeries<HighLowClose<number
   }
 
   update(candle: HighLowClose<number>, replace: boolean) {
-    pushUpdate(this.#candles, replace, candle, this.getRequiredInputs());
+    pushUpdate({array: this.#candles, item: candle, maxLength: this.getRequiredInputs(), replace: replace});
 
     if (this.#candles.length < this.getRequiredInputs()) {
       return null;

--- a/packages/trading-signals/src/momentum/WILLR/WilliamsR.test.ts
+++ b/packages/trading-signals/src/momentum/WILLR/WilliamsR.test.ts
@@ -1,7 +1,6 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {WilliamsR} from './WilliamsR.js';
 import {StochasticOscillator} from '../STOCH/StochasticOscillator.js';
-import {NotEnoughDataError} from '../../error/index.js';
 import {TradingSignal} from '../../base/index.js';
 import candles from '../../fixtures/STOCH/candles.json' with {type: 'json'};
 
@@ -37,17 +36,6 @@ describe('WilliamsR', () => {
       expect(willR.isStable).toBe(true);
       expect(willR.getRequiredInputs()).toBe(5);
       expect(willR.getResultOrThrow().toFixed(2)).toBe('-17.88');
-    });
-
-    it('returns null until enough values are provided', () => {
-      const willR = new WilliamsR(5);
-
-      for (let i = 0; i < 4; i++) {
-        const result = willR.add({close: i, high: i + 1, low: i - 1});
-        expect(result).toBeNull();
-      }
-
-      expect(willR.isStable).toBe(false);
     });
 
     it('prevents division by zero when highest high and lowest low have the same value', () => {
@@ -108,23 +96,6 @@ describe('WilliamsR', () => {
     });
   });
 
-  describe('getResultOrThrow', () => {
-    it('throws an error when there is not enough input data', () => {
-      const willR = new WilliamsR(14);
-
-      for (let i = 0; i < 13; i++) {
-        willR.add({close: i, high: i + 1, low: i - 1});
-      }
-
-      try {
-        willR.getResultOrThrow();
-        throw new Error('Expected error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotEnoughDataError);
-      }
-    });
-  });
-
   describe('getSignal', () => {
     it('returns UNKNOWN when there is no result', () => {
       const willR = new WilliamsR(14);
@@ -166,7 +137,7 @@ describe('WilliamsR', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new WilliamsR(5),
   divergentInput: {close: 900, high: 1_000, low: 800},
   inputs: [

--- a/packages/trading-signals/src/momentum/WILLR/WilliamsR.test.ts
+++ b/packages/trading-signals/src/momentum/WILLR/WilliamsR.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {WilliamsR} from './WilliamsR.js';
 import {StochasticOscillator} from '../STOCH/StochasticOscillator.js';
 import {NotEnoughDataError} from '../../error/index.js';
@@ -163,4 +164,17 @@ describe('WilliamsR', () => {
       expect(signal).toBe(TradingSignal.SIDEWAYS);
     });
   });
+});
+
+testReplaceContract({
+  create: () => new WilliamsR(5),
+  divergentInput: {close: 900, high: 1_000, low: 800},
+  inputs: [
+    {close: 10, high: 11, low: 9},
+    {close: 11, high: 12, low: 10},
+    {close: 12, high: 13, low: 11},
+    {close: 11.5, high: 12.5, low: 10.5},
+    {close: 12.5, high: 13.5, low: 11.5},
+    {close: 13, high: 14, low: 12},
+  ],
 });

--- a/packages/trading-signals/src/momentum/WILLR/WilliamsR.ts
+++ b/packages/trading-signals/src/momentum/WILLR/WilliamsR.ts
@@ -38,7 +38,7 @@ export class WilliamsR extends TrendIndicatorSeries<HighLowClose<number>> {
   }
 
   override update(candle: HighLowClose<number>, replace: boolean) {
-    pushUpdate(this.candles, replace, candle, this.interval);
+    pushUpdate({array: this.candles, item: candle, maxLength: this.interval, replace: replace});
 
     if (this.candles.length === this.interval) {
       let highest = this.candles[0].high;

--- a/packages/trading-signals/src/trend/ADX/ADX.test.ts
+++ b/packages/trading-signals/src/trend/ADX/ADX.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {ADX} from './ADX.js';
 
 describe('ADX', () => {
@@ -91,4 +92,26 @@ describe('ADX', () => {
       expect(adx.isStable).toBe(true);
     });
   });
+});
+
+testReplaceContract({
+  create: () => new ADX(5),
+  divergentInput: {close: 1_000, high: 1_000, low: 1_000},
+  inputs: [
+    {close: 81.59, high: 82.15, low: 81.29},
+    {close: 81.06, high: 81.89, low: 80.64},
+    {close: 82.87, high: 83.03, low: 81.31},
+    {close: 83.0, high: 83.3, low: 82.65},
+    {close: 83.61, high: 83.85, low: 83.07},
+    {close: 83.15, high: 83.9, low: 83.11},
+    {close: 82.84, high: 83.33, low: 82.49},
+    {close: 83.99, high: 84.3, low: 82.3},
+    {close: 84.55, high: 84.84, low: 84.15},
+    {close: 84.36, high: 85.0, low: 84.11},
+    {close: 85.53, high: 85.9, low: 84.03},
+    {close: 86.54, high: 86.58, low: 85.39},
+    {close: 86.89, high: 86.98, low: 85.76},
+    {close: 87.77, high: 88.0, low: 87.17},
+    {close: 87.29, high: 87.87, low: 87.01},
+  ],
 });

--- a/packages/trading-signals/src/trend/ADX/ADX.test.ts
+++ b/packages/trading-signals/src/trend/ADX/ADX.test.ts
@@ -1,4 +1,4 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {ADX} from './ADX.js';
 
 describe('ADX', () => {
@@ -94,7 +94,7 @@ describe('ADX', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new ADX(5),
   divergentInput: {close: 1_000, high: 1_000, low: 1_000},
   inputs: [

--- a/packages/trading-signals/src/trend/AROON/Aroon.test.ts
+++ b/packages/trading-signals/src/trend/AROON/Aroon.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {Aroon} from './Aroon.js';
 import {NotEnoughDataError} from '../../error/index.js';
 
@@ -119,4 +120,19 @@ describe('Aroon', () => {
       }
     });
   });
+});
+
+testReplaceContract({
+  create: () => new Aroon(5),
+  divergentInput: {high: 500, low: 1},
+  inputs: [
+    {high: 82.15, low: 81.29},
+    {high: 81.89, low: 80.64},
+    {high: 83.03, low: 81.31},
+    {high: 83.3, low: 82.65},
+    {high: 83.85, low: 83.07},
+    {high: 83.9, low: 83.11},
+    {high: 83.33, low: 82.49},
+    {high: 84.3, low: 82.3},
+  ],
 });

--- a/packages/trading-signals/src/trend/AROON/Aroon.test.ts
+++ b/packages/trading-signals/src/trend/AROON/Aroon.test.ts
@@ -1,6 +1,5 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {Aroon} from './Aroon.js';
-import {NotEnoughDataError} from '../../error/index.js';
 
 describe('Aroon', () => {
   /*
@@ -108,21 +107,10 @@ describe('Aroon', () => {
 
       expect(aroon.getResultOrThrow()).toEqual({aroonDown: 60, aroonUp: 60});
     });
-
-    it('throws an error when there is not enough input data', () => {
-      const aroon = new Aroon(5);
-
-      try {
-        aroon.getResultOrThrow();
-        throw new Error('Expected error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotEnoughDataError);
-      }
-    });
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new Aroon(5),
   divergentInput: {high: 500, low: 1},
   inputs: [

--- a/packages/trading-signals/src/trend/AROON/Aroon.ts
+++ b/packages/trading-signals/src/trend/AROON/Aroon.ts
@@ -35,7 +35,7 @@ export class Aroon extends TechnicalIndicator<AroonResult, HighLow<number>> {
   }
 
   update(candle: HighLow<number>, replace: boolean) {
-    pushUpdate(this.#candles, replace, candle, this.getRequiredInputs());
+    pushUpdate({array: this.#candles, item: candle, maxLength: this.getRequiredInputs(), replace: replace});
 
     if (this.#candles.length < this.getRequiredInputs()) {
       return null;

--- a/packages/trading-signals/src/trend/BREAKOUT_BAR_LOW/BreakoutBarLow.test.ts
+++ b/packages/trading-signals/src/trend/BREAKOUT_BAR_LOW/BreakoutBarLow.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {NotEnoughDataError} from '../../error/NotEnoughDataError.js';
 import {BreakoutBarLow} from './BreakoutBarLow.js';
 
@@ -115,4 +116,16 @@ describe('BreakoutBarLow', () => {
       expect(breakout.getRequiredInputs()).toBe(21);
     });
   });
+});
+
+testReplaceContract({
+  create: () => new BreakoutBarLow({lookback: 3}),
+  divergentInput: {high: 1_000, low: 999},
+  inputs: [
+    {high: 10, low: 8},
+    {high: 12, low: 10},
+    {high: 11, low: 9},
+    {high: 15, low: 11},
+    {high: 13, low: 10},
+  ],
 });

--- a/packages/trading-signals/src/trend/BREAKOUT_BAR_LOW/BreakoutBarLow.test.ts
+++ b/packages/trading-signals/src/trend/BREAKOUT_BAR_LOW/BreakoutBarLow.test.ts
@@ -1,5 +1,4 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
-import {NotEnoughDataError} from '../../error/NotEnoughDataError.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {BreakoutBarLow} from './BreakoutBarLow.js';
 
 describe('BreakoutBarLow', () => {
@@ -62,16 +61,6 @@ describe('BreakoutBarLow', () => {
 
       expect(breakout.getResult()).toBeNull();
     });
-
-    it('throws when accessed before enough data has been added', () => {
-      const breakout = new BreakoutBarLow({lookback: 3});
-
-      breakout.add({high: 10, low: 8});
-      breakout.add({high: 12, low: 10});
-
-      expect(() => breakout.getResultOrThrow()).toThrow(NotEnoughDataError);
-      expect(breakout.isStable).toBe(false);
-    });
   });
 
   describe('replace', () => {
@@ -118,7 +107,7 @@ describe('BreakoutBarLow', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new BreakoutBarLow({lookback: 3}),
   divergentInput: {high: 1_000, low: 999},
   inputs: [

--- a/packages/trading-signals/src/trend/BREAKOUT_BAR_LOW/BreakoutBarLow.ts
+++ b/packages/trading-signals/src/trend/BREAKOUT_BAR_LOW/BreakoutBarLow.ts
@@ -48,7 +48,7 @@ export class BreakoutBarLow extends IndicatorSeries<HighLow> {
     }
     this.#lastEmitted = false;
 
-    pushUpdate(this.#highs, replace, candle.high, this.getRequiredInputs());
+    pushUpdate({array: this.#highs, item: candle.high, maxLength: this.getRequiredInputs(), replace: replace});
 
     if (this.#highs.length < this.getRequiredInputs()) {
       return null;

--- a/packages/trading-signals/src/trend/CE/ChandelierExit.test.ts
+++ b/packages/trading-signals/src/trend/CE/ChandelierExit.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {ChandelierExit} from './ChandelierExit.js';
 import {NotEnoughDataError} from '../../error/index.js';
 
@@ -113,4 +114,19 @@ describe('ChandelierExit', () => {
       }
     });
   });
+});
+
+testReplaceContract({
+  create: () => new ChandelierExit({interval: 5, multiplier: 3}),
+  divergentInput: {close: 500, high: 510, low: 490},
+  inputs: [
+    {close: 81.59, high: 82.15, low: 81.29},
+    {close: 81.06, high: 81.89, low: 80.64},
+    {close: 82.87, high: 83.03, low: 81.31},
+    {close: 83.0, high: 83.3, low: 82.65},
+    {close: 83.61, high: 83.85, low: 83.07},
+    {close: 83.15, high: 83.9, low: 83.11},
+    {close: 82.84, high: 83.33, low: 82.49},
+    {close: 83.99, high: 84.3, low: 82.3},
+  ],
 });

--- a/packages/trading-signals/src/trend/CE/ChandelierExit.test.ts
+++ b/packages/trading-signals/src/trend/CE/ChandelierExit.test.ts
@@ -1,6 +1,5 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {ChandelierExit} from './ChandelierExit.js';
-import {NotEnoughDataError} from '../../error/index.js';
 
 describe('ChandelierExit', () => {
   /*
@@ -102,21 +101,10 @@ describe('ChandelierExit', () => {
       expect(ce.getRequiredInputs()).toBe(22);
       expect(ce.multiplier).toBe(3);
     });
-
-    it('throws an error when there is not enough input data', () => {
-      const ce = new ChandelierExit({interval: 5, multiplier: 3});
-
-      try {
-        ce.getResultOrThrow();
-        throw new Error('Expected error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotEnoughDataError);
-      }
-    });
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new ChandelierExit({interval: 5, multiplier: 3}),
   divergentInput: {close: 500, high: 510, low: 490},
   inputs: [

--- a/packages/trading-signals/src/trend/CE/ChandelierExit.ts
+++ b/packages/trading-signals/src/trend/CE/ChandelierExit.ts
@@ -52,7 +52,7 @@ export class ChandelierExit extends TechnicalIndicator<ChandelierExitResult, Hig
 
   update(candle: HighLowClose<number>, replace: boolean) {
     const atr = this.#atr.update(candle, replace);
-    pushUpdate(this.#candles, replace, candle, this.interval);
+    pushUpdate({array: this.#candles, item: candle, maxLength: this.interval, replace: replace});
 
     // The candle window fills in lockstep with the ATR warm-up, so this single guard covers both
     if (atr === null) {

--- a/packages/trading-signals/src/trend/DEMA/DEMA.test.ts
+++ b/packages/trading-signals/src/trend/DEMA/DEMA.test.ts
@@ -1,6 +1,5 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {DEMA} from './DEMA.js';
-import {NotEnoughDataError} from '../../error/index.js';
 
 const dema10results = [
   81, 62.157024793388416, 65.1412471825695, 49.61361928829999, 42.570707415663364, 34.597495090487996,
@@ -55,17 +54,6 @@ describe('DEMA', () => {
       expect(dema.isStable).toBe(true);
       expect(dema.getRequiredInputs()).toBe(interval);
     });
-
-    it('throws an error when there is not enough input data', () => {
-      const dema = new DEMA(10);
-
-      try {
-        dema.getResultOrThrow();
-        throw new Error('Expected error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotEnoughDataError);
-      }
-    });
   });
 
   describe('isStable', () => {
@@ -79,7 +67,7 @@ describe('DEMA', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new DEMA(10),
   divergentInput: 1_000,
   inputs: [81, 24, 75, 21, 34, 25, 72, 92, 99, 2, 86, 80],

--- a/packages/trading-signals/src/trend/DEMA/DEMA.test.ts
+++ b/packages/trading-signals/src/trend/DEMA/DEMA.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {DEMA} from './DEMA.js';
 import {NotEnoughDataError} from '../../error/index.js';
 
@@ -76,4 +77,10 @@ describe('DEMA', () => {
       expect(dema.isStable).toBe(true);
     });
   });
+});
+
+testReplaceContract({
+  create: () => new DEMA(10),
+  divergentInput: 1_000,
+  inputs: [81, 24, 75, 21, 34, 25, 72, 92, 99, 2, 86, 80],
 });

--- a/packages/trading-signals/src/trend/DEMA/DEMA.ts
+++ b/packages/trading-signals/src/trend/DEMA/DEMA.ts
@@ -1,5 +1,6 @@
 import {EMA} from '../EMA/EMA.js';
 import {IndicatorSeries} from '../../base/Indicator.js';
+import {NotEnoughDataError} from '../../error/index.js';
 
 /**
  * Double Exponential Moving Average (DEMA)
@@ -30,6 +31,14 @@ export class DEMA extends IndicatorSeries {
     const innerResult = this.#inner.update(price, replace);
     const outerResult = this.#outer.update(innerResult, replace);
     return this.setResult(innerResult * 2 - outerResult, replace);
+  }
+
+  override getResultOrThrow() {
+    if (!this.isStable) {
+      throw new NotEnoughDataError(this.getRequiredInputs());
+    }
+
+    return super.getResultOrThrow();
   }
 
   override get isStable() {

--- a/packages/trading-signals/src/trend/DMA/DMA.test.ts
+++ b/packages/trading-signals/src/trend/DMA/DMA.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {EMA, SMA} from '../../index.js';
 import twoDays from '../../fixtures/DMA/LTC-USDT-1h-2d.json' with {type: 'json'};
 import {DMA} from './DMA.js';
@@ -90,4 +91,10 @@ describe('DMA', () => {
       expect(short > long).toBe(true);
     });
   });
+});
+
+testReplaceContract({
+  create: () => new DMA(3, 6, SMA),
+  divergentInput: 1_000,
+  inputs: [41, 37, 20.9, 100, 30.71, 40, 30],
 });

--- a/packages/trading-signals/src/trend/DMA/DMA.test.ts
+++ b/packages/trading-signals/src/trend/DMA/DMA.test.ts
@@ -1,4 +1,4 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {EMA, SMA} from '../../index.js';
 import twoDays from '../../fixtures/DMA/LTC-USDT-1h-2d.json' with {type: 'json'};
 import {DMA} from './DMA.js';
@@ -93,7 +93,7 @@ describe('DMA', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new DMA(3, 6, SMA),
   divergentInput: 1_000,
   inputs: [41, 37, 20.9, 100, 30.71, 40, 30],

--- a/packages/trading-signals/src/trend/DX/DX.test.ts
+++ b/packages/trading-signals/src/trend/DX/DX.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {DX} from './DX.js';
 
 describe('DX', () => {
@@ -96,4 +97,26 @@ describe('DX', () => {
       expect(dx.getResultOrThrow()).toBe(0);
     });
   });
+});
+
+testReplaceContract({
+  create: () => new DX(5),
+  divergentInput: {close: 9_000, high: 9_000, low: 9_000},
+  inputs: [
+    {close: 81.59, high: 82.15, low: 81.29},
+    {close: 81.06, high: 81.89, low: 80.64},
+    {close: 82.87, high: 83.03, low: 81.31},
+    {close: 83.0, high: 83.3, low: 82.65},
+    {close: 83.61, high: 83.85, low: 83.07},
+    {close: 83.15, high: 83.9, low: 83.11},
+    {close: 82.84, high: 83.33, low: 82.49},
+    {close: 83.99, high: 84.3, low: 82.3},
+    {close: 84.55, high: 84.84, low: 84.15},
+    {close: 84.36, high: 85.0, low: 84.11},
+    {close: 85.53, high: 85.9, low: 84.03},
+    {close: 86.54, high: 86.58, low: 85.39},
+    {close: 86.89, high: 86.98, low: 85.76},
+    {close: 87.77, high: 88.0, low: 87.17},
+    {close: 87.29, high: 87.87, low: 87.01},
+  ],
 });

--- a/packages/trading-signals/src/trend/DX/DX.test.ts
+++ b/packages/trading-signals/src/trend/DX/DX.test.ts
@@ -1,4 +1,4 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {DX} from './DX.js';
 
 describe('DX', () => {
@@ -99,7 +99,7 @@ describe('DX', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new DX(5),
   divergentInput: {close: 9_000, high: 9_000, low: 9_000},
   inputs: [

--- a/packages/trading-signals/src/trend/EMA/EMA.test.ts
+++ b/packages/trading-signals/src/trend/EMA/EMA.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {EMA, NotEnoughDataError} from '../../index.js';
 
 describe('EMA', () => {
@@ -111,4 +112,10 @@ describe('EMA', () => {
       }
     });
   });
+});
+
+testReplaceContract({
+  create: () => new EMA(5),
+  divergentInput: 1_000,
+  inputs: [81.59, 81.06, 82.87, 83.0, 83.61, 83.15],
 });

--- a/packages/trading-signals/src/trend/EMA/EMA.test.ts
+++ b/packages/trading-signals/src/trend/EMA/EMA.test.ts
@@ -1,5 +1,5 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
-import {EMA, NotEnoughDataError} from '../../index.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {EMA} from '../../index.js';
 
 describe('EMA', () => {
   /*
@@ -99,22 +99,10 @@ describe('EMA', () => {
 
       expect(ema.getResultOrThrow().toFixed(2)).toBe('86.70');
     });
-
-    it('throws an error when there is not enough input data', () => {
-      const ema = new EMA(10);
-
-      try {
-        ema.getResultOrThrow();
-        throw new Error('Expected error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotEnoughDataError);
-        expect(ema.isStable).toBe(false);
-      }
-    });
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new EMA(5),
   divergentInput: 1_000,
   inputs: [81.59, 81.06, 82.87, 83.0, 83.61, 83.15],

--- a/packages/trading-signals/src/trend/HIGHER_LOW_TRAIL/HigherLowTrail.test.ts
+++ b/packages/trading-signals/src/trend/HIGHER_LOW_TRAIL/HigherLowTrail.test.ts
@@ -1,5 +1,4 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
-import {NotEnoughDataError} from '../../error/NotEnoughDataError.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {HigherLowTrail} from './HigherLowTrail.js';
 
 describe('HigherLowTrail', () => {
@@ -100,15 +99,6 @@ describe('HigherLowTrail', () => {
 
       expect(detected).toEqual([5]);
     });
-
-    it('throws when accessed before enough data has been added', () => {
-      const trail = new HigherLowTrail({lookback: 1});
-
-      trail.add({high: 12, low: 10});
-
-      expect(() => trail.getResultOrThrow()).toThrow(NotEnoughDataError);
-      expect(trail.isStable).toBe(false);
-    });
   });
 
   describe('replace', () => {
@@ -185,7 +175,7 @@ describe('HigherLowTrail', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new HigherLowTrail({lookback: 1}),
   divergentInput: {high: 1_000, low: 1},
   inputs: [

--- a/packages/trading-signals/src/trend/HIGHER_LOW_TRAIL/HigherLowTrail.test.ts
+++ b/packages/trading-signals/src/trend/HIGHER_LOW_TRAIL/HigherLowTrail.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {NotEnoughDataError} from '../../error/NotEnoughDataError.js';
 import {HigherLowTrail} from './HigherLowTrail.js';
 
@@ -182,4 +183,14 @@ describe('HigherLowTrail', () => {
       expect(trail.getRequiredInputs()).toBe(4);
     });
   });
+});
+
+testReplaceContract({
+  create: () => new HigherLowTrail({lookback: 1}),
+  divergentInput: {high: 1_000, low: 1},
+  inputs: [
+    {high: 12, low: 10},
+    {high: 10, low: 8},
+    {high: 14, low: 12},
+  ],
 });

--- a/packages/trading-signals/src/trend/HIGHER_LOW_TRAIL/HigherLowTrail.ts
+++ b/packages/trading-signals/src/trend/HIGHER_LOW_TRAIL/HigherLowTrail.ts
@@ -58,7 +58,7 @@ export class HigherLowTrail extends IndicatorSeries<HighLow> {
     }
     this.#lastEmitted = false;
 
-    pushUpdate(this.#window, replace, candle.low, this.getRequiredInputs());
+    pushUpdate({array: this.#window, item: candle.low, maxLength: this.getRequiredInputs(), replace: replace});
 
     if (this.#window.length < this.getRequiredInputs()) {
       return null;

--- a/packages/trading-signals/src/trend/HMA/HMA.test.ts
+++ b/packages/trading-signals/src/trend/HMA/HMA.test.ts
@@ -1,6 +1,5 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {HMA} from './HMA.js';
-import {NotEnoughDataError} from '../../error/index.js';
 
 describe('HMA', () => {
   /*
@@ -64,21 +63,10 @@ describe('HMA', () => {
       expect(hma.isStable).toBe(true);
       expect(hma.getRequiredInputs()).toBe(6);
     });
-
-    it('throws an error when there is not enough input data', () => {
-      const hma = new HMA(5);
-
-      try {
-        hma.getResultOrThrow();
-        throw new Error('Expected error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotEnoughDataError);
-      }
-    });
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new HMA(5),
   divergentInput: 1_000,
   inputs: [81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84, 83.99],

--- a/packages/trading-signals/src/trend/HMA/HMA.test.ts
+++ b/packages/trading-signals/src/trend/HMA/HMA.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {HMA} from './HMA.js';
 import {NotEnoughDataError} from '../../error/index.js';
 
@@ -75,4 +76,10 @@ describe('HMA', () => {
       }
     });
   });
+});
+
+testReplaceContract({
+  create: () => new HMA(5),
+  divergentInput: 1_000,
+  inputs: [81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84, 83.99],
 });

--- a/packages/trading-signals/src/trend/KAMA/KAMA.test.ts
+++ b/packages/trading-signals/src/trend/KAMA/KAMA.test.ts
@@ -1,6 +1,5 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {KAMA} from './KAMA.js';
-import {NotEnoughDataError} from '../../error/index.js';
 
 describe('KAMA', () => {
   /*
@@ -75,21 +74,10 @@ describe('KAMA', () => {
 
       expect(kama.getResultOrThrow()).toBe(100);
     });
-
-    it('throws an error when there is not enough input data', () => {
-      const kama = new KAMA(5);
-
-      try {
-        kama.getResultOrThrow();
-        throw new Error('Expected error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotEnoughDataError);
-      }
-    });
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new KAMA(5),
   divergentInput: 1_000,
   inputs: [81.59, 81.06, 82.87, 83.0, 83.61, 83.15],

--- a/packages/trading-signals/src/trend/KAMA/KAMA.test.ts
+++ b/packages/trading-signals/src/trend/KAMA/KAMA.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {KAMA} from './KAMA.js';
 import {NotEnoughDataError} from '../../error/index.js';
 
@@ -86,4 +87,10 @@ describe('KAMA', () => {
       }
     });
   });
+});
+
+testReplaceContract({
+  create: () => new KAMA(5),
+  divergentInput: 1_000,
+  inputs: [81.59, 81.06, 82.87, 83.0, 83.61, 83.15],
 });

--- a/packages/trading-signals/src/trend/KAMA/KAMA.ts
+++ b/packages/trading-signals/src/trend/KAMA/KAMA.ts
@@ -26,7 +26,7 @@ export class KAMA extends MovingAverage {
   }
 
   update(price: number, replace: boolean) {
-    pushUpdate(this.#prices, replace, price, this.interval + 1);
+    pushUpdate({array: this.#prices, item: price, maxLength: this.interval + 1, replace: replace});
 
     if (this.#prices.length < this.interval) {
       return null;

--- a/packages/trading-signals/src/trend/LINREG/LinearRegression.test.ts
+++ b/packages/trading-signals/src/trend/LINREG/LinearRegression.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {LinearRegression} from '../../index.js';
 import {NotEnoughDataError} from '../../error/index.js';
 
@@ -109,4 +110,10 @@ describe('LinearRegression', () => {
       expect(linreg.add(10)).toBeNull();
     });
   });
+});
+
+testReplaceContract({
+  create: () => new LinearRegression(5),
+  divergentInput: 1_000,
+  inputs: [10, 11, 12, 13, 14, 15],
 });

--- a/packages/trading-signals/src/trend/LINREG/LinearRegression.test.ts
+++ b/packages/trading-signals/src/trend/LINREG/LinearRegression.test.ts
@@ -1,6 +1,5 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {LinearRegression} from '../../index.js';
-import {NotEnoughDataError} from '../../error/index.js';
 
 describe('LinearRegression', () => {
   describe('intercept (linregintercept)', () => {
@@ -100,11 +99,6 @@ describe('LinearRegression', () => {
   });
 
   describe('error handling', () => {
-    it('throws NotEnoughDataError when getting result without enough data', () => {
-      const linreg = new LinearRegression(5);
-      expect(() => linreg.getResultOrThrow()).toThrow(NotEnoughDataError);
-    });
-
     it('returns null when updating with insufficient data', () => {
       const linreg = new LinearRegression(5);
       expect(linreg.add(10)).toBeNull();
@@ -112,7 +106,7 @@ describe('LinearRegression', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new LinearRegression(5),
   divergentInput: 1_000,
   inputs: [10, 11, 12, 13, 14, 15],

--- a/packages/trading-signals/src/trend/LINREG/LinearRegression.ts
+++ b/packages/trading-signals/src/trend/LINREG/LinearRegression.ts
@@ -69,7 +69,7 @@ export class LinearRegression extends TechnicalIndicator<LinearRegressionResult,
   }
 
   update(price: number, replace: boolean): LinearRegressionResult | null {
-    pushUpdate(this.prices, replace, price, this.interval);
+    pushUpdate({array: this.prices, item: price, maxLength: this.interval, replace: replace});
 
     if (this.prices.length < this.interval) {
       return null;

--- a/packages/trading-signals/src/trend/PSAR/PSAR.test.ts
+++ b/packages/trading-signals/src/trend/PSAR/PSAR.test.ts
@@ -378,9 +378,9 @@ describe('PSAR', () => {
     psar.add({high: 9, low: 8});
 
     // Directly set the acceleration to just below max
-    psar['acceleration'] = 0.19;
-    psar['extreme'] = 8;
-    psar['isLong'] = false;
+    psar['state'].acceleration = 0.19;
+    psar['state'].extreme = 8;
+    psar['state'].isLong = false;
 
     /*
      * Now make a new low that will cause acceleration to exceed max
@@ -392,7 +392,7 @@ describe('PSAR', () => {
     expect(result).toBeGreaterThan(7);
 
     // Verify acceleration was capped
-    expect(psar['acceleration']).toBe(psar['accelerationMax']);
+    expect(psar['state'].acceleration).toBe(psar['accelerationMax']);
   });
 
   it('adjusts SAR on reversal when SAR >= low', () => {
@@ -446,7 +446,7 @@ describe('PSAR', () => {
     psar.update({high: 15, low: 14}, false);
 
     // Verify acceleration has hit the max at some point
-    expect(psar['acceleration']).toBe(psar['accelerationMax']);
+    expect(psar['state'].acceleration).toBe(psar['accelerationMax']);
   });
 
   it('caps acceleration when exceeding max in uptrend', () => {
@@ -457,9 +457,9 @@ describe('PSAR', () => {
     psar.update({high: 11, low: 10}, false);
 
     // Directly set acceleration to a specific value that will exceed max after one more step
-    psar['acceleration'] = psar['accelerationMax'] * 0.95;
-    psar['isLong'] = true;
-    psar['extreme'] = 11;
+    psar['state'].acceleration = psar['accelerationMax'] * 0.95;
+    psar['state'].isLong = true;
+    psar['state'].extreme = 11;
 
     /*
      * Make a new high that will cause acceleration to exceed max
@@ -468,7 +468,7 @@ describe('PSAR', () => {
     psar.update({high: 12, low: 11}, false);
 
     // Verify acceleration was capped at max (not higher)
-    expect(psar['acceleration']).toBe(psar['accelerationMax']);
+    expect(psar['state'].acceleration).toBe(psar['accelerationMax']);
   });
 
   it('adjusts SAR to previous high in short position', () => {
@@ -479,11 +479,11 @@ describe('PSAR', () => {
     psar.update({high: 9, low: 8}, false);
 
     // Directly set the state to test the specific code path
-    psar['isLong'] = false; // Downtrend
-    psar['lastSar'] = 8; // Set SAR
-    psar['extreme'] = 7; // Set extreme point
-    psar['prePreviousCandle'] = null; // Ensure no pre-previous influence
-    psar['previousCandle'] = {high: 9, low: 8}; // Previous candle with high > SAR
+    psar['state'].isLong = false; // Downtrend
+    psar['state'].lastSar = 8; // Set SAR
+    psar['state'].extreme = 7; // Set extreme point
+    psar['state'].prePreviousCandle = null; // Ensure no pre-previous influence
+    psar['state'].previousCandle = {high: 9, low: 8}; // Previous candle with high > SAR
 
     // This should hit line 299-301
     const result = psar.update({high: 7.5, low: 7}, false);
@@ -500,11 +500,11 @@ describe('PSAR', () => {
     psar.update({high: 9, low: 8}, false);
 
     // Set up a specific scenario to test lines 292-298
-    psar['isLong'] = false; // Downtrend
-    psar['lastSar'] = 8.5; // Set SAR
-    psar['extreme'] = 7; // Set extreme point
-    psar['prePreviousCandle'] = {high: 9, low: 8}; // prePreviousCandle.high > SAR
-    psar['previousCandle'] = {high: 8, low: 7}; // previousCandle.high < SAR
+    psar['state'].isLong = false; // Downtrend
+    psar['state'].lastSar = 8.5; // Set SAR
+    psar['state'].extreme = 7; // Set extreme point
+    psar['state'].prePreviousCandle = {high: 9, low: 8}; // prePreviousCandle.high > SAR
+    psar['state'].previousCandle = {high: 8, low: 7}; // previousCandle.high < SAR
 
     // This update should test line 292-293 (prePreviousCandle.high > sar) but skip 296-297
     const result = psar.update({high: 7.5, low: 7}, false);
@@ -521,11 +521,11 @@ describe('PSAR', () => {
     psar.update({high: 9, low: 8}, false);
 
     // Set up all with specific values
-    psar['isLong'] = false; // Downtrend
-    psar['lastSar'] = 8; // Set SAR
-    psar['extreme'] = 7; // Set extreme point
-    psar['prePreviousCandle'] = {high: 8.5, low: 7.5}; // prePreviousCandle exists with high < sar
-    psar['previousCandle'] = {high: 9.5, low: 8.5}; // previousCandle.high > SAR
+    psar['state'].isLong = false; // Downtrend
+    psar['state'].lastSar = 8; // Set SAR
+    psar['state'].extreme = 7; // Set extreme point
+    psar['state'].prePreviousCandle = {high: 8.5, low: 7.5}; // prePreviousCandle exists with high < sar
+    psar['state'].previousCandle = {high: 9.5, low: 8.5}; // previousCandle.high > SAR
 
     // First ensure high > sar to trigger prePreviousCandle branch, but only previousCandle.high > sar
     const result = psar.update({high: 8.2, low: 7.2}, false);
@@ -571,11 +571,11 @@ describe('PSAR', () => {
     psar.update({high: 9, low: 8}, false);
 
     // Set up a specific scenario to test lines 258-264
-    psar['isLong'] = true; // Uptrend
-    psar['lastSar'] = 7.5; // Set SAR
-    psar['extreme'] = 9; // Set extreme point
-    psar['prePreviousCandle'] = {high: 9, low: 8}; // prePreviousCandle.low > SAR
-    psar['previousCandle'] = {high: 8, low: 6}; // previousCandle.low < SAR
+    psar['state'].isLong = true; // Uptrend
+    psar['state'].lastSar = 7.5; // Set SAR
+    psar['state'].extreme = 9; // Set extreme point
+    psar['state'].prePreviousCandle = {high: 9, low: 8}; // prePreviousCandle.low > SAR
+    psar['state'].previousCandle = {high: 8, low: 6}; // previousCandle.low < SAR
 
     // This update should hit lines 262-264 with previousCandle.low < sar
     const result = psar.update({high: 8.5, low: 7}, false);
@@ -592,11 +592,11 @@ describe('PSAR', () => {
     psar.update({high: 9, low: 8}, false);
 
     // Directly set internal state
-    psar['isLong'] = true; // Uptrend
-    psar['lastSar'] = 8.5; // Set SAR above both lows
-    psar['extreme'] = 10; // Set extreme point
-    psar['prePreviousCandle'] = {high: 9, low: 7}; // prePreviousCandle.low < SAR
-    psar['previousCandle'] = {high: 10, low: 7.5}; // previousCandle.low < SAR
+    psar['state'].isLong = true; // Uptrend
+    psar['state'].lastSar = 8.5; // Set SAR above both lows
+    psar['state'].extreme = 10; // Set extreme point
+    psar['state'].prePreviousCandle = {high: 9, low: 7}; // prePreviousCandle.low < SAR
+    psar['state'].previousCandle = {high: 10, low: 7.5}; // previousCandle.low < SAR
 
     // This update should hit both lines 258-260 AND 262-264
     const result = psar.update({high: 11, low: 9.5}, false);
@@ -614,11 +614,11 @@ describe('PSAR', () => {
     psar.update({high: 9, low: 8}, false);
 
     // Set up a specific scenario to test line 258-260
-    psar['isLong'] = true; // Uptrend
-    psar['lastSar'] = 8; // Set SAR
-    psar['extreme'] = 9.5; // Set extreme point
-    psar['prePreviousCandle'] = {high: 9, low: 7.5}; // prePreviousCandle.low < SAR
-    psar['previousCandle'] = {high: 10, low: 8.5}; // previousCandle.low > SAR
+    psar['state'].isLong = true; // Uptrend
+    psar['state'].lastSar = 8; // Set SAR
+    psar['state'].extreme = 9.5; // Set extreme point
+    psar['state'].prePreviousCandle = {high: 9, low: 7.5}; // prePreviousCandle.low < SAR
+    psar['state'].previousCandle = {high: 10, low: 8.5}; // previousCandle.low > SAR
 
     // This update should specifically hit line 258-260 with prePreviousCandle.low < sar
     const result = psar.update({high: 10.5, low: 8}, false);
@@ -635,11 +635,11 @@ describe('PSAR', () => {
     psar.update({high: 11, low: 10}, false);
 
     // Set up a specific scenario to test line 99-101
-    psar['isLong'] = true;
-    psar['lastSar'] = 11; // Set SAR high
-    psar['extreme'] = 12;
-    psar['prePreviousCandle'] = {high: 12, low: 10.5}; // prePreviousCandle.low < sar
-    psar['previousCandle'] = {high: 12.5, low: 10.2}; // previousCandle.low < sar
+    psar['state'].isLong = true;
+    psar['state'].lastSar = 11; // Set SAR high
+    psar['state'].extreme = 12;
+    psar['state'].prePreviousCandle = {high: 12, low: 10.5}; // prePreviousCandle.low < sar
+    psar['state'].previousCandle = {high: 12.5, low: 10.2}; // previousCandle.low < sar
 
     /*
      * This update should hit both prePreviousLow and previousLow checks
@@ -703,13 +703,13 @@ describe('PSAR', () => {
     psar.update({high: 9, low: 8}, false); // First calculation
 
     // Set up a scenario where we're in a downtrend
-    psar['isLong'] = false;
-    psar['lastSar'] = 8;
-    psar['extreme'] = 7;
+    psar['state'].isLong = false;
+    psar['state'].lastSar = 8;
+    psar['state'].extreme = 7;
 
     // Set up a previous candle with high > sar but no pre-previous candle
-    psar['prePreviousCandle'] = null;
-    psar['previousCandle'] = {high: 8.5, low: 7.5};
+    psar['state'].prePreviousCandle = null;
+    psar['state'].previousCandle = {high: 8.5, low: 7.5};
 
     /*
      * This should test the specific branch on line 139-141
@@ -718,8 +718,8 @@ describe('PSAR', () => {
     psar.update({high: 7.5, low: 7}, false);
 
     // Now add a candle with prePreviousCandle to hit lines 136-138
-    psar['prePreviousCandle'] = {high: 8.5, low: 7.5};
-    psar['previousCandle'] = {high: 8.6, low: 7.6};
+    psar['state'].prePreviousCandle = {high: 8.5, low: 7.5};
+    psar['state'].previousCandle = {high: 8.6, low: 7.6};
 
     // Update with a price that triggers high > sar but only in previousCandle
     const result = psar.update({high: 8.1, low: 7.1}, false);
@@ -736,11 +736,11 @@ describe('PSAR', () => {
     psar.update({high: 11, low: 10}, false);
 
     // Set up a specific scenario to test line 102-104
-    psar['isLong'] = true;
-    psar['prePreviousCandle'] = null; // Ensure no pre-previous influence
-    psar['lastSar'] = 9.5; // Set SAR above previous low
-    psar['extreme'] = 11;
-    psar['previousCandle'] = {high: 11, low: 9}; // previousCandle.low < sar
+    psar['state'].isLong = true;
+    psar['state'].prePreviousCandle = null; // Ensure no pre-previous influence
+    psar['state'].lastSar = 9.5; // Set SAR above previous low
+    psar['state'].extreme = 11;
+    psar['state'].previousCandle = {high: 11, low: 9}; // previousCandle.low < sar
 
     /*
      * This should trigger the branch in line 102-104 where previousCandle.low < sar
@@ -769,8 +769,8 @@ describe('PSAR', () => {
     psar.update({high: 12, low: 11}, false);
 
     // 2. This update will create a previousCandle, and SAR will be below low
-    psar['lastSar'] = 12.5; // Setting high to ensure lt conditions are met
-    psar['isLong'] = true;
+    psar['state'].lastSar = 12.5; // Setting high to ensure lt conditions are met
+    psar['state'].isLong = true;
 
     // 3. Make low < sar, to trigger the branch where previousLow < sar
     const testCandle = {high: 15, low: 10}; // Low is less than SAR
@@ -786,8 +786,8 @@ describe('PSAR', () => {
     psarDown.add({high: 13, low: 12}); // Sets up prePreviousCandle
 
     // Set up specific state for hitting line 150-151
-    psarDown['isLong'] = false; // Downtrend
-    psarDown['lastSar'] = 10; // Low SAR
+    psarDown['state'].isLong = false; // Downtrend
+    psarDown['state'].lastSar = 10; // Low SAR
 
     // Execute with high > sar to hit the branch
     const downTrendResult = psarDown.add({high: 15, low: 12});
@@ -802,13 +802,13 @@ describe('PSAR', () => {
     psar.update({high: 9, low: 8}, false);
 
     // Set up a very specific scenario to target lines 137-138
-    psar['isLong'] = false;
-    psar['lastSar'] = 7;
-    psar['extreme'] = 6;
+    psar['state'].isLong = false;
+    psar['state'].lastSar = 7;
+    psar['state'].extreme = 6;
 
     // Set both prePreviousCandle.high > sar and previousCandle.high > sar
-    psar['prePreviousCandle'] = {high: 8, low: 7.5}; // prePrevious.high > sar
-    psar['previousCandle'] = {high: 7.5, low: 7}; // previous.high > sar
+    psar['state'].prePreviousCandle = {high: 8, low: 7.5}; // prePrevious.high > sar
+    psar['state'].previousCandle = {high: 7.5, low: 7}; // previous.high > sar
 
     // This update must hit both conditions and specifically lines 137-138
     const result = psar.update({high: 7.2, low: 6.8}, false);
@@ -902,8 +902,8 @@ describe('PSAR', () => {
     psar.update({high: 11, low: 10}, false);
 
     // Create a scenario where previousLow is less than SAR
-    psar['lastSar'] = 12; // SAR higher than previous low
-    psar['isLong'] = true;
+    psar['state'].lastSar = 12; // SAR higher than previous low
+    psar['state'].isLong = true;
 
     // This will call updateSARWithPreviousLow with previousLow < sar
     psar.update({high: 13, low: 11}, false);
@@ -916,8 +916,8 @@ describe('PSAR', () => {
     psarDownTrend.update({high: 12, low: 11}, false);
 
     // Set up conditions
-    psarDownTrend['lastSar'] = 10; // SAR lower than previous high
-    psarDownTrend['isLong'] = false;
+    psarDownTrend['state'].lastSar = 10; // SAR lower than previous high
+    psarDownTrend['state'].isLong = false;
 
     // This will call updateSARWithPreviousHigh with previousHigh > sar
     psarDownTrend.update({high: 11, low: 10}, false);
@@ -935,10 +935,10 @@ describe('PSAR', () => {
      * Use prePreviousCandle branch path but make sure previousLow is NOT < SAR
      * Set state for an uptrend with pre-previous candle
      */
-    psar['lastSar'] = 5; // SAR much lower than low price
-    psar['prePreviousCandle'] = {high: 9, low: 8};
-    psar['previousCandle'] = {high: 9.5, low: 8.5};
-    psar['isLong'] = true;
+    psar['state'].lastSar = 5; // SAR much lower than low price
+    psar['state'].prePreviousCandle = {high: 9, low: 8};
+    psar['state'].previousCandle = {high: 9.5, low: 8.5};
+    psar['state'].isLong = true;
 
     // This should hit the ternary operator with previousLow < sar = false
     psar.update({high: 10, low: 9}, false);
@@ -952,10 +952,10 @@ describe('PSAR', () => {
      * Use prePreviousCandle branch path but make sure previousHigh is NOT > SAR
      * Set state for a downtrend with pre-previous candle
      */
-    psarDownTrend['lastSar'] = 12; // SAR much higher than high price
-    psarDownTrend['prePreviousCandle'] = {high: 9, low: 8};
-    psarDownTrend['previousCandle'] = {high: 8.5, low: 7.5};
-    psarDownTrend['isLong'] = false;
+    psarDownTrend['state'].lastSar = 12; // SAR much higher than high price
+    psarDownTrend['state'].prePreviousCandle = {high: 9, low: 8};
+    psarDownTrend['state'].previousCandle = {high: 8.5, low: 7.5};
+    psarDownTrend['state'].isLong = false;
 
     // This should hit the ternary operator with previousHigh > sar = false
     psarDownTrend.update({high: 8, low: 7}, false);

--- a/packages/trading-signals/src/trend/PSAR/PSAR.test.ts
+++ b/packages/trading-signals/src/trend/PSAR/PSAR.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {PSAR} from './PSAR.js';
 import {NotEnoughDataError} from '../../error/index.js';
 
@@ -960,4 +961,19 @@ describe('PSAR', () => {
     // This should hit the ternary operator with previousHigh > sar = false
     psarDownTrend.update({high: 8, low: 7}, false);
   });
+});
+
+testReplaceContract({
+  create: () => new PSAR({accelerationMax: 0.2, accelerationStep: 0.02}),
+  divergentInput: {high: 999, low: 1},
+  inputs: [
+    {high: 82.15, low: 81.29},
+    {high: 81.89, low: 80.64},
+    {high: 83.03, low: 81.31},
+    {high: 83.3, low: 82.65},
+    {high: 83.85, low: 83.07},
+    {high: 83.9, low: 83.11},
+    {high: 83.33, low: 82.49},
+    {high: 84.3, low: 82.3},
+  ],
 });

--- a/packages/trading-signals/src/trend/PSAR/PSAR.test.ts
+++ b/packages/trading-signals/src/trend/PSAR/PSAR.test.ts
@@ -99,6 +99,20 @@ describe('PSAR', () => {
     expect(replacedResult, 'a reversal caused by the replaced candle must be undone too').toBe(referenceResult);
   });
 
+  it('treats repeated replacements before any input as replacing the same bar', () => {
+    const doubleReplaced = new PSAR({accelerationMax: 0.2, accelerationStep: 0.02});
+    doubleReplaced.replace({high: 22, low: 20});
+    doubleReplaced.replace({high: 10, low: 9});
+
+    const reference = new PSAR({accelerationMax: 0.2, accelerationStep: 0.02});
+    reference.add({high: 10, low: 9});
+
+    expect(
+      doubleReplaced.getState(),
+      'two replacements without any prior input must not act as two logical bars'
+    ).toEqual(reference.getState());
+  });
+
   it('returns null when replacing without enough data', () => {
     const psar = new PSAR({accelerationMax: 0.2, accelerationStep: 0.02});
 

--- a/packages/trading-signals/src/trend/PSAR/PSAR.test.ts
+++ b/packages/trading-signals/src/trend/PSAR/PSAR.test.ts
@@ -1,4 +1,4 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {PSAR} from './PSAR.js';
 import {NotEnoughDataError} from '../../error/index.js';
 
@@ -963,7 +963,7 @@ describe('PSAR', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new PSAR({accelerationMax: 0.2, accelerationStep: 0.02}),
   divergentInput: {high: 999, low: 1},
   inputs: [

--- a/packages/trading-signals/src/trend/PSAR/PSAR.test.ts
+++ b/packages/trading-signals/src/trend/PSAR/PSAR.test.ts
@@ -48,21 +48,60 @@ describe('PSAR', () => {
     });
   });
 
-  it('handles replace correctly', () => {
-    const psar = new PSAR({accelerationMax: 0.2, accelerationStep: 0.02});
+  it('changes nothing when the latest candle is replaced with the same values', () => {
+    const candles = testData.map(({high, low}) => ({high, low}));
 
-    // Add first two candles
-    psar.add({high: testData[0].high, low: testData[0].low});
-    const initialResult = psar.add({high: testData[1].high, low: testData[1].low});
+    // Swept over every length because the carried state only diverges at some of them.
+    for (let length = 1; length <= candles.length; length++) {
+      const psar = new PSAR({accelerationMax: 0.2, accelerationStep: 0.02});
 
-    // Replace the second candle
-    const replacedResult = psar.replace({high: testData[1].high, low: testData[1].low});
+      candles.slice(0, length).forEach(candle => psar.add(candle));
 
-    // Allow small differences due to floating point arithmetic
-    const diff = Math.abs((initialResult || 0) - (replacedResult || 0));
-    // Use a reasonable tolerance - 1% or 0.1 absolute
-    const tolerance = Math.max((initialResult || 0) * 0.01, 0.1);
-    expect(diff).toBeLessThanOrEqual(tolerance);
+      const resultBefore = psar.getResult();
+      const stableBefore = psar.isStable;
+
+      psar.replace(candles[length - 1]);
+
+      expect(psar.getResult(), `replacing candle ${length} with itself is a no-op`).toBe(resultBefore);
+      expect(psar.isStable, `and does not change stability at ${length} candles`).toBe(stableBefore);
+    }
+  });
+
+  it('reproduces an add-only series after a replacement', () => {
+    const candles = testData.slice(0, 20).map(({high, low}) => ({high, low}));
+    const decoy = {high: 999, low: 1};
+
+    const replaced = new PSAR({accelerationMax: 0.2, accelerationStep: 0.02});
+    candles.slice(0, -1).forEach(candle => replaced.add(candle));
+    replaced.add(decoy);
+    const replacedResult = replaced.replace(candles[candles.length - 1]);
+
+    const reference = new PSAR({accelerationMax: 0.2, accelerationStep: 0.02});
+    let referenceResult: number | null = null;
+    candles.forEach(candle => {
+      referenceResult = reference.add(candle);
+    });
+
+    expect(replacedResult, 'a replacement must undo the state the decoy candle left behind').toBe(referenceResult);
+  });
+
+  it('reproduces an add-only series when the decoy candle reversed the trend', () => {
+    const candles = testData.slice(0, 12).map(({high, low}) => ({high, low}));
+    // A deep low forces a long-to-short reversal, which resets acceleration and the extreme point.
+    const reversingDecoy = {high: 84, low: 40};
+
+    const replaced = new PSAR({accelerationMax: 0.2, accelerationStep: 0.02});
+    candles.slice(0, -1).forEach(candle => replaced.add(candle));
+    replaced.add(reversingDecoy);
+    const replacedResult = replaced.replace(candles[candles.length - 1]);
+
+    const reference = new PSAR({accelerationMax: 0.2, accelerationStep: 0.02});
+    let referenceResult: number | null = null;
+    candles.forEach(candle => {
+      referenceResult = reference.add(candle);
+    });
+
+    expect(replacedResult, 'a reversal caused by the replaced candle must be undone too').toBe(referenceResult);
   });
 
   it('returns null when replacing without enough data', () => {

--- a/packages/trading-signals/src/trend/PSAR/PSAR.test.ts
+++ b/packages/trading-signals/src/trend/PSAR/PSAR.test.ts
@@ -55,7 +55,7 @@ describe('PSAR', () => {
     for (let length = 1; length <= candles.length; length++) {
       const psar = new PSAR({accelerationMax: 0.2, accelerationStep: 0.02});
 
-      candles.slice(0, length).forEach(candle => psar.add(candle));
+      psar.updates(candles.slice(0, length));
 
       const resultBefore = psar.getResult();
       const stableBefore = psar.isStable;
@@ -72,15 +72,12 @@ describe('PSAR', () => {
     const decoy = {high: 999, low: 1};
 
     const replaced = new PSAR({accelerationMax: 0.2, accelerationStep: 0.02});
-    candles.slice(0, -1).forEach(candle => replaced.add(candle));
+    replaced.updates(candles.slice(0, -1));
     replaced.add(decoy);
     const replacedResult = replaced.replace(candles[candles.length - 1]);
 
     const reference = new PSAR({accelerationMax: 0.2, accelerationStep: 0.02});
-    let referenceResult: number | null = null;
-    candles.forEach(candle => {
-      referenceResult = reference.add(candle);
-    });
+    const referenceResult = reference.updates(candles).at(-1);
 
     expect(replacedResult, 'a replacement must undo the state the decoy candle left behind').toBe(referenceResult);
   });
@@ -91,15 +88,12 @@ describe('PSAR', () => {
     const reversingDecoy = {high: 84, low: 40};
 
     const replaced = new PSAR({accelerationMax: 0.2, accelerationStep: 0.02});
-    candles.slice(0, -1).forEach(candle => replaced.add(candle));
+    replaced.updates(candles.slice(0, -1));
     replaced.add(reversingDecoy);
     const replacedResult = replaced.replace(candles[candles.length - 1]);
 
     const reference = new PSAR({accelerationMax: 0.2, accelerationStep: 0.02});
-    let referenceResult: number | null = null;
-    candles.forEach(candle => {
-      referenceResult = reference.add(candle);
-    });
+    const referenceResult = reference.updates(candles).at(-1);
 
     expect(replacedResult, 'a reversal caused by the replaced candle must be undone too').toBe(referenceResult);
   });

--- a/packages/trading-signals/src/trend/PSAR/PSAR.ts
+++ b/packages/trading-signals/src/trend/PSAR/PSAR.ts
@@ -15,6 +15,19 @@ export type PSARConfig = {
 };
 
 /**
+ * Everything {@link PSAR.update} reads before it decides on the next SAR. Capturing it lets a
+ * replacement re-run the latest candle from the state that candle originally saw.
+ */
+type PSARState = {
+  acceleration: number;
+  extreme: number | null;
+  isLong: boolean | null;
+  lastSar: number | null;
+  prePreviousCandle: HighLow<number> | null;
+  previousCandle: HighLow<number> | null;
+};
+
+/**
  * Parabolic SAR
  * Type: Trend
  *
@@ -36,6 +49,7 @@ export class PSAR extends IndicatorSeries<HighLow<number>> {
   private isLong: boolean | null = null;
   private previousCandle: HighLow<number> | null = null;
   private prePreviousCandle: HighLow<number> | null = null;
+  private previousState: PSARState | null = null;
 
   constructor(config: PSARConfig) {
     super();
@@ -58,14 +72,35 @@ export class PSAR extends IndicatorSeries<HighLow<number>> {
     return 2;
   }
 
+  private captureState(): PSARState {
+    return {
+      acceleration: this.acceleration,
+      extreme: this.extreme,
+      isLong: this.isLong,
+      lastSar: this.lastSar,
+      prePreviousCandle: this.prePreviousCandle,
+      previousCandle: this.previousCandle,
+    };
+  }
+
+  private restoreState(state: PSARState) {
+    this.acceleration = state.acceleration;
+    this.extreme = state.extreme;
+    this.isLong = state.isLong;
+    this.lastSar = state.lastSar;
+    this.prePreviousCandle = state.prePreviousCandle;
+    this.previousCandle = state.previousCandle;
+  }
+
   update(candle: HighLow<number>, replace: boolean): number | null {
     const {high, low} = candle;
 
-    // If replacing the last candle and we haven't processed enough data yet
-    const notEnoughData = !this.previousCandle || this.lastSar === null;
-    if (replace && notEnoughData) {
-      this.previousCandle = candle;
-      return null;
+    if (replace) {
+      if (this.previousState !== null) {
+        this.restoreState(this.previousState);
+      }
+    } else {
+      this.previousState = this.captureState();
     }
 
     // First candle, just store it and return null

--- a/packages/trading-signals/src/trend/PSAR/PSAR.ts
+++ b/packages/trading-signals/src/trend/PSAR/PSAR.ts
@@ -40,16 +40,17 @@ type PSARState = {
  * It's particularly useful in trending markets, but less reliable in sideways or choppy markets.
  *
  */
-export class PSAR extends IndicatorSeries<HighLow<number>> {
+export class PSAR extends IndicatorSeries<HighLow<number>, PSARState> {
   private readonly accelerationStep: number;
   private readonly accelerationMax: number;
-  private acceleration: number = 0;
-  private extreme: number | null = null;
-  private lastSar: number | null = null;
-  private isLong: boolean | null = null;
-  private previousCandle: HighLow<number> | null = null;
-  private prePreviousCandle: HighLow<number> | null = null;
-  private previousState: PSARState | null = null;
+  protected override state: PSARState = {
+    acceleration: 0,
+    extreme: null,
+    isLong: null,
+    lastSar: null,
+    prePreviousCandle: null,
+    previousCandle: null,
+  };
 
   constructor(config: PSARConfig) {
     super();
@@ -65,104 +66,80 @@ export class PSAR extends IndicatorSeries<HighLow<number>> {
   }
 
   override get isStable() {
-    return this.lastSar !== null;
+    return this.state.lastSar !== null;
   }
 
   override getRequiredInputs() {
     return 2;
   }
 
-  private captureState(): PSARState {
-    return {
-      acceleration: this.acceleration,
-      extreme: this.extreme,
-      isLong: this.isLong,
-      lastSar: this.lastSar,
-      prePreviousCandle: this.prePreviousCandle,
-      previousCandle: this.previousCandle,
-    };
-  }
-
-  private restoreState(state: PSARState) {
-    this.acceleration = state.acceleration;
-    this.extreme = state.extreme;
-    this.isLong = state.isLong;
-    this.lastSar = state.lastSar;
-    this.prePreviousCandle = state.prePreviousCandle;
-    this.previousCandle = state.previousCandle;
-  }
-
   update(candle: HighLow<number>, replace: boolean): number | null {
     const {high, low} = candle;
 
-    if (replace) {
-      if (this.previousState !== null) {
-        this.restoreState(this.previousState);
-      }
-    } else {
-      this.previousState = this.captureState();
-    }
+    this.trackState(replace);
+
+    const state = this.state;
 
     // First candle, just store it and return null
-    if (!this.previousCandle) {
-      this.previousCandle = candle;
+    if (!state.previousCandle) {
+      state.previousCandle = candle;
       return null;
     }
 
     // Second candle (first calculation)
-    if (this.lastSar === null) {
+    if (state.lastSar === null) {
       // Determine initial trend direction - match Tulip Indicators approach
       const currentMidpoint = (high + low) / 2;
-      const previousMidpoint = (this.previousCandle.high + this.previousCandle.low) / 2;
+      const previousMidpoint = (state.previousCandle.high + state.previousCandle.low) / 2;
 
-      this.isLong = currentMidpoint >= previousMidpoint; // Using >= like Tulip implementation
+      state.isLong = currentMidpoint >= previousMidpoint; // Using >= like Tulip implementation
 
-      if (this.isLong) {
-        this.extreme = high;
-        this.lastSar = this.previousCandle.low;
+      if (state.isLong) {
+        state.extreme = high;
+        state.lastSar = state.previousCandle.low;
       } else {
-        this.extreme = low;
-        this.lastSar = this.previousCandle.high;
+        state.extreme = low;
+        state.lastSar = state.previousCandle.high;
       }
 
-      this.acceleration = this.accelerationStep;
-      this.prePreviousCandle = this.previousCandle;
-      this.previousCandle = candle;
+      state.acceleration = this.accelerationStep;
+      state.prePreviousCandle = state.previousCandle;
+      state.previousCandle = candle;
 
-      return this.setResult(this.lastSar, replace);
+      return this.setResult(state.lastSar, replace);
     }
 
     // Calculate SAR for the current period
-    let sar = (this.extreme! - this.lastSar) * this.acceleration + this.lastSar;
+    let sar = (state.extreme! - state.lastSar) * state.acceleration + state.lastSar;
 
     // Adjust SAR position if needed
-    if (this.isLong) {
+    if (state.isLong) {
       /*
        * Adjust SAR based on previous lows
        * If pre-previous candle exists and current low is less than SAR
        */
-      const hasPrevPrev = this.prePreviousCandle != null;
+      const hasPrevPrev = state.prePreviousCandle != null;
       if (hasPrevPrev && low < sar) {
         // Apply pre-previous low adjustment if needed
-        if (this.prePreviousCandle!.low < sar) {
-          sar = this.prePreviousCandle!.low;
+        if (state.prePreviousCandle!.low < sar) {
+          sar = state.prePreviousCandle!.low;
         }
 
         // Apply previous low adjustment
-        sar = this.previousCandle.low < sar ? this.previousCandle.low : sar;
+        sar = state.previousCandle.low < sar ? state.previousCandle.low : sar;
       }
       // No pre-previous candle, but check previous low
-      else if (this.previousCandle.low < sar) {
-        sar = this.previousCandle.low;
+      else if (state.previousCandle.low < sar) {
+        sar = state.previousCandle.low;
       }
 
       // Update acceleration factor and extreme point if price makes new high
-      if (high > this.extreme!) {
-        this.extreme = high;
-        if (this.acceleration < this.accelerationMax) {
-          this.acceleration += this.accelerationStep;
-          if (this.acceleration > this.accelerationMax) {
-            this.acceleration = this.accelerationMax;
+      if (high > state.extreme!) {
+        state.extreme = high;
+        if (state.acceleration < this.accelerationMax) {
+          state.acceleration += this.accelerationStep;
+          if (state.acceleration > this.accelerationMax) {
+            state.acceleration = this.accelerationMax;
           }
         }
       }
@@ -170,10 +147,10 @@ export class PSAR extends IndicatorSeries<HighLow<number>> {
       // Check if trend reverses (price falls below SAR)
       if (low < sar) {
         // Reverse to short
-        this.isLong = false;
-        sar = this.extreme!; // Set SAR to the extreme point
-        this.extreme = low; // Set new extreme to current low
-        this.acceleration = this.accelerationStep; // Reset acceleration
+        state.isLong = false;
+        sar = state.extreme!; // Set SAR to the extreme point
+        state.extreme = low; // Set new extreme to current low
+        state.acceleration = this.accelerationStep; // Reset acceleration
       }
     } else {
       /*
@@ -181,37 +158,37 @@ export class PSAR extends IndicatorSeries<HighLow<number>> {
        * Adjust SAR based on previous highs
        * If pre-previous candle exists and current high is greater than SAR
        */
-      const hasPrevPrev = this.prePreviousCandle != null;
+      const hasPrevPrev = state.prePreviousCandle != null;
       if (hasPrevPrev && high > sar) {
         // Apply pre-previous high adjustment if needed
-        if (this.prePreviousCandle!.high > sar) {
-          sar = this.prePreviousCandle!.high;
+        if (state.prePreviousCandle!.high > sar) {
+          sar = state.prePreviousCandle!.high;
         }
 
         // Apply previous high adjustment
-        sar = this.previousCandle.high > sar ? this.previousCandle.high : sar;
+        sar = state.previousCandle.high > sar ? state.previousCandle.high : sar;
       }
       // No pre-previous candle, but check previous high
-      else if (this.previousCandle.high > sar) {
-        sar = this.previousCandle.high;
+      else if (state.previousCandle.high > sar) {
+        sar = state.previousCandle.high;
       }
 
       // Update acceleration factor and extreme point if price makes new low
-      if (low < this.extreme!) {
-        this.extreme = low;
-        this.acceleration += this.accelerationStep;
-        if (this.acceleration > this.accelerationMax) {
-          this.acceleration = this.accelerationMax;
+      if (low < state.extreme!) {
+        state.extreme = low;
+        state.acceleration += this.accelerationStep;
+        if (state.acceleration > this.accelerationMax) {
+          state.acceleration = this.accelerationMax;
         }
       }
 
       // Check if trend reverses (price rises above SAR)
       if (high > sar) {
         // Reverse to long
-        this.isLong = true;
-        sar = this.extreme!; // Set SAR to the extreme point
-        this.extreme = high; // Set new extreme to current high
-        this.acceleration = this.accelerationStep; // Reset acceleration
+        state.isLong = true;
+        sar = state.extreme!; // Set SAR to the extreme point
+        state.extreme = high; // Set new extreme to current high
+        state.acceleration = this.accelerationStep; // Reset acceleration
 
         /*
          * Ensure the SAR is below the price in the uptrend by setting it slightly below the low
@@ -223,9 +200,9 @@ export class PSAR extends IndicatorSeries<HighLow<number>> {
       }
     }
 
-    this.lastSar = sar;
-    this.prePreviousCandle = this.previousCandle;
-    this.previousCandle = candle;
+    state.lastSar = sar;
+    state.prePreviousCandle = state.previousCandle;
+    state.previousCandle = candle;
 
     return this.setResult(sar, replace);
   }

--- a/packages/trading-signals/src/trend/RMA/RMA.test.ts
+++ b/packages/trading-signals/src/trend/RMA/RMA.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {RMA, NotEnoughDataError} from '../../index.js';
 
 describe('RMA', () => {
@@ -108,4 +109,10 @@ describe('RMA', () => {
       }
     });
   });
+});
+
+testReplaceContract({
+  create: () => new RMA(5),
+  divergentInput: 1_000,
+  inputs: [81.59, 81.06, 82.87, 83.0, 83.61, 83.15],
 });

--- a/packages/trading-signals/src/trend/RMA/RMA.test.ts
+++ b/packages/trading-signals/src/trend/RMA/RMA.test.ts
@@ -1,5 +1,5 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
-import {RMA, NotEnoughDataError} from '../../index.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {RMA} from '../../index.js';
 
 describe('RMA', () => {
   const prices = [
@@ -96,22 +96,10 @@ describe('RMA', () => {
       }
       expect(rma.getResultOrThrow().toFixed(2)).toBe('85.83');
     });
-
-    it('throws an error when there is not enough input data', () => {
-      const rma = new RMA(10);
-
-      try {
-        rma.getResultOrThrow();
-        throw new Error('Expected error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotEnoughDataError);
-        expect(rma.isStable).toBe(false);
-      }
-    });
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new RMA(5),
   divergentInput: 1_000,
   inputs: [81.59, 81.06, 82.87, 83.0, 83.61, 83.15],

--- a/packages/trading-signals/src/trend/SMA/SMA.test.ts
+++ b/packages/trading-signals/src/trend/SMA/SMA.test.ts
@@ -1,5 +1,5 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
-import {SMA, NotEnoughDataError} from '../../index.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {SMA} from '../../index.js';
 
 describe('SMA', () => {
   describe('prices', () => {
@@ -113,17 +113,6 @@ describe('SMA', () => {
       expect(sma.getRequiredInputs()).toBe(interval);
       expect(sma.getResultOrThrow()).toBe(86.804);
     });
-
-    it('throws an error when there is not enough input data', () => {
-      const sma = new SMA(5);
-
-      try {
-        sma.getResultOrThrow();
-        throw new Error('Expected error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotEnoughDataError);
-      }
-    });
   });
 
   describe('getRequiredInputs', () => {
@@ -146,7 +135,7 @@ describe('SMA', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new SMA(3),
   divergentInput: 1_000,
   inputs: [10, 20, 30, 40, 50],

--- a/packages/trading-signals/src/trend/SMA/SMA.test.ts
+++ b/packages/trading-signals/src/trend/SMA/SMA.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {SMA, NotEnoughDataError} from '../../index.js';
 
 describe('SMA', () => {
@@ -143,4 +144,10 @@ describe('SMA', () => {
       expect(sma.getResult()).toBe(expected);
     });
   });
+});
+
+testReplaceContract({
+  create: () => new SMA(3),
+  divergentInput: 1_000,
+  inputs: [10, 20, 30, 40, 50],
 });

--- a/packages/trading-signals/src/trend/SMA/SMA.ts
+++ b/packages/trading-signals/src/trend/SMA/SMA.ts
@@ -18,7 +18,7 @@ export class SMA extends MovingAverage {
   }
 
   update(price: number, replace: boolean) {
-    pushUpdate(this.prices, replace, price, this.interval);
+    pushUpdate({array: this.prices, item: price, maxLength: this.interval, replace: replace});
 
     if (this.prices.length === this.interval) {
       return this.setResult(getAverage(this.prices), replace);

--- a/packages/trading-signals/src/trend/SMA15/SMA15.test.ts
+++ b/packages/trading-signals/src/trend/SMA15/SMA15.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {SMA15, NotEnoughDataError} from '../../index.js';
 
 describe('SMA15', () => {
@@ -79,4 +80,10 @@ describe('SMA15', () => {
       }
     });
   });
+});
+
+testReplaceContract({
+  create: () => new SMA15(15),
+  divergentInput: 1_000,
+  inputs: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
 });

--- a/packages/trading-signals/src/trend/SMA15/SMA15.test.ts
+++ b/packages/trading-signals/src/trend/SMA15/SMA15.test.ts
@@ -1,5 +1,5 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
-import {SMA15, NotEnoughDataError} from '../../index.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {SMA15} from '../../index.js';
 
 describe('SMA15', () => {
   describe('prices', () => {
@@ -66,23 +66,9 @@ describe('SMA15', () => {
       expect(sma15.isStable).toBe(true);
     });
   });
-
-  describe('getResultOrThrow', () => {
-    it('throws an error when there is not enough input data', () => {
-      const interval = 15;
-      const sma15 = new SMA15(interval);
-
-      try {
-        sma15.getResultOrThrow();
-        throw new Error('Expected error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotEnoughDataError);
-      }
-    });
-  });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new SMA15(15),
   divergentInput: 1_000,
   inputs: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],

--- a/packages/trading-signals/src/trend/SMA15/SMA15.ts
+++ b/packages/trading-signals/src/trend/SMA15/SMA15.ts
@@ -24,7 +24,7 @@ export class SMA15 extends MovingAverage {
   }
 
   update(price: number, replace: boolean) {
-    pushUpdate(this.prices, replace, price, this.getRequiredInputs());
+    pushUpdate({array: this.prices, item: price, maxLength: this.getRequiredInputs(), replace: replace});
 
     if (this.prices.length === this.getRequiredInputs()) {
       let weightedPricesSum = 0;

--- a/packages/trading-signals/src/trend/SUPERTREND/SuperTrend.test.ts
+++ b/packages/trading-signals/src/trend/SUPERTREND/SuperTrend.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {SuperTrend} from './SuperTrend.js';
 import {NotEnoughDataError} from '../../error/index.js';
 
@@ -125,4 +126,21 @@ describe('SuperTrend', () => {
       }
     });
   });
+});
+
+testReplaceContract({
+  create: () => new SuperTrend({interval: 5, multiplier: 2}),
+  divergentInput: {close: 10, high: 90, low: 9},
+  inputs: [
+    {close: 81, high: 82, low: 80},
+    {close: 82, high: 83, low: 81},
+    {close: 83, high: 84, low: 82},
+    {close: 84, high: 85, low: 83},
+    {close: 85, high: 86, low: 84},
+    {close: 86, high: 87, low: 85},
+    {close: 87, high: 88, low: 86},
+    {close: 90.5, high: 91, low: 87},
+    {close: 91, high: 92, low: 89},
+    {close: 92, high: 93, low: 90},
+  ],
 });

--- a/packages/trading-signals/src/trend/SUPERTREND/SuperTrend.test.ts
+++ b/packages/trading-signals/src/trend/SUPERTREND/SuperTrend.test.ts
@@ -1,6 +1,5 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {SuperTrend} from './SuperTrend.js';
-import {NotEnoughDataError} from '../../error/index.js';
 
 describe('SuperTrend', () => {
   /*
@@ -114,21 +113,10 @@ describe('SuperTrend', () => {
       expect(result?.supertrend.toFixed(3)).toBe('10.025');
       expect(result?.trend).toBe('BULLISH');
     });
-
-    it('throws an error when there is not enough input data', () => {
-      const supertrend = new SuperTrend({interval: 5, multiplier: 2});
-
-      try {
-        supertrend.getResultOrThrow();
-        throw new Error('Expected error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotEnoughDataError);
-      }
-    });
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new SuperTrend({interval: 5, multiplier: 2}),
   divergentInput: {close: 10, high: 90, low: 9},
   inputs: [

--- a/packages/trading-signals/src/trend/SWING_HIGH/SwingHigh.test.ts
+++ b/packages/trading-signals/src/trend/SWING_HIGH/SwingHigh.test.ts
@@ -1,5 +1,4 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
-import {NotEnoughDataError} from '../../error/NotEnoughDataError.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {SwingLookback} from '../SWING_LOW/SwingLookback.js';
 import {SwingHigh} from './SwingHigh.js';
 
@@ -96,16 +95,6 @@ describe('SwingHigh', () => {
 
       expect(detected).toEqual([20]);
     });
-
-    it('throws when accessed before enough data has been added', () => {
-      const swingHigh = new SwingHigh({lookback: SwingLookback.BILL_WILLIAMS});
-
-      swingHigh.add({high: 4, low: 2});
-      swingHigh.add({high: 6, low: 4});
-
-      expect(() => swingHigh.getResultOrThrow()).toThrow(NotEnoughDataError);
-      expect(swingHigh.isStable).toBe(false);
-    });
   });
 
   describe('replace', () => {
@@ -153,7 +142,7 @@ describe('SwingHigh', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new SwingHigh({lookback: SwingLookback.BILL_WILLIAMS}),
   divergentInput: {high: 1_000, low: 998},
   inputs: [

--- a/packages/trading-signals/src/trend/SWING_HIGH/SwingHigh.test.ts
+++ b/packages/trading-signals/src/trend/SWING_HIGH/SwingHigh.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {NotEnoughDataError} from '../../error/NotEnoughDataError.js';
 import {SwingLookback} from '../SWING_LOW/SwingLookback.js';
 import {SwingHigh} from './SwingHigh.js';
@@ -150,4 +151,17 @@ describe('SwingHigh', () => {
       expect(swingHigh.getRequiredInputs()).toBe(11);
     });
   });
+});
+
+testReplaceContract({
+  create: () => new SwingHigh({lookback: SwingLookback.BILL_WILLIAMS}),
+  divergentInput: {high: 1_000, low: 998},
+  inputs: [
+    {high: 3, low: 1},
+    {high: 4, low: 2},
+    {high: 6, low: 4},
+    {high: 9, low: 7},
+    {high: 7, low: 5},
+    {high: 5, low: 3},
+  ],
 });

--- a/packages/trading-signals/src/trend/SWING_HIGH/SwingHigh.ts
+++ b/packages/trading-signals/src/trend/SWING_HIGH/SwingHigh.ts
@@ -43,7 +43,7 @@ export class SwingHigh extends IndicatorSeries<HighLow> {
     }
     this.#lastEmitted = false;
 
-    pushUpdate(this.#window, replace, candle.high, this.getRequiredInputs());
+    pushUpdate({array: this.#window, item: candle.high, maxLength: this.getRequiredInputs(), replace: replace});
 
     if (this.#window.length < this.getRequiredInputs()) {
       return null;

--- a/packages/trading-signals/src/trend/SWING_LOW/SwingLow.test.ts
+++ b/packages/trading-signals/src/trend/SWING_LOW/SwingLow.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {NotEnoughDataError} from '../../error/NotEnoughDataError.js';
 import {SwingLookback} from './SwingLookback.js';
 import {SwingLow} from './SwingLow.js';
@@ -150,4 +151,17 @@ describe('SwingLow', () => {
       expect(swingLow.getRequiredInputs()).toBe(11);
     });
   });
+});
+
+testReplaceContract({
+  create: () => new SwingLow({lookback: SwingLookback.BILL_WILLIAMS}),
+  divergentInput: {high: 2, low: 1},
+  inputs: [
+    {high: 12, low: 11},
+    {high: 11, low: 10},
+    {high: 9, low: 8},
+    {high: 6, low: 5},
+    {high: 8, low: 7},
+    {high: 10, low: 9},
+  ],
 });

--- a/packages/trading-signals/src/trend/SWING_LOW/SwingLow.test.ts
+++ b/packages/trading-signals/src/trend/SWING_LOW/SwingLow.test.ts
@@ -1,5 +1,4 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
-import {NotEnoughDataError} from '../../error/NotEnoughDataError.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {SwingLookback} from './SwingLookback.js';
 import {SwingLow} from './SwingLow.js';
 
@@ -96,16 +95,6 @@ describe('SwingLow', () => {
 
       expect(detected).toEqual([10]);
     });
-
-    it('throws when accessed before enough data has been added', () => {
-      const swingLow = new SwingLow({lookback: SwingLookback.BILL_WILLIAMS});
-
-      swingLow.add({high: 11, low: 10});
-      swingLow.add({high: 9, low: 8});
-
-      expect(() => swingLow.getResultOrThrow()).toThrow(NotEnoughDataError);
-      expect(swingLow.isStable).toBe(false);
-    });
   });
 
   describe('replace', () => {
@@ -153,7 +142,7 @@ describe('SwingLow', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new SwingLow({lookback: SwingLookback.BILL_WILLIAMS}),
   divergentInput: {high: 2, low: 1},
   inputs: [

--- a/packages/trading-signals/src/trend/SWING_LOW/SwingLow.ts
+++ b/packages/trading-signals/src/trend/SWING_LOW/SwingLow.ts
@@ -48,7 +48,7 @@ export class SwingLow extends IndicatorSeries<HighLow> {
     }
     this.#lastEmitted = false;
 
-    pushUpdate(this.#window, replace, candle.low, this.getRequiredInputs());
+    pushUpdate({array: this.#window, item: candle.low, maxLength: this.getRequiredInputs(), replace: replace});
 
     if (this.#window.length < this.getRequiredInputs()) {
       return null;

--- a/packages/trading-signals/src/trend/TEMA/TEMA.test.ts
+++ b/packages/trading-signals/src/trend/TEMA/TEMA.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {TEMA} from './TEMA.js';
 import {NotEnoughDataError} from '../../error/index.js';
 
@@ -64,4 +65,10 @@ describe('TEMA', () => {
       }
     });
   });
+});
+
+testReplaceContract({
+  create: () => new TEMA(5),
+  divergentInput: 1_000,
+  inputs: [81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84, 83.99, 84.55, 84.36, 85.53, 86.54, 86.89, 87.77, 87.29],
 });

--- a/packages/trading-signals/src/trend/TEMA/TEMA.test.ts
+++ b/packages/trading-signals/src/trend/TEMA/TEMA.test.ts
@@ -1,6 +1,5 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {TEMA} from './TEMA.js';
-import {NotEnoughDataError} from '../../error/index.js';
 
 describe('TEMA', () => {
   /*
@@ -53,21 +52,10 @@ describe('TEMA', () => {
       expect(tema.isStable).toBe(true);
       expect(tema.getRequiredInputs()).toBe(13);
     });
-
-    it('throws an error when there is not enough input data', () => {
-      const tema = new TEMA(5);
-
-      try {
-        tema.getResultOrThrow();
-        throw new Error('Expected error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotEnoughDataError);
-      }
-    });
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new TEMA(5),
   divergentInput: 1_000,
   inputs: [81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84, 83.99, 84.55, 84.36, 85.53, 86.54, 86.89, 87.77, 87.29],

--- a/packages/trading-signals/src/trend/VSTOP/VolatilityStop.test.ts
+++ b/packages/trading-signals/src/trend/VSTOP/VolatilityStop.test.ts
@@ -1,6 +1,5 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {VolatilityStop} from './VolatilityStop.js';
-import {NotEnoughDataError} from '../../error/index.js';
 
 describe('VolatilityStop', () => {
   /*
@@ -97,21 +96,10 @@ describe('VolatilityStop', () => {
       expect(vstop.getRequiredInputs()).toBe(5);
       expect(vstop.multiplier).toBe(3.5);
     });
-
-    it('throws an error when there is not enough input data', () => {
-      const vstop = new VolatilityStop({interval: 5, multiplier: 1});
-
-      try {
-        vstop.getResultOrThrow();
-        throw new Error('Expected error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotEnoughDataError);
-      }
-    });
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new VolatilityStop({interval: 5, multiplier: 1}),
   divergentInput: {close: 1, high: 14, low: 0.5},
   inputs: [

--- a/packages/trading-signals/src/trend/VSTOP/VolatilityStop.test.ts
+++ b/packages/trading-signals/src/trend/VSTOP/VolatilityStop.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {VolatilityStop} from './VolatilityStop.js';
 import {NotEnoughDataError} from '../../error/index.js';
 
@@ -108,4 +109,23 @@ describe('VolatilityStop', () => {
       }
     });
   });
+});
+
+testReplaceContract({
+  create: () => new VolatilityStop({interval: 5, multiplier: 1}),
+  divergentInput: {close: 1, high: 14, low: 0.5},
+  inputs: [
+    {close: 10, high: 11, low: 9},
+    {close: 11, high: 12, low: 10},
+    {close: 12, high: 13, low: 11},
+    {close: 13, high: 14, low: 12},
+    {close: 14, high: 15, low: 13},
+    {close: 15, high: 16, low: 14},
+    {close: 14.5, high: 15.5, low: 13.5},
+    {close: 10, high: 15, low: 9.5},
+    {close: 9, high: 10, low: 8},
+    {close: 9.5, high: 10.5, low: 8.5},
+    {close: 13, high: 13.5, low: 9},
+    {close: 14, high: 15, low: 13},
+  ],
 });

--- a/packages/trading-signals/src/trend/VWAP/VWAP.test.ts
+++ b/packages/trading-signals/src/trend/VWAP/VWAP.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {VWAP} from './VWAP.js';
 
 // @see https://github.com/cinar/indicatorts/blob/main/src/indicator/volume/volumeWeightedAveragePrice.test.ts
@@ -62,4 +63,16 @@ describe('VWAP', () => {
       expect(vwap.getResultOrThrow().toFixed(2)).toBe('9.18');
     });
   });
+});
+
+testReplaceContract({
+  create: () => new VWAP(),
+  divergentInput: {close: 1_000, high: 1_000, low: 1_000, volume: 1_000},
+  inputs: [
+    {close: 9, high: 9, low: 9, volume: 100},
+    {close: 11, high: 11, low: 11, volume: 110},
+    {close: 7, high: 7, low: 7, volume: 80},
+    {close: 10, high: 10, low: 10, volume: 120},
+    {close: 8, high: 8, low: 8, volume: 90},
+  ],
 });

--- a/packages/trading-signals/src/trend/VWAP/VWAP.test.ts
+++ b/packages/trading-signals/src/trend/VWAP/VWAP.test.ts
@@ -1,4 +1,4 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {VWAP} from './VWAP.js';
 
 // @see https://github.com/cinar/indicatorts/blob/main/src/indicator/volume/volumeWeightedAveragePrice.test.ts
@@ -59,13 +59,13 @@ describe('VWAP', () => {
         expect(result?.toFixed(2)).toBe(expected[index]);
       }
 
-      expect(vwap.getRequiredInputs()).toBe(2);
+      expect(vwap.getRequiredInputs()).toBe(1);
       expect(vwap.getResultOrThrow().toFixed(2)).toBe('9.18');
     });
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new VWAP(),
   divergentInput: {close: 1_000, high: 1_000, low: 1_000, volume: 1_000},
   inputs: [

--- a/packages/trading-signals/src/trend/VWAP/VWAP.ts
+++ b/packages/trading-signals/src/trend/VWAP/VWAP.ts
@@ -26,7 +26,7 @@ export class VWAP extends IndicatorSeries<HighLowCloseVolume<number>> {
   }
 
   override getRequiredInputs() {
-    return 2;
+    return 1;
   }
 
   override update(candle: HighLowCloseVolume<number>, replace: boolean) {

--- a/packages/trading-signals/src/trend/WMA/WMA.test.ts
+++ b/packages/trading-signals/src/trend/WMA/WMA.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {WMA, NotEnoughDataError} from '../../index.js';
 
 describe('WMA', () => {
@@ -123,4 +124,10 @@ describe('WMA', () => {
       }
     });
   });
+});
+
+testReplaceContract({
+  create: () => new WMA(3),
+  divergentInput: 1_000,
+  inputs: [11, 12, 13, 14, 15],
 });

--- a/packages/trading-signals/src/trend/WMA/WMA.test.ts
+++ b/packages/trading-signals/src/trend/WMA/WMA.test.ts
@@ -1,5 +1,5 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
-import {WMA, NotEnoughDataError} from '../../index.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {WMA} from '../../index.js';
 
 describe('WMA', () => {
   describe('prices', () => {
@@ -112,21 +112,10 @@ describe('WMA', () => {
 
       expect(wma.isStable).toBe(true);
     });
-
-    it('throws an error when there is not enough input data', () => {
-      const wma = new WMA(5);
-
-      try {
-        wma.getResultOrThrow();
-        throw new Error('Expected error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotEnoughDataError);
-      }
-    });
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new WMA(3),
   divergentInput: 1_000,
   inputs: [11, 12, 13, 14, 15],

--- a/packages/trading-signals/src/trend/WMA/WMA.ts
+++ b/packages/trading-signals/src/trend/WMA/WMA.ts
@@ -23,7 +23,7 @@ export class WMA extends MovingAverage {
   }
 
   update(price: number, replace: boolean) {
-    pushUpdate(this.prices, replace, price, this.interval);
+    pushUpdate({array: this.prices, item: price, maxLength: this.interval, replace: replace});
 
     if (this.prices.length === this.interval) {
       const weightedPricesSum = this.prices.reduce((acc: number, price: number, index: number) => {

--- a/packages/trading-signals/src/trend/WSMA/WSMA.test.ts
+++ b/packages/trading-signals/src/trend/WSMA/WSMA.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {WSMA} from './WSMA.js';
 import {NotEnoughDataError} from '../../error/index.js';
 
@@ -162,4 +163,10 @@ describe('WSMA', () => {
       expect(wsma.isStable).toBe(true);
     });
   });
+});
+
+testReplaceContract({
+  create: () => new WSMA(3),
+  divergentInput: 1_000,
+  inputs: [11, 12, 13, 14, 15],
 });

--- a/packages/trading-signals/src/trend/WSMA/WSMA.test.ts
+++ b/packages/trading-signals/src/trend/WSMA/WSMA.test.ts
@@ -1,6 +1,5 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {WSMA} from './WSMA.js';
-import {NotEnoughDataError} from '../../error/index.js';
 
 describe('WSMA', () => {
   describe('replace', () => {
@@ -115,30 +114,6 @@ describe('WSMA', () => {
       expect(wsma.isStable).toBe(true);
       expect(wsma.getResultOrThrow().toFixed(4)).toBe('62.8540');
     });
-
-    it('throws an error when there is no input data', () => {
-      const wsma = new WSMA(3);
-
-      try {
-        wsma.getResultOrThrow();
-        throw new Error('Expected error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotEnoughDataError);
-      }
-    });
-
-    it('throws an error when there is not enough input data', () => {
-      const wsma = new WSMA(3);
-      wsma.add(1);
-      wsma.add(2);
-
-      try {
-        wsma.getResultOrThrow();
-        throw new Error('Expected error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotEnoughDataError);
-      }
-    });
   });
 
   describe('updates', () => {
@@ -165,7 +140,7 @@ describe('WSMA', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new WSMA(3),
   divergentInput: 1_000,
   inputs: [11, 12, 13, 14, 15],

--- a/packages/trading-signals/src/trend/ZIGZAG/ZigZag.test.ts
+++ b/packages/trading-signals/src/trend/ZIGZAG/ZigZag.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {ZigZag} from './ZigZag.js';
 
 describe('ZigZag', () => {
@@ -128,4 +129,31 @@ describe('ZigZag', () => {
       expect(zigzag.getRequiredInputs()).toBe(expected);
     });
   });
+});
+
+testReplaceContract({
+  create: () => new ZigZag({deviation: 15}),
+  divergentInput: {high: 60, low: 1},
+  inputs: [
+    {high: -8, low: -9},
+    {high: -4, low: -5},
+    {high: -1, low: -2},
+    {high: 9, low: 8},
+    {high: 8, low: 7},
+    {high: 7, low: 6},
+    {high: 6, low: 5},
+    {high: 5, low: 4},
+    {high: 4, low: 3},
+    {high: 3, low: 2},
+    {high: 2, low: 1},
+    {high: 1, low: 0},
+    {high: 11, low: 10},
+    {high: 22, low: 20},
+    {high: 33, low: 30},
+    {high: 44, low: 40},
+    {high: 55, low: 50},
+    {high: 66, low: 60},
+    {high: 77, low: 70},
+    {high: 88, low: 80},
+  ],
 });

--- a/packages/trading-signals/src/trend/ZIGZAG/ZigZag.test.ts
+++ b/packages/trading-signals/src/trend/ZIGZAG/ZigZag.test.ts
@@ -30,14 +30,7 @@ describe('ZigZag', () => {
         };
       });
 
-      const results = [];
-
-      for (const candle of candles) {
-        const result = zigzag.add(candle);
-        if (result !== null) {
-          results.push(result);
-        }
-      }
+      const results = zigzag.updates(candles).filter(result => result !== null);
 
       expect(results).toEqual(expected);
     });
@@ -54,28 +47,14 @@ describe('ZigZag', () => {
 
     const candles = highs.map((high, index) => ({high, low: lows[index]}));
 
-    function collect(zigzag: ZigZag, inputs: readonly {high: number; low: number}[]) {
-      const results: number[] = [];
-
-      for (const candle of inputs) {
-        const result = zigzag.add(candle);
-
-        if (result !== null) {
-          results.push(result);
-        }
-      }
-
-      return results;
-    }
-
     it('reproduces an add-only series after a replacement', () => {
       const replaced = new ZigZag({deviation: 15});
-      collect(replaced, candles.slice(0, -1));
+      replaced.updates(candles.slice(0, -1));
       replaced.add({high: 500, low: 400});
       replaced.replace(candles[candles.length - 1]);
 
       const reference = new ZigZag({deviation: 15});
-      collect(reference, candles);
+      reference.updates(candles);
 
       expect(replaced.getResult(), 'a replacement must undo the state the decoy candle left behind').toBe(
         reference.getResult()
@@ -99,7 +78,7 @@ describe('ZigZag', () => {
       for (let length = 1; length <= candles.length; length++) {
         const zigzag = new ZigZag({deviation: 15});
 
-        collect(zigzag, candles.slice(0, length));
+        zigzag.updates(candles.slice(0, length));
 
         const resultBefore = zigzag.getResult();
 
@@ -112,7 +91,7 @@ describe('ZigZag', () => {
     it('keeps an earlier pivot when the replaced candle reversed nothing', () => {
       const zigzag = new ZigZag({deviation: 15});
 
-      collect(zigzag, candles.slice(0, 20));
+      zigzag.updates(candles.slice(0, 20));
 
       const pivot = zigzag.getResult();
 
@@ -128,7 +107,7 @@ describe('ZigZag', () => {
     it('takes back a pivot when the replacement no longer reverses the trend', () => {
       const zigzag = new ZigZag({deviation: 15});
 
-      collect(zigzag, candles.slice(0, 20));
+      zigzag.updates(candles.slice(0, 20));
 
       const resultBeforeReversal = zigzag.getResult();
 

--- a/packages/trading-signals/src/trend/ZIGZAG/ZigZag.test.ts
+++ b/packages/trading-signals/src/trend/ZIGZAG/ZigZag.test.ts
@@ -1,4 +1,4 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {ZigZag} from './ZigZag.js';
 
 describe('ZigZag', () => {
@@ -131,7 +131,7 @@ describe('ZigZag', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new ZigZag({deviation: 15}),
   divergentInput: {high: 60, low: 1},
   inputs: [

--- a/packages/trading-signals/src/trend/ZIGZAG/ZigZag.test.ts
+++ b/packages/trading-signals/src/trend/ZIGZAG/ZigZag.test.ts
@@ -43,6 +43,105 @@ describe('ZigZag', () => {
     });
   });
 
+  describe('replace', () => {
+    const highs = [
+      -8, -4, -1, 9, 8, 7, 6, 5, 4, 3, 2, 1, 11, 22, 33, 44, 55, 66, 77, 88, 88, 71, 61, 51, 41, 51, 61, 71, 81, 91,
+    ] as const;
+
+    const lows = [
+      -9, -5, -2, 8, 7, 6, 5, 4, 3, 2, 1, 0, 10, 20, 30, 40, 50, 60, 70, 80, 85, 70, 60, 50, 40, 50, 60, 70, 80, 90,
+    ] as const;
+
+    const candles = highs.map((high, index) => ({high, low: lows[index]}));
+
+    function collect(zigzag: ZigZag, inputs: readonly {high: number; low: number}[]) {
+      const results: number[] = [];
+
+      for (const candle of inputs) {
+        const result = zigzag.add(candle);
+
+        if (result !== null) {
+          results.push(result);
+        }
+      }
+
+      return results;
+    }
+
+    it('reproduces an add-only series after a replacement', () => {
+      const replaced = new ZigZag({deviation: 15});
+      collect(replaced, candles.slice(0, -1));
+      replaced.add({high: 500, low: 400});
+      replaced.replace(candles[candles.length - 1]);
+
+      const reference = new ZigZag({deviation: 15});
+      collect(reference, candles);
+
+      expect(replaced.getResult(), 'a replacement must undo the state the decoy candle left behind').toBe(
+        reference.getResult()
+      );
+    });
+
+    it('treats a replacement before any candle like a first candle', () => {
+      const candle = {high: 9, low: -9} as const;
+
+      const replacedFirst = new ZigZag({deviation: 15});
+      const addedFirst = new ZigZag({deviation: 15});
+
+      expect(
+        replacedFirst.replace(candle),
+        'with no candle to roll back to, a replacement is just the first candle'
+      ).toBe(addedFirst.add(candle));
+    });
+
+    it('changes nothing when the latest candle is replaced with the same values', () => {
+      // Swept over every length because the swing state only diverges at some of them.
+      for (let length = 1; length <= candles.length; length++) {
+        const zigzag = new ZigZag({deviation: 15});
+
+        collect(zigzag, candles.slice(0, length));
+
+        const resultBefore = zigzag.getResult();
+
+        zigzag.replace(candles[length - 1]);
+
+        expect(zigzag.getResult(), `replacing candle ${length} with itself is a no-op`).toBe(resultBefore);
+      }
+    });
+
+    it('keeps an earlier pivot when the replaced candle reversed nothing', () => {
+      const zigzag = new ZigZag({deviation: 15});
+
+      collect(zigzag, candles.slice(0, 20));
+
+      const pivot = zigzag.getResult();
+
+      expect(pivot, 'the series has already reported a pivot').not.toBeNull();
+
+      // Neither candle reverses the trend, so the earlier pivot stands.
+      expect(zigzag.add({high: 89, low: 86}), 'a quiet candle reports nothing').toBeNull();
+      expect(zigzag.replace({high: 90, low: 87}), 'nor does its replacement').toBeNull();
+
+      expect(zigzag.getResult(), 'replacing a candle that reported nothing must not drop an older pivot').toBe(pivot);
+    });
+
+    it('takes back a pivot when the replacement no longer reverses the trend', () => {
+      const zigzag = new ZigZag({deviation: 15});
+
+      collect(zigzag, candles.slice(0, 20));
+
+      const resultBeforeReversal = zigzag.getResult();
+
+      // A deep low reverses the uptrend and reports the highest extreme as a pivot.
+      expect(zigzag.add({high: 88, low: 10}), 'a deep low ends the uptrend and emits the swing high').toBe(88);
+
+      // Replacing it with a quiet candle means no reversal happened after all.
+      zigzag.replace({high: 88, low: 85});
+
+      expect(zigzag.getResult(), 'the withdrawn pivot must not linger').toBe(resultBeforeReversal);
+    });
+  });
+
   describe('getRequiredInputs', () => {
     it('returns the amount of required data needed for a calculation', () => {
       const expected = 1;

--- a/packages/trading-signals/src/trend/ZIGZAG/ZigZag.ts
+++ b/packages/trading-signals/src/trend/ZIGZAG/ZigZag.ts
@@ -10,6 +10,16 @@ export type ZigZagConfig = {
 };
 
 /**
+ * The swing state {@link ZigZag.update} carries between candles. Capturing it lets a replacement
+ * re-run the latest candle from the state that candle originally saw.
+ */
+type ZigZagState = {
+  highestExtreme: number | null;
+  isUp: boolean;
+  lowestExtreme: number | null;
+};
+
+/**
  * ZigZag Indicator (ZigZag)
  * Type: Trend
  *
@@ -29,6 +39,12 @@ export class ZigZag extends IndicatorSeries<HighLow> {
   #isUp: boolean = false;
   #highestExtreme: number | null = null;
   #lowestExtreme: number | null = null;
+  #previousState: ZigZagState | null = null;
+  /**
+   * Whether the latest candle reversed the trend. ZigZag emits only on a reversal and its result
+   * persists in between, so only a candle that emitted may withdraw that pivot when replaced.
+   */
+  #lastCandleReversed: boolean = false;
 
   constructor(config: ZigZagConfig) {
     super();
@@ -42,6 +58,25 @@ export class ZigZag extends IndicatorSeries<HighLow> {
   update(candle: HighLow<number>, replace: boolean): number | null {
     const low = candle.low;
     const high = candle.high;
+
+    if (replace) {
+      if (this.#previousState !== null) {
+        this.#isUp = this.#previousState.isUp;
+        this.#highestExtreme = this.#previousState.highestExtreme;
+        this.#lowestExtreme = this.#previousState.lowestExtreme;
+      }
+      if (this.#lastCandleReversed) {
+        this.rollbackLastResult();
+      }
+    } else {
+      this.#previousState = {
+        highestExtreme: this.#highestExtreme,
+        isUp: this.#isUp,
+        lowestExtreme: this.#lowestExtreme,
+      };
+    }
+
+    this.#lastCandleReversed = false;
 
     if (this.#lowestExtreme === null) {
       this.#lowestExtreme = low;
@@ -60,6 +95,7 @@ export class ZigZag extends IndicatorSeries<HighLow> {
       } else if (low < uptrendReversal) {
         this.#isUp = false;
         this.#lowestExtreme = low;
+        this.#lastCandleReversed = true;
         return this.setResult(this.#highestExtreme, replace);
       }
     } else {
@@ -70,6 +106,7 @@ export class ZigZag extends IndicatorSeries<HighLow> {
       } else if (high > downtrendReversal) {
         this.#isUp = true;
         this.#highestExtreme = high;
+        this.#lastCandleReversed = true;
         return this.setResult(this.#lowestExtreme, replace);
       }
     }

--- a/packages/trading-signals/src/trend/ZIGZAG/ZigZag.ts
+++ b/packages/trading-signals/src/trend/ZIGZAG/ZigZag.ts
@@ -10,12 +10,17 @@ export type ZigZagConfig = {
 };
 
 /**
- * The swing state {@link ZigZag.update} carries between candles. Capturing it lets a replacement
- * re-run the latest candle from the state that candle originally saw.
+ * The swing state {@link ZigZag.update} carries between candles. Held in the base-class state
+ * container so a replacement re-runs the latest candle from the state that candle originally saw.
  */
 type ZigZagState = {
   highestExtreme: number | null;
   isUp: boolean;
+  /*
+   * Whether the latest candle reversed the trend. ZigZag emits only on a reversal and its result
+   * persists in between, so only a candle that emitted may withdraw that pivot when replaced.
+   */
+  lastCandleReversedTrend: boolean;
   lowestExtreme: number | null;
 };
 
@@ -34,17 +39,14 @@ type ZigZagState = {
  * @see https://capex.com/en/academy/zigzag
  * @see https://corporatefinanceinstitute.com/resources/career-map/sell-side/capital-markets/zig-zag-indicator/
  */
-export class ZigZag extends IndicatorSeries<HighLow> {
+export class ZigZag extends IndicatorSeries<HighLow, ZigZagState> {
   readonly #deviation: number;
-  #isUp: boolean = false;
-  #highestExtreme: number | null = null;
-  #lowestExtreme: number | null = null;
-  #previousState: ZigZagState | null = null;
-  /**
-   * Whether the latest candle reversed the trend. ZigZag emits only on a reversal and its result
-   * persists in between, so only a candle that emitted may withdraw that pivot when replaced.
-   */
-  #lastCandleReversed: boolean = false;
+  protected override state: ZigZagState = {
+    highestExtreme: null,
+    isUp: false,
+    lastCandleReversedTrend: false,
+    lowestExtreme: null,
+  };
 
   constructor(config: ZigZagConfig) {
     super();
@@ -59,55 +61,47 @@ export class ZigZag extends IndicatorSeries<HighLow> {
     const low = candle.low;
     const high = candle.high;
 
-    if (replace) {
-      if (this.#previousState !== null) {
-        this.#isUp = this.#previousState.isUp;
-        this.#highestExtreme = this.#previousState.highestExtreme;
-        this.#lowestExtreme = this.#previousState.lowestExtreme;
-      }
-      if (this.#lastCandleReversed) {
-        this.rollbackLastResult();
-      }
-    } else {
-      this.#previousState = {
-        highestExtreme: this.#highestExtreme,
-        isUp: this.#isUp,
-        lowestExtreme: this.#lowestExtreme,
-      };
+    // Read before trackState() rewinds the flag to what the candle before the replaced one found
+    if (replace && this.state.lastCandleReversedTrend) {
+      this.rollbackLastResult();
     }
 
-    this.#lastCandleReversed = false;
+    this.trackState(replace);
 
-    if (this.#lowestExtreme === null) {
-      this.#lowestExtreme = low;
+    const state = this.state;
+
+    state.lastCandleReversedTrend = false;
+
+    if (state.lowestExtreme === null) {
+      state.lowestExtreme = low;
     }
 
-    if (this.#highestExtreme === null) {
-      this.#highestExtreme = high;
+    if (state.highestExtreme === null) {
+      state.highestExtreme = high;
     }
 
-    if (this.#isUp) {
+    if (state.isUp) {
       const uptrendReversal =
-        this.#lowestExtreme + ((this.#highestExtreme - this.#lowestExtreme) * (100 - this.#deviation)) / 100;
+        state.lowestExtreme + ((state.highestExtreme - state.lowestExtreme) * (100 - this.#deviation)) / 100;
 
-      if (high > this.#highestExtreme) {
-        this.#highestExtreme = high;
+      if (high > state.highestExtreme) {
+        state.highestExtreme = high;
       } else if (low < uptrendReversal) {
-        this.#isUp = false;
-        this.#lowestExtreme = low;
-        this.#lastCandleReversed = true;
-        return this.setResult(this.#highestExtreme, replace);
+        state.isUp = false;
+        state.lowestExtreme = low;
+        state.lastCandleReversedTrend = true;
+        return this.setResult(state.highestExtreme, replace);
       }
     } else {
-      const downtrendReversal = low + ((this.#highestExtreme - low) * this.#deviation) / 100;
+      const downtrendReversal = low + ((state.highestExtreme - low) * this.#deviation) / 100;
 
-      if (low < this.#lowestExtreme) {
-        this.#lowestExtreme = low;
+      if (low < state.lowestExtreme) {
+        state.lowestExtreme = low;
       } else if (high > downtrendReversal) {
-        this.#isUp = true;
-        this.#highestExtreme = high;
-        this.#lastCandleReversed = true;
-        return this.setResult(this.#lowestExtreme, replace);
+        state.isUp = true;
+        state.highestExtreme = high;
+        state.lastCandleReversedTrend = true;
+        return this.setResult(state.lowestExtreme, replace);
       }
     }
 

--- a/packages/trading-signals/src/trend/ZIGZAG/ZigZag.ts
+++ b/packages/trading-signals/src/trend/ZIGZAG/ZigZag.ts
@@ -16,7 +16,7 @@ export type ZigZagConfig = {
 type ZigZagState = {
   highestExtreme: number | null;
   isUp: boolean;
-  /*
+  /**
    * Whether the latest candle reversed the trend. ZigZag emits only on a reversal and its result
    * persists in between, so only a candle that emitted may withdraw that pivot when replaced.
    */

--- a/packages/trading-signals/src/util/pushUpdate.ts
+++ b/packages/trading-signals/src/util/pushUpdate.ts
@@ -1,8 +1,19 @@
+type PushUpdateOptions<T> = {
+  /** Array that receives the item; mutated in place */
+  array: T[];
+  /** Item to append, or to overwrite the last element with */
+  item: T;
+  /** Size at which the array should be capped */
+  maxLength: number;
+  /** Overwrite the last element instead of appending */
+  replace: boolean;
+};
+
 /**
  * Adds an item to the array or replaces the last item in the array.
  * If the array limit size is exceeded, the oldest array element will be removed and returned by the function.
  */
-export function pushUpdate<T>(array: T[], replace: boolean, item: T, maxLength: number) {
+export function pushUpdate<T>({array, item, maxLength, replace}: PushUpdateOptions<T>) {
   if (array.length > 0 && replace === true) {
     array[array.length - 1] = item;
   } else {

--- a/packages/trading-signals/src/volatility/ABANDS/AccelerationBands.test.ts
+++ b/packages/trading-signals/src/volatility/ABANDS/AccelerationBands.test.ts
@@ -1,6 +1,5 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {EMA} from '../../trend/EMA/EMA.js';
-import {NotEnoughDataError} from '../../error/index.js';
 import {SMA} from '../../trend/SMA/SMA.js';
 import {TradingSignal} from '../../base/Indicator.js';
 import {AccelerationBands} from './AccelerationBands.js';
@@ -66,16 +65,6 @@ describe('AccelerationBands', () => {
       expect(result.lower.toFixed(4)).toBe('187.1217');
       expect(result.middle.toFixed(4)).toBe('194.5920');
       expect(result.upper.toFixed(4)).toBe('201.9392');
-    });
-
-    it('throws an error when there is not enough input data', () => {
-      const accBands = new AccelerationBands(20, 2);
-      try {
-        accBands.getResultOrThrow();
-        throw new Error('Expected error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotEnoughDataError);
-      }
     });
   });
 
@@ -181,7 +170,7 @@ describe('AccelerationBands', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new AccelerationBands(5, 4),
   divergentInput: {close: 300, high: 320, low: 280},
   inputs: [

--- a/packages/trading-signals/src/volatility/ABANDS/AccelerationBands.test.ts
+++ b/packages/trading-signals/src/volatility/ABANDS/AccelerationBands.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {EMA} from '../../trend/EMA/EMA.js';
 import {NotEnoughDataError} from '../../error/index.js';
 import {SMA} from '../../trend/SMA/SMA.js';
@@ -178,4 +179,17 @@ describe('AccelerationBands', () => {
       expect(accBands.getSignal().state).toBe(TradingSignal.SIDEWAYS);
     });
   });
+});
+
+testReplaceContract({
+  create: () => new AccelerationBands(5, 4),
+  divergentInput: {close: 300, high: 320, low: 280},
+  inputs: [
+    {close: 195.55, high: 198.05, low: 194.96},
+    {close: 192.59, high: 193.86, low: 191.61},
+    {close: 197.43, high: 197.61, low: 195.17},
+    {close: 194.79, high: 199.47, low: 194.35},
+    {close: 195.85, high: 197.22, low: 194.25},
+    {close: 196.74, high: 196.82, low: 194.53},
+  ],
 });

--- a/packages/trading-signals/src/volatility/ATR/ATR.test.ts
+++ b/packages/trading-signals/src/volatility/ATR/ATR.test.ts
@@ -1,5 +1,4 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
-import {NotEnoughDataError} from '../../index.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {ATR} from './ATR.js';
 
 describe('ATR', () => {
@@ -77,17 +76,6 @@ describe('ATR', () => {
       expect(atr.getRequiredInputs()).toBe(interval);
       expect(atr.getResultOrThrow().toFixed(2)).toBe('1.14');
     });
-
-    it('throws an error when there is not enough input data', () => {
-      const atr = new ATR(14);
-
-      try {
-        atr.getResultOrThrow();
-        throw new Error('Expected error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotEnoughDataError);
-      }
-    });
   });
 
   describe('replace', () => {
@@ -126,7 +114,7 @@ describe('ATR', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new ATR(3),
   divergentInput: {close: 200, high: 250, low: 150},
   inputs: [

--- a/packages/trading-signals/src/volatility/ATR/ATR.test.ts
+++ b/packages/trading-signals/src/volatility/ATR/ATR.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {NotEnoughDataError} from '../../index.js';
 import {ATR} from './ATR.js';
 
@@ -123,4 +124,17 @@ describe('ATR', () => {
       expect(atr.getResultOrThrow().toFixed(2)).toBe(latestResult);
     });
   });
+});
+
+testReplaceContract({
+  create: () => new ATR(3),
+  divergentInput: {close: 200, high: 250, low: 150},
+  inputs: [
+    {close: 81.59, high: 82.15, low: 81.29},
+    {close: 81.06, high: 81.89, low: 80.64},
+    {close: 82.87, high: 83.03, low: 81.31},
+    {close: 83.0, high: 83.3, low: 82.65},
+    {close: 83.61, high: 83.85, low: 83.07},
+    {close: 83.15, high: 83.9, low: 83.11},
+  ],
 });

--- a/packages/trading-signals/src/volatility/BBANDS/BollingerBands.test.ts
+++ b/packages/trading-signals/src/volatility/BBANDS/BollingerBands.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {BollingerBands} from './BollingerBands.js';
 import data from '../../fixtures/BB/data.json' with {type: 'json'};
 import {NotEnoughDataError} from '../../error/index.js';
@@ -267,4 +268,10 @@ describe('BollingerBands', () => {
       expect(bb.getSignal().state).toBe(TradingSignal.SIDEWAYS);
     });
   });
+});
+
+testReplaceContract({
+  create: () => new BollingerBands(5, 2),
+  divergentInput: 1_000,
+  inputs: [81.59, 81.06, 82.87, 83.0, 83.61, 83.15],
 });

--- a/packages/trading-signals/src/volatility/BBANDS/BollingerBands.test.ts
+++ b/packages/trading-signals/src/volatility/BBANDS/BollingerBands.test.ts
@@ -1,7 +1,6 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {BollingerBands} from './BollingerBands.js';
 import data from '../../fixtures/BB/data.json' with {type: 'json'};
-import {NotEnoughDataError} from '../../error/index.js';
 import {TradingSignal} from '../../base/Indicator.js';
 
 describe('BollingerBands', () => {
@@ -62,17 +61,6 @@ describe('BollingerBands', () => {
 
       expect(bb.isStable, 'the fifth price completes the interval').toBe(true);
       expect(result?.middle, 'the first band averages all five prices').toBe(12);
-    });
-
-    it('throws an error when there is not enough input data', () => {
-      const bb = new BollingerBands(20);
-
-      try {
-        bb.getResultOrThrow();
-        throw new Error('Expected error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotEnoughDataError);
-      }
     });
 
     it('is compatible with results from Tulip Indicators (TI)', {tags: ['tulipindicators']}, () => {
@@ -270,7 +258,7 @@ describe('BollingerBands', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new BollingerBands(5, 2),
   divergentInput: 1_000,
   inputs: [81.59, 81.06, 82.87, 83.0, 83.61, 83.15],

--- a/packages/trading-signals/src/volatility/BBANDS/BollingerBands.test.ts
+++ b/packages/trading-signals/src/volatility/BBANDS/BollingerBands.test.ts
@@ -144,6 +144,46 @@ describe('BollingerBands', () => {
     });
   });
 
+  describe('update', () => {
+    it('recalculates the bands when replacing the latest price', () => {
+      const bb = new BollingerBands(5, 2);
+      const prices = [81.59, 81.06, 82.87, 83.0, 83.61, 83.15] as const;
+
+      prices.forEach(price => bb.add(price));
+
+      const originalResult = bb.getResultOrThrow();
+      const replacedResult = bb.replace(90);
+
+      expect(replacedResult?.middle, 'a replacement recalculates the bands').not.toBe(originalResult.middle);
+
+      const restoredResult = bb.replace(83.15);
+
+      expect(restoredResult?.middle, 'replacing back restores the original bands').toBe(originalResult.middle);
+    });
+
+    it('changes nothing when the latest price is replaced with the same value', () => {
+      const bb = new BollingerBands(5, 2);
+      const prices = [81.59, 81.06, 82.87, 83.0, 83.61, 83.15] as const;
+
+      prices.forEach(price => bb.add(price));
+
+      const resultBefore = bb.getResultOrThrow();
+
+      bb.replace(83.15);
+
+      expect(bb.getResultOrThrow(), 'replacing a price with itself is a no-op').toEqual(resultBefore);
+      expect(bb.isStable, 'and it stays stable').toBe(true);
+    });
+
+    it('keeps calculating when a price of zero drops out of the window', () => {
+      const bb = new BollingerBands(3, 2);
+
+      [0, 1, 2, 3].forEach(price => bb.add(price));
+
+      expect(bb.getResultOrThrow().middle, 'a zero drop-out must not suppress the calculation').toBe(2);
+    });
+  });
+
   describe('getSignal', () => {
     it('returns UNKNOWN when there is no result', () => {
       const bb = new BollingerBands(10);

--- a/packages/trading-signals/src/volatility/BBANDS/BollingerBands.test.ts
+++ b/packages/trading-signals/src/volatility/BBANDS/BollingerBands.test.ts
@@ -49,6 +49,20 @@ describe('BollingerBands', () => {
       expect(bb.deviationMultiplier).toBe(2);
     });
 
+    it('emits the first result as soon as the interval is filled', () => {
+      const bb = new BollingerBands(5, 2);
+      const prices = [10, 11, 12, 13, 14] as const;
+
+      prices.slice(0, -1).forEach(price => bb.add(price));
+
+      expect(bb.isStable, 'four prices do not fill an interval of five').toBe(false);
+
+      const result = bb.add(prices[4]);
+
+      expect(bb.isStable, 'the fifth price completes the interval').toBe(true);
+      expect(result?.middle, 'the first band averages all five prices').toBe(12);
+    });
+
     it('throws an error when there is not enough input data', () => {
       const bb = new BollingerBands(20);
 
@@ -193,7 +207,7 @@ describe('BollingerBands', () => {
 
     it('returns BULLISH when price breaks above the previous upper band', () => {
       const bb = new BollingerBands(10, 2);
-      // Need 12 adds: 11 for first result, 12th to have a previous result to compare against
+      // The signal compares against the previous bands, so more than one result must exist
       for (let i = 0; i < 11; i++) {
         bb.add(50);
       }
@@ -225,7 +239,7 @@ describe('BollingerBands', () => {
 
     it('tracks signal state changes', () => {
       const bb = new BollingerBands(10, 2);
-      // Build up stable data: 12 adds to get a previous result for comparison
+      // Build up stable data so a previous result exists for comparison
       for (let i = 0; i < 12; i++) {
         bb.add(50);
       }

--- a/packages/trading-signals/src/volatility/BBANDS/BollingerBands.test.ts
+++ b/packages/trading-signals/src/volatility/BBANDS/BollingerBands.test.ts
@@ -53,7 +53,7 @@ describe('BollingerBands', () => {
       const bb = new BollingerBands(5, 2);
       const prices = [10, 11, 12, 13, 14] as const;
 
-      prices.slice(0, -1).forEach(price => bb.add(price));
+      bb.updates(prices.slice(0, -1));
 
       expect(bb.isStable, 'four prices do not fill an interval of five').toBe(false);
 
@@ -163,7 +163,7 @@ describe('BollingerBands', () => {
       const bb = new BollingerBands(5, 2);
       const prices = [81.59, 81.06, 82.87, 83.0, 83.61, 83.15] as const;
 
-      prices.forEach(price => bb.add(price));
+      bb.updates(prices);
 
       const originalResult = bb.getResultOrThrow();
       const replacedResult = bb.replace(90);
@@ -179,7 +179,7 @@ describe('BollingerBands', () => {
       const bb = new BollingerBands(5, 2);
       const prices = [81.59, 81.06, 82.87, 83.0, 83.61, 83.15] as const;
 
-      prices.forEach(price => bb.add(price));
+      bb.updates(prices);
 
       const resultBefore = bb.getResultOrThrow();
 
@@ -192,7 +192,7 @@ describe('BollingerBands', () => {
     it('keeps calculating when a price of zero drops out of the window', () => {
       const bb = new BollingerBands(3, 2);
 
-      [0, 1, 2, 3].forEach(price => bb.add(price));
+      bb.updates([0, 1, 2, 3]);
 
       expect(bb.getResultOrThrow().middle, 'a zero drop-out must not suppress the calculation').toBe(2);
     });
@@ -207,7 +207,7 @@ describe('BollingerBands', () => {
 
     it('returns BULLISH when price breaks above the previous upper band', () => {
       const bb = new BollingerBands(10, 2);
-      // The signal compares against the previous bands, so more than one result must exist
+      // Need 12 adds: 10 for the first result, 12th to have a previous result to compare against
       for (let i = 0; i < 11; i++) {
         bb.add(50);
       }
@@ -239,7 +239,7 @@ describe('BollingerBands', () => {
 
     it('tracks signal state changes', () => {
       const bb = new BollingerBands(10, 2);
-      // Build up stable data so a previous result exists for comparison
+      // Build up stable data: 12 adds to get a previous result for comparison
       for (let i = 0; i < 12; i++) {
         bb.add(50);
       }

--- a/packages/trading-signals/src/volatility/BBANDS/BollingerBands.ts
+++ b/packages/trading-signals/src/volatility/BBANDS/BollingerBands.ts
@@ -33,7 +33,7 @@ export class BollingerBands extends TechnicalIndicator<BandsResult, number> {
   }
 
   update(price: number, replace: boolean) {
-    pushUpdate(this.prices, replace, price, this.interval);
+    pushUpdate({array: this.prices, item: price, maxLength: this.interval, replace: replace});
 
     if (replace) {
       this.result = this.#previousResult;

--- a/packages/trading-signals/src/volatility/BBANDS/BollingerBands.ts
+++ b/packages/trading-signals/src/volatility/BBANDS/BollingerBands.ts
@@ -18,11 +18,6 @@ export class BollingerBands extends TechnicalIndicator<BandsResult, number> {
   #twoPreviousResult?: BandsResult;
   #lastPrice?: number;
   #previousPrice?: number;
-  /**
-   * Latches on the first evicted price. Only an `add()` evicts, so reading the eviction directly
-   * made every `replace()` fall through and drop the result.
-   */
-  #hasEvictedPrice: boolean = false;
 
   public readonly interval: number;
   public readonly deviationMultiplier: number;
@@ -38,11 +33,7 @@ export class BollingerBands extends TechnicalIndicator<BandsResult, number> {
   }
 
   update(price: number, replace: boolean) {
-    const dropOut = pushUpdate(this.prices, replace, price, this.interval);
-
-    if (dropOut !== null) {
-      this.#hasEvictedPrice = true;
-    }
+    pushUpdate(this.prices, replace, price, this.interval);
 
     if (replace) {
       this.result = this.#previousResult;
@@ -55,7 +46,7 @@ export class BollingerBands extends TechnicalIndicator<BandsResult, number> {
     this.#previousPrice = this.#lastPrice;
     this.#lastPrice = price;
 
-    if (this.#hasEvictedPrice) {
+    if (this.prices.length === this.interval) {
       const middle = getAverage(this.prices);
       const standardDeviation = getStandardDeviation(this.prices, middle);
 

--- a/packages/trading-signals/src/volatility/BBANDS/BollingerBands.ts
+++ b/packages/trading-signals/src/volatility/BBANDS/BollingerBands.ts
@@ -18,6 +18,11 @@ export class BollingerBands extends TechnicalIndicator<BandsResult, number> {
   #twoPreviousResult?: BandsResult;
   #lastPrice?: number;
   #previousPrice?: number;
+  /**
+   * Latches on the first evicted price. Only an `add()` evicts, so reading the eviction directly
+   * made every `replace()` fall through and drop the result.
+   */
+  #hasEvictedPrice: boolean = false;
 
   public readonly interval: number;
   public readonly deviationMultiplier: number;
@@ -35,6 +40,10 @@ export class BollingerBands extends TechnicalIndicator<BandsResult, number> {
   update(price: number, replace: boolean) {
     const dropOut = pushUpdate(this.prices, replace, price, this.interval);
 
+    if (dropOut !== null) {
+      this.#hasEvictedPrice = true;
+    }
+
     if (replace) {
       this.result = this.#previousResult;
       this.#previousResult = this.#twoPreviousResult;
@@ -46,7 +55,7 @@ export class BollingerBands extends TechnicalIndicator<BandsResult, number> {
     this.#previousPrice = this.#lastPrice;
     this.#lastPrice = price;
 
-    if (dropOut) {
+    if (this.#hasEvictedPrice) {
       const middle = getAverage(this.prices);
       const standardDeviation = getStandardDeviation(this.prices, middle);
 

--- a/packages/trading-signals/src/volatility/BBW/BollingerBandsWidth.test.ts
+++ b/packages/trading-signals/src/volatility/BBW/BollingerBandsWidth.test.ts
@@ -42,24 +42,31 @@ describe('BollingerBandsWidth', () => {
       /*
        * Test data verified with:
        * https://www.tradingview.com/support/solutions/43000501972/
+       *
+       * TradingView reports BBW to two decimals, which is too coarse to tell neighbouring readings
+       * apart: the first two bars below both display as "0.19". These expectations are the same
+       * series carried out to eight decimals, derived from the definition
+       * `(upper - lower) / middle` over a 20-price window with a population standard deviation.
+       * Each one still rounds to the TradingView figure quoted beside it.
        */
       const expectations = [
-        '0.19',
-        '0.21',
-        '0.21',
-        '0.21',
-        '0.20',
-        '0.18',
-        '0.15',
-        '0.13',
-        '0.11',
-        '0.09',
-        '0.09',
+        '0.18527244', // 0.19
+        '0.19448621', // 0.19
+        '0.20620703', // 0.21
+        '0.20947164', // 0.21
+        '0.20811594', // 0.21
+        '0.20235584', // 0.20
+        '0.18343591', // 0.18
+        '0.15339154', // 0.15
+        '0.12996632', // 0.13
+        '0.10676506', // 0.11
+        '0.08600268', // 0.09
+        '0.08869419', // 0.09
       ] as const;
 
       const interval = 20;
       const bbw = new BollingerBandsWidth(new BollingerBands(interval, 2));
-      const offset = bbw.getRequiredInputs();
+      const offset = bbw.getRequiredInputs() - 1;
 
       expect(bbw.getRequiredInputs()).toBe(interval);
 
@@ -67,7 +74,7 @@ describe('BollingerBandsWidth', () => {
         bbw.add(close);
         if (bbw.isStable) {
           const expected = expectations[i - offset];
-          expect(bbw.getResultOrThrow().toFixed(2)).toBe(`${expected}`);
+          expect(bbw.getResultOrThrow().toFixed(8)).toBe(`${expected}`);
         }
       });
     });

--- a/packages/trading-signals/src/volatility/BBW/BollingerBandsWidth.test.ts
+++ b/packages/trading-signals/src/volatility/BBW/BollingerBandsWidth.test.ts
@@ -48,6 +48,10 @@ describe('BollingerBandsWidth', () => {
        * series carried out to eight decimals, derived from the definition
        * `(upper - lower) / middle` over a 20-price window with a population standard deviation.
        * Each one still rounds to the TradingView figure quoted beside it.
+       *
+       * TradingView plots its first BBW value on the 20th bar, exactly where the first
+       * expectation below sits. The previous implementation became stable one bar late, so the
+       * old test silently skipped TradingView's first plotted value.
        */
       const expectations = [
         '0.18527244', // 0.19

--- a/packages/trading-signals/src/volatility/BBW/BollingerBandsWidth.test.ts
+++ b/packages/trading-signals/src/volatility/BBW/BollingerBandsWidth.test.ts
@@ -1,4 +1,4 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {BollingerBands} from '../BBANDS/BollingerBands.js';
 import {BollingerBandsWidth} from './BollingerBandsWidth.js';
 
@@ -86,7 +86,7 @@ describe('BollingerBandsWidth', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new BollingerBandsWidth(new BollingerBands(5, 2)),
   divergentInput: 500,
   inputs: [68.21, 68.63, 68.01, 68.0, 67.28, 65.49],

--- a/packages/trading-signals/src/volatility/BBW/BollingerBandsWidth.test.ts
+++ b/packages/trading-signals/src/volatility/BBW/BollingerBandsWidth.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {BollingerBands} from '../BBANDS/BollingerBands.js';
 import {BollingerBandsWidth} from './BollingerBandsWidth.js';
 
@@ -83,4 +84,10 @@ describe('BollingerBandsWidth', () => {
       });
     });
   });
+});
+
+testReplaceContract({
+  create: () => new BollingerBandsWidth(new BollingerBands(5, 2)),
+  divergentInput: 500,
+  inputs: [68.21, 68.63, 68.01, 68.0, 67.28, 65.49],
 });

--- a/packages/trading-signals/src/volatility/IQR/IQR.test.ts
+++ b/packages/trading-signals/src/volatility/IQR/IQR.test.ts
@@ -1,4 +1,4 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {IQR} from './IQR.js';
 
 describe('IQR', () => {
@@ -107,7 +107,7 @@ describe('IQR', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new IQR(5),
   divergentInput: 1_000,
   inputs: [7, 7, 31, 31, 47, 75],

--- a/packages/trading-signals/src/volatility/IQR/IQR.test.ts
+++ b/packages/trading-signals/src/volatility/IQR/IQR.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {IQR} from './IQR.js';
 
 describe('IQR', () => {
@@ -104,4 +105,10 @@ describe('IQR', () => {
       expect(iqr.getResultOrThrow()).toBe(3);
     });
   });
+});
+
+testReplaceContract({
+  create: () => new IQR(5),
+  divergentInput: 1_000,
+  inputs: [7, 7, 31, 31, 47, 75],
 });

--- a/packages/trading-signals/src/volatility/MAD/MAD.test.ts
+++ b/packages/trading-signals/src/volatility/MAD/MAD.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {MAD} from './MAD.js';
 import {NotEnoughDataError} from '../../error/index.js';
 
@@ -117,4 +118,10 @@ describe('MAD', () => {
       expect(MAD.getResultFromBatch(prices, mean)).toBe(3.6);
     });
   });
+});
+
+testReplaceContract({
+  create: () => new MAD(5),
+  divergentInput: 1_000,
+  inputs: [81.59, 81.06, 82.87, 83.0, 83.61, 83.15],
 });

--- a/packages/trading-signals/src/volatility/MAD/MAD.test.ts
+++ b/packages/trading-signals/src/volatility/MAD/MAD.test.ts
@@ -1,6 +1,5 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {MAD} from './MAD.js';
-import {NotEnoughDataError} from '../../error/index.js';
 
 describe('MAD', () => {
   /*
@@ -81,16 +80,6 @@ describe('MAD', () => {
       }
       expect(mad.getResultOrThrow().toFixed(2)).toBe('0.62');
     });
-
-    it('throws an error when there is not enough input data', () => {
-      const mad = new MAD(5);
-      try {
-        mad.getResultOrThrow();
-        throw new Error('Expected error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotEnoughDataError);
-      }
-    });
   });
 
   describe('getResultFromBatch', () => {
@@ -120,7 +109,7 @@ describe('MAD', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new MAD(5),
   divergentInput: 1_000,
   inputs: [81.59, 81.06, 82.87, 83.0, 83.61, 83.15],

--- a/packages/trading-signals/src/volatility/MAD/MAD.ts
+++ b/packages/trading-signals/src/volatility/MAD/MAD.ts
@@ -24,7 +24,7 @@ export class MAD extends IndicatorSeries {
   }
 
   update(price: number, replace: boolean) {
-    pushUpdate(this.prices, replace, price, this.interval);
+    pushUpdate({array: this.prices, item: price, maxLength: this.interval, replace: replace});
 
     if (this.prices.length === this.interval) {
       const mean = getAverage(this.prices);

--- a/packages/trading-signals/src/volatility/NATR/NATR.test.ts
+++ b/packages/trading-signals/src/volatility/NATR/NATR.test.ts
@@ -1,6 +1,5 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {NATR} from './NATR.js';
-import {NotEnoughDataError} from '../../error/index.js';
 
 describe('NATR', () => {
   /*
@@ -79,21 +78,10 @@ describe('NATR', () => {
       expect(natr.isStable).toBe(true);
       expect(natr.getRequiredInputs()).toBe(interval);
     });
-
-    it('throws an error when there is not enough input data', () => {
-      const natr = new NATR(5);
-
-      try {
-        natr.getResultOrThrow();
-        throw new Error('Expected error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotEnoughDataError);
-      }
-    });
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new NATR(5),
   divergentInput: {close: 200, high: 250, low: 150},
   inputs: [

--- a/packages/trading-signals/src/volatility/NATR/NATR.test.ts
+++ b/packages/trading-signals/src/volatility/NATR/NATR.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {NATR} from './NATR.js';
 import {NotEnoughDataError} from '../../error/index.js';
 
@@ -90,4 +91,17 @@ describe('NATR', () => {
       }
     });
   });
+});
+
+testReplaceContract({
+  create: () => new NATR(5),
+  divergentInput: {close: 200, high: 250, low: 150},
+  inputs: [
+    {close: 81.59, high: 82.15, low: 81.29},
+    {close: 81.06, high: 81.89, low: 80.64},
+    {close: 82.87, high: 83.03, low: 81.31},
+    {close: 83.0, high: 83.3, low: 82.65},
+    {close: 83.61, high: 83.85, low: 83.07},
+    {close: 83.15, high: 83.9, low: 83.11},
+  ],
 });

--- a/packages/trading-signals/src/volatility/TR/TR.test.ts
+++ b/packages/trading-signals/src/volatility/TR/TR.test.ts
@@ -1,4 +1,4 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {TR} from './TR.js';
 
 describe('TR', () => {
@@ -54,7 +54,7 @@ describe('TR', () => {
       });
 
       expect(tr.isStable).toBe(true);
-      expect(tr.getRequiredInputs()).toBe(2);
+      expect(tr.getRequiredInputs()).toBe(1);
       expect(tr.getResultOrThrow().toFixed(2)).toBe('0.86');
     });
   });
@@ -95,7 +95,7 @@ describe('TR', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new TR(),
   divergentInput: {close: 200, high: 250, low: 150},
   inputs: [

--- a/packages/trading-signals/src/volatility/TR/TR.test.ts
+++ b/packages/trading-signals/src/volatility/TR/TR.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {TR} from './TR.js';
 
 describe('TR', () => {
@@ -92,4 +93,14 @@ describe('TR', () => {
       expect(tr.getResultOrThrow().toFixed(2)).toBe(latestResult);
     });
   });
+});
+
+testReplaceContract({
+  create: () => new TR(),
+  divergentInput: {close: 200, high: 250, low: 150},
+  inputs: [
+    {close: 81.59, high: 82.15, low: 81.29},
+    {close: 81.06, high: 81.89, low: 80.64},
+    {close: 82.87, high: 83.03, low: 81.31},
+  ],
 });

--- a/packages/trading-signals/src/volatility/TR/TR.ts
+++ b/packages/trading-signals/src/volatility/TR/TR.ts
@@ -16,7 +16,7 @@ export class TR extends IndicatorSeries<HighLowClose<number>> {
   #twoPreviousCandle?: HighLowClose<number>;
 
   override getRequiredInputs() {
-    return 2;
+    return 1;
   }
 
   update(candle: HighLowClose<number>, replace: boolean) {

--- a/packages/trading-signals/src/volume/AD/AD.test.ts
+++ b/packages/trading-signals/src/volume/AD/AD.test.ts
@@ -1,4 +1,4 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {AD} from './AD.js';
 import {TradingSignal} from '../../base/index.js';
 
@@ -82,7 +82,7 @@ describe('AD', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new AD(),
   divergentInput: {close: 509, high: 510, low: 490, volume: 99_000},
   inputs: [

--- a/packages/trading-signals/src/volume/AD/AD.test.ts
+++ b/packages/trading-signals/src/volume/AD/AD.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {AD} from './AD.js';
 import {TradingSignal} from '../../base/index.js';
 
@@ -79,4 +80,16 @@ describe('AD', () => {
       expect(restoredResult).toBe(originalResult);
     });
   });
+});
+
+testReplaceContract({
+  create: () => new AD(),
+  divergentInput: {close: 509, high: 510, low: 490, volume: 99_000},
+  inputs: [
+    {close: 62.15, high: 62.34, low: 61.37, volume: 7849},
+    {close: 60.81, high: 62.05, low: 60.69, volume: 11692},
+    {close: 60.45, high: 62.27, low: 60.1, volume: 10575},
+    {close: 59.18, high: 60.79, low: 58.61, volume: 13059},
+    {close: 59.24, high: 59.93, low: 58.71, volume: 20734},
+  ],
 });

--- a/packages/trading-signals/src/volume/ADOSC/ADOSC.test.ts
+++ b/packages/trading-signals/src/volume/ADOSC/ADOSC.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {ADOSC} from './ADOSC.js';
 import {NotEnoughDataError} from '../../error/index.js';
 import {TradingSignal} from '../../base/index.js';
@@ -131,4 +132,17 @@ describe('ADOSC', () => {
       expect(adosc.getSignal().state).toBe(TradingSignal.SIDEWAYS);
     });
   });
+});
+
+testReplaceContract({
+  create: () => new ADOSC({fastPeriod: 2, slowPeriod: 5}),
+  divergentInput: {close: 249, high: 250, low: 150, volume: 99_000_000},
+  inputs: [
+    {close: 81.59, high: 82.15, low: 81.29, volume: 5_653_100},
+    {close: 81.06, high: 81.89, low: 80.64, volume: 6_447_400},
+    {close: 82.87, high: 83.03, low: 81.31, volume: 7_690_900},
+    {close: 83.0, high: 83.3, low: 82.65, volume: 3_831_400},
+    {close: 83.61, high: 83.85, low: 83.07, volume: 4_455_100},
+    {close: 83.15, high: 83.9, low: 83.11, volume: 3_798_000},
+  ],
 });

--- a/packages/trading-signals/src/volume/ADOSC/ADOSC.test.ts
+++ b/packages/trading-signals/src/volume/ADOSC/ADOSC.test.ts
@@ -1,6 +1,5 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {ADOSC} from './ADOSC.js';
-import {NotEnoughDataError} from '../../error/index.js';
 import {TradingSignal} from '../../base/index.js';
 
 describe('ADOSC', () => {
@@ -79,17 +78,6 @@ describe('ADOSC', () => {
       expect(adosc.isStable).toBe(true);
       expect(adosc.getRequiredInputs()).toBe(5);
     });
-
-    it('throws an error when there is not enough input data', () => {
-      const adosc = new ADOSC();
-
-      try {
-        adosc.getResultOrThrow();
-        throw new Error('Expected error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotEnoughDataError);
-      }
-    });
   });
 
   describe('getSignal', () => {
@@ -134,7 +122,7 @@ describe('ADOSC', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new ADOSC({fastPeriod: 2, slowPeriod: 5}),
   divergentInput: {close: 249, high: 250, low: 150, volume: 99_000_000},
   inputs: [

--- a/packages/trading-signals/src/volume/CMF/CMF.test.ts
+++ b/packages/trading-signals/src/volume/CMF/CMF.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {CMF} from './CMF.js';
 import {NotEnoughDataError} from '../../error/index.js';
 import {TradingSignal} from '../../base/index.js';
@@ -150,4 +151,17 @@ describe('CMF', () => {
       expect(restoredResult).toBe(originalResult);
     });
   });
+});
+
+testReplaceContract({
+  create: () => new CMF(5),
+  divergentInput: {close: 509, high: 510, low: 490, volume: 99_000},
+  inputs: [
+    {close: 62.15, high: 62.34, low: 61.37, volume: 7849},
+    {close: 60.81, high: 62.05, low: 60.69, volume: 11692},
+    {close: 60.45, high: 62.27, low: 60.1, volume: 10575},
+    {close: 59.18, high: 60.79, low: 58.61, volume: 13059},
+    {close: 59.24, high: 59.93, low: 58.71, volume: 20734},
+    {close: 60.2, high: 61.75, low: 59.86, volume: 29630},
+  ],
 });

--- a/packages/trading-signals/src/volume/CMF/CMF.test.ts
+++ b/packages/trading-signals/src/volume/CMF/CMF.test.ts
@@ -1,6 +1,5 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {CMF} from './CMF.js';
-import {NotEnoughDataError} from '../../error/index.js';
 import {TradingSignal} from '../../base/index.js';
 
 describe('CMF', () => {
@@ -30,18 +29,6 @@ describe('CMF', () => {
       const result = cmf.getResultOrThrow();
 
       expect(result).toBeLessThan(0);
-    });
-
-    it('throws an error when there is not enough input data', () => {
-      const cmf = new CMF(5);
-      expect(cmf.isStable).toBe(false);
-
-      try {
-        cmf.getResultOrThrow();
-        throw new Error('Expected error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotEnoughDataError);
-      }
     });
 
     it('handles candles where high equals low', () => {
@@ -153,7 +140,7 @@ describe('CMF', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new CMF(5),
   divergentInput: {close: 509, high: 510, low: 490, volume: 99_000},
   inputs: [

--- a/packages/trading-signals/src/volume/CMF/CMF.ts
+++ b/packages/trading-signals/src/volume/CMF/CMF.ts
@@ -32,7 +32,7 @@ export class CMF extends TrendIndicatorSeries<HighLowCloseVolume> {
   }
 
   update(candle: HighLowCloseVolume, replace: boolean) {
-    pushUpdate(this.#candles, replace, candle, this.interval);
+    pushUpdate({array: this.#candles, item: candle, maxLength: this.interval, replace: replace});
 
     if (this.#candles.length < this.interval) {
       return null;

--- a/packages/trading-signals/src/volume/EMV/EMV.test.ts
+++ b/packages/trading-signals/src/volume/EMV/EMV.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {EMV} from './EMV.js';
 import {NotEnoughDataError} from '../../error/index.js';
 import {TradingSignal} from '../../base/index.js';
@@ -148,4 +149,18 @@ describe('EMV', () => {
       expect(restoredResult).toBe(originalResult);
     });
   });
+});
+
+testReplaceContract({
+  create: () => new EMV(5),
+  divergentInput: {close: 509, high: 510, low: 490, volume: 99_000},
+  inputs: [
+    {close: 62.15, high: 62.34, low: 61.37, volume: 7849},
+    {close: 60.81, high: 62.05, low: 60.69, volume: 11692},
+    {close: 60.45, high: 62.27, low: 60.1, volume: 10575},
+    {close: 59.18, high: 60.79, low: 58.61, volume: 13059},
+    {close: 59.24, high: 59.93, low: 58.71, volume: 20734},
+    {close: 60.2, high: 61.75, low: 59.86, volume: 29630},
+    {close: 58.48, high: 60.0, low: 57.97, volume: 17705},
+  ],
 });

--- a/packages/trading-signals/src/volume/EMV/EMV.test.ts
+++ b/packages/trading-signals/src/volume/EMV/EMV.test.ts
@@ -1,6 +1,5 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {EMV} from './EMV.js';
-import {NotEnoughDataError} from '../../error/index.js';
 import {TradingSignal} from '../../base/index.js';
 
 describe('EMV', () => {
@@ -24,18 +23,6 @@ describe('EMV', () => {
 
       expect(emv.isStable).toBe(true);
       expect(emv.getRequiredInputs()).toBe(6);
-    });
-
-    it('throws an error when there is not enough input data', () => {
-      const emv = new EMV(5);
-      expect(emv.isStable).toBe(false);
-
-      try {
-        emv.getResultOrThrow();
-        throw new Error('Expected error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotEnoughDataError);
-      }
     });
   });
 
@@ -151,7 +138,7 @@ describe('EMV', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new EMV(5),
   divergentInput: {close: 509, high: 510, low: 490, volume: 99_000},
   inputs: [

--- a/packages/trading-signals/src/volume/EMV/EMV.ts
+++ b/packages/trading-signals/src/volume/EMV/EMV.ts
@@ -38,7 +38,7 @@ export class EMV extends TrendIndicatorSeries<HighLowCloseVolume> {
   }
 
   update(candle: HighLowCloseVolume, replace: boolean) {
-    pushUpdate(this.#candles, replace, candle, 2);
+    pushUpdate({array: this.#candles, item: candle, maxLength: 2, replace: replace});
 
     if (this.#candles.length < 2) {
       return null;

--- a/packages/trading-signals/src/volume/PVT/PVT.test.ts
+++ b/packages/trading-signals/src/volume/PVT/PVT.test.ts
@@ -106,6 +106,40 @@ describe('PVT', () => {
   });
 
   describe('replace', () => {
+    it('accumulates onto the total from before the replaced candle', () => {
+      const candle = (close: number) => ({close, high: close, low: close, volume: 1000}) as const;
+
+      const replaced = new PVT();
+      replaced.add(candle(100));
+      replaced.add(candle(110));
+      replaced.add(candle(120));
+      replaced.replace(candle(130));
+
+      const reference = new PVT();
+      reference.add(candle(100));
+      reference.add(candle(110));
+      reference.add(candle(130));
+
+      expect(replaced.getResultOrThrow(), 'a replacement must not count the replaced candle twice').toBe(
+        reference.getResultOrThrow()
+      );
+    });
+
+    it('changes nothing when the latest candle is replaced with the same values', () => {
+      const candle = (close: number) => ({close, high: close, low: close, volume: 1000}) as const;
+      const pvt = new PVT();
+
+      pvt.add(candle(100));
+      pvt.add(candle(110));
+      pvt.add(candle(120));
+
+      const resultBefore = pvt.getResultOrThrow();
+
+      pvt.replace(candle(120));
+
+      expect(pvt.getResultOrThrow(), 'replacing a candle with itself is a no-op').toBe(resultBefore);
+    });
+
     it('replaces the most recently added value', () => {
       const pvt = new PVT();
       pvt.add({close: 10, high: 10, low: 9, volume: 25000});

--- a/packages/trading-signals/src/volume/PVT/PVT.test.ts
+++ b/packages/trading-signals/src/volume/PVT/PVT.test.ts
@@ -18,9 +18,7 @@ describe('PVT', () => {
 
       const pvt = new PVT();
 
-      for (const candle of candles) {
-        pvt.add(candle);
-      }
+      pvt.updates(candles);
 
       expect(pvt.isStable).toBe(true);
       expect(pvt.getRequiredInputs()).toBe(2);
@@ -82,9 +80,7 @@ describe('PVT', () => {
         {close: 11.5, high: 12, low: 10, volume: 35000},
       ] as const;
 
-      for (const candle of candles) {
-        pvt.add(candle);
-      }
+      pvt.updates(candles);
 
       expect(pvt.getSignal().state).toBe(TradingSignal.BULLISH);
     });
@@ -97,28 +93,23 @@ describe('PVT', () => {
         {close: 9.5, high: 10, low: 9, volume: 25000},
       ] as const;
 
-      for (const candle of candles) {
-        pvt.add(candle);
-      }
+      pvt.updates(candles);
 
       expect(pvt.getSignal().state).toBe(TradingSignal.BEARISH);
     });
   });
 
   describe('replace', () => {
-    it('accumulates onto the total from before the replaced candle', () => {
-      const candle = (close: number) => ({close, high: close, low: close, volume: 1000}) as const;
+    /** Keeps the tests focused on the close price by faking a candle that has no intra-bar movement. */
+    const fakeFlatCandle = (close: number) => ({close, high: close, low: close, volume: 1000}) as const;
 
+    it('accumulates onto the total from before the replaced candle', () => {
       const replaced = new PVT();
-      replaced.add(candle(100));
-      replaced.add(candle(110));
-      replaced.add(candle(120));
-      replaced.replace(candle(130));
+      replaced.updates([fakeFlatCandle(100), fakeFlatCandle(110), fakeFlatCandle(120)]);
+      replaced.replace(fakeFlatCandle(130));
 
       const reference = new PVT();
-      reference.add(candle(100));
-      reference.add(candle(110));
-      reference.add(candle(130));
+      reference.updates([fakeFlatCandle(100), fakeFlatCandle(110), fakeFlatCandle(130)]);
 
       expect(replaced.getResultOrThrow(), 'a replacement must not count the replaced candle twice').toBe(
         reference.getResultOrThrow()
@@ -126,16 +117,13 @@ describe('PVT', () => {
     });
 
     it('changes nothing when the latest candle is replaced with the same values', () => {
-      const candle = (close: number) => ({close, high: close, low: close, volume: 1000}) as const;
       const pvt = new PVT();
 
-      pvt.add(candle(100));
-      pvt.add(candle(110));
-      pvt.add(candle(120));
+      pvt.updates([fakeFlatCandle(100), fakeFlatCandle(110), fakeFlatCandle(120)]);
 
       const resultBefore = pvt.getResultOrThrow();
 
-      pvt.replace(candle(120));
+      pvt.replace(fakeFlatCandle(120));
 
       expect(pvt.getResultOrThrow(), 'replacing a candle with itself is a no-op').toBe(resultBefore);
     });

--- a/packages/trading-signals/src/volume/PVT/PVT.test.ts
+++ b/packages/trading-signals/src/volume/PVT/PVT.test.ts
@@ -1,6 +1,5 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {PVT} from './PVT.js';
-import {NotEnoughDataError} from '../../error/index.js';
 import {TradingSignal} from '../../base/index.js';
 
 describe('PVT', () => {
@@ -38,18 +37,6 @@ describe('PVT', () => {
 
       expect(pvt.isStable).toBe(true);
       expect(pvt.getResultOrThrow()).toBe(0);
-    });
-
-    it('throws an error when there is not enough input data', () => {
-      const pvt = new PVT();
-      expect(pvt.isStable).toBe(false);
-
-      try {
-        pvt.getResultOrThrow();
-        throw new Error('Expected error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotEnoughDataError);
-      }
     });
   });
 
@@ -148,7 +135,7 @@ describe('PVT', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new PVT(),
   divergentInput: {close: 500, high: 500, low: 500, volume: 99_000},
   inputs: [

--- a/packages/trading-signals/src/volume/PVT/PVT.test.ts
+++ b/packages/trading-signals/src/volume/PVT/PVT.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {PVT} from './PVT.js';
 import {NotEnoughDataError} from '../../error/index.js';
 import {TradingSignal} from '../../base/index.js';
@@ -145,4 +146,15 @@ describe('PVT', () => {
       expect(restoredResult).toBe(originalResult);
     });
   });
+});
+
+testReplaceContract({
+  create: () => new PVT(),
+  divergentInput: {close: 500, high: 500, low: 500, volume: 99_000},
+  inputs: [
+    {close: 10, high: 10, low: 9, volume: 25_000},
+    {close: 10.5, high: 11, low: 9.5, volume: 30_000},
+    {close: 10.2, high: 10.8, low: 10, volume: 28_000},
+    {close: 10.3, high: 10.5, low: 9.8, volume: 26_000},
+  ],
 });

--- a/packages/trading-signals/src/volume/PVT/PVT.ts
+++ b/packages/trading-signals/src/volume/PVT/PVT.ts
@@ -30,7 +30,12 @@ export class PVT extends TrendIndicatorSeries<HighLowCloseVolume> {
     }
 
     const previousClose = this.#candles[0].close;
-    const previousPVT = this.result ?? 0;
+    /*
+     * PVT accumulates onto the running total, so a replacement has to build on the total from
+     * before the replaced candle. `this.result` still carries that candle's contribution until
+     * `setResult()` unwinds it, which would count the bar twice.
+     */
+    const previousPVT = (replace ? this.previousResult : this.result) ?? 0;
 
     if (previousClose === 0) {
       return this.setResult(previousPVT, replace);

--- a/packages/trading-signals/src/volume/PVT/PVT.ts
+++ b/packages/trading-signals/src/volume/PVT/PVT.ts
@@ -39,8 +39,7 @@ export class PVT extends TrendIndicatorSeries<HighLowCloseVolume, TradingSignals
     const previousClose = this.state.candles[0].close;
     /*
      * PVT accumulates onto the running total, so a replacement has to build on the total from
-     * before the replaced candle. `this.result` still carries that candle's contribution until
-     * `setResult()` unwinds it, which would count the bar twice.
+     * before the replaced candle.
      */
     const previousPVT = (replace ? this.previousResult : this.result) ?? 0;
 

--- a/packages/trading-signals/src/volume/PVT/PVT.ts
+++ b/packages/trading-signals/src/volume/PVT/PVT.ts
@@ -1,6 +1,10 @@
 import type {HighLowCloseVolume} from '../../base/Candle.type.js';
-import {TradingSignal, TrendIndicatorSeries} from '../../base/Indicator.js';
+import {TradingSignal, TrendIndicatorSeries, type TradingSignals} from '../../base/Indicator.js';
 import {pushUpdate} from '../../util/pushUpdate.js';
+
+type PVTState = {
+  candles: HighLowCloseVolume[];
+};
 
 /**
  * Price Volume Trend (PVT)
@@ -15,21 +19,24 @@ import {pushUpdate} from '../../util/pushUpdate.js';
  *
  * @see https://www.investopedia.com/terms/p/pvt.asp
  */
-export class PVT extends TrendIndicatorSeries<HighLowCloseVolume> {
-  readonly #candles: HighLowCloseVolume[] = [];
+export class PVT extends TrendIndicatorSeries<HighLowCloseVolume, TradingSignals, PVTState> {
+  protected override state: PVTState = {candles: []};
 
   override getRequiredInputs() {
     return 2;
   }
 
   update(candle: HighLowCloseVolume, replace: boolean) {
-    pushUpdate(this.#candles, replace, candle, 2);
+    this.trackState(replace);
 
-    if (this.#candles.length < 2) {
+    // trackState() already rewound the window on a replacement, so the candle is always appended
+    pushUpdate({array: this.state.candles, item: candle, maxLength: 2, replace: false});
+
+    if (this.state.candles.length < 2) {
       return null;
     }
 
-    const previousClose = this.#candles[0].close;
+    const previousClose = this.state.candles[0].close;
     /*
      * PVT accumulates onto the running total, so a replacement has to build on the total from
      * before the replaced candle. `this.result` still carries that candle's contribution until

--- a/packages/trading-signals/src/volume/RVOL/RVOL.test.ts
+++ b/packages/trading-signals/src/volume/RVOL/RVOL.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {NotEnoughDataError} from '../../error/index.js';
 import {RVOL} from './RVOL.js';
 
@@ -153,4 +154,10 @@ describe('RVOL', () => {
 
     expect(rvol.isStable).toBe(true);
   });
+});
+
+testReplaceContract({
+  create: () => new RVOL(3),
+  divergentInput: 9_999,
+  inputs: [100, 100, 100, 200, 300],
 });

--- a/packages/trading-signals/src/volume/RVOL/RVOL.test.ts
+++ b/packages/trading-signals/src/volume/RVOL/RVOL.test.ts
@@ -1,5 +1,4 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
-import {NotEnoughDataError} from '../../error/index.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {RVOL} from './RVOL.js';
 
 describe('RVOL', () => {
@@ -87,12 +86,6 @@ describe('RVOL', () => {
     expect(rvol.getResultOrThrow()).toBeCloseTo(200 / ((100 + 100 + 200) / 3), 4);
   });
 
-  it('throws NotEnoughDataError before warm-up completes', () => {
-    const rvol = new RVOL(5);
-    rvol.add(100);
-    expect(() => rvol.getResultOrThrow()).toThrowError(NotEnoughDataError);
-  });
-
   it('replaces the most recent value', () => {
     const rvol = new RVOL(3);
     [100, 100, 100].forEach(v => rvol.add(v));
@@ -156,7 +149,7 @@ describe('RVOL', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new RVOL(3),
   divergentInput: 9_999,
   inputs: [100, 100, 100, 200, 300],

--- a/packages/trading-signals/src/volume/VROC/VROC.test.ts
+++ b/packages/trading-signals/src/volume/VROC/VROC.test.ts
@@ -1,6 +1,5 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {VROC} from './VROC.js';
-import {NotEnoughDataError} from '../../error/index.js';
 import {TradingSignal} from '../../base/index.js';
 
 describe('VROC', () => {
@@ -29,18 +28,6 @@ describe('VROC', () => {
 
       expect(vroc.isStable).toBe(true);
       expect(vroc.getRequiredInputs()).toBe(4);
-    });
-
-    it('throws an error when there is not enough input data', () => {
-      const vroc = new VROC(5);
-      expect(vroc.isStable).toBe(false);
-
-      try {
-        vroc.getResultOrThrow();
-        throw new Error('Expected error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotEnoughDataError);
-      }
     });
 
     it('returns 0 when previous volume is 0', () => {
@@ -131,7 +118,7 @@ describe('VROC', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new VROC(3),
   divergentInput: 99_000,
   inputs: [1000, 1500, 2000, 2500, 3000],

--- a/packages/trading-signals/src/volume/VROC/VROC.test.ts
+++ b/packages/trading-signals/src/volume/VROC/VROC.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {VROC} from './VROC.js';
 import {NotEnoughDataError} from '../../error/index.js';
 import {TradingSignal} from '../../base/index.js';
@@ -128,4 +129,10 @@ describe('VROC', () => {
       expect(restoredResult).toBe(originalResult);
     });
   });
+});
+
+testReplaceContract({
+  create: () => new VROC(3),
+  divergentInput: 99_000,
+  inputs: [1000, 1500, 2000, 2500, 3000],
 });

--- a/packages/trading-signals/src/volume/VROC/VROC.ts
+++ b/packages/trading-signals/src/volume/VROC/VROC.ts
@@ -31,7 +31,7 @@ export class VROC extends TrendIndicatorSeries {
   }
 
   update(volume: number, replace: boolean) {
-    pushUpdate(this.#volumes, replace, volume, this.#historyLength);
+    pushUpdate({array: this.#volumes, item: volume, maxLength: this.#historyLength, replace: replace});
 
     if (this.#volumes.length < this.#historyLength) {
       return null;

--- a/packages/trading-signals/src/volume/VWMA/VWMA.test.ts
+++ b/packages/trading-signals/src/volume/VWMA/VWMA.test.ts
@@ -1,6 +1,5 @@
-import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {VWMA} from './VWMA.js';
-import {NotEnoughDataError} from '../../error/index.js';
 import {TradingSignal} from '../../base/index.js';
 import {EMA} from '../../trend/EMA/EMA.js';
 
@@ -53,18 +52,6 @@ describe('VWMA', () => {
       }
 
       expect(vwmaWeighted.getResultOrThrow()).toBeGreaterThan(vwmaEven.getResultOrThrow());
-    });
-
-    it('throws an error when there is not enough input data', () => {
-      const vwma = new VWMA(5);
-      expect(vwma.isStable).toBe(false);
-
-      try {
-        vwma.getResultOrThrow();
-        throw new Error('Expected error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(NotEnoughDataError);
-      }
     });
 
     it('returns null when all volumes are zero', () => {
@@ -201,7 +188,7 @@ describe('VWMA', () => {
   });
 });
 
-testReplaceContract({
+testIndicatorContract({
   create: () => new VWMA(3),
   divergentInput: {close: 500, high: 510, low: 490, volume: 99_000},
   inputs: [

--- a/packages/trading-signals/src/volume/VWMA/VWMA.test.ts
+++ b/packages/trading-signals/src/volume/VWMA/VWMA.test.ts
@@ -1,3 +1,4 @@
+import {testReplaceContract} from '../../fixtures/testReplaceContract.js';
 import {VWMA} from './VWMA.js';
 import {NotEnoughDataError} from '../../error/index.js';
 import {TradingSignal} from '../../base/index.js';
@@ -198,4 +199,15 @@ describe('VWMA', () => {
       expect(restoredResult).toBe(originalResult);
     });
   });
+});
+
+testReplaceContract({
+  create: () => new VWMA(3),
+  divergentInput: {close: 500, high: 510, low: 490, volume: 99_000},
+  inputs: [
+    {close: 10, high: 11, low: 9, volume: 100},
+    {close: 12, high: 13, low: 11, volume: 200},
+    {close: 11, high: 12, low: 10, volume: 150},
+    {close: 14, high: 15, low: 12, volume: 300},
+  ],
 });

--- a/packages/trading-signals/src/volume/VWMA/VWMA.ts
+++ b/packages/trading-signals/src/volume/VWMA/VWMA.ts
@@ -38,7 +38,7 @@ export class VWMA extends TrendIndicatorSeries<HighLowCloseVolume> {
   }
 
   update(candle: HighLowCloseVolume, replace: boolean) {
-    pushUpdate(this.#candles, replace, candle, this.interval);
+    pushUpdate({array: this.#candles, item: candle, maxLength: this.interval, replace: replace});
 
     if (this.#candles.length < this.interval) {
       return null;


### PR DESCRIPTION
Supersedes #1243, #1244, #1245, #1256, #1257, #1258, #1259, #1260 — same content, one PR. Eight commits, one per fix, each green on its own.

## How these were found

A differential harness over all 62 exported indicators, testing two properties:

1. a series with a decoy final bar plus `replace()` must equal the equivalent add-only series
2. `replace()` must never flip `isStable` from false to true, since it adds no input

That flagged 5 drift failures and 2 stability failures. A later sweep added a third property — replacing the last input with an **identical** value must change nothing — which failed on exactly the same six indicators, at 6 of 2480 scenarios.

## What was wrong

| Indicator | Defect |
|---|---|
| **BollingerBands** | `replace()` returned `null` and wiped the result to `undefined`; a dropped-out price of `0` suppressed the calculation; first band emitted one bar late |
| **BollingerBandsWidth** | inherited all three |
| **PVT** | replaced candle counted twice (`372.7` vs `281.8`) |
| **TDS** | setup counters never rolled back — a replacement could fabricate a completed setup |
| **PSAR** | six mutable fields never rolled back — a discarded candle's high of `999` stayed in the result |
| **ZigZag** | swing state never rolled back; had **no** `replace()` test at all |
| **ROC** | `getRequiredInputs()` off by one; replacing at the warm-up boundary fabricated a result |

Two shapes of root cause. Window-based indicators (BollingerBands, ROC) gated on the wrong thing or evicted the value they still needed — fixed by making the window the only state, so `pushUpdate()` handles `replace()` on its own, as `packages/trading-signals/CLAUDE.md` prescribes. State-machine indicators (PVT, TDS, PSAR, ZigZag) carried mutations across a replacement — fixed by snapshotting and restoring.

## Behaviour change

`BollingerBands` and `BollingerBandsWidth` now emit their first result one bar earlier. Values at every later bar are unchanged. This is a fix, not a tweak: `src/fixtures/BB/data.json` has `middle[19] = 74.3 = avg(prices[0..19])`, but the indicator stayed unstable until the 21st price. The test looped with `if (!bb.isStable) return;`, so that expected value was silently skipped. The Tulip test skipped its index 4 for the same reason. Both now assert the value they were skipping.

`ROC.getRequiredInputs()` returns `interval + 1`, matching `MOM` and `VROC`. Emitted values are unchanged.

## Verification

- **No Tulip divergence.** Every reference array is byte-identical to `main`. BollingerBands now asserts 11 bars against Tulip instead of 10, all matching — it moved toward the reference. ROC's mapping is unchanged: same bars, same expectations. PSAR's Tulip test only uses `add()`.
- **ROC values checked against the definition** `(p[k] - p[k-interval]) / p[k-interval]` — 2322 emissions across intervals 1–12, zero mismatches.
- **BBW tightened from 2 to 8 decimals.** TradingView's 2dp cannot separate neighbouring readings (the first two bars both display `0.19` while actually being `0.1853` and `0.1945`). The tighter values are derived from the definition rather than read back from our output, and each still rounds to the TradingView figure.
- **All three harness properties clean** across 62 indicators after the fixes.
- 563 tests, coverage stays at 100%, lint and `tsc --noEmit` clean, `trading-strategies` unchanged at 259 tests.

## Tests

Every new test was verified to fail without its fix. All six indicators now have an explicitly named same-value test; where the state only diverges at certain series lengths (ROC, PSAR, ZigZag) the test sweeps every length, because a single fixed length silently passed.