### PR TITLE
fix(trading-signals, trading-strategies, candles, exchange): add repository metadata for npm provenance

### DIFF
--- a/packages/candles/package.json
+++ b/packages/candles/package.json
@@ -2,6 +2,11 @@
   "name": "@typedtrader/candles",
   "version": "0.2.1",
   "description": "Labeled market-condition candle datasets (uptrend, downtrend, sideways, …) for tests and docs.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/bennycode/trading-signals.git",
+    "directory": "packages/candles"
+  },
   "files": [
     "dist",
     "json"

--- a/packages/exchange/package.json
+++ b/packages/exchange/package.json
@@ -11,6 +11,11 @@
     "url": "https://github.com/bennycode/trading-signals/issues"
   },
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/bennycode/trading-signals.git",
+    "directory": "packages/exchange"
+  },
   "files": [
     "dist",
     "!dist/start",

--- a/packages/trading-signals/package.json
+++ b/packages/trading-signals/package.json
@@ -35,7 +35,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/bennycode/trading-signals.git"
+    "url": "git+https://github.com/bennycode/trading-signals.git",
+    "directory": "packages/trading-signals"
   },
   "files": [
     "dist",

--- a/packages/trading-strategies/package.json
+++ b/packages/trading-strategies/package.json
@@ -10,6 +10,11 @@
     "url": "https://github.com/bennycode/trading-signals/issues"
   },
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/bennycode/trading-signals.git",
+    "directory": "packages/trading-strategies"
+  },
   "files": [
     "dist",
     "!dist/start",


### PR DESCRIPTION
Release [30755884162](https://github.com/bennycode/trading-signals/actions/runs/30755884162) published `trading-signals@8.1.0` and failed the other three packages:

```
E422 Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is "", expected to match "https://github.com/bennycode/trading-signals" from provenance
```

Trusted publishing worked (`oidc Successfully retrieved and set token`, `oidc Enabling provenance`). The problem is that provenance makes `repository.url` mandatory: npm cross-checks the attestation's source repository against the manifest and rejects the tarball when they do not match. An absent field reads as `""`.

`trading-signals` already had a `repository` entry, which is exactly why it was the only package that published.

This adds the field to the three that lacked it, with `directory` set so each package points at its own subdirectory in the monorepo.

## Effect on versions

`trading-strategies@0.4.1`, `@typedtrader/candles@0.2.1` and `@typedtrader/exchange@0.3.1` are tagged in git but never reached npm. Since this commit touches those three packages, the next release bumps them to `0.4.2`, `0.2.2` and `0.3.2` and publishes those instead. The `.1` tags stay behind as versions that only ever existed in git.

`trading-signals` is untouched here, so it stays at `8.1.0` and will not be republished.