### PR TITLE
refactor(trading-signals): share one typical price definition

### DIFF
--- a/packages/trading-signals/src/momentum/CCI/CCI.ts
+++ b/packages/trading-signals/src/momentum/CCI/CCI.ts
@@ -2,7 +2,7 @@ import {SMA} from '../../trend/SMA/SMA.js';
 import type {HighLowClose} from '../../base/Candle.type.js';
 import {TradingSignal, TrendIndicatorSeries} from '../../base/Indicator.js';
 import type {SignalThresholds} from '../../base/SignalThresholds.type.js';
-import {pushUpdate} from '../../util/index.js';
+import {getTypicalPrice, pushUpdate} from '../../util/index.js';
 import {MAD} from '../../volatility/MAD/MAD.js';
 
 /**
@@ -64,8 +64,8 @@ export class CCI extends TrendIndicatorSeries<HighLowClose<number>> {
     return null;
   }
 
-  #cacheTypicalPrice({close, high, low}: HighLowClose<number>, replace: boolean) {
-    const typicalPrice = (high + low + close) / 3;
+  #cacheTypicalPrice(candle: HighLowClose<number>, replace: boolean) {
+    const typicalPrice = getTypicalPrice(candle);
     pushUpdate(this.#typicalPrices, replace, typicalPrice, this.interval);
     return typicalPrice;
   }

--- a/packages/trading-signals/src/momentum/MFI/MFI.ts
+++ b/packages/trading-signals/src/momentum/MFI/MFI.ts
@@ -1,6 +1,7 @@
 import type {HighLowCloseVolume} from '../../base/Candle.type.js';
 import {TradingSignal, TrendIndicatorSeries} from '../../base/Indicator.js';
 import type {SignalThresholds} from '../../base/SignalThresholds.type.js';
+import {getTypicalPrice} from '../../util/getTypicalPrice.js';
 import {pushUpdate} from '../../util/pushUpdate.js';
 
 /**
@@ -44,7 +45,7 @@ export class MFI extends TrendIndicatorSeries<HighLowCloseVolume<number>> {
       return null;
     }
 
-    const typicalPrices = this.#candles.map(({close, high, low}) => (high + low + close) / 3);
+    const typicalPrices = this.#candles.map(getTypicalPrice);
     let positiveFlow = 0;
     let negativeFlow = 0;
 

--- a/packages/trading-signals/src/trend/TYPPRICE/TypicalPrice.ts
+++ b/packages/trading-signals/src/trend/TYPPRICE/TypicalPrice.ts
@@ -1,5 +1,6 @@
 import {IndicatorSeries} from '../../base/Indicator.js';
 import type {HighLowClose} from '../../base/Candle.type.js';
+import {getTypicalPrice} from '../../util/getTypicalPrice.js';
 
 /**
  * Typical Price (TYPPRICE)
@@ -19,8 +20,6 @@ export class TypicalPrice extends IndicatorSeries<HighLowClose<number>> {
   }
 
   update(candle: HighLowClose<number>, replace: boolean) {
-    const {high, low, close} = candle;
-
-    return this.setResult((high + low + close) / 3, replace);
+    return this.setResult(getTypicalPrice(candle), replace);
   }
 }

--- a/packages/trading-signals/src/trend/VWAP/VWAP.ts
+++ b/packages/trading-signals/src/trend/VWAP/VWAP.ts
@@ -1,5 +1,6 @@
 import {IndicatorSeries} from '../../base/Indicator.js';
 import type {HighLowCloseVolume} from '../../base/Candle.type.js';
+import {getTypicalPrice} from '../../util/getTypicalPrice.js';
 
 /**
  * Volume-Weighted Average Price (VWAP)
@@ -20,9 +21,8 @@ export class VWAP extends IndicatorSeries<HighLowCloseVolume<number>> {
     super();
   }
 
-  #calculateTypicalPriceVolume(data: HighLowCloseVolume<number>) {
-    const hlc3 = (data.high + data.low + data.close) / 3;
-    return hlc3 * data.volume;
+  #calculateTypicalPriceVolume(candle: HighLowCloseVolume<number>) {
+    return getTypicalPrice(candle) * candle.volume;
   }
 
   override getRequiredInputs() {

--- a/packages/trading-signals/src/util/getTypicalPrice.test.ts
+++ b/packages/trading-signals/src/util/getTypicalPrice.test.ts
@@ -1,0 +1,15 @@
+import {getTypicalPrice} from './getTypicalPrice.js';
+
+describe('getTypicalPrice', () => {
+  it('averages high, low and close', () => {
+    expect(getTypicalPrice({close: 81.59, high: 82.15, low: 81.29}).toFixed(3)).toBe('81.677');
+  });
+
+  it('keeps the bar range in the price', () => {
+    const ranUpAndGaveItBack = getTypicalPrice({close: 100, high: 110, low: 100});
+    const droppedAndRecovered = getTypicalPrice({close: 100, high: 100, low: 90});
+
+    expect(ranUpAndGaveItBack.toFixed(2), 'sits above a close that ended at the low of the bar').toBe('103.33');
+    expect(droppedAndRecovered.toFixed(2), 'sits below a close that ended at the high of the bar').toBe('96.67');
+  });
+});

--- a/packages/trading-signals/src/util/getTypicalPrice.ts
+++ b/packages/trading-signals/src/util/getTypicalPrice.ts
@@ -1,0 +1,11 @@
+import type {HighLowClose} from '../base/Candle.type.js';
+
+/**
+ * Collapses a candle into the single price most of its trading happened around. Used wherever an indicator needs a
+ * candle's price without discarding where it travelled during the bar, which a close on its own would.
+ *
+ * @see https://tulipindicators.org/typprice
+ */
+export function getTypicalPrice({high, low, close}: HighLowClose<number>) {
+  return (high + low + close) / 3;
+}

--- a/packages/trading-signals/src/util/index.ts
+++ b/packages/trading-signals/src/util/index.ts
@@ -9,5 +9,6 @@ export * from './getQuartile.js';
 export * from './getShare.js';
 export * from './getStandardDeviation.js';
 export * from './getStreaks.js';
+export * from './getTypicalPrice.js';
 export * from './getWeekday.js';
 export * from './pushUpdate.js';


### PR DESCRIPTION
Stacked on #1270. Base is `feat/typical-price`, so the diff shows only the refactor.

`(high + low + close) / 3` was written out four times once #1270 lands — in CCI, MFI, VWAP and the new `TypicalPrice` indicator. All four now call one helper.

## Why a helper rather than the indicator

#1270's follow-up note suggested having CCI, MFI and VWAP consume the `TypicalPrice` indicator. Reading them, that does not fit:

- MFI maps its whole candle window to typical prices on every update. Feeding a window through one sequential indicator instance would corrupt its result and `previousResult` tracking.
- VWAP recomputes the typical price of a *cached past candle* when replacing, to subtract it from the running total. An indicator instance cannot produce a value for an arbitrary earlier candle without disturbing its own state.

Both need a pure function. `src/util/` already holds exactly this kind of helper (`getAverage`, `getMedian`, `getStandardDeviation`), so `getTypicalPrice` goes there and the indicator uses it too.

Doing it the other way would have meant restructuring working `replace()` logic in two indicators to fit an abstraction that does not suit them.

## Verification

No behaviour change. All 548 tests pass and coverage stays at 100%, including the existing Tulip-referenced CCI, MFI and VWAP suites which would catch any drift in the formula.

The helper has its own test covering the formula and the range-retention property.