### PR TITLE
chore: switch workflow validation from action-validator to actionlint

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -6,8 +6,6 @@ pre-commit:
         npx oxlint --fix --no-error-on-unmatched-pattern {staged_files}
         npx oxfmt --no-error-on-unmatched-pattern {staged_files}
       stage_fixed: true
-    action-validator:
+    actionlint:
       glob: '.github/workflows/*.{yml,yaml}'
-      # action-validator takes a single file, so staging two workflows at once
-      # would otherwise pass it two arguments and fail on its usage message.
-      run: for file in {staged_files}; do npx action-validator "$file" || exit 1; done
+      run: npx github-actionlint {staged_files}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,11 @@
       "name": "typedtrader",
       "version": "0.0.0",
       "devDependencies": {
-        "@action-validator/cli": "^0.6.0",
-        "@action-validator/core": "^0.6.0",
         "@stylistic/eslint-plugin": "^5.10.0",
         "@types/node": "^26.1.0",
         "@vitest/coverage-v8": "^4.0.18",
         "conventional-changelog-conventionalcommits": "^9.3.1",
+        "github-actionlint": "^1.7.12",
         "jsdom": "^30.0.0",
         "knip": "^6.29.0",
         "lefthook": "^2.1.9",
@@ -35,42 +34,6 @@
           "packages/*"
         ]
       }
-    },
-    "node_modules/@action-validator/cli": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@action-validator/cli/-/cli-0.6.0.tgz",
-      "integrity": "sha512-Z8TYOK4GqUIpI0UuspUJPB6dhr0niTumhwI5iiZVqFRXm4u05bZawnFKltpvoFUfJg9mHbbIBlleqsRJAgl53Q==",
-      "dev": true,
-      "license": "GPL-3.0-only",
-      "dependencies": {
-        "chalk": "5.2.0"
-      },
-      "bin": {
-        "action-validator": "cli.mjs"
-      },
-      "peerDependencies": {
-        "@action-validator/core": "0.6.0"
-      }
-    },
-    "node_modules/@action-validator/cli/node_modules/chalk": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
-      "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@action-validator/core": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@action-validator/core/-/core-0.6.0.tgz",
-      "integrity": "sha512-tPglwCr8Mm8SWzwnVewwFmqRx91F0WvMsM0BRAqH4CLalyGndm53Xvp+UcUSzswpk1wkjIDYI7RyEhWMLyPkig==",
-      "dev": true,
-      "license": "GPL-3.0-only"
     },
     "node_modules/@adobe/css-tools": {
       "version": "4.5.0",
@@ -2219,9 +2182,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2237,9 +2197,6 @@
       "integrity": "sha512-ftdSy3vYHmrGPBPSVIpKstmjZeI7kd83/5Q6cgcwPLyzOQzQEhcGqQM0u+HLq+lIcephTh6oTtwvOvx6QxWcyQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2257,9 +2214,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2275,9 +2229,6 @@
       "integrity": "sha512-p8AVApwWPAmVS0gzk119ZxqZUB6Jc6uQ/USbWzJNOBSmG9PWSg+SS+rQPG+zHi8lWyFO++VwiLghG7jI/VjIbw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4104,9 +4055,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4124,9 +4072,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4144,9 +4089,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4164,9 +4106,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4184,9 +4123,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4204,9 +4140,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4224,9 +4157,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4244,9 +4174,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4535,9 +4462,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4555,9 +4479,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4575,9 +4496,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4595,9 +4513,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4615,9 +4530,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4635,9 +4547,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4655,9 +4564,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4675,9 +4581,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6685,6 +6588,16 @@
       "integrity": "sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.18",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.18.tgz",
+      "integrity": "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      }
     },
     "node_modules/agent-base": {
       "version": "7.1.4",
@@ -9357,6 +9270,23 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/github-actionlint": {
+      "version": "1.7.12",
+      "resolved": "https://registry.npmjs.org/github-actionlint/-/github-actionlint-1.7.12.tgz",
+      "integrity": "sha512-kSVz5clt9voatp2Tdh1BETKNooT358/nPChYseaDC4M6f9Hc/sBRMbhagx2FTu2F/WHzDoxlNPh2EqwBngTYQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "adm-zip": "^0.5.16",
+        "tar": "^7.4.0"
+      },
+      "bin": {
+        "github-actionlint": "dist/bin/actionlint.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/github-from-package": {
       "version": "0.0.0",
@@ -13444,6 +13374,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -29,12 +29,11 @@
     "version": "oxfmt packages/*/CHANGELOG.md"
   },
   "devDependencies": {
-    "@action-validator/cli": "^0.6.0",
-    "@action-validator/core": "^0.6.0",
     "@stylistic/eslint-plugin": "^5.10.0",
     "@types/node": "^26.1.0",
     "@vitest/coverage-v8": "^4.0.18",
     "conventional-changelog-conventionalcommits": "^9.3.1",
+    "github-actionlint": "^1.7.12",
     "jsdom": "^30.0.0",
     "knip": "^6.29.0",
     "lefthook": "^2.1.9",


### PR DESCRIPTION
## Why

The `@action-validator/cli` npm package is a dead end:

- Frozen at **0.6.0 since Feb 2024** — it ships a 2.5-year-old snapshot of the workflow schema, so newer GitHub workflow syntax validates against stale definitions.
- Only accepts a **single file argument**, which forced the `for`-loop workaround in `lefthook.yml` (multi-file support was fixed upstream in Feb 2025 but never published).
- Upstream has **no plans to publish new npm releases**: the maintainer closed the release request as *not planned* (mpalmer/action-validator#119) and calls the npm build "very, very Not Recommended" (mpalmer/action-validator#76).

## What

Replace it with [actionlint](https://github.com/rhysd/actionlint) via [`github-actionlint`](https://www.npmjs.com/package/github-actionlint), an npm wrapper that downloads the official binary from GitHub releases and tracks upstream versions 1:1 (currently 1.7.12, ~150k downloads/month).

- `package.json`: drop `@action-validator/cli` + `@action-validator/core`, add `github-actionlint`
- `lefthook.yml`: actionlint accepts multiple files natively, so the per-file loop and its explanatory comment are gone — the hook is a one-liner again

## Bonus

actionlint checks more than schema validity: expression syntax in `if:`/`${{ }}`, context field names, action inputs, and runner labels.

## Verification

- ✅ All 7 existing workflows pass clean
- ✅ Multi-file invocation works (the original pain point)
- ✅ A deliberately broken workflow exits 1 with a precise error
- ✅ `npx lefthook dump` parses the new config
- ✅ `npx knip` reports no unused dependencies