### PR TITLE
fix: format lerna-generated changelogs via the version lifecycle

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "pretest": "lerna run dist",
     "test": "npm run test:imports && lerna run --no-sort --concurrency 8 test",
     "test:imports": "knip",
-    "test:types": "lerna run --no-sort --concurrency 8 test:types"
+    "test:types": "lerna run --no-sort --concurrency 8 test:types",
+    "version": "oxfmt packages/*/CHANGELOG.md"
   },
   "devDependencies": {
     "@action-validator/cli": "^0.6.0",

--- a/packages/candles/CHANGELOG.md
+++ b/packages/candles/CHANGELOG.md
@@ -1,15 +1,10 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 ## [0.2.1](https://github.com/bennycode/trading-signals/compare/@typedtrader/candles@0.2.0...@typedtrader/candles@0.2.1) (2026-08-02)
 
 **Note:** Version bump only for package @typedtrader/candles
-
-
-
-
 
 ## 0.2.0 (2026-07-24)
 

--- a/packages/exchange/CHANGELOG.md
+++ b/packages/exchange/CHANGELOG.md
@@ -1,14 +1,12 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 ## [0.3.1](https://github.com/bennycode/trading-signals/compare/@typedtrader/exchange@0.3.0...@typedtrader/exchange@0.3.1) (2026-08-02)
 
 ### Bug Fixes
 
-* **exchange:** remove console noise and dotenv-defaults from consumer install ([#1240](https://github.com/bennycode/trading-signals/issues/1240))
-
+- **exchange:** remove console noise and dotenv-defaults from consumer install ([#1240](https://github.com/bennycode/trading-signals/issues/1240))
 
 ## [0.3.0](https://github.com/bennycode/trading-signals/compare/@typedtrader/exchange@0.2.5...@typedtrader/exchange@0.3.0) (2026-07-24)
 

--- a/packages/messaging/CHANGELOG.md
+++ b/packages/messaging/CHANGELOG.md
@@ -1,15 +1,10 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 ## [0.5.1](https://github.com/bennycode/trading-signals/compare/@typedtrader/messaging@0.5.0...@typedtrader/messaging@0.5.1) (2026-08-02)
 
 **Note:** Version bump only for package @typedtrader/messaging
-
-
-
-
 
 ## [0.5.0](https://github.com/bennycode/trading-signals/compare/@typedtrader/messaging@0.4.0...@typedtrader/messaging@0.5.0) (2026-07-24)
 

--- a/packages/trading-signals-docs/CHANGELOG.md
+++ b/packages/trading-signals-docs/CHANGELOG.md
@@ -1,14 +1,12 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 ## [2.1.0](https://github.com/bennycode/trading-signals/compare/trading-signals-docs@2.0.0...trading-signals-docs@2.1.0) (2026-08-02)
 
 ### Features
 
-* **trading-signals-docs:** add SuperTrend and Volatility Stop demos ([#1239](https://github.com/bennycode/trading-signals/issues/1239))
-
+- **trading-signals-docs:** add SuperTrend and Volatility Stop demos ([#1239](https://github.com/bennycode/trading-signals/issues/1239))
 
 ## [2.0.0](https://github.com/bennycode/trading-signals/compare/trading-signals-docs@1.4.0...trading-signals-docs@2.0.0) (2026-07-24)
 

--- a/packages/trading-signals/CHANGELOG.md
+++ b/packages/trading-signals/CHANGELOG.md
@@ -1,19 +1,17 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 ## [8.1.0](https://github.com/bennycode/trading-signals/compare/trading-signals@8.0.0...trading-signals@8.1.0) (2026-08-02)
 
 ### Features
 
-* **trading-signals:** add SuperTrend indicator (SUPERTREND) ([#1238](https://github.com/bennycode/trading-signals/issues/1238))
-* **trading-signals:** add Volatility Stop indicator (VSTOP) ([#1237](https://github.com/bennycode/trading-signals/issues/1237))
+- **trading-signals:** add SuperTrend indicator (SUPERTREND) ([#1238](https://github.com/bennycode/trading-signals/issues/1238))
+- **trading-signals:** add Volatility Stop indicator (VSTOP) ([#1237](https://github.com/bennycode/trading-signals/issues/1237))
 
 ### Bug Fixes
 
-* **trading-signals:** use correct comparand when replacing ROC values ([#1242](https://github.com/bennycode/trading-signals/issues/1242))
-
+- **trading-signals:** use correct comparand when replacing ROC values ([#1242](https://github.com/bennycode/trading-signals/issues/1242))
 
 ## [8.0.0](https://github.com/bennycode/trading-signals/compare/trading-signals@7.4.3...trading-signals@8.0.0) (2026-07-24)
 

--- a/packages/trading-strategies/CHANGELOG.md
+++ b/packages/trading-strategies/CHANGELOG.md
@@ -1,15 +1,10 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+All notable changes to this project will be documented in this file. See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 ## [0.4.1](https://github.com/bennycode/trading-signals/compare/trading-strategies@0.4.0...trading-strategies@0.4.1) (2026-08-02)
 
 **Note:** Version bump only for package trading-strategies
-
-
-
-
 
 ## [0.4.0](https://github.com/bennycode/trading-signals/compare/trading-strategies@0.3.5...trading-strategies@0.4.0) (2026-07-24)
 


### PR DESCRIPTION
`main` currently fails `npm run lint`, which blocks every open PR including #1267:

```
> oxfmt --list-different
packages/candles/CHANGELOG.md
packages/exchange/CHANGELOG.md
... (all six)
```

## Why it started

lerna already formats files it writes during a release — but only with prettier, which the oxlint/oxfmt migration removed:

```js
const hasPrettier = packageJson.devDependencies?.prettier || packageJson.dependencies?.prettier;
if (!hasPrettier) return;
```

That check now fails silently, so changelogs land with `*` bullets and wrapped prose. Since the publish commit carries `[skip ci]`, nothing reformats them afterwards and `main` breaks the moment a release lands. It happened before and was patched by hand in 82be9b3.

## Fix

lerna runs the root `version` lifecycle **after** generating changelogs and **before** staging them, so formatting there lands inside the publish commit:

```json
"version": "oxfmt packages/*/CHANGELOG.md"
```

Verified with a local `lerna version --no-git-tag-version --no-push`:

```
lerna info lifecycle typedtrader@0.0.0~version: typedtrader@0.0.0
> typedtrader@0.0.0 version
> oxfmt packages/*/CHANGELOG.md
Finished in 237ms on 6 files
```

Afterwards `oxfmt --list-different` reports the freshly generated entries as already clean.

This also reformats the six changelogs that were committed unformatted by the 8.1.0 release, so `npm run lint` passes on a clean checkout.

Output matches the pre-migration style (`-` bullets, unwrapped prose), so changelog history stays visually consistent rather than changing style mid-file.