### PR TITLE
feat(trading-signals): compare indicator state via getState()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ lerna-debug.log
 node_modules/
 npm-debug.log*
 .claude/scheduled_tasks.lock
+.claude/worktrees/

--- a/packages/trading-signals/src/base/Indicator.ts
+++ b/packages/trading-signals/src/base/Indicator.ts
@@ -42,12 +42,6 @@ export abstract class TechnicalIndicator<
 
   abstract getRequiredInputs(): number;
 
-  /**
-   * Rewinds `state` by one bar on a replacement, or snapshots it before a regular add. Stateful
-   * indicators call this first in `update()`, so a replacement re-runs the latest bar from the
-   * exact state that bar originally saw — without per-field rollback bookkeeping, which is easy
-   * to get wrong when a field is forgotten.
-   */
   protected trackState(replace: boolean) {
     if (replace) {
       if (this.#previousState !== undefined) {
@@ -59,9 +53,8 @@ export abstract class TechnicalIndicator<
   }
 
   /**
-   * Snapshot of the result and the declared mutable state. Two indicators fed equivalent input
-   * series must produce identical snapshots, which makes state divergence visible as a diff in
-   * tests: `expect(a.getState()).toEqual(b.getState())`.
+   * Snapshot of the result and the mutable state, so two indicator instances fed the same
+   * inputs can be compared.
    */
   getState() {
     return structuredClone({...this.state, result: this.result});

--- a/packages/trading-signals/src/base/Indicator.ts
+++ b/packages/trading-signals/src/base/Indicator.ts
@@ -25,10 +25,47 @@ export type TradingSignals = (typeof TradingSignal)[keyof typeof TradingSignal];
 /**
  * Implements common update behaviour among indicators.
  */
-export abstract class TechnicalIndicator<Result, Input> implements Indicator<Result, Input> {
+export abstract class TechnicalIndicator<
+  Result,
+  Input,
+  State extends object = Record<string, never>,
+> implements Indicator<Result, Input> {
   protected result: Result | undefined;
+  /**
+   * Single container for every mutable field (beyond the result) that `update()` may change.
+   * Keeping such fields here instead of in loose class fields lets the base class rewind them
+   * generically on `replace()` (see {@link trackState}) and makes two indicator instances
+   * comparable via {@link getState}.
+   */
+  protected state: State = {} as State;
+  #previousState?: State;
 
   abstract getRequiredInputs(): number;
+
+  /**
+   * Rewinds `state` by one bar on a replacement, or snapshots it before a regular add. Stateful
+   * indicators call this first in `update()`, so a replacement re-runs the latest bar from the
+   * exact state that bar originally saw — without per-field rollback bookkeeping, which is easy
+   * to get wrong when a field is forgotten.
+   */
+  protected trackState(replace: boolean) {
+    if (replace) {
+      if (this.#previousState !== undefined) {
+        this.state = structuredClone(this.#previousState);
+      }
+    } else {
+      this.#previousState = structuredClone(this.state);
+    }
+  }
+
+  /**
+   * Snapshot of the result and the declared mutable state. Two indicators fed equivalent input
+   * series must produce identical snapshots, which makes state divergence visible as a diff in
+   * tests: `expect(a.getState()).toEqual(b.getState())`.
+   */
+  getState() {
+    return structuredClone({...this.state, result: this.result});
+  }
 
   getResult() {
     try {
@@ -68,7 +105,10 @@ export abstract class TechnicalIndicator<Result, Input> implements Indicator<Res
 /**
  * Tracks results of an indicator over time.
  */
-export abstract class IndicatorSeries<Input = number> extends TechnicalIndicator<number, Input> {
+export abstract class IndicatorSeries<
+  Input = number,
+  State extends object = Record<string, never>,
+> extends TechnicalIndicator<number, Input, State> {
   protected previousResult?: number;
 
   protected setResult(value: number, replace: boolean) {
@@ -101,7 +141,8 @@ export abstract class IndicatorSeries<Input = number> extends TechnicalIndicator
 export abstract class TrendIndicatorSeries<
   Input = number,
   SignalState = TradingSignals,
-> extends IndicatorSeries<Input> {
+  State extends object = Record<string, never>,
+> extends IndicatorSeries<Input, State> {
   protected abstract calculateSignalState(result?: number | null | undefined): SignalState;
   #previousSignalState?: SignalState;
 

--- a/packages/trading-signals/src/base/Period.ts
+++ b/packages/trading-signals/src/base/Period.ts
@@ -34,7 +34,7 @@ export class Period extends TechnicalIndicator<PeriodResult, number> {
   }
 
   update(value: number, replace: boolean) {
-    pushUpdate(this.values, replace, value, this.interval);
+    pushUpdate({array: this.values, item: value, maxLength: this.interval, replace: replace});
 
     if (this.values.length === this.interval) {
       this.#lowest = Math.min(...this.values);

--- a/packages/trading-signals/src/momentum/CCI/CCI.ts
+++ b/packages/trading-signals/src/momentum/CCI/CCI.ts
@@ -66,7 +66,7 @@ export class CCI extends TrendIndicatorSeries<HighLowClose<number>> {
 
   #cacheTypicalPrice({close, high, low}: HighLowClose<number>, replace: boolean) {
     const typicalPrice = (high + low + close) / 3;
-    pushUpdate(this.#typicalPrices, replace, typicalPrice, this.interval);
+    pushUpdate({array: this.#typicalPrices, item: typicalPrice, maxLength: this.interval, replace: replace});
     return typicalPrice;
   }
 

--- a/packages/trading-signals/src/momentum/CG/CG.ts
+++ b/packages/trading-signals/src/momentum/CG/CG.ts
@@ -60,7 +60,7 @@ export class CG extends TrendIndicatorSeries {
   }
 
   update(price: number, replace: boolean) {
-    pushUpdate(this.prices, replace, price, this.interval);
+    pushUpdate({array: this.prices, item: price, maxLength: this.interval, replace: replace});
 
     let nominator = 0;
     let denominator = 0;

--- a/packages/trading-signals/src/momentum/CMO/CMO.ts
+++ b/packages/trading-signals/src/momentum/CMO/CMO.ts
@@ -37,7 +37,7 @@ export class CMO extends TrendIndicatorSeries {
   }
 
   update(price: number, replace: boolean) {
-    pushUpdate(this.#prices, replace, price, this.getRequiredInputs());
+    pushUpdate({array: this.#prices, item: price, maxLength: this.getRequiredInputs(), replace: replace});
 
     if (this.#prices.length < this.getRequiredInputs()) {
       return null;

--- a/packages/trading-signals/src/momentum/ER/ER.ts
+++ b/packages/trading-signals/src/momentum/ER/ER.ts
@@ -41,9 +41,9 @@ export class ER extends TrendIndicatorSeries<HighLowClose> {
   }
 
   update(candle: HighLowClose, replace: boolean) {
-    pushUpdate(this.#closes, replace, candle.close, this.interval);
-    pushUpdate(this.#highs, replace, candle.high, this.interval);
-    pushUpdate(this.#lows, replace, candle.low, this.interval);
+    pushUpdate({array: this.#closes, item: candle.close, maxLength: this.interval, replace: replace});
+    pushUpdate({array: this.#highs, item: candle.high, maxLength: this.interval, replace: replace});
+    pushUpdate({array: this.#lows, item: candle.low, maxLength: this.interval, replace: replace});
 
     if (this.#closes.length < this.interval) {
       return null;

--- a/packages/trading-signals/src/momentum/MACD/MACD.ts
+++ b/packages/trading-signals/src/momentum/MACD/MACD.ts
@@ -38,7 +38,7 @@ export class MACD extends TechnicalIndicator<MACDResult, number> {
   }
 
   update(price: number, replace: boolean) {
-    pushUpdate(this.prices, replace, price, this.long.interval);
+    pushUpdate({array: this.prices, item: price, maxLength: this.long.interval, replace: replace});
 
     const short = this.short.update(price, replace);
     const long = this.long.update(price, replace);

--- a/packages/trading-signals/src/momentum/MFI/MFI.ts
+++ b/packages/trading-signals/src/momentum/MFI/MFI.ts
@@ -38,7 +38,7 @@ export class MFI extends TrendIndicatorSeries<HighLowCloseVolume<number>> {
   }
 
   update(candle: HighLowCloseVolume<number>, replace: boolean) {
-    pushUpdate(this.#candles, replace, candle, this.getRequiredInputs());
+    pushUpdate({array: this.#candles, item: candle, maxLength: this.getRequiredInputs(), replace: replace});
 
     if (this.#candles.length < this.getRequiredInputs()) {
       return null;

--- a/packages/trading-signals/src/momentum/MOM/MOM.ts
+++ b/packages/trading-signals/src/momentum/MOM/MOM.ts
@@ -28,7 +28,7 @@ export class MOM extends TrendIndicatorSeries {
   }
 
   update(value: number, replace: boolean) {
-    pushUpdate(this.#history, replace, value, this.#historyLength);
+    pushUpdate({array: this.#history, item: value, maxLength: this.#historyLength, replace: replace});
 
     if (this.#history.length === this.#historyLength) {
       return this.setResult(value - this.#history[0], replace);

--- a/packages/trading-signals/src/momentum/OBV/OBV.ts
+++ b/packages/trading-signals/src/momentum/OBV/OBV.ts
@@ -25,7 +25,7 @@ export class OBV extends TrendIndicatorSeries<OpenHighLowCloseVolume<number>> {
   }
 
   update(candle: OpenHighLowCloseVolume<number>, replace: boolean) {
-    pushUpdate(this.candles, replace, candle, this.getRequiredInputs());
+    pushUpdate({array: this.candles, item: candle, maxLength: this.getRequiredInputs(), replace: replace});
 
     if (this.candles.length < this.getRequiredInputs()) {
       return null;

--- a/packages/trading-signals/src/momentum/ROC/ROC.ts
+++ b/packages/trading-signals/src/momentum/ROC/ROC.ts
@@ -30,7 +30,7 @@ export class ROC extends TrendIndicatorSeries {
      * Keeping the comparand inside the window makes `replace()` correct for free: the window is the
      * only state, so re-running the latest bar cannot read anything the previous bar left behind.
      */
-    pushUpdate(this.prices, replace, price, this.getRequiredInputs());
+    pushUpdate({array: this.prices, item: price, maxLength: this.getRequiredInputs(), replace: replace});
 
     if (this.prices.length === this.getRequiredInputs()) {
       const comparePrice = this.prices[0];

--- a/packages/trading-signals/src/momentum/RSI/RSI.ts
+++ b/packages/trading-signals/src/momentum/RSI/RSI.ts
@@ -48,7 +48,7 @@ export class RSI extends TrendIndicatorSeries {
   }
 
   update(price: number, replace: boolean) {
-    pushUpdate(this.#previousPrices, replace, price, this.interval);
+    pushUpdate({array: this.#previousPrices, item: price, maxLength: this.interval, replace: replace});
 
     // Ensure at least 2 prices are available for calculation
     if (this.#previousPrices.length < 2) {

--- a/packages/trading-signals/src/momentum/STOCH/StochasticOscillator.ts
+++ b/packages/trading-signals/src/momentum/STOCH/StochasticOscillator.ts
@@ -69,7 +69,7 @@ export class StochasticOscillator extends TechnicalIndicator<StochasticResult, H
   }
 
   update(candle: HighLowClose<number>, replace: boolean) {
-    pushUpdate(this.candles, replace, candle, this.kPeriod);
+    pushUpdate({array: this.candles, item: candle, maxLength: this.kPeriod, replace: replace});
 
     if (this.candles.length === this.kPeriod) {
       const highest = Math.max(...this.candles.map(candle => candle.high));

--- a/packages/trading-signals/src/momentum/TDS/TDS.test.ts
+++ b/packages/trading-signals/src/momentum/TDS/TDS.test.ts
@@ -1,15 +1,6 @@
 import {TDS} from './TDS.js';
 import {TradingSignal} from '../../base/index.js';
 
-/** Captures everything a replacement could corrupt, so tests compare the whole setup state at once. */
-function getSetupState(tds: TDS) {
-  return {
-    result: tds.getResult(),
-    setupCount: tds['setupCount'],
-    setupDirection: tds['setupDirection'],
-  };
-}
-
 describe('TDS', () => {
   it('does not return a result for less than 9 prices', () => {
     const tds = new TDS();
@@ -54,7 +45,7 @@ describe('TDS', () => {
     for (let i = 0; i < 20; i++) {
       tds.add(i);
     }
-    expect(tds['closes'].length).toBeLessThanOrEqual(13);
+    expect(tds.getState().closes.length).toBeLessThanOrEqual(13);
   });
 
   it('detects a direction change from bearish to bullish', () => {
@@ -66,8 +57,8 @@ describe('TDS', () => {
     tds.add(4);
     tds.add(3);
     const result = tds.add(20);
-    expect(tds['setupCount']).toBe(1);
-    expect(tds['setupDirection']).toBe('bullish');
+    expect(tds.getState().setupCount).toBe(1);
+    expect(tds.getState().setupDirection).toBe('bullish');
     expect(result).toBeNull();
   });
 
@@ -80,8 +71,8 @@ describe('TDS', () => {
     tds.add(21);
     tds.add(22);
     const result = tds.add(5);
-    expect(tds['setupCount']).toBe(1);
-    expect(tds['setupDirection']).toBe('bearish');
+    expect(tds.getState().setupCount).toBe(1);
+    expect(tds.getState().setupDirection).toBe('bearish');
     expect(result).toBeNull();
   });
 
@@ -97,15 +88,15 @@ describe('TDS', () => {
     tds.add(16);
 
     // Current setup should be bullish with count 2
-    expect(tds['setupCount']).toBe(2);
-    expect(tds['setupDirection']).toBe('bullish');
+    expect(tds.getState().setupCount).toBe(2);
+    expect(tds.getState().setupDirection).toBe('bullish');
 
     // Add a close equal to "prev4" (10 === 10)
     const result = tds.add(prev4);
 
     // Setup count and direction should remain unchanged
-    expect(tds['setupCount']).toBe(2);
-    expect(tds['setupDirection']).toBe('bullish');
+    expect(tds.getState().setupCount).toBe(2);
+    expect(tds.getState().setupDirection).toBe('bullish');
     expect(result).toBeNull();
   });
 
@@ -126,11 +117,11 @@ describe('TDS', () => {
 
       tds.updates(closes);
 
-      const stateBefore = getSetupState(tds);
+      const stateBefore = tds.getState();
 
       tds.replace(19);
 
-      expect(getSetupState(tds), 'replacing a close with itself is a no-op').toEqual(stateBefore);
+      expect(tds.getState(), 'replacing a close with itself is a no-op').toEqual(stateBefore);
     });
 
     it('does not advance the setup count twice for the same bar', () => {
@@ -143,12 +134,12 @@ describe('TDS', () => {
       tds.add(15);
       tds.add(16);
 
-      expect(tds['setupCount'], 'two bars closed above the close four bars earlier').toBe(2);
+      expect(tds.getState().setupCount, 'two bars closed above the close four bars earlier').toBe(2);
 
       tds.replace(17);
 
-      expect(tds['setupCount'], 'replacing the second bar must not count it again').toBe(2);
-      expect(tds['setupDirection']).toBe('bullish');
+      expect(tds.getState().setupCount, 'replacing the second bar must not count it again').toBe(2);
+      expect(tds.getState().setupDirection).toBe('bullish');
     });
 
     it('restores the setup direction when a replacement reverses the bar', () => {
@@ -162,8 +153,8 @@ describe('TDS', () => {
       tds.add(16);
       tds.replace(5);
 
-      expect(tds['setupCount'], 'a bearish bar restarts the count').toBe(1);
-      expect(tds['setupDirection'], 'the direction flips with the replaced bar').toBe('bearish');
+      expect(tds.getState().setupCount, 'a bearish bar restarts the count').toBe(1);
+      expect(tds.getState().setupDirection, 'the direction flips with the replaced bar').toBe('bearish');
     });
 
     it('matches an equivalent series that never used replace', () => {
@@ -172,14 +163,17 @@ describe('TDS', () => {
       const replaced = new TDS();
       replaced.updates(closes.slice(0, -1));
       replaced.add(99);
-      replaced.replace(closes[closes.length - 1]);
 
       const reference = new TDS();
       reference.updates(closes);
 
-      expect(getSetupState(replaced), 'a replacement must reproduce the add-only series').toEqual(
-        getSetupState(reference)
+      expect(replaced.getState(), 'the decoy bar leaves the two indicators in different states').not.toEqual(
+        reference.getState()
       );
+
+      replaced.replace(closes[closes.length - 1]);
+
+      expect(replaced.getState(), 'a replacement must reproduce the add-only series').toEqual(reference.getState());
     });
 
     it('keeps an earlier setup when the replaced bar completed nothing', () => {

--- a/packages/trading-signals/src/momentum/TDS/TDS.ts
+++ b/packages/trading-signals/src/momentum/TDS/TDS.ts
@@ -1,4 +1,15 @@
-import {TradingSignal, TrendIndicatorSeries} from '../../base/Indicator.js';
+import {TradingSignal, TrendIndicatorSeries, type TradingSignals} from '../../base/Indicator.js';
+
+type TDSState = {
+  closes: number[];
+  /*
+   * Whether the latest bar completed a setup. TDS emits sparsely and its result persists between
+   * setups, so only a bar that emitted may withdraw that emission when it gets replaced.
+   */
+  lastBarCompletedSetup: boolean;
+  setupCount: number;
+  setupDirection: 'bullish' | 'bearish' | null;
+};
 
 /**
  * Tom Demark's Sequential Indicator (TDS)
@@ -15,75 +26,63 @@ import {TradingSignal, TrendIndicatorSeries} from '../../base/Indicator.js';
  * @see https://hackernoon.com/how-to-buy-sell-cryptocurrency-with-number-indicator-td-sequential-5af46f0ebce1
  * @see https://practicaltechnicalanalysis.blogspot.com/2013/01/tom-demark-sequential.html
  */
-export class TDS extends TrendIndicatorSeries {
-  private readonly closes: number[] = [];
-  private setupCount: number = 0;
-  private setupDirection: 'bullish' | 'bearish' | null = null;
-  /*
-   * The setup state as of the bar before the current one. A replacement re-runs the latest bar, so
-   * the count has to start again from what that bar originally found, not from what it left behind.
-   */
-  private previousSetupCount: number = 0;
-  private previousSetupDirection: 'bullish' | 'bearish' | null = null;
-  /*
-   * Whether the latest bar completed a setup. TDS emits sparsely and its result persists between
-   * setups, so only a bar that emitted may withdraw that emission when it gets replaced.
-   */
-  private lastBarCompletedSetup: boolean = false;
+export class TDS extends TrendIndicatorSeries<number, TradingSignals, TDSState> {
+  protected override state: TDSState = {
+    closes: [],
+    lastBarCompletedSetup: false,
+    setupCount: 0,
+    setupDirection: null,
+  };
 
   override getRequiredInputs() {
     return 9;
   }
 
   update(close: number, replace: boolean): number | null {
-    if (replace) {
-      this.closes.pop();
-      this.setupCount = this.previousSetupCount;
-      this.setupDirection = this.previousSetupDirection;
-
-      if (this.lastBarCompletedSetup) {
-        this.rollbackLastResult();
-      }
-    } else {
-      this.previousSetupCount = this.setupCount;
-      this.previousSetupDirection = this.setupDirection;
+    // Read before trackState() rewinds the flag to what the bar before the replaced one found
+    if (replace && this.state.lastBarCompletedSetup) {
+      this.rollbackLastResult();
     }
 
-    this.closes.push(close);
-    this.lastBarCompletedSetup = false;
+    this.trackState(replace);
 
-    if (this.closes.length < 5) {
+    const state = this.state;
+
+    state.closes.push(close);
+    state.lastBarCompletedSetup = false;
+
+    if (state.closes.length < 5) {
       return null;
     }
     // Only keep the last 13 closes for memory efficiency
-    if (this.closes.length > 13) {
-      this.closes.shift();
+    if (state.closes.length > 13) {
+      state.closes.shift();
     }
-    const index = this.closes.length - 1;
-    const prev4 = this.closes[index - 4];
+    const index = state.closes.length - 1;
+    const prev4 = state.closes[index - 4];
     if (close > prev4) {
-      if (this.setupDirection === 'bearish') {
-        this.setupCount = 1;
-        this.setupDirection = 'bullish';
+      if (state.setupDirection === 'bearish') {
+        state.setupCount = 1;
+        state.setupDirection = 'bullish';
       } else {
-        this.setupCount++;
-        this.setupDirection = 'bullish';
+        state.setupCount++;
+        state.setupDirection = 'bullish';
       }
     } else if (close < prev4) {
-      if (this.setupDirection === 'bullish') {
-        this.setupCount = 1;
-        this.setupDirection = 'bearish';
+      if (state.setupDirection === 'bullish') {
+        state.setupCount = 1;
+        state.setupDirection = 'bearish';
       } else {
-        this.setupCount++;
-        this.setupDirection = 'bearish';
+        state.setupCount++;
+        state.setupDirection = 'bearish';
       }
     }
     // Setup completed
-    if (this.setupCount >= this.getRequiredInputs()) {
-      const result = this.setupDirection === 'bullish' ? 1 : -1;
-      this.setupCount = 0;
-      this.setupDirection = null;
-      this.lastBarCompletedSetup = true;
+    if (state.setupCount >= this.getRequiredInputs()) {
+      const result = state.setupDirection === 'bullish' ? 1 : -1;
+      state.setupCount = 0;
+      state.setupDirection = null;
+      state.lastBarCompletedSetup = true;
       return this.setResult(result, replace);
     }
     return null;

--- a/packages/trading-signals/src/momentum/ULTOSC/UltimateOscillator.ts
+++ b/packages/trading-signals/src/momentum/ULTOSC/UltimateOscillator.ts
@@ -55,7 +55,7 @@ export class UltimateOscillator extends TrendIndicatorSeries<HighLowClose<number
   }
 
   update(candle: HighLowClose<number>, replace: boolean) {
-    pushUpdate(this.#candles, replace, candle, this.getRequiredInputs());
+    pushUpdate({array: this.#candles, item: candle, maxLength: this.getRequiredInputs(), replace: replace});
 
     if (this.#candles.length < this.getRequiredInputs()) {
       return null;

--- a/packages/trading-signals/src/momentum/WILLR/WilliamsR.ts
+++ b/packages/trading-signals/src/momentum/WILLR/WilliamsR.ts
@@ -38,7 +38,7 @@ export class WilliamsR extends TrendIndicatorSeries<HighLowClose<number>> {
   }
 
   override update(candle: HighLowClose<number>, replace: boolean) {
-    pushUpdate(this.candles, replace, candle, this.interval);
+    pushUpdate({array: this.candles, item: candle, maxLength: this.interval, replace: replace});
 
     if (this.candles.length === this.interval) {
       let highest = this.candles[0].high;

--- a/packages/trading-signals/src/trend/AROON/Aroon.ts
+++ b/packages/trading-signals/src/trend/AROON/Aroon.ts
@@ -35,7 +35,7 @@ export class Aroon extends TechnicalIndicator<AroonResult, HighLow<number>> {
   }
 
   update(candle: HighLow<number>, replace: boolean) {
-    pushUpdate(this.#candles, replace, candle, this.getRequiredInputs());
+    pushUpdate({array: this.#candles, item: candle, maxLength: this.getRequiredInputs(), replace: replace});
 
     if (this.#candles.length < this.getRequiredInputs()) {
       return null;

--- a/packages/trading-signals/src/trend/BREAKOUT_BAR_LOW/BreakoutBarLow.ts
+++ b/packages/trading-signals/src/trend/BREAKOUT_BAR_LOW/BreakoutBarLow.ts
@@ -48,7 +48,7 @@ export class BreakoutBarLow extends IndicatorSeries<HighLow> {
     }
     this.#lastEmitted = false;
 
-    pushUpdate(this.#highs, replace, candle.high, this.getRequiredInputs());
+    pushUpdate({array: this.#highs, item: candle.high, maxLength: this.getRequiredInputs(), replace: replace});
 
     if (this.#highs.length < this.getRequiredInputs()) {
       return null;

--- a/packages/trading-signals/src/trend/CE/ChandelierExit.ts
+++ b/packages/trading-signals/src/trend/CE/ChandelierExit.ts
@@ -52,7 +52,7 @@ export class ChandelierExit extends TechnicalIndicator<ChandelierExitResult, Hig
 
   update(candle: HighLowClose<number>, replace: boolean) {
     const atr = this.#atr.update(candle, replace);
-    pushUpdate(this.#candles, replace, candle, this.interval);
+    pushUpdate({array: this.#candles, item: candle, maxLength: this.interval, replace: replace});
 
     // The candle window fills in lockstep with the ATR warm-up, so this single guard covers both
     if (atr === null) {

--- a/packages/trading-signals/src/trend/HIGHER_LOW_TRAIL/HigherLowTrail.ts
+++ b/packages/trading-signals/src/trend/HIGHER_LOW_TRAIL/HigherLowTrail.ts
@@ -58,7 +58,7 @@ export class HigherLowTrail extends IndicatorSeries<HighLow> {
     }
     this.#lastEmitted = false;
 
-    pushUpdate(this.#window, replace, candle.low, this.getRequiredInputs());
+    pushUpdate({array: this.#window, item: candle.low, maxLength: this.getRequiredInputs(), replace: replace});
 
     if (this.#window.length < this.getRequiredInputs()) {
       return null;

--- a/packages/trading-signals/src/trend/KAMA/KAMA.ts
+++ b/packages/trading-signals/src/trend/KAMA/KAMA.ts
@@ -26,7 +26,7 @@ export class KAMA extends MovingAverage {
   }
 
   update(price: number, replace: boolean) {
-    pushUpdate(this.#prices, replace, price, this.interval + 1);
+    pushUpdate({array: this.#prices, item: price, maxLength: this.interval + 1, replace: replace});
 
     if (this.#prices.length < this.interval) {
       return null;

--- a/packages/trading-signals/src/trend/LINREG/LinearRegression.ts
+++ b/packages/trading-signals/src/trend/LINREG/LinearRegression.ts
@@ -69,7 +69,7 @@ export class LinearRegression extends TechnicalIndicator<LinearRegressionResult,
   }
 
   update(price: number, replace: boolean): LinearRegressionResult | null {
-    pushUpdate(this.prices, replace, price, this.interval);
+    pushUpdate({array: this.prices, item: price, maxLength: this.interval, replace: replace});
 
     if (this.prices.length < this.interval) {
       return null;

--- a/packages/trading-signals/src/trend/PSAR/PSAR.test.ts
+++ b/packages/trading-signals/src/trend/PSAR/PSAR.test.ts
@@ -378,9 +378,9 @@ describe('PSAR', () => {
     psar.add({high: 9, low: 8});
 
     // Directly set the acceleration to just below max
-    psar['acceleration'] = 0.19;
-    psar['extreme'] = 8;
-    psar['isLong'] = false;
+    psar['state'].acceleration = 0.19;
+    psar['state'].extreme = 8;
+    psar['state'].isLong = false;
 
     /*
      * Now make a new low that will cause acceleration to exceed max
@@ -392,7 +392,7 @@ describe('PSAR', () => {
     expect(result).toBeGreaterThan(7);
 
     // Verify acceleration was capped
-    expect(psar['acceleration']).toBe(psar['accelerationMax']);
+    expect(psar['state'].acceleration).toBe(psar['accelerationMax']);
   });
 
   it('adjusts SAR on reversal when SAR >= low', () => {
@@ -446,7 +446,7 @@ describe('PSAR', () => {
     psar.update({high: 15, low: 14}, false);
 
     // Verify acceleration has hit the max at some point
-    expect(psar['acceleration']).toBe(psar['accelerationMax']);
+    expect(psar['state'].acceleration).toBe(psar['accelerationMax']);
   });
 
   it('caps acceleration when exceeding max in uptrend', () => {
@@ -457,9 +457,9 @@ describe('PSAR', () => {
     psar.update({high: 11, low: 10}, false);
 
     // Directly set acceleration to a specific value that will exceed max after one more step
-    psar['acceleration'] = psar['accelerationMax'] * 0.95;
-    psar['isLong'] = true;
-    psar['extreme'] = 11;
+    psar['state'].acceleration = psar['accelerationMax'] * 0.95;
+    psar['state'].isLong = true;
+    psar['state'].extreme = 11;
 
     /*
      * Make a new high that will cause acceleration to exceed max
@@ -468,7 +468,7 @@ describe('PSAR', () => {
     psar.update({high: 12, low: 11}, false);
 
     // Verify acceleration was capped at max (not higher)
-    expect(psar['acceleration']).toBe(psar['accelerationMax']);
+    expect(psar['state'].acceleration).toBe(psar['accelerationMax']);
   });
 
   it('adjusts SAR to previous high in short position', () => {
@@ -479,11 +479,11 @@ describe('PSAR', () => {
     psar.update({high: 9, low: 8}, false);
 
     // Directly set the state to test the specific code path
-    psar['isLong'] = false; // Downtrend
-    psar['lastSar'] = 8; // Set SAR
-    psar['extreme'] = 7; // Set extreme point
-    psar['prePreviousCandle'] = null; // Ensure no pre-previous influence
-    psar['previousCandle'] = {high: 9, low: 8}; // Previous candle with high > SAR
+    psar['state'].isLong = false; // Downtrend
+    psar['state'].lastSar = 8; // Set SAR
+    psar['state'].extreme = 7; // Set extreme point
+    psar['state'].prePreviousCandle = null; // Ensure no pre-previous influence
+    psar['state'].previousCandle = {high: 9, low: 8}; // Previous candle with high > SAR
 
     // This should hit line 299-301
     const result = psar.update({high: 7.5, low: 7}, false);
@@ -500,11 +500,11 @@ describe('PSAR', () => {
     psar.update({high: 9, low: 8}, false);
 
     // Set up a specific scenario to test lines 292-298
-    psar['isLong'] = false; // Downtrend
-    psar['lastSar'] = 8.5; // Set SAR
-    psar['extreme'] = 7; // Set extreme point
-    psar['prePreviousCandle'] = {high: 9, low: 8}; // prePreviousCandle.high > SAR
-    psar['previousCandle'] = {high: 8, low: 7}; // previousCandle.high < SAR
+    psar['state'].isLong = false; // Downtrend
+    psar['state'].lastSar = 8.5; // Set SAR
+    psar['state'].extreme = 7; // Set extreme point
+    psar['state'].prePreviousCandle = {high: 9, low: 8}; // prePreviousCandle.high > SAR
+    psar['state'].previousCandle = {high: 8, low: 7}; // previousCandle.high < SAR
 
     // This update should test line 292-293 (prePreviousCandle.high > sar) but skip 296-297
     const result = psar.update({high: 7.5, low: 7}, false);
@@ -521,11 +521,11 @@ describe('PSAR', () => {
     psar.update({high: 9, low: 8}, false);
 
     // Set up all with specific values
-    psar['isLong'] = false; // Downtrend
-    psar['lastSar'] = 8; // Set SAR
-    psar['extreme'] = 7; // Set extreme point
-    psar['prePreviousCandle'] = {high: 8.5, low: 7.5}; // prePreviousCandle exists with high < sar
-    psar['previousCandle'] = {high: 9.5, low: 8.5}; // previousCandle.high > SAR
+    psar['state'].isLong = false; // Downtrend
+    psar['state'].lastSar = 8; // Set SAR
+    psar['state'].extreme = 7; // Set extreme point
+    psar['state'].prePreviousCandle = {high: 8.5, low: 7.5}; // prePreviousCandle exists with high < sar
+    psar['state'].previousCandle = {high: 9.5, low: 8.5}; // previousCandle.high > SAR
 
     // First ensure high > sar to trigger prePreviousCandle branch, but only previousCandle.high > sar
     const result = psar.update({high: 8.2, low: 7.2}, false);
@@ -571,11 +571,11 @@ describe('PSAR', () => {
     psar.update({high: 9, low: 8}, false);
 
     // Set up a specific scenario to test lines 258-264
-    psar['isLong'] = true; // Uptrend
-    psar['lastSar'] = 7.5; // Set SAR
-    psar['extreme'] = 9; // Set extreme point
-    psar['prePreviousCandle'] = {high: 9, low: 8}; // prePreviousCandle.low > SAR
-    psar['previousCandle'] = {high: 8, low: 6}; // previousCandle.low < SAR
+    psar['state'].isLong = true; // Uptrend
+    psar['state'].lastSar = 7.5; // Set SAR
+    psar['state'].extreme = 9; // Set extreme point
+    psar['state'].prePreviousCandle = {high: 9, low: 8}; // prePreviousCandle.low > SAR
+    psar['state'].previousCandle = {high: 8, low: 6}; // previousCandle.low < SAR
 
     // This update should hit lines 262-264 with previousCandle.low < sar
     const result = psar.update({high: 8.5, low: 7}, false);
@@ -592,11 +592,11 @@ describe('PSAR', () => {
     psar.update({high: 9, low: 8}, false);
 
     // Directly set internal state
-    psar['isLong'] = true; // Uptrend
-    psar['lastSar'] = 8.5; // Set SAR above both lows
-    psar['extreme'] = 10; // Set extreme point
-    psar['prePreviousCandle'] = {high: 9, low: 7}; // prePreviousCandle.low < SAR
-    psar['previousCandle'] = {high: 10, low: 7.5}; // previousCandle.low < SAR
+    psar['state'].isLong = true; // Uptrend
+    psar['state'].lastSar = 8.5; // Set SAR above both lows
+    psar['state'].extreme = 10; // Set extreme point
+    psar['state'].prePreviousCandle = {high: 9, low: 7}; // prePreviousCandle.low < SAR
+    psar['state'].previousCandle = {high: 10, low: 7.5}; // previousCandle.low < SAR
 
     // This update should hit both lines 258-260 AND 262-264
     const result = psar.update({high: 11, low: 9.5}, false);
@@ -614,11 +614,11 @@ describe('PSAR', () => {
     psar.update({high: 9, low: 8}, false);
 
     // Set up a specific scenario to test line 258-260
-    psar['isLong'] = true; // Uptrend
-    psar['lastSar'] = 8; // Set SAR
-    psar['extreme'] = 9.5; // Set extreme point
-    psar['prePreviousCandle'] = {high: 9, low: 7.5}; // prePreviousCandle.low < SAR
-    psar['previousCandle'] = {high: 10, low: 8.5}; // previousCandle.low > SAR
+    psar['state'].isLong = true; // Uptrend
+    psar['state'].lastSar = 8; // Set SAR
+    psar['state'].extreme = 9.5; // Set extreme point
+    psar['state'].prePreviousCandle = {high: 9, low: 7.5}; // prePreviousCandle.low < SAR
+    psar['state'].previousCandle = {high: 10, low: 8.5}; // previousCandle.low > SAR
 
     // This update should specifically hit line 258-260 with prePreviousCandle.low < sar
     const result = psar.update({high: 10.5, low: 8}, false);
@@ -635,11 +635,11 @@ describe('PSAR', () => {
     psar.update({high: 11, low: 10}, false);
 
     // Set up a specific scenario to test line 99-101
-    psar['isLong'] = true;
-    psar['lastSar'] = 11; // Set SAR high
-    psar['extreme'] = 12;
-    psar['prePreviousCandle'] = {high: 12, low: 10.5}; // prePreviousCandle.low < sar
-    psar['previousCandle'] = {high: 12.5, low: 10.2}; // previousCandle.low < sar
+    psar['state'].isLong = true;
+    psar['state'].lastSar = 11; // Set SAR high
+    psar['state'].extreme = 12;
+    psar['state'].prePreviousCandle = {high: 12, low: 10.5}; // prePreviousCandle.low < sar
+    psar['state'].previousCandle = {high: 12.5, low: 10.2}; // previousCandle.low < sar
 
     /*
      * This update should hit both prePreviousLow and previousLow checks
@@ -703,13 +703,13 @@ describe('PSAR', () => {
     psar.update({high: 9, low: 8}, false); // First calculation
 
     // Set up a scenario where we're in a downtrend
-    psar['isLong'] = false;
-    psar['lastSar'] = 8;
-    psar['extreme'] = 7;
+    psar['state'].isLong = false;
+    psar['state'].lastSar = 8;
+    psar['state'].extreme = 7;
 
     // Set up a previous candle with high > sar but no pre-previous candle
-    psar['prePreviousCandle'] = null;
-    psar['previousCandle'] = {high: 8.5, low: 7.5};
+    psar['state'].prePreviousCandle = null;
+    psar['state'].previousCandle = {high: 8.5, low: 7.5};
 
     /*
      * This should test the specific branch on line 139-141
@@ -718,8 +718,8 @@ describe('PSAR', () => {
     psar.update({high: 7.5, low: 7}, false);
 
     // Now add a candle with prePreviousCandle to hit lines 136-138
-    psar['prePreviousCandle'] = {high: 8.5, low: 7.5};
-    psar['previousCandle'] = {high: 8.6, low: 7.6};
+    psar['state'].prePreviousCandle = {high: 8.5, low: 7.5};
+    psar['state'].previousCandle = {high: 8.6, low: 7.6};
 
     // Update with a price that triggers high > sar but only in previousCandle
     const result = psar.update({high: 8.1, low: 7.1}, false);
@@ -736,11 +736,11 @@ describe('PSAR', () => {
     psar.update({high: 11, low: 10}, false);
 
     // Set up a specific scenario to test line 102-104
-    psar['isLong'] = true;
-    psar['prePreviousCandle'] = null; // Ensure no pre-previous influence
-    psar['lastSar'] = 9.5; // Set SAR above previous low
-    psar['extreme'] = 11;
-    psar['previousCandle'] = {high: 11, low: 9}; // previousCandle.low < sar
+    psar['state'].isLong = true;
+    psar['state'].prePreviousCandle = null; // Ensure no pre-previous influence
+    psar['state'].lastSar = 9.5; // Set SAR above previous low
+    psar['state'].extreme = 11;
+    psar['state'].previousCandle = {high: 11, low: 9}; // previousCandle.low < sar
 
     /*
      * This should trigger the branch in line 102-104 where previousCandle.low < sar
@@ -769,8 +769,8 @@ describe('PSAR', () => {
     psar.update({high: 12, low: 11}, false);
 
     // 2. This update will create a previousCandle, and SAR will be below low
-    psar['lastSar'] = 12.5; // Setting high to ensure lt conditions are met
-    psar['isLong'] = true;
+    psar['state'].lastSar = 12.5; // Setting high to ensure lt conditions are met
+    psar['state'].isLong = true;
 
     // 3. Make low < sar, to trigger the branch where previousLow < sar
     const testCandle = {high: 15, low: 10}; // Low is less than SAR
@@ -786,8 +786,8 @@ describe('PSAR', () => {
     psarDown.add({high: 13, low: 12}); // Sets up prePreviousCandle
 
     // Set up specific state for hitting line 150-151
-    psarDown['isLong'] = false; // Downtrend
-    psarDown['lastSar'] = 10; // Low SAR
+    psarDown['state'].isLong = false; // Downtrend
+    psarDown['state'].lastSar = 10; // Low SAR
 
     // Execute with high > sar to hit the branch
     const downTrendResult = psarDown.add({high: 15, low: 12});
@@ -802,13 +802,13 @@ describe('PSAR', () => {
     psar.update({high: 9, low: 8}, false);
 
     // Set up a very specific scenario to target lines 137-138
-    psar['isLong'] = false;
-    psar['lastSar'] = 7;
-    psar['extreme'] = 6;
+    psar['state'].isLong = false;
+    psar['state'].lastSar = 7;
+    psar['state'].extreme = 6;
 
     // Set both prePreviousCandle.high > sar and previousCandle.high > sar
-    psar['prePreviousCandle'] = {high: 8, low: 7.5}; // prePrevious.high > sar
-    psar['previousCandle'] = {high: 7.5, low: 7}; // previous.high > sar
+    psar['state'].prePreviousCandle = {high: 8, low: 7.5}; // prePrevious.high > sar
+    psar['state'].previousCandle = {high: 7.5, low: 7}; // previous.high > sar
 
     // This update must hit both conditions and specifically lines 137-138
     const result = psar.update({high: 7.2, low: 6.8}, false);
@@ -902,8 +902,8 @@ describe('PSAR', () => {
     psar.update({high: 11, low: 10}, false);
 
     // Create a scenario where previousLow is less than SAR
-    psar['lastSar'] = 12; // SAR higher than previous low
-    psar['isLong'] = true;
+    psar['state'].lastSar = 12; // SAR higher than previous low
+    psar['state'].isLong = true;
 
     // This will call updateSARWithPreviousLow with previousLow < sar
     psar.update({high: 13, low: 11}, false);
@@ -916,8 +916,8 @@ describe('PSAR', () => {
     psarDownTrend.update({high: 12, low: 11}, false);
 
     // Set up conditions
-    psarDownTrend['lastSar'] = 10; // SAR lower than previous high
-    psarDownTrend['isLong'] = false;
+    psarDownTrend['state'].lastSar = 10; // SAR lower than previous high
+    psarDownTrend['state'].isLong = false;
 
     // This will call updateSARWithPreviousHigh with previousHigh > sar
     psarDownTrend.update({high: 11, low: 10}, false);
@@ -935,10 +935,10 @@ describe('PSAR', () => {
      * Use prePreviousCandle branch path but make sure previousLow is NOT < SAR
      * Set state for an uptrend with pre-previous candle
      */
-    psar['lastSar'] = 5; // SAR much lower than low price
-    psar['prePreviousCandle'] = {high: 9, low: 8};
-    psar['previousCandle'] = {high: 9.5, low: 8.5};
-    psar['isLong'] = true;
+    psar['state'].lastSar = 5; // SAR much lower than low price
+    psar['state'].prePreviousCandle = {high: 9, low: 8};
+    psar['state'].previousCandle = {high: 9.5, low: 8.5};
+    psar['state'].isLong = true;
 
     // This should hit the ternary operator with previousLow < sar = false
     psar.update({high: 10, low: 9}, false);
@@ -952,10 +952,10 @@ describe('PSAR', () => {
      * Use prePreviousCandle branch path but make sure previousHigh is NOT > SAR
      * Set state for a downtrend with pre-previous candle
      */
-    psarDownTrend['lastSar'] = 12; // SAR much higher than high price
-    psarDownTrend['prePreviousCandle'] = {high: 9, low: 8};
-    psarDownTrend['previousCandle'] = {high: 8.5, low: 7.5};
-    psarDownTrend['isLong'] = false;
+    psarDownTrend['state'].lastSar = 12; // SAR much higher than high price
+    psarDownTrend['state'].prePreviousCandle = {high: 9, low: 8};
+    psarDownTrend['state'].previousCandle = {high: 8.5, low: 7.5};
+    psarDownTrend['state'].isLong = false;
 
     // This should hit the ternary operator with previousHigh > sar = false
     psarDownTrend.update({high: 8, low: 7}, false);

--- a/packages/trading-signals/src/trend/PSAR/PSAR.ts
+++ b/packages/trading-signals/src/trend/PSAR/PSAR.ts
@@ -40,16 +40,17 @@ type PSARState = {
  * It's particularly useful in trending markets, but less reliable in sideways or choppy markets.
  *
  */
-export class PSAR extends IndicatorSeries<HighLow<number>> {
+export class PSAR extends IndicatorSeries<HighLow<number>, PSARState> {
   private readonly accelerationStep: number;
   private readonly accelerationMax: number;
-  private acceleration: number = 0;
-  private extreme: number | null = null;
-  private lastSar: number | null = null;
-  private isLong: boolean | null = null;
-  private previousCandle: HighLow<number> | null = null;
-  private prePreviousCandle: HighLow<number> | null = null;
-  private previousState: PSARState | null = null;
+  protected override state: PSARState = {
+    acceleration: 0,
+    extreme: null,
+    isLong: null,
+    lastSar: null,
+    prePreviousCandle: null,
+    previousCandle: null,
+  };
 
   constructor(config: PSARConfig) {
     super();
@@ -65,104 +66,80 @@ export class PSAR extends IndicatorSeries<HighLow<number>> {
   }
 
   override get isStable() {
-    return this.lastSar !== null;
+    return this.state.lastSar !== null;
   }
 
   override getRequiredInputs() {
     return 2;
   }
 
-  private captureState(): PSARState {
-    return {
-      acceleration: this.acceleration,
-      extreme: this.extreme,
-      isLong: this.isLong,
-      lastSar: this.lastSar,
-      prePreviousCandle: this.prePreviousCandle,
-      previousCandle: this.previousCandle,
-    };
-  }
-
-  private restoreState(state: PSARState) {
-    this.acceleration = state.acceleration;
-    this.extreme = state.extreme;
-    this.isLong = state.isLong;
-    this.lastSar = state.lastSar;
-    this.prePreviousCandle = state.prePreviousCandle;
-    this.previousCandle = state.previousCandle;
-  }
-
   update(candle: HighLow<number>, replace: boolean): number | null {
     const {high, low} = candle;
 
-    if (replace) {
-      if (this.previousState !== null) {
-        this.restoreState(this.previousState);
-      }
-    } else {
-      this.previousState = this.captureState();
-    }
+    this.trackState(replace);
+
+    const state = this.state;
 
     // First candle, just store it and return null
-    if (!this.previousCandle) {
-      this.previousCandle = candle;
+    if (!state.previousCandle) {
+      state.previousCandle = candle;
       return null;
     }
 
     // Second candle (first calculation)
-    if (this.lastSar === null) {
+    if (state.lastSar === null) {
       // Determine initial trend direction - match Tulip Indicators approach
       const currentMidpoint = (high + low) / 2;
-      const previousMidpoint = (this.previousCandle.high + this.previousCandle.low) / 2;
+      const previousMidpoint = (state.previousCandle.high + state.previousCandle.low) / 2;
 
-      this.isLong = currentMidpoint >= previousMidpoint; // Using >= like Tulip implementation
+      state.isLong = currentMidpoint >= previousMidpoint; // Using >= like Tulip implementation
 
-      if (this.isLong) {
-        this.extreme = high;
-        this.lastSar = this.previousCandle.low;
+      if (state.isLong) {
+        state.extreme = high;
+        state.lastSar = state.previousCandle.low;
       } else {
-        this.extreme = low;
-        this.lastSar = this.previousCandle.high;
+        state.extreme = low;
+        state.lastSar = state.previousCandle.high;
       }
 
-      this.acceleration = this.accelerationStep;
-      this.prePreviousCandle = this.previousCandle;
-      this.previousCandle = candle;
+      state.acceleration = this.accelerationStep;
+      state.prePreviousCandle = state.previousCandle;
+      state.previousCandle = candle;
 
-      return this.setResult(this.lastSar, replace);
+      return this.setResult(state.lastSar, replace);
     }
 
     // Calculate SAR for the current period
-    let sar = (this.extreme! - this.lastSar) * this.acceleration + this.lastSar;
+    let sar = (state.extreme! - state.lastSar) * state.acceleration + state.lastSar;
 
     // Adjust SAR position if needed
-    if (this.isLong) {
+    if (state.isLong) {
       /*
        * Adjust SAR based on previous lows
        * If pre-previous candle exists and current low is less than SAR
        */
-      const hasPrevPrev = this.prePreviousCandle != null;
+      const hasPrevPrev = state.prePreviousCandle != null;
       if (hasPrevPrev && low < sar) {
         // Apply pre-previous low adjustment if needed
-        if (this.prePreviousCandle!.low < sar) {
-          sar = this.prePreviousCandle!.low;
+        if (state.prePreviousCandle!.low < sar) {
+          sar = state.prePreviousCandle!.low;
         }
 
         // Apply previous low adjustment
-        sar = this.previousCandle.low < sar ? this.previousCandle.low : sar;
+        sar = state.previousCandle.low < sar ? state.previousCandle.low : sar;
       }
       // No pre-previous candle, but check previous low
-      else if (this.previousCandle.low < sar) {
-        sar = this.previousCandle.low;
+      else if (state.previousCandle.low < sar) {
+        sar = state.previousCandle.low;
       }
 
       // Update acceleration factor and extreme point if price makes new high
-      if (high > this.extreme!) {
-        this.extreme = high;
-        if (this.acceleration < this.accelerationMax) {
-          this.acceleration += this.accelerationStep;
-          if (this.acceleration > this.accelerationMax) {
-            this.acceleration = this.accelerationMax;
+      if (high > state.extreme!) {
+        state.extreme = high;
+        if (state.acceleration < this.accelerationMax) {
+          state.acceleration += this.accelerationStep;
+          if (state.acceleration > this.accelerationMax) {
+            state.acceleration = this.accelerationMax;
           }
         }
       }
@@ -170,10 +147,10 @@ export class PSAR extends IndicatorSeries<HighLow<number>> {
       // Check if trend reverses (price falls below SAR)
       if (low < sar) {
         // Reverse to short
-        this.isLong = false;
-        sar = this.extreme!; // Set SAR to the extreme point
-        this.extreme = low; // Set new extreme to current low
-        this.acceleration = this.accelerationStep; // Reset acceleration
+        state.isLong = false;
+        sar = state.extreme!; // Set SAR to the extreme point
+        state.extreme = low; // Set new extreme to current low
+        state.acceleration = this.accelerationStep; // Reset acceleration
       }
     } else {
       /*
@@ -181,37 +158,37 @@ export class PSAR extends IndicatorSeries<HighLow<number>> {
        * Adjust SAR based on previous highs
        * If pre-previous candle exists and current high is greater than SAR
        */
-      const hasPrevPrev = this.prePreviousCandle != null;
+      const hasPrevPrev = state.prePreviousCandle != null;
       if (hasPrevPrev && high > sar) {
         // Apply pre-previous high adjustment if needed
-        if (this.prePreviousCandle!.high > sar) {
-          sar = this.prePreviousCandle!.high;
+        if (state.prePreviousCandle!.high > sar) {
+          sar = state.prePreviousCandle!.high;
         }
 
         // Apply previous high adjustment
-        sar = this.previousCandle.high > sar ? this.previousCandle.high : sar;
+        sar = state.previousCandle.high > sar ? state.previousCandle.high : sar;
       }
       // No pre-previous candle, but check previous high
-      else if (this.previousCandle.high > sar) {
-        sar = this.previousCandle.high;
+      else if (state.previousCandle.high > sar) {
+        sar = state.previousCandle.high;
       }
 
       // Update acceleration factor and extreme point if price makes new low
-      if (low < this.extreme!) {
-        this.extreme = low;
-        this.acceleration += this.accelerationStep;
-        if (this.acceleration > this.accelerationMax) {
-          this.acceleration = this.accelerationMax;
+      if (low < state.extreme!) {
+        state.extreme = low;
+        state.acceleration += this.accelerationStep;
+        if (state.acceleration > this.accelerationMax) {
+          state.acceleration = this.accelerationMax;
         }
       }
 
       // Check if trend reverses (price rises above SAR)
       if (high > sar) {
         // Reverse to long
-        this.isLong = true;
-        sar = this.extreme!; // Set SAR to the extreme point
-        this.extreme = high; // Set new extreme to current high
-        this.acceleration = this.accelerationStep; // Reset acceleration
+        state.isLong = true;
+        sar = state.extreme!; // Set SAR to the extreme point
+        state.extreme = high; // Set new extreme to current high
+        state.acceleration = this.accelerationStep; // Reset acceleration
 
         /*
          * Ensure the SAR is below the price in the uptrend by setting it slightly below the low
@@ -223,9 +200,9 @@ export class PSAR extends IndicatorSeries<HighLow<number>> {
       }
     }
 
-    this.lastSar = sar;
-    this.prePreviousCandle = this.previousCandle;
-    this.previousCandle = candle;
+    state.lastSar = sar;
+    state.prePreviousCandle = state.previousCandle;
+    state.previousCandle = candle;
 
     return this.setResult(sar, replace);
   }

--- a/packages/trading-signals/src/trend/SMA/SMA.ts
+++ b/packages/trading-signals/src/trend/SMA/SMA.ts
@@ -18,7 +18,7 @@ export class SMA extends MovingAverage {
   }
 
   update(price: number, replace: boolean) {
-    pushUpdate(this.prices, replace, price, this.interval);
+    pushUpdate({array: this.prices, item: price, maxLength: this.interval, replace: replace});
 
     if (this.prices.length === this.interval) {
       return this.setResult(getAverage(this.prices), replace);

--- a/packages/trading-signals/src/trend/SMA15/SMA15.ts
+++ b/packages/trading-signals/src/trend/SMA15/SMA15.ts
@@ -24,7 +24,7 @@ export class SMA15 extends MovingAverage {
   }
 
   update(price: number, replace: boolean) {
-    pushUpdate(this.prices, replace, price, this.getRequiredInputs());
+    pushUpdate({array: this.prices, item: price, maxLength: this.getRequiredInputs(), replace: replace});
 
     if (this.prices.length === this.getRequiredInputs()) {
       let weightedPricesSum = 0;

--- a/packages/trading-signals/src/trend/SWING_HIGH/SwingHigh.ts
+++ b/packages/trading-signals/src/trend/SWING_HIGH/SwingHigh.ts
@@ -43,7 +43,7 @@ export class SwingHigh extends IndicatorSeries<HighLow> {
     }
     this.#lastEmitted = false;
 
-    pushUpdate(this.#window, replace, candle.high, this.getRequiredInputs());
+    pushUpdate({array: this.#window, item: candle.high, maxLength: this.getRequiredInputs(), replace: replace});
 
     if (this.#window.length < this.getRequiredInputs()) {
       return null;

--- a/packages/trading-signals/src/trend/SWING_LOW/SwingLow.ts
+++ b/packages/trading-signals/src/trend/SWING_LOW/SwingLow.ts
@@ -48,7 +48,7 @@ export class SwingLow extends IndicatorSeries<HighLow> {
     }
     this.#lastEmitted = false;
 
-    pushUpdate(this.#window, replace, candle.low, this.getRequiredInputs());
+    pushUpdate({array: this.#window, item: candle.low, maxLength: this.getRequiredInputs(), replace: replace});
 
     if (this.#window.length < this.getRequiredInputs()) {
       return null;

--- a/packages/trading-signals/src/trend/WMA/WMA.ts
+++ b/packages/trading-signals/src/trend/WMA/WMA.ts
@@ -23,7 +23,7 @@ export class WMA extends MovingAverage {
   }
 
   update(price: number, replace: boolean) {
-    pushUpdate(this.prices, replace, price, this.interval);
+    pushUpdate({array: this.prices, item: price, maxLength: this.interval, replace: replace});
 
     if (this.prices.length === this.interval) {
       const weightedPricesSum = this.prices.reduce((acc: number, price: number, index: number) => {

--- a/packages/trading-signals/src/trend/ZIGZAG/ZigZag.ts
+++ b/packages/trading-signals/src/trend/ZIGZAG/ZigZag.ts
@@ -10,12 +10,17 @@ export type ZigZagConfig = {
 };
 
 /**
- * The swing state {@link ZigZag.update} carries between candles. Capturing it lets a replacement
- * re-run the latest candle from the state that candle originally saw.
+ * The swing state {@link ZigZag.update} carries between candles. Held in the base-class state
+ * container so a replacement re-runs the latest candle from the state that candle originally saw.
  */
 type ZigZagState = {
   highestExtreme: number | null;
   isUp: boolean;
+  /*
+   * Whether the latest candle reversed the trend. ZigZag emits only on a reversal and its result
+   * persists in between, so only a candle that emitted may withdraw that pivot when replaced.
+   */
+  lastCandleReversed: boolean;
   lowestExtreme: number | null;
 };
 
@@ -34,17 +39,14 @@ type ZigZagState = {
  * @see https://capex.com/en/academy/zigzag
  * @see https://corporatefinanceinstitute.com/resources/career-map/sell-side/capital-markets/zig-zag-indicator/
  */
-export class ZigZag extends IndicatorSeries<HighLow> {
+export class ZigZag extends IndicatorSeries<HighLow, ZigZagState> {
   readonly #deviation: number;
-  #isUp: boolean = false;
-  #highestExtreme: number | null = null;
-  #lowestExtreme: number | null = null;
-  #previousState: ZigZagState | null = null;
-  /**
-   * Whether the latest candle reversed the trend. ZigZag emits only on a reversal and its result
-   * persists in between, so only a candle that emitted may withdraw that pivot when replaced.
-   */
-  #lastCandleReversed: boolean = false;
+  protected override state: ZigZagState = {
+    highestExtreme: null,
+    isUp: false,
+    lastCandleReversed: false,
+    lowestExtreme: null,
+  };
 
   constructor(config: ZigZagConfig) {
     super();
@@ -59,55 +61,47 @@ export class ZigZag extends IndicatorSeries<HighLow> {
     const low = candle.low;
     const high = candle.high;
 
-    if (replace) {
-      if (this.#previousState !== null) {
-        this.#isUp = this.#previousState.isUp;
-        this.#highestExtreme = this.#previousState.highestExtreme;
-        this.#lowestExtreme = this.#previousState.lowestExtreme;
-      }
-      if (this.#lastCandleReversed) {
-        this.rollbackLastResult();
-      }
-    } else {
-      this.#previousState = {
-        highestExtreme: this.#highestExtreme,
-        isUp: this.#isUp,
-        lowestExtreme: this.#lowestExtreme,
-      };
+    // Read before trackState() rewinds the flag to what the candle before the replaced one found
+    if (replace && this.state.lastCandleReversed) {
+      this.rollbackLastResult();
     }
 
-    this.#lastCandleReversed = false;
+    this.trackState(replace);
 
-    if (this.#lowestExtreme === null) {
-      this.#lowestExtreme = low;
+    const state = this.state;
+
+    state.lastCandleReversed = false;
+
+    if (state.lowestExtreme === null) {
+      state.lowestExtreme = low;
     }
 
-    if (this.#highestExtreme === null) {
-      this.#highestExtreme = high;
+    if (state.highestExtreme === null) {
+      state.highestExtreme = high;
     }
 
-    if (this.#isUp) {
+    if (state.isUp) {
       const uptrendReversal =
-        this.#lowestExtreme + ((this.#highestExtreme - this.#lowestExtreme) * (100 - this.#deviation)) / 100;
+        state.lowestExtreme + ((state.highestExtreme - state.lowestExtreme) * (100 - this.#deviation)) / 100;
 
-      if (high > this.#highestExtreme) {
-        this.#highestExtreme = high;
+      if (high > state.highestExtreme) {
+        state.highestExtreme = high;
       } else if (low < uptrendReversal) {
-        this.#isUp = false;
-        this.#lowestExtreme = low;
-        this.#lastCandleReversed = true;
-        return this.setResult(this.#highestExtreme, replace);
+        state.isUp = false;
+        state.lowestExtreme = low;
+        state.lastCandleReversed = true;
+        return this.setResult(state.highestExtreme, replace);
       }
     } else {
-      const downtrendReversal = low + ((this.#highestExtreme - low) * this.#deviation) / 100;
+      const downtrendReversal = low + ((state.highestExtreme - low) * this.#deviation) / 100;
 
-      if (low < this.#lowestExtreme) {
-        this.#lowestExtreme = low;
+      if (low < state.lowestExtreme) {
+        state.lowestExtreme = low;
       } else if (high > downtrendReversal) {
-        this.#isUp = true;
-        this.#highestExtreme = high;
-        this.#lastCandleReversed = true;
-        return this.setResult(this.#lowestExtreme, replace);
+        state.isUp = true;
+        state.highestExtreme = high;
+        state.lastCandleReversed = true;
+        return this.setResult(state.lowestExtreme, replace);
       }
     }
 

--- a/packages/trading-signals/src/trend/ZIGZAG/ZigZag.ts
+++ b/packages/trading-signals/src/trend/ZIGZAG/ZigZag.ts
@@ -20,7 +20,7 @@ type ZigZagState = {
    * Whether the latest candle reversed the trend. ZigZag emits only on a reversal and its result
    * persists in between, so only a candle that emitted may withdraw that pivot when replaced.
    */
-  lastCandleReversed: boolean;
+  lastCandleReversedTrend: boolean;
   lowestExtreme: number | null;
 };
 
@@ -44,7 +44,7 @@ export class ZigZag extends IndicatorSeries<HighLow, ZigZagState> {
   protected override state: ZigZagState = {
     highestExtreme: null,
     isUp: false,
-    lastCandleReversed: false,
+    lastCandleReversedTrend: false,
     lowestExtreme: null,
   };
 
@@ -62,7 +62,7 @@ export class ZigZag extends IndicatorSeries<HighLow, ZigZagState> {
     const high = candle.high;
 
     // Read before trackState() rewinds the flag to what the candle before the replaced one found
-    if (replace && this.state.lastCandleReversed) {
+    if (replace && this.state.lastCandleReversedTrend) {
       this.rollbackLastResult();
     }
 
@@ -70,7 +70,7 @@ export class ZigZag extends IndicatorSeries<HighLow, ZigZagState> {
 
     const state = this.state;
 
-    state.lastCandleReversed = false;
+    state.lastCandleReversedTrend = false;
 
     if (state.lowestExtreme === null) {
       state.lowestExtreme = low;
@@ -89,7 +89,7 @@ export class ZigZag extends IndicatorSeries<HighLow, ZigZagState> {
       } else if (low < uptrendReversal) {
         state.isUp = false;
         state.lowestExtreme = low;
-        state.lastCandleReversed = true;
+        state.lastCandleReversedTrend = true;
         return this.setResult(state.highestExtreme, replace);
       }
     } else {
@@ -100,7 +100,7 @@ export class ZigZag extends IndicatorSeries<HighLow, ZigZagState> {
       } else if (high > downtrendReversal) {
         state.isUp = true;
         state.highestExtreme = high;
-        state.lastCandleReversed = true;
+        state.lastCandleReversedTrend = true;
         return this.setResult(state.lowestExtreme, replace);
       }
     }

--- a/packages/trading-signals/src/util/pushUpdate.ts
+++ b/packages/trading-signals/src/util/pushUpdate.ts
@@ -1,7 +1,11 @@
 type PushUpdateOptions<T> = {
+  /** Array that receives the item; mutated in place */
   array: T[];
+  /** Item to append, or to overwrite the last element with */
   item: T;
+  /** Size at which the array should be capped */
   maxLength: number;
+  /** Overwrite the last element instead of appending */
   replace: boolean;
 };
 

--- a/packages/trading-signals/src/util/pushUpdate.ts
+++ b/packages/trading-signals/src/util/pushUpdate.ts
@@ -1,8 +1,15 @@
+type PushUpdateOptions<T> = {
+  array: T[];
+  item: T;
+  maxLength: number;
+  replace: boolean;
+};
+
 /**
  * Adds an item to the array or replaces the last item in the array.
  * If the array limit size is exceeded, the oldest array element will be removed and returned by the function.
  */
-export function pushUpdate<T>(array: T[], replace: boolean, item: T, maxLength: number) {
+export function pushUpdate<T>({array, item, maxLength, replace}: PushUpdateOptions<T>) {
   if (array.length > 0 && replace === true) {
     array[array.length - 1] = item;
   } else {

--- a/packages/trading-signals/src/volatility/BBANDS/BollingerBands.ts
+++ b/packages/trading-signals/src/volatility/BBANDS/BollingerBands.ts
@@ -33,7 +33,7 @@ export class BollingerBands extends TechnicalIndicator<BandsResult, number> {
   }
 
   update(price: number, replace: boolean) {
-    pushUpdate(this.prices, replace, price, this.interval);
+    pushUpdate({array: this.prices, item: price, maxLength: this.interval, replace: replace});
 
     if (replace) {
       this.result = this.#previousResult;

--- a/packages/trading-signals/src/volatility/MAD/MAD.ts
+++ b/packages/trading-signals/src/volatility/MAD/MAD.ts
@@ -24,7 +24,7 @@ export class MAD extends IndicatorSeries {
   }
 
   update(price: number, replace: boolean) {
-    pushUpdate(this.prices, replace, price, this.interval);
+    pushUpdate({array: this.prices, item: price, maxLength: this.interval, replace: replace});
 
     if (this.prices.length === this.interval) {
       const mean = getAverage(this.prices);

--- a/packages/trading-signals/src/volume/CMF/CMF.ts
+++ b/packages/trading-signals/src/volume/CMF/CMF.ts
@@ -32,7 +32,7 @@ export class CMF extends TrendIndicatorSeries<HighLowCloseVolume> {
   }
 
   update(candle: HighLowCloseVolume, replace: boolean) {
-    pushUpdate(this.#candles, replace, candle, this.interval);
+    pushUpdate({array: this.#candles, item: candle, maxLength: this.interval, replace: replace});
 
     if (this.#candles.length < this.interval) {
       return null;

--- a/packages/trading-signals/src/volume/EMV/EMV.ts
+++ b/packages/trading-signals/src/volume/EMV/EMV.ts
@@ -38,7 +38,7 @@ export class EMV extends TrendIndicatorSeries<HighLowCloseVolume> {
   }
 
   update(candle: HighLowCloseVolume, replace: boolean) {
-    pushUpdate(this.#candles, replace, candle, 2);
+    pushUpdate({array: this.#candles, item: candle, maxLength: 2, replace: replace});
 
     if (this.#candles.length < 2) {
       return null;

--- a/packages/trading-signals/src/volume/PVT/PVT.ts
+++ b/packages/trading-signals/src/volume/PVT/PVT.ts
@@ -1,6 +1,10 @@
 import type {HighLowCloseVolume} from '../../base/Candle.type.js';
-import {TradingSignal, TrendIndicatorSeries} from '../../base/Indicator.js';
+import {TradingSignal, TrendIndicatorSeries, type TradingSignals} from '../../base/Indicator.js';
 import {pushUpdate} from '../../util/pushUpdate.js';
+
+type PVTState = {
+  candles: HighLowCloseVolume[];
+};
 
 /**
  * Price Volume Trend (PVT)
@@ -15,21 +19,24 @@ import {pushUpdate} from '../../util/pushUpdate.js';
  *
  * @see https://www.investopedia.com/terms/p/pvt.asp
  */
-export class PVT extends TrendIndicatorSeries<HighLowCloseVolume> {
-  readonly #candles: HighLowCloseVolume[] = [];
+export class PVT extends TrendIndicatorSeries<HighLowCloseVolume, TradingSignals, PVTState> {
+  protected override state: PVTState = {candles: []};
 
   override getRequiredInputs() {
     return 2;
   }
 
   update(candle: HighLowCloseVolume, replace: boolean) {
-    pushUpdate(this.#candles, replace, candle, 2);
+    this.trackState(replace);
 
-    if (this.#candles.length < 2) {
+    // trackState() already rewound the window on a replacement, so the candle is always appended
+    pushUpdate(this.state.candles, false, candle, 2);
+
+    if (this.state.candles.length < 2) {
       return null;
     }
 
-    const previousClose = this.#candles[0].close;
+    const previousClose = this.state.candles[0].close;
     /*
      * PVT accumulates onto the running total, so a replacement has to build on the total from
      * before the replaced candle. `this.result` still carries that candle's contribution until

--- a/packages/trading-signals/src/volume/PVT/PVT.ts
+++ b/packages/trading-signals/src/volume/PVT/PVT.ts
@@ -30,7 +30,7 @@ export class PVT extends TrendIndicatorSeries<HighLowCloseVolume, TradingSignals
     this.trackState(replace);
 
     // trackState() already rewound the window on a replacement, so the candle is always appended
-    pushUpdate(this.state.candles, false, candle, 2);
+    pushUpdate({array: this.state.candles, item: candle, maxLength: 2, replace: false});
 
     if (this.state.candles.length < 2) {
       return null;

--- a/packages/trading-signals/src/volume/VROC/VROC.ts
+++ b/packages/trading-signals/src/volume/VROC/VROC.ts
@@ -31,7 +31,7 @@ export class VROC extends TrendIndicatorSeries {
   }
 
   update(volume: number, replace: boolean) {
-    pushUpdate(this.#volumes, replace, volume, this.#historyLength);
+    pushUpdate({array: this.#volumes, item: volume, maxLength: this.#historyLength, replace: replace});
 
     if (this.#volumes.length < this.#historyLength) {
       return null;

--- a/packages/trading-signals/src/volume/VWMA/VWMA.ts
+++ b/packages/trading-signals/src/volume/VWMA/VWMA.ts
@@ -38,7 +38,7 @@ export class VWMA extends TrendIndicatorSeries<HighLowCloseVolume> {
   }
 
   update(candle: HighLowCloseVolume, replace: boolean) {
-    pushUpdate(this.#candles, replace, candle, this.interval);
+    pushUpdate({array: this.#candles, item: candle, maxLength: this.interval, replace: replace});
 
     if (this.#candles.length < this.interval) {
       return null;


### PR DESCRIPTION
# Good design decisions remove a whole class of bugs.

Stacked on #1261 — retarget to `main` once that merges. Follows up on [this review thread](https://github.com/bennycode/trading-signals/pull/1261#discussion_r3703885704): instead of a test-local comparator, internal state is now comparable on the base class.

## What

`TechnicalIndicator` gains a third generic `State` and a single mutable-state container:

- **`protected state: State`** — every mutable field `update()` may touch (beyond the result) lives in one object.
- **`trackState(replace)`** — snapshots `state` before each add, rewinds it on replace. One call at the top of `update()` replaces all per-field rollback bookkeeping.
- **`getState()`** — defensive snapshot of `result` + `state`. Tests assert `expect(a.getState()).toEqual(b.getState())` and get a real diff on failure.

Migrated: **PVT, TDS, PSAR, ZigZag** — the four state-machine indicators fixed in #1261. Their hand-rolled snapshot/restore code (PSAR's `captureState`/`restoreState`, TDS's three shadow fields, ZigZag's inline state copy) is deleted; the `replace()` semantics are unchanged and the whole suite passes untouched except for private-field access moving to `getState()`.

## Why the container instead of a hand-maintained `getState()`

TypeScript cannot reflect over private fields, so a hand-written state snapshot can silently omit a field — the same failure mode as the forgotten rollbacks #1261 fixed. With the container, completeness holds by construction: a field in `state` is rewound and compared automatically; a field outside it sticks out in review.

## Design notes

- `State` is appended **after** existing type parameters on all three base classes — existing subclasses (internal and external) compile unchanged.
- Comparing two indicators is left to `getState()` plus the test framework's own deep equality, which reports a diff on failure. No `equals()` helper on the base class ([review feedback](https://github.com/bennycode/trading-signals/pull/1277#discussion_r3710235735)).
- Indicators not yet migrated expose their result alone. Migration of the remaining stateful indicators (smoothing-based ones like EMA/ATR/ADX and window-based ones) can follow incrementally; end state is that `update()` becomes a base-class template method and the `replace` flag disappears from indicator logic entirely.
- Snapshots use `structuredClone` (Node ≥ 17, all evergreen browsers). Per-add cost is a clone of a small plain-data object (ZigZag: 4 scalars, TDS: ≤ 13 closes, PSAR: 6 fields, PVT: 2 candles).
- Result withdrawal for sparse emitters (TDS setups, ZigZag pivots) keeps using `rollbackLastResult()`; the emitted-flag now lives in `state` and is read before `trackState()` rewinds it.

## Verification

- 564 tests pass, coverage stays at 100% (statements, branches, functions, lines)
- `tsc --noEmit` clean, oxlint/oxfmt clean
- `trading-strategies` unchanged: compiles and passes all 259 tests
- All #1261 replace-correctness sweeps (same-value no-op at every series length, add-only equivalence with decoy bars) pass against the rewritten indicators
