### PR TITLE
ci: drop GitHub Releases and use a dedicated push token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,10 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          # Persisted as the credential lerna's git push reuses. main requires the
+          # test-coverage check, which a brand-new publish commit cannot have yet,
+          # so GITHUB_TOKEN is rejected and an admin PAT is needed to bypass it.
+          token: ${{ secrets.RELEASE_TOKEN }}
       - uses: actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'
@@ -32,10 +36,11 @@ jobs:
           npm test
       - name: 'Build'
         run: npm run dist
+      # npm auth comes from the OIDC exchange enabled by id-token above. No
+      # GH_TOKEN: createRelease is off in lerna.json, so nothing calls the
+      # GitHub API here.
       - name: 'Publish'
         run: npx lerna publish --yes
-        env:
-          GH_TOKEN: ${{ secrets.GH_AUTOMERGE_TOKEN }}
       - name: 'Summary'
         if: always()
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,9 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          # Persisted as the credential lerna's git push reuses. main requires the
-          # test-coverage check, which a brand-new publish commit cannot have yet,
-          # so GITHUB_TOKEN is rejected and an admin PAT is needed to bypass it.
+          # Create PAT at:
+          # https://github.com/settings/personal-access-tokens
+          # Repository permissions: "Contents" (Read and write)
           token: ${{ secrets.RELEASE_TOKEN }}
       - uses: actions/setup-node@v7
         with:
@@ -36,9 +36,6 @@ jobs:
           npm test
       - name: 'Build'
         run: npm run dist
-      # npm auth comes from the OIDC exchange enabled by id-token above. No
-      # GH_TOKEN: createRelease is off in lerna.json, so nothing calls the
-      # GitHub API here.
       - name: 'Publish'
         run: npx lerna publish --yes
       - name: 'Summary'

--- a/lerna.json
+++ b/lerna.json
@@ -4,7 +4,6 @@
       "allowBranch": "main",
       "changelogPreset": "conventional-changelog-conventionalcommits",
       "conventionalCommits": true,
-      "createRelease": "github",
       "message": "[skip ci] chore: Publish"
     }
   },


### PR DESCRIPTION
The release needs a GitHub credential for two separate things:

1. pushing the publish commit and tags to `main`, which requires bypassing the `test-coverage` check a brand-new commit cannot have yet
2. creating a GitHub Release per package, via `createRelease: "github"`

Turning off `createRelease` removes the second, so the token is now only a git push credential and never touches the GitHub API. The `GH_TOKEN` env var is gone from the publish step.

## Token

`GH_AUTOMERGE_TOKEN` is expired (it broke the last release run at checkout) and is named after an auto-merge workflow that no longer exists — `release.yml` was its only remaining reference. This switches to a purpose-named `RELEASE_TOKEN`.

It sits on `actions/checkout` because that is what persists the credential lerna's `git push` reuses. Lerna shells out to a plain `git push` with no token argument of its own, so there is nowhere else to supply it.

## npm is unchanged

Publishing still authenticates through the OIDC exchange enabled by `id-token: write`. No npm token is involved.

## Setup before the next run

- Create a PAT with `repo` scope (or fine-grained with Contents: read and write on this repo) and store it as `RELEASE_TOKEN`
- `GH_AUTOMERGE_TOKEN` can be deleted afterwards, nothing references it
- Trusted publishing still has to be enabled on npmjs.com for `trading-signals`, `trading-strategies`, `@typedtrader/candles` and `@typedtrader/exchange`

## Trade-off

No more per-package GitHub Releases. Tags are still pushed and the changelogs are still generated and committed, so the release history stays readable in the repo — it just is not mirrored to the Releases tab.