### PR TITLE
fix: make the .vscode gitignore negations work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 .cache
 .DS_Store
 .idea/
-.vscode/
+.vscode/*
 !.vscode/extensions.json
 !.vscode/settings.json
 config.json


### PR DESCRIPTION
```diff
-.vscode/
+.vscode/*
 !.vscode/extensions.json
 !.vscode/settings.json
```

Git cannot re-include a file whose parent directory is excluded, so the two negation lines were dead. `.vscode/` stops the directory walk at the directory itself, and nothing inside is ever considered.

`.vscode/settings.json` and `.vscode/extensions.json` are in the repository only because they were committed before the rule existed — tracked files bypass `.gitignore` entirely. The breakage is invisible until someone deletes one and tries to re-add it, or a contributor recreates it after a fresh clone: both hit `The following paths are ignored by one of your .gitignore files` and need `-f`.

## Verified by traversal, not by check-ignore

`git check-ignore` reports these paths as *not* ignored under both patterns, because it matches a path against the rules and the negation is the last match. That disagrees with what git actually does when walking the tree, so it is the wrong instrument here.

Using `git status --untracked-files=all` against the real `.gitignore` in a scratch repository:

```
--- OLD pattern ---
  (nothing under .vscode is visible to git)
--- NEW pattern ---
?? .vscode/extensions.json
?? .vscode/settings.json
```

`.vscode/launch.json` stays ignored under both, so the change re-includes exactly the two intended files and nothing more.