### PR TITLE
chore: pin the editor formatter per language

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,32 @@
   "js/ts.tsdk.promptToUseWorkspaceVersion": true,
   "search.exclude": {
     "**/docs": true
+  },
+  "[github-actions-workflow]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode"
+  },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode"
+  },
+  "[markdown]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode"
+  },
+  "[yaml]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode"
   }
 }


### PR DESCRIPTION
Saving a workflow file in VS Code reformatted it with something other than oxc.

## Cause

`.vscode/settings.json` sets a generic formatter:

```json
"editor.defaultFormatter": "oxc.oxc-vscode",
```

VS Code resolves language-specific settings ahead of generic ones, and that ordering ignores scope — a *user-level* `[yaml]` entry beats a *workspace-level* generic one. Personal settings containing this are enough to override the project:

```json
"[yaml]": { "editor.defaultFormatter": "redhat.vscode-yaml" },
"[github-actions-workflow]": { "editor.defaultFormatter": "redhat.vscode-yaml" }
```

It is not limited to YAML. The same pattern commonly pins `[typescript]`, `[javascript]`, `[json]` and `[jsonc]` to Prettier, so this repo's TypeScript was being formatted by the tool it migrated away from, while CI verified it with `oxfmt --list-different`. That has not caused a failure yet only because oxfmt is largely Prettier-compatible.

## Fix

Pin every language the repo formats. Workspace language-specific settings take precedence over user language-specific ones, so this holds regardless of a contributor's personal config.

oxfmt handles all of them, verified directly on a YAML file:

```
name:    "Test"          ->   name: 'Test'
    push:                ->     push:
         branches:   [main]  ->     branches: [main]
```