### PR TITLE
ci: set a git identity for the release commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,8 @@ jobs:
       # "empty ident name" before it can tag or publish anything.
       - name: 'Identity'
         run: |
-          git config user.name 'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git config user.name 'Benny Neugebauer'
+          git config user.email 'mail@bennycode.com'
       - uses: actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,12 @@ jobs:
           # https://github.com/settings/personal-access-tokens
           # Repository permissions: "Contents" (Read and write)
           token: ${{ secrets.RELEASE_TOKEN }}
+      # A fresh runner has no git identity, so lerna's version commit fails with
+      # "empty ident name" before it can tag or publish anything.
+      - name: 'Identity'
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
       - uses: actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'


### PR DESCRIPTION
Run [30755394672](https://github.com/bennycode/trading-signals/actions/runs/30755394672) got through checkout, install, audit, tests and build, then failed in `lerna publish`:

```
*** Please tell me who you are.
fatal: empty ident name (for <runner@runnervmvrwv9...internal.cloudapp.net>) not allowed
```

A fresh runner has no `user.name` or `user.email`, so the version commit cannot be created. It works locally only because developer machines have a global identity.

This adds the config step before the publish. Commits are attributed to `github-actions[bot]` with the matching noreply address, so they link to the bot account rather than to whoever owns the PAT.

Nothing was tagged, pushed or published by the failed run — it aborted at `git commit`, which comes first.