### PR TITLE
ci: publish via npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,11 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'
-      - name: 'Install dependencies'
+      - name: 'Install'
         run: npm ci
-      - name: 'Verify provenance and registry signatures of installed dependencies'
+      - name: 'Audit'
         run: npm audit signatures
-      - name: 'Verify'
+      - name: 'Test'
         run: |
           npm run lint
           npm test
@@ -36,7 +36,7 @@ jobs:
         run: npx lerna publish --yes
         env:
           GH_TOKEN: ${{ secrets.GH_AUTOMERGE_TOKEN }}
-      - name: 'Summarize what was published'
+      - name: 'Summary'
         if: always()
         run: |
           {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
           # main requires the test-coverage check, which a brand-new publish commit
           # cannot have yet. GITHUB_TOKEN gets rejected; an admin PAT bypasses it
           # because the branch has enforce_admins disabled.
-          token: ${{ secrets.GH_AUTOMERGE_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_AUTOMERGE_TOKEN }}
       - uses: actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'
@@ -50,7 +50,7 @@ jobs:
       - name: 'Publish'
         run: npx lerna publish --yes
         env:
-          GH_TOKEN: ${{ secrets.GH_AUTOMERGE_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_AUTOMERGE_TOKEN }}
       - name: 'Summarize what was published'
         if: always()
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,10 @@ name: 'Release'
 
 permissions:
   contents: write
-  # Lets lerna trade a GitHub OIDC token for a short-lived npm token, so no
-  # long-lived NPM_TOKEN is needed once trusted publishing is configured for
-  # each package. It also makes lerna attach provenance to public packages.
+  # The only npm credential. Lerna trades this for a short-lived npm token per
+  # package and attaches provenance to public ones. Every published package
+  # therefore needs trusted publishing configured on npmjs.com, pointing at this
+  # repository and this workflow file, or its publish fails.
   id-token: write
 
 on:
@@ -29,9 +30,9 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'
-          # Writes the auth token to a separate user-level .npmrc, leaving the
-          # repo's own .npmrc (registry, min-release-age) untouched.
-          registry-url: 'https://registry.npmjs.org'
+          # No registry-url on purpose: it would write _authToken=${NODE_AUTH_TOKEN}
+          # into an .npmrc, and npm fails to parse that when no token is set. The
+          # registry comes from lerna.json and the repo's own .npmrc instead.
       - name: 'Configure git author for the publish commit'
         run: |
           git config user.name 'github-actions[bot]'
@@ -49,9 +50,6 @@ jobs:
       - name: 'Publish'
         run: npx lerna publish --yes
         env:
-          # Fallback for packages that do not have trusted publishing configured
-          # yet. OIDC takes precedence whenever the exchange succeeds.
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
       - name: 'Summarize what was published'
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
           # main requires the test-coverage check, which a brand-new publish commit
           # cannot have yet. GITHUB_TOKEN gets rejected; an admin PAT bypasses it
           # because the branch has enforce_admins disabled.
-          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_AUTOMERGE_TOKEN || secrets.GITHUB_TOKEN }}
       - uses: actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'
@@ -50,7 +50,7 @@ jobs:
       - name: 'Publish'
         run: npx lerna publish --yes
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_AUTOMERGE_TOKEN || secrets.GITHUB_TOKEN }}
       - name: 'Summarize what was published'
         if: always()
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,10 +2,6 @@ name: 'Release'
 
 permissions:
   contents: write
-  # The only npm credential. Lerna trades this for a short-lived npm token per
-  # package and attaches provenance to public ones. Every published package
-  # therefore needs trusted publishing configured on npmjs.com, pointing at this
-  # repository and this workflow file, or its publish fails.
   id-token: write
 
 on:
@@ -21,22 +17,11 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          # Lerna derives bumps and changelogs from the whole commit and tag history.
           fetch-depth: 0
-          # main requires the test-coverage check, which a brand-new publish commit
-          # cannot have yet. GITHUB_TOKEN gets rejected; an admin PAT bypasses it
-          # because the branch has enforce_admins disabled.
           token: ${{ secrets.GH_AUTOMERGE_TOKEN }}
       - uses: actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'
-          # No registry-url on purpose: it would write _authToken=${NODE_AUTH_TOKEN}
-          # into an .npmrc, and npm fails to parse that when no token is set. The
-          # registry comes from lerna.json and the repo's own .npmrc instead.
-      - name: 'Configure git author for the publish commit'
-        run: |
-          git config user.name 'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
       - name: 'Install dependencies'
         run: npm ci
       - name: 'Verify provenance and registry signatures of installed dependencies'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,10 @@ name: 'Release'
 
 permissions:
   contents: write
+  # Lets lerna trade a GitHub OIDC token for a short-lived npm token, so no
+  # long-lived NPM_TOKEN is needed once trusted publishing is configured for
+  # each package. It also makes lerna attach provenance to public packages.
+  id-token: write
 
 on:
   workflow_dispatch:
@@ -34,6 +38,8 @@ jobs:
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
       - name: 'Install dependencies'
         run: npm ci
+      - name: 'Verify provenance and registry signatures of installed dependencies'
+        run: npm audit signatures
       - name: 'Verify'
         run: |
           npm run lint
@@ -43,5 +49,14 @@ jobs:
       - name: 'Publish'
         run: npx lerna publish --yes
         env:
+          # Fallback for packages that do not have trusted publishing configured
+          # yet. OIDC takes precedence whenever the exchange succeeds.
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+      - name: 'Summarize what was published'
+        if: always()
+        run: |
+          {
+            echo "### Published"
+            git tag --points-at HEAD | sed 's/^/- /'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: 'release'
+  group: ${{ github.workflow }}
   cancel-in-progress: false
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .cache
 .DS_Store
 .idea/
+.vscode/
 !.vscode/extensions.json
 !.vscode/settings.json
 config.json

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 .cache
 .DS_Store
 .idea/
-.vscode/
+!.vscode/extensions.json
 !.vscode/settings.json
 config.json
 coverage/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["vitest.explorer", "bennycode.sort-everything", "oxc.oxc-vscode", "ms-playwright.playwright"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
+  "editor.defaultFormatter": "oxc.oxc-vscode",
+  "editor.formatOnSave": true,
+  "editor.formatOnSaveMode": "file",
   "js/ts.tsdk.path": "node_modules/typescript/lib",
   "js/ts.tsdk.promptToUseWorkspaceVersion": true,
   "search.exclude": {


### PR DESCRIPTION
Follow-up to the release workflow, taking a few ideas from [xmtp-js](https://github.com/xmtp/xmtp-js/blob/main/.github/workflows/release.yml).

## Trusted publishing as the only npm credential

Lerna 9 already implements npm's OIDC token exchange. Given `id-token: write`, it requests a GitHub OIDC token, swaps it for a short-lived npm token per package, and turns on provenance for public packages:

```js
const audience = `npm:${new URL(registry).hostname}`;
// POST /-/npm/v1/oidc/token/exchange/package/<name>
opts[authTokenKey] = response["token"];
…
opts.provenance = true;
```

No long-lived npm token is stored anywhere, and npm's 2FA gate on publish no longer applies, which is what broke the last release attempt.

There is deliberately no token fallback. A fallback lets a release succeed through a stored token when trusted publishing is misconfigured, hiding the problem until that token expires. Without one, a misconfigured package fails its publish immediately.

`setup-node`'s `registry-url` is left off for the same reason: it writes `_authToken=${NODE_AUTH_TOKEN}` into an `.npmrc`, which npm cannot parse when the variable is unset. The registry comes from `lerna.json` and the repo's own `.npmrc`.

### Required before the first release

Trusted publishing has to be enabled on npmjs.com for every published package, each pointing at this repository and `release.yml`:

- `trading-signals`
- `trading-strategies`
- `@typedtrader/candles`
- `@typedtrader/exchange`

A package without it will fail to publish.

## Git push uses the existing GH_AUTOMERGE_TOKEN

Lerna pushes the publish commit and tags to `main`, which requires the `test-coverage` check that a new commit cannot have yet. `GITHUB_TOKEN` is rejected there, so the workflow reuses the repository's existing `GH_AUTOMERGE_TOKEN`, which carries the admin bypass. No new secret is introduced.

## Smaller additions

- `npm audit signatures` checks provenance and registry signatures of installed dependencies before anything is published.
- The run summary lists the tags that were published, so the outcome is visible without opening the job log.

## Not included

xmtp's prerelease and nightly jobs are extra release paths, and this workflow is meant to be the only one. Their `push: main` trigger also publishes automatically, whereas this stays on manual dispatch.

Untested end to end: the OIDC path is verified by reading lerna's source, not by a real run. With the fallback gone, the first release is a real test of both the npmjs.com configuration and the token's scopes.