### PR TITLE
ci: create GitHub Releases during a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,11 @@ jobs:
         run: npm run dist
       - name: 'Publish'
         run: npx lerna publish --yes
+        env:
+          # Required by createRelease in lerna.json. Uses the PAT rather than
+          # GITHUB_TOKEN so the releases are attributed to the same person as
+          # the publish commit. npm auth is unrelated and comes from OIDC.
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
       - name: 'Summary'
         if: always()
         run: |

--- a/lerna.json
+++ b/lerna.json
@@ -4,6 +4,7 @@
       "allowBranch": "main",
       "changelogPreset": "conventional-changelog-conventionalcommits",
       "conventionalCommits": true,
+      "createRelease": "github",
       "message": "[skip ci] chore: Publish"
     }
   },


### PR DESCRIPTION
Restores `createRelease`, which was turned off in #1265 while the release pipeline was being debugged.

```json
"createRelease": "github",
```

lerna requires a `GH_TOKEN` environment variable for this:

```js
const { GH_TOKEN, GHE_API_URL, GHE_VERSION } = process.env;
if (!GH_TOKEN) throw `A GH_TOKEN environment variable is required when "createRelease" is set to "github"`
```

`RELEASE_TOKEN` is used rather than `GITHUB_TOKEN` so the releases are attributed to the same person as the publish commit, which is already authored as `Benny Neugebauer <mail@bennycode.com>`.

No token permissions needed changing. A fine-grained PAT's `Contents: read and write` already covers releases, which was verified before wiring this up by having both tokens create and delete a draft release from a scratch workflow:

```
GITHUB_TOKEN:  created draft release 363841149 -> deleted
RELEASE_TOKEN: created draft release 363841154 -> deleted
```

npm authentication is unaffected and still comes from the OIDC exchange.

## What to expect

lerna creates one release per versioned package, including the private ones. A cycle like 8.1.1 produces six: `trading-signals`, `trading-strategies`, `@typedtrader/candles`, `@typedtrader/exchange`, plus `@typedtrader/messaging` and `trading-signals-docs`, neither of which publishes to npm. That matches how the Releases tab looked before #1265.