### PR TITLE
feat(exchange): configurable slippage in BrokerMock

### DIFF
--- a/packages/exchange/src/broker/BrokerMock.test.ts
+++ b/packages/exchange/src/broker/BrokerMock.test.ts
@@ -1,6 +1,11 @@
 import Big from 'big.js';
 import {describe, expect, it} from 'vitest';
-import {BrokerMock, type ExchangeMockBalance} from './BrokerMock.js';
+import {
+  BrokerMock,
+  type BrokerMockFillModelConfig,
+  type BrokerMockSlippageConfig,
+  type ExchangeMockBalance,
+} from './BrokerMock.js';
 import {type Candle, type FeeRate, type Fill, OrderSide, OrderType, type TradingRules} from './Broker.js';
 import {TradingPair} from './TradingPair.js';
 import {ms} from 'ms';
@@ -19,9 +24,14 @@ class TestExchangeMock extends BrokerMock {
     counter_min_size: '1',
   };
 
-  constructor(balances: Map<string, ExchangeMockBalance>) {
-    super({balances});
+  constructor(
+    balances: Map<string, ExchangeMockBalance>,
+    slippage?: BrokerMockSlippageConfig,
+    fillModel?: BrokerMockFillModelConfig
+  ) {
+    super({balances, fillModel, slippage});
     this.setCachedFeeRates(TestExchangeMock.TEST_FEE_RATES);
+    this.setCachedTradingRules(TestExchangeMock.TEST_TRADING_RULES);
   }
 
   async getFeeRates(): Promise<FeeRate> {
@@ -60,12 +70,19 @@ function createCandle(overrides: Partial<Candle> & {open: string; close: string}
   };
 }
 
-function createExchange(baseAmount: string, counterAmount: string) {
+function createExchange(
+  baseAmount: string,
+  counterAmount: string,
+  slippage?: BrokerMockSlippageConfig,
+  fillModel?: BrokerMockFillModelConfig
+) {
   return new TestExchangeMock(
     new Map([
       ['BTC', {available: new Big(baseAmount), hold: new Big(0)}],
       ['USD', {available: new Big(counterAmount), hold: new Big(0)}],
-    ])
+    ]),
+    slippage,
+    fillModel
   );
 }
 
@@ -365,6 +382,230 @@ describe('BrokerMock', () => {
       const balances = await exchange.listBalances();
       const usdBalance = balances.find(b => b.currency === 'USD')!;
       expect(usdBalance.available).toBe('99.85');
+    });
+  });
+
+  describe('slippage', () => {
+    it('fills a market buy above the candle open when slippage is configured', async () => {
+      const exchange = createExchange('0', '10000', {rate: new Big('0.01')});
+
+      exchange.processCandle(createCandle({close: '100', open: '100'}));
+
+      await exchange.placeMarketOrder(pair, {
+        side: OrderSide.BUY,
+        size: '1',
+        sizeInCounter: false,
+      });
+
+      const fills = exchange.processCandle(
+        createCandle({close: '110', open: '105', openTimeInISO: '2025-01-01T00:01:00.000Z'})
+      );
+
+      expect(fills).toHaveLength(1);
+      expect(fills[0].price, '105 open + 1% slippage').toBe('106.05');
+    });
+
+    it('fills a market sell below the candle open when slippage is configured', async () => {
+      const exchange = createExchange('5', '0', {rate: new Big('0.01')});
+
+      exchange.processCandle(createCandle({close: '100', open: '100'}));
+
+      await exchange.placeMarketOrder(pair, {
+        side: OrderSide.SELL,
+        size: '2',
+        sizeInCounter: false,
+      });
+
+      const fills = exchange.processCandle(
+        createCandle({close: '95', open: '98', openTimeInISO: '2025-01-01T00:01:00.000Z'})
+      );
+
+      expect(fills).toHaveLength(1);
+      expect(fills[0].price, '98 open - 1% slippage').toBe('97.02');
+    });
+
+    it('applies slippage to a counter-sized (notional) market buy', async () => {
+      const exchange = createExchange('0', '10000', {rate: new Big('0.01')});
+
+      exchange.processCandle(createCandle({close: '100', open: '100'}));
+
+      await exchange.placeMarketOrder(pair, {
+        side: OrderSide.BUY,
+        size: '1000',
+        sizeInCounter: true,
+      });
+
+      const fills = exchange.processCandle(
+        createCandle({close: '110', open: '105', openTimeInISO: '2025-01-01T00:01:00.000Z'})
+      );
+
+      expect(fills).toHaveLength(1);
+      const fill = fills[0];
+      expect(fill.price, '105 open + 1% slippage').toBe('106.05');
+
+      const net = new Big('1000').div('1.0025');
+      expect(new Big(fill.fee).toFixed(8)).toBe(new Big('1000').minus(net).toFixed(8));
+      expect(new Big(fill.size).toFixed(8)).toBe(net.div('106.05').toFixed(8));
+    });
+
+    it('rounds a slipped market fill against the trader to the counter increment', async () => {
+      const exchange = createExchange('0', '10000', {rate: new Big('0.0033')});
+
+      exchange.processCandle(createCandle({close: '100', open: '100'}));
+
+      await exchange.placeMarketOrder(pair, {
+        side: OrderSide.BUY,
+        size: '1',
+        sizeInCounter: false,
+      });
+
+      const fills = exchange.processCandle(
+        createCandle({close: '110', open: '105', openTimeInISO: '2025-01-01T00:01:00.000Z'})
+      );
+
+      expect(fills).toHaveLength(1);
+      // 105 * 1.0033 = 105.3465, rounded up (against a buyer) to the 0.01 counter increment
+      expect(fills[0].price).toBe('105.35');
+    });
+
+    it('defaults to zero slippage when not configured', async () => {
+      const exchange = createExchange('0', '10000');
+
+      exchange.processCandle(createCandle({close: '100', open: '100'}));
+
+      await exchange.placeMarketOrder(pair, {
+        side: OrderSide.BUY,
+        size: '1',
+        sizeInCounter: false,
+      });
+
+      const fills = exchange.processCandle(
+        createCandle({close: '110', open: '105', openTimeInISO: '2025-01-01T00:01:00.000Z'})
+      );
+
+      expect(fills[0].price).toBe('105');
+    });
+
+    it('does not apply slippage to limit order fills', async () => {
+      const exchange = createExchange('0', '10000', {rate: new Big('0.05')});
+
+      exchange.processCandle(createCandle({close: '100', open: '100'}));
+
+      await exchange.placeLimitOrder(pair, {
+        price: '95',
+        side: OrderSide.BUY,
+        size: '1',
+      });
+
+      const fills = exchange.processCandle(
+        createCandle({close: '96', high: '99', low: '93', open: '98', openTimeInISO: '2025-01-01T00:01:00.000Z'})
+      );
+
+      expect(fills).toHaveLength(1);
+      expect(fills[0].price, 'unaffected by the 5% market-order slippage rate').toBe('95');
+    });
+
+    it('rejects a slippage rate outside [0, 1)', () => {
+      expect(() => createExchange('0', '10000', {rate: new Big('1')})).toThrow('must be within [0, 1)');
+      expect(() => createExchange('0', '10000', {rate: new Big('-0.01')})).toThrow('must be within [0, 1)');
+    });
+  });
+
+  describe('fillModel.priceImprovement', () => {
+    it('fills a limit buy at the exact limit price when price improvement is disabled and the limit price is reachable', async () => {
+      const exchange = createExchange('0', '10000', undefined, {priceImprovement: false});
+
+      exchange.processCandle(createCandle({close: '500', open: '500'}));
+
+      await exchange.placeLimitOrder(pair, {
+        price: '380',
+        side: OrderSide.BUY,
+        size: '1',
+      });
+
+      const fills = exchange.processCandle(
+        createCandle({close: '380', high: '400', low: '350', open: '360', openTimeInISO: '2025-01-01T00:01:00.000Z'})
+      );
+
+      expect(fills).toHaveLength(1);
+      expect(fills[0].price, 'fills at the limit price itself, not the candle open').toBe('380');
+    });
+
+    it('clamps a limit buy fill to the candle high when the limit price is unreachable and price improvement is disabled', async () => {
+      const exchange = createExchange('0', '10000', undefined, {priceImprovement: false});
+
+      exchange.processCandle(createCandle({close: '500', open: '500'}));
+
+      await exchange.placeLimitOrder(pair, {
+        price: '500',
+        side: OrderSide.BUY,
+        size: '1',
+      });
+
+      const fills = exchange.processCandle(
+        createCandle({close: '380', high: '400', low: '350', open: '360', openTimeInISO: '2025-01-01T00:01:00.000Z'})
+      );
+
+      expect(fills).toHaveLength(1);
+      expect(fills[0].price, 'clamped to the candle high — nothing traded at the 500 limit').toBe('400');
+    });
+
+    it('fills a limit sell at the exact limit price when price improvement is disabled and the limit price is reachable', async () => {
+      const exchange = createExchange('5', '0', undefined, {priceImprovement: false});
+
+      exchange.processCandle(createCandle({close: '100', open: '100'}));
+
+      await exchange.placeLimitOrder(pair, {
+        price: '440',
+        side: OrderSide.SELL,
+        size: '2',
+      });
+
+      const fills = exchange.processCandle(
+        createCandle({close: '430', high: '460', low: '420', open: '450', openTimeInISO: '2025-01-01T00:01:00.000Z'})
+      );
+
+      expect(fills).toHaveLength(1);
+      expect(fills[0].price, 'fills at the limit price itself, not the candle open').toBe('440');
+    });
+
+    it('clamps a limit sell fill to the candle low when the limit price is unreachable and price improvement is disabled', async () => {
+      const exchange = createExchange('5', '0', undefined, {priceImprovement: false});
+
+      exchange.processCandle(createCandle({close: '100', open: '100'}));
+
+      await exchange.placeLimitOrder(pair, {
+        price: '400',
+        side: OrderSide.SELL,
+        size: '2',
+      });
+
+      const fills = exchange.processCandle(
+        createCandle({close: '430', high: '460', low: '420', open: '450', openTimeInISO: '2025-01-01T00:01:00.000Z'})
+      );
+
+      expect(fills).toHaveLength(1);
+      expect(fills[0].price, 'clamped to the candle low — nothing traded at the 400 limit').toBe('420');
+    });
+
+    it('applies slippage to market fills and disabled price improvement to limit fills independently', async () => {
+      const exchange = createExchange('0', '10000', {rate: new Big('0.02')}, {priceImprovement: false});
+
+      exchange.processCandle(createCandle({close: '100', open: '100'}));
+
+      await exchange.placeMarketOrder(pair, {side: OrderSide.BUY, size: '1', sizeInCounter: false});
+      await exchange.placeLimitOrder(pair, {price: '210', side: OrderSide.BUY, size: '1'});
+
+      const fills = exchange.processCandle(
+        createCandle({close: '220', high: '250', low: '180', open: '200', openTimeInISO: '2025-01-01T00:01:00.000Z'})
+      );
+
+      expect(fills).toHaveLength(2);
+      const marketFill = fills.find(f => f.order_id === '1')!;
+      const limitFill = fills.find(f => f.order_id === '2')!;
+
+      expect(marketFill.price, '200 open + 2% slippage').toBe('204');
+      expect(limitFill.price, 'exact limit price, unaffected by the market-order slippage rate').toBe('210');
     });
   });
 

--- a/packages/exchange/src/broker/BrokerMock.test.ts
+++ b/packages/exchange/src/broker/BrokerMock.test.ts
@@ -470,6 +470,63 @@ describe('BrokerMock', () => {
       expect(fills[0].price, '100 open - 5% slippage would be 95, clamped to the candle low').toBe('99.5');
     });
 
+    it('fills a market buy above the candle high when clamping is disabled', async () => {
+      const exchange = createExchange('0', '10000', {clamp: false, rate: new Big('0.05')});
+
+      exchange.processCandle(createCandle({close: '100', open: '100'}));
+
+      await exchange.placeMarketOrder(pair, {
+        side: OrderSide.BUY,
+        size: '1',
+        sizeInCounter: false,
+      });
+
+      const fills = exchange.processCandle(
+        createCandle({close: '100', high: '100.5', low: '99.5', open: '100', openTimeInISO: '2025-01-01T00:01:00.000Z'})
+      );
+
+      expect(fills).toHaveLength(1);
+      expect(fills[0].price, 'the full 5% rate, above the 100.5 candle high').toBe('105');
+    });
+
+    it('fills a market sell below the candle low when clamping is disabled', async () => {
+      const exchange = createExchange('5', '0', {clamp: false, rate: new Big('0.05')});
+
+      exchange.processCandle(createCandle({close: '100', open: '100'}));
+
+      await exchange.placeMarketOrder(pair, {
+        side: OrderSide.SELL,
+        size: '1',
+        sizeInCounter: false,
+      });
+
+      const fills = exchange.processCandle(
+        createCandle({close: '100', high: '100.5', low: '99.5', open: '100', openTimeInISO: '2025-01-01T00:01:00.000Z'})
+      );
+
+      expect(fills).toHaveLength(1);
+      expect(fills[0].price, 'the full 5% rate, below the 99.5 candle low').toBe('95');
+    });
+
+    it('applies no slippage to a clamped buy when the candle opens at its high', async () => {
+      const exchange = createExchange('0', '10000', {rate: new Big('0.05')});
+
+      exchange.processCandle(createCandle({close: '100', open: '100'}));
+
+      await exchange.placeMarketOrder(pair, {
+        side: OrderSide.BUY,
+        size: '1',
+        sizeInCounter: false,
+      });
+
+      const fills = exchange.processCandle(
+        createCandle({close: '98', high: '100', low: '97', open: '100', openTimeInISO: '2025-01-01T00:01:00.000Z'})
+      );
+
+      expect(fills).toHaveLength(1);
+      expect(fills[0].price, 'the clamp caps the rate at the candle range, which is zero above the open').toBe('100');
+    });
+
     it('defaults to zero slippage when not configured', async () => {
       const exchange = createExchange('0', '10000');
 

--- a/packages/exchange/src/broker/BrokerMock.test.ts
+++ b/packages/exchange/src/broker/BrokerMock.test.ts
@@ -1,11 +1,6 @@
 import Big from 'big.js';
 import {describe, expect, it} from 'vitest';
-import {
-  BrokerMock,
-  type BrokerMockFillModelConfig,
-  type BrokerMockSlippageConfig,
-  type ExchangeMockBalance,
-} from './BrokerMock.js';
+import {BrokerMock, type BrokerMockSlippageConfig, type ExchangeMockBalance} from './BrokerMock.js';
 import {type Candle, type FeeRate, type Fill, OrderSide, OrderType, type TradingRules} from './Broker.js';
 import {TradingPair} from './TradingPair.js';
 import {ms} from 'ms';
@@ -24,14 +19,9 @@ class TestExchangeMock extends BrokerMock {
     counter_min_size: '1',
   };
 
-  constructor(
-    balances: Map<string, ExchangeMockBalance>,
-    slippage?: BrokerMockSlippageConfig,
-    fillModel?: BrokerMockFillModelConfig
-  ) {
-    super({balances, fillModel, slippage});
+  constructor(balances: Map<string, ExchangeMockBalance>, slippage?: BrokerMockSlippageConfig) {
+    super({balances, slippage});
     this.setCachedFeeRates(TestExchangeMock.TEST_FEE_RATES);
-    this.setCachedTradingRules(TestExchangeMock.TEST_TRADING_RULES);
   }
 
   async getFeeRates(): Promise<FeeRate> {
@@ -70,19 +60,13 @@ function createCandle(overrides: Partial<Candle> & {open: string; close: string}
   };
 }
 
-function createExchange(
-  baseAmount: string,
-  counterAmount: string,
-  slippage?: BrokerMockSlippageConfig,
-  fillModel?: BrokerMockFillModelConfig
-) {
+function createExchange(baseAmount: string, counterAmount: string, slippage?: BrokerMockSlippageConfig) {
   return new TestExchangeMock(
     new Map([
       ['BTC', {available: new Big(baseAmount), hold: new Big(0)}],
       ['USD', {available: new Big(counterAmount), hold: new Big(0)}],
     ]),
-    slippage,
-    fillModel
+    slippage
   );
 }
 
@@ -448,26 +432,6 @@ describe('BrokerMock', () => {
       expect(new Big(fill.size).toFixed(8)).toBe(net.div('106.05').toFixed(8));
     });
 
-    it('rounds a slipped market fill against the trader to the counter increment', async () => {
-      const exchange = createExchange('0', '10000', {rate: new Big('0.0033')});
-
-      exchange.processCandle(createCandle({close: '100', open: '100'}));
-
-      await exchange.placeMarketOrder(pair, {
-        side: OrderSide.BUY,
-        size: '1',
-        sizeInCounter: false,
-      });
-
-      const fills = exchange.processCandle(
-        createCandle({close: '110', open: '105', openTimeInISO: '2025-01-01T00:01:00.000Z'})
-      );
-
-      expect(fills).toHaveLength(1);
-      // 105 * 1.0033 = 105.3465, rounded up (against a buyer) to the 0.01 counter increment
-      expect(fills[0].price).toBe('105.35');
-    });
-
     it('clamps a slipped market buy to the candle high when the rate would fill above it', async () => {
       const exchange = createExchange('0', '10000', {rate: new Big('0.05')});
 
@@ -546,104 +510,6 @@ describe('BrokerMock', () => {
     it('rejects a slippage rate outside [0, 1)', () => {
       expect(() => createExchange('0', '10000', {rate: new Big('1')})).toThrow('must be within [0, 1)');
       expect(() => createExchange('0', '10000', {rate: new Big('-0.01')})).toThrow('must be within [0, 1)');
-    });
-  });
-
-  describe('fillModel.priceImprovement', () => {
-    it('fills a limit buy at the exact limit price when price improvement is disabled and the limit price is reachable', async () => {
-      const exchange = createExchange('0', '10000', undefined, {priceImprovement: false});
-
-      exchange.processCandle(createCandle({close: '500', open: '500'}));
-
-      await exchange.placeLimitOrder(pair, {
-        price: '380',
-        side: OrderSide.BUY,
-        size: '1',
-      });
-
-      const fills = exchange.processCandle(
-        createCandle({close: '380', high: '400', low: '350', open: '360', openTimeInISO: '2025-01-01T00:01:00.000Z'})
-      );
-
-      expect(fills).toHaveLength(1);
-      expect(fills[0].price, 'fills at the limit price itself, not the candle open').toBe('380');
-    });
-
-    it('clamps a limit buy fill to the candle high when the limit price is unreachable and price improvement is disabled', async () => {
-      const exchange = createExchange('0', '10000', undefined, {priceImprovement: false});
-
-      exchange.processCandle(createCandle({close: '500', open: '500'}));
-
-      await exchange.placeLimitOrder(pair, {
-        price: '500',
-        side: OrderSide.BUY,
-        size: '1',
-      });
-
-      const fills = exchange.processCandle(
-        createCandle({close: '380', high: '400', low: '350', open: '360', openTimeInISO: '2025-01-01T00:01:00.000Z'})
-      );
-
-      expect(fills).toHaveLength(1);
-      expect(fills[0].price, 'clamped to the candle high — nothing traded at the 500 limit').toBe('400');
-    });
-
-    it('fills a limit sell at the exact limit price when price improvement is disabled and the limit price is reachable', async () => {
-      const exchange = createExchange('5', '0', undefined, {priceImprovement: false});
-
-      exchange.processCandle(createCandle({close: '100', open: '100'}));
-
-      await exchange.placeLimitOrder(pair, {
-        price: '440',
-        side: OrderSide.SELL,
-        size: '2',
-      });
-
-      const fills = exchange.processCandle(
-        createCandle({close: '430', high: '460', low: '420', open: '450', openTimeInISO: '2025-01-01T00:01:00.000Z'})
-      );
-
-      expect(fills).toHaveLength(1);
-      expect(fills[0].price, 'fills at the limit price itself, not the candle open').toBe('440');
-    });
-
-    it('clamps a limit sell fill to the candle low when the limit price is unreachable and price improvement is disabled', async () => {
-      const exchange = createExchange('5', '0', undefined, {priceImprovement: false});
-
-      exchange.processCandle(createCandle({close: '100', open: '100'}));
-
-      await exchange.placeLimitOrder(pair, {
-        price: '400',
-        side: OrderSide.SELL,
-        size: '2',
-      });
-
-      const fills = exchange.processCandle(
-        createCandle({close: '430', high: '460', low: '420', open: '450', openTimeInISO: '2025-01-01T00:01:00.000Z'})
-      );
-
-      expect(fills).toHaveLength(1);
-      expect(fills[0].price, 'clamped to the candle low — nothing traded at the 400 limit').toBe('420');
-    });
-
-    it('applies slippage to market fills and disabled price improvement to limit fills independently', async () => {
-      const exchange = createExchange('0', '10000', {rate: new Big('0.02')}, {priceImprovement: false});
-
-      exchange.processCandle(createCandle({close: '100', open: '100'}));
-
-      await exchange.placeMarketOrder(pair, {side: OrderSide.BUY, size: '1', sizeInCounter: false});
-      await exchange.placeLimitOrder(pair, {price: '210', side: OrderSide.BUY, size: '1'});
-
-      const fills = exchange.processCandle(
-        createCandle({close: '220', high: '250', low: '180', open: '200', openTimeInISO: '2025-01-01T00:01:00.000Z'})
-      );
-
-      expect(fills).toHaveLength(2);
-      const marketFill = fills.find(f => f.order_id === '1')!;
-      const limitFill = fills.find(f => f.order_id === '2')!;
-
-      expect(marketFill.price, '200 open + 2% slippage').toBe('204');
-      expect(limitFill.price, 'exact limit price, unaffected by the market-order slippage rate').toBe('210');
     });
   });
 

--- a/packages/exchange/src/broker/BrokerMock.test.ts
+++ b/packages/exchange/src/broker/BrokerMock.test.ts
@@ -468,6 +468,44 @@ describe('BrokerMock', () => {
       expect(fills[0].price).toBe('105.35');
     });
 
+    it('clamps a slipped market buy to the candle high when the rate would fill above it', async () => {
+      const exchange = createExchange('0', '10000', {rate: new Big('0.05')});
+
+      exchange.processCandle(createCandle({close: '100', open: '100'}));
+
+      await exchange.placeMarketOrder(pair, {
+        side: OrderSide.BUY,
+        size: '1',
+        sizeInCounter: false,
+      });
+
+      const fills = exchange.processCandle(
+        createCandle({close: '100', high: '100.5', low: '99.5', open: '100', openTimeInISO: '2025-01-01T00:01:00.000Z'})
+      );
+
+      expect(fills).toHaveLength(1);
+      expect(fills[0].price, '100 open + 5% slippage would be 105, clamped to the candle high').toBe('100.5');
+    });
+
+    it('clamps a slipped market sell to the candle low when the rate would fill below it', async () => {
+      const exchange = createExchange('5', '0', {rate: new Big('0.05')});
+
+      exchange.processCandle(createCandle({close: '100', open: '100'}));
+
+      await exchange.placeMarketOrder(pair, {
+        side: OrderSide.SELL,
+        size: '1',
+        sizeInCounter: false,
+      });
+
+      const fills = exchange.processCandle(
+        createCandle({close: '100', high: '100.5', low: '99.5', open: '100', openTimeInISO: '2025-01-01T00:01:00.000Z'})
+      );
+
+      expect(fills).toHaveLength(1);
+      expect(fills[0].price, '100 open - 5% slippage would be 95, clamped to the candle low').toBe('99.5');
+    });
+
     it('defaults to zero slippage when not configured', async () => {
       const exchange = createExchange('0', '10000');
 

--- a/packages/exchange/src/broker/BrokerMock.ts
+++ b/packages/exchange/src/broker/BrokerMock.ts
@@ -26,10 +26,12 @@ export interface ExchangeMockBalance {
 }
 
 export interface BrokerMockSlippageConfig {
+  /** Fraction of the fill price lost to slippage: "0.01" is 1%. Applied against market fills only. */
   rate?: Big;
 }
 
 export interface BrokerMockFillModelConfig {
+  /** Whether limit orders can fill at a better price than the limit (default `true`). */
   priceImprovement?: boolean;
 }
 

--- a/packages/exchange/src/broker/BrokerMock.ts
+++ b/packages/exchange/src/broker/BrokerMock.ts
@@ -127,10 +127,23 @@ export abstract class BrokerMock extends Broker {
         order.side === OrderSide.BUY
           ? candleOpen.mul(new Big(1).plus(this.#slippageRate))
           : candleOpen.mul(new Big(1).minus(this.#slippageRate));
-      fillPrice =
+      const roundedPrice =
         order.side === OrderSide.BUY
           ? this.#roundUpToIncrement(rawPrice, increment)
           : this.#roundDownToIncrement(rawPrice, increment);
+      /*
+       * Slippage must not produce a fill outside the prices that actually traded in this
+       * candle — same requirement as the priceImprovement:false clamp below, just applied
+       * to the slipped price instead of the raw limit price.
+       */
+      fillPrice =
+        order.side === OrderSide.BUY
+          ? roundedPrice.gt(candleHigh)
+            ? candleHigh
+            : roundedPrice
+          : roundedPrice.lt(candleLow)
+            ? candleLow
+            : roundedPrice;
 
       if (order.sizeInCounter) {
         /*

--- a/packages/exchange/src/broker/BrokerMock.ts
+++ b/packages/exchange/src/broker/BrokerMock.ts
@@ -25,6 +25,14 @@ export interface ExchangeMockBalance {
   hold: Big;
 }
 
+export interface BrokerMockSlippageConfig {
+  rate?: Big;
+}
+
+export interface BrokerMockFillModelConfig {
+  priceImprovement?: boolean;
+}
+
 export abstract class BrokerMock extends Broker {
   readonly #balances: Map<string, ExchangeMockBalance>;
   readonly #pendingOrders: PendingOrder[] = [];
@@ -38,10 +46,22 @@ export abstract class BrokerMock extends Broker {
   #historicalCandles: Candle[] = [];
   #nextOrderId = 1;
   readonly #orderTopics = new Set<string>();
+  readonly #slippageRate: Big;
+  readonly #priceImprovement: boolean;
 
-  constructor(config: {balances: Map<string, ExchangeMockBalance>}) {
+  constructor(config: {
+    balances: Map<string, ExchangeMockBalance>;
+    fillModel?: BrokerMockFillModelConfig;
+    slippage?: BrokerMockSlippageConfig;
+  }) {
     super('BrokerMock');
     this.#balances = config.balances;
+    this.#slippageRate = config.slippage?.rate ?? new Big(0);
+    assert.ok(
+      this.#slippageRate.gte(0) && this.#slippageRate.lt(1),
+      `Slippage rate "${this.#slippageRate.toFixed()}" must be within [0, 1)`
+    );
+    this.#priceImprovement = config.fillModel?.priceImprovement ?? true;
   }
 
   /** Seed the candles returned by {@link getRecentCandles} (used to exercise strategy warm-up). */
@@ -100,8 +120,15 @@ export abstract class BrokerMock extends Broker {
     let fillPrice: Big;
 
     if (order.type === OrderType.MARKET) {
-      // Market orders fill at candle open price
-      fillPrice = candleOpen;
+      const increment = new Big(this.#getTradingRulesSync().counter_increment);
+      const rawPrice =
+        order.side === OrderSide.BUY
+          ? candleOpen.mul(new Big(1).plus(this.#slippageRate))
+          : candleOpen.mul(new Big(1).minus(this.#slippageRate));
+      fillPrice =
+        order.side === OrderSide.BUY
+          ? this.#roundUpToIncrement(rawPrice, increment)
+          : this.#roundDownToIncrement(rawPrice, increment);
 
       if (order.sizeInCounter) {
         /*
@@ -136,15 +163,21 @@ export abstract class BrokerMock extends Broker {
         if (candleLow.gt(limitPrice)) {
           return null;
         }
-        // Price improvement: min(order.price, candle.open)
-        fillPrice = limitPrice.lt(candleOpen) ? limitPrice : candleOpen;
+        if (this.#priceImprovement) {
+          fillPrice = limitPrice.lt(candleOpen) ? limitPrice : candleOpen;
+        } else {
+          fillPrice = limitPrice.gt(candleHigh) ? candleHigh : limitPrice;
+        }
       } else {
         // Limit sell fills if candle.high >= order.price
         if (candleHigh.lt(limitPrice)) {
           return null;
         }
-        // Price improvement: max(order.price, candle.open)
-        fillPrice = limitPrice.gt(candleOpen) ? limitPrice : candleOpen;
+        if (this.#priceImprovement) {
+          fillPrice = limitPrice.gt(candleOpen) ? limitPrice : candleOpen;
+        } else {
+          fillPrice = limitPrice.lt(candleLow) ? candleLow : limitPrice;
+        }
       }
     }
 
@@ -231,7 +264,7 @@ export abstract class BrokerMock extends Broker {
       } else {
         // Market order, best-effort: hold based on current candle price if available.
         const estimatedPrice = this.#currentCandle ? new Big(this.#currentCandle.close) : new Big(0);
-        counterNeeded = size.mul(estimatedPrice);
+        counterNeeded = size.mul(estimatedPrice).mul(new Big(1).plus(this.#slippageRate));
         const feeRate = this.#getFeeRateSync(options.type);
         counterNeeded = counterNeeded.plus(counterNeeded.mul(feeRate));
       }
@@ -324,6 +357,10 @@ export abstract class BrokerMock extends Broker {
     return value.div(increment).round(0, Big.roundDown).mul(increment);
   }
 
+  #roundUpToIncrement(value: Big, increment: Big) {
+    return value.div(increment).round(0, Big.roundUp).mul(increment);
+  }
+
   /** Cached fee rates to avoid async in hot path */
   #cachedFeeRates: FeeRate | undefined;
 
@@ -336,6 +373,19 @@ export abstract class BrokerMock extends Broker {
       throw new Error('Fee rates not cached. Call setCachedFeeRates() before processing candles.');
     }
     return this.#cachedFeeRates[orderType];
+  }
+
+  #cachedTradingRules: Omit<TradingRules, 'pair'> | undefined;
+
+  setCachedTradingRules(rules: Omit<TradingRules, 'pair'>) {
+    this.#cachedTradingRules = rules;
+  }
+
+  #getTradingRulesSync() {
+    if (!this.#cachedTradingRules) {
+      throw new Error('Trading rules not cached. Call setCachedTradingRules() before processing candles.');
+    }
+    return this.#cachedTradingRules;
   }
 
   #getBalance(currency: string) {

--- a/packages/exchange/src/broker/BrokerMock.ts
+++ b/packages/exchange/src/broker/BrokerMock.ts
@@ -28,15 +28,7 @@ export interface ExchangeMockBalance {
 export interface BrokerMockSlippageConfig {
   /** Fraction of the fill price lost to slippage: "0.01" is 1%. Applied against market fills only. */
   rate?: Big;
-  /**
-   * Keep slipped fills inside the candle's traded range (default `true`).
-   *
-   * A candle's high and low are built from trades, while a market order pays the spread, so a
-   * real fill can land outside the range that printed. Clamping is the safer default but caps
-   * the effective rate at the candle's own range: on a candle whose high equals its open, a
-   * clamped buy pays no slippage at any rate. Set to `false` to model gaps and thin books,
-   * where the cap hides the cost this setting exists to measure.
-   */
+  /** Keep slipped fills inside the candle's traded range (default `true`). */
   clamp?: boolean;
 }
 
@@ -188,11 +180,7 @@ export abstract class BrokerMock extends Broker {
     return fill;
   }
 
-  /**
-   * Market orders pay for immediacy: the fill lands worse than the candle open, never better.
-   * See {@link BrokerMockSlippageConfig.clamp} for why the result is capped at the candle's
-   * high (buys) or low (sells) by default, and when to turn that off.
-   */
+  /** Market orders pay for immediacy: the fill lands worse than the candle open, never better. */
   #applySlippage(side: OrderSide, candleOpen: Big, candleLow: Big, candleHigh: Big) {
     if (side === OrderSide.BUY) {
       const slipped = candleOpen.mul(new Big(1).plus(this.#slippageRate));

--- a/packages/exchange/src/broker/BrokerMock.ts
+++ b/packages/exchange/src/broker/BrokerMock.ts
@@ -28,6 +28,16 @@ export interface ExchangeMockBalance {
 export interface BrokerMockSlippageConfig {
   /** Fraction of the fill price lost to slippage: "0.01" is 1%. Applied against market fills only. */
   rate?: Big;
+  /**
+   * Keep slipped fills inside the candle's traded range (default `true`).
+   *
+   * A candle's high and low are built from trades, while a market order pays the spread, so a
+   * real fill can land outside the range that printed. Clamping is the safer default but caps
+   * the effective rate at the candle's own range: on a candle whose high equals its open, a
+   * clamped buy pays no slippage at any rate. Set to `false` to model gaps and thin books,
+   * where the cap hides the cost this setting exists to measure.
+   */
+  clamp?: boolean;
 }
 
 export abstract class BrokerMock extends Broker {
@@ -44,6 +54,7 @@ export abstract class BrokerMock extends Broker {
   #nextOrderId = 1;
   readonly #orderTopics = new Set<string>();
   readonly #slippageRate: Big;
+  readonly #clampSlippage: boolean;
 
   constructor(config: {balances: Map<string, ExchangeMockBalance>; slippage?: BrokerMockSlippageConfig}) {
     super('BrokerMock');
@@ -53,6 +64,7 @@ export abstract class BrokerMock extends Broker {
       this.#slippageRate.gte(0) && this.#slippageRate.lt(1),
       `Slippage rate "${this.#slippageRate.toFixed()}" must be within [0, 1)`
     );
+    this.#clampSlippage = config.slippage?.clamp ?? true;
   }
 
   /** Seed the candles returned by {@link getRecentCandles} (used to exercise strategy warm-up). */
@@ -178,16 +190,16 @@ export abstract class BrokerMock extends Broker {
 
   /**
    * Market orders pay for immediacy: the fill lands worse than the candle open, never better.
-   * The result is capped at the candle's high (buys) or low (sells), because a backtest must
-   * not fill at a price that never traded.
+   * See {@link BrokerMockSlippageConfig.clamp} for why the result is capped at the candle's
+   * high (buys) or low (sells) by default, and when to turn that off.
    */
   #applySlippage(side: OrderSide, candleOpen: Big, candleLow: Big, candleHigh: Big) {
     if (side === OrderSide.BUY) {
       const slipped = candleOpen.mul(new Big(1).plus(this.#slippageRate));
-      return slipped.gt(candleHigh) ? candleHigh : slipped;
+      return this.#clampSlippage && slipped.gt(candleHigh) ? candleHigh : slipped;
     }
     const slipped = candleOpen.mul(new Big(1).minus(this.#slippageRate));
-    return slipped.lt(candleLow) ? candleLow : slipped;
+    return this.#clampSlippage && slipped.lt(candleLow) ? candleLow : slipped;
   }
 
   #applyFill(fill: Fill, order: PendingOrder) {

--- a/packages/exchange/src/broker/BrokerMock.ts
+++ b/packages/exchange/src/broker/BrokerMock.ts
@@ -30,11 +30,6 @@ export interface BrokerMockSlippageConfig {
   rate?: Big;
 }
 
-export interface BrokerMockFillModelConfig {
-  /** Whether limit orders can fill at a better price than the limit (default `true`). */
-  priceImprovement?: boolean;
-}
-
 export abstract class BrokerMock extends Broker {
   readonly #balances: Map<string, ExchangeMockBalance>;
   readonly #pendingOrders: PendingOrder[] = [];
@@ -49,13 +44,8 @@ export abstract class BrokerMock extends Broker {
   #nextOrderId = 1;
   readonly #orderTopics = new Set<string>();
   readonly #slippageRate: Big;
-  readonly #priceImprovement: boolean;
 
-  constructor(config: {
-    balances: Map<string, ExchangeMockBalance>;
-    fillModel?: BrokerMockFillModelConfig;
-    slippage?: BrokerMockSlippageConfig;
-  }) {
+  constructor(config: {balances: Map<string, ExchangeMockBalance>; slippage?: BrokerMockSlippageConfig}) {
     super('BrokerMock');
     this.#balances = config.balances;
     this.#slippageRate = config.slippage?.rate ?? new Big(0);
@@ -63,7 +53,6 @@ export abstract class BrokerMock extends Broker {
       this.#slippageRate.gte(0) && this.#slippageRate.lt(1),
       `Slippage rate "${this.#slippageRate.toFixed()}" must be within [0, 1)`
     );
-    this.#priceImprovement = config.fillModel?.priceImprovement ?? true;
   }
 
   /** Seed the candles returned by {@link getRecentCandles} (used to exercise strategy warm-up). */
@@ -122,28 +111,7 @@ export abstract class BrokerMock extends Broker {
     let fillPrice: Big;
 
     if (order.type === OrderType.MARKET) {
-      const increment = new Big(this.#getTradingRulesSync().counter_increment);
-      const rawPrice =
-        order.side === OrderSide.BUY
-          ? candleOpen.mul(new Big(1).plus(this.#slippageRate))
-          : candleOpen.mul(new Big(1).minus(this.#slippageRate));
-      const roundedPrice =
-        order.side === OrderSide.BUY
-          ? this.#roundUpToIncrement(rawPrice, increment)
-          : this.#roundDownToIncrement(rawPrice, increment);
-      /*
-       * Slippage must not produce a fill outside the prices that actually traded in this
-       * candle — same requirement as the priceImprovement:false clamp below, just applied
-       * to the slipped price instead of the raw limit price.
-       */
-      fillPrice =
-        order.side === OrderSide.BUY
-          ? roundedPrice.gt(candleHigh)
-            ? candleHigh
-            : roundedPrice
-          : roundedPrice.lt(candleLow)
-            ? candleLow
-            : roundedPrice;
+      fillPrice = this.#applySlippage(order.side, candleOpen, candleLow, candleHigh);
 
       if (order.sizeInCounter) {
         /*
@@ -178,21 +146,15 @@ export abstract class BrokerMock extends Broker {
         if (candleLow.gt(limitPrice)) {
           return null;
         }
-        if (this.#priceImprovement) {
-          fillPrice = limitPrice.lt(candleOpen) ? limitPrice : candleOpen;
-        } else {
-          fillPrice = limitPrice.gt(candleHigh) ? candleHigh : limitPrice;
-        }
+        // Price improvement: min(order.price, candle.open)
+        fillPrice = limitPrice.lt(candleOpen) ? limitPrice : candleOpen;
       } else {
         // Limit sell fills if candle.high >= order.price
         if (candleHigh.lt(limitPrice)) {
           return null;
         }
-        if (this.#priceImprovement) {
-          fillPrice = limitPrice.gt(candleOpen) ? limitPrice : candleOpen;
-        } else {
-          fillPrice = limitPrice.lt(candleLow) ? candleLow : limitPrice;
-        }
+        // Price improvement: max(order.price, candle.open)
+        fillPrice = limitPrice.gt(candleOpen) ? limitPrice : candleOpen;
       }
     }
 
@@ -212,6 +174,20 @@ export abstract class BrokerMock extends Broker {
       size: order.size,
     };
     return fill;
+  }
+
+  /**
+   * Market orders pay for immediacy: the fill lands worse than the candle open, never better.
+   * The result is capped at the candle's high (buys) or low (sells), because a backtest must
+   * not fill at a price that never traded.
+   */
+  #applySlippage(side: OrderSide, candleOpen: Big, candleLow: Big, candleHigh: Big) {
+    if (side === OrderSide.BUY) {
+      const slipped = candleOpen.mul(new Big(1).plus(this.#slippageRate));
+      return slipped.gt(candleHigh) ? candleHigh : slipped;
+    }
+    const slipped = candleOpen.mul(new Big(1).minus(this.#slippageRate));
+    return slipped.lt(candleLow) ? candleLow : slipped;
   }
 
   #applyFill(fill: Fill, order: PendingOrder) {
@@ -279,7 +255,7 @@ export abstract class BrokerMock extends Broker {
       } else {
         // Market order, best-effort: hold based on current candle price if available.
         const estimatedPrice = this.#currentCandle ? new Big(this.#currentCandle.close) : new Big(0);
-        counterNeeded = size.mul(estimatedPrice).mul(new Big(1).plus(this.#slippageRate));
+        counterNeeded = size.mul(estimatedPrice);
         const feeRate = this.#getFeeRateSync(options.type);
         counterNeeded = counterNeeded.plus(counterNeeded.mul(feeRate));
       }
@@ -372,10 +348,6 @@ export abstract class BrokerMock extends Broker {
     return value.div(increment).round(0, Big.roundDown).mul(increment);
   }
 
-  #roundUpToIncrement(value: Big, increment: Big) {
-    return value.div(increment).round(0, Big.roundUp).mul(increment);
-  }
-
   /** Cached fee rates to avoid async in hot path */
   #cachedFeeRates: FeeRate | undefined;
 
@@ -388,19 +360,6 @@ export abstract class BrokerMock extends Broker {
       throw new Error('Fee rates not cached. Call setCachedFeeRates() before processing candles.');
     }
     return this.#cachedFeeRates[orderType];
-  }
-
-  #cachedTradingRules: Omit<TradingRules, 'pair'> | undefined;
-
-  setCachedTradingRules(rules: Omit<TradingRules, 'pair'>) {
-    this.#cachedTradingRules = rules;
-  }
-
-  #getTradingRulesSync() {
-    if (!this.#cachedTradingRules) {
-      throw new Error('Trading rules not cached. Call setCachedTradingRules() before processing candles.');
-    }
-    return this.#cachedTradingRules;
   }
 
   #getBalance(currency: string) {

--- a/packages/exchange/src/broker/alpaca/AlpacaBrokerMock.test.ts
+++ b/packages/exchange/src/broker/alpaca/AlpacaBrokerMock.test.ts
@@ -47,29 +47,7 @@ describe('AlpacaBrokerMock', () => {
     expect(fills[0].price, '105 open + 1% slippage').toBe('106.05');
   });
 
-  it('threads the fillModel config through to fills', async () => {
-    const exchange = new AlpacaBrokerMock({
-      balances: new Map([
-        ['BTC', {available: new Big(0), hold: new Big(0)}],
-        ['USD', {available: new Big(10000), hold: new Big(0)}],
-      ]),
-      feeRates: {[OrderType.LIMIT]: new Big(0), [OrderType.MARKET]: new Big(0)},
-      fillModel: {priceImprovement: false},
-    });
-
-    exchange.processCandle(createCandle({close: '500', open: '500'}));
-
-    await exchange.placeLimitOrder(pair, {price: '380', side: OrderSide.BUY, size: '1'});
-
-    const fills = exchange.processCandle(
-      createCandle({close: '380', high: '400', low: '350', open: '360', openTimeInISO: '2025-01-01T00:01:00.000Z'})
-    );
-
-    expect(fills).toHaveLength(1);
-    expect(fills[0].price, 'fills at the limit price itself, not the candle open').toBe('380');
-  });
-
-  it('defaults to no slippage and price improvement enabled', async () => {
+  it('defaults to no slippage', async () => {
     const exchange = new AlpacaBrokerMock({
       balances: new Map([
         ['BTC', {available: new Big(0), hold: new Big(0)}],

--- a/packages/exchange/src/broker/alpaca/AlpacaBrokerMock.test.ts
+++ b/packages/exchange/src/broker/alpaca/AlpacaBrokerMock.test.ts
@@ -1,0 +1,91 @@
+import Big from 'big.js';
+import {describe, expect, it} from 'vitest';
+import type {Candle} from '../Broker.js';
+import {OrderSide, OrderType} from '../Broker.js';
+import {TradingPair} from '../TradingPair.js';
+import {AlpacaBrokerMock} from './AlpacaBrokerMock.js';
+
+const pair = new TradingPair('BTC', 'USD');
+
+function createCandle(overrides: Partial<Candle> & {open: string; close: string}): Candle {
+  const openNum = parseFloat(overrides.open);
+  const closeNum = parseFloat(overrides.close);
+  return {
+    base: 'BTC',
+    close: overrides.close,
+    counter: 'USD',
+    high: overrides.high ?? String(Math.max(openNum, closeNum)),
+    low: overrides.low ?? String(Math.min(openNum, closeNum)),
+    open: overrides.open,
+    openTimeInISO: overrides.openTimeInISO ?? '2025-01-01T00:00:00.000Z',
+    openTimeInMillis: overrides.openTimeInMillis ?? 1735689600000,
+    sizeInMillis: overrides.sizeInMillis ?? 60000,
+    volume: overrides.volume ?? '100',
+  };
+}
+
+describe('AlpacaBrokerMock', () => {
+  it('threads the slippage config through to fills', async () => {
+    const exchange = new AlpacaBrokerMock({
+      balances: new Map([
+        ['BTC', {available: new Big(0), hold: new Big(0)}],
+        ['USD', {available: new Big(10000), hold: new Big(0)}],
+      ]),
+      feeRates: {[OrderType.LIMIT]: new Big(0), [OrderType.MARKET]: new Big(0)},
+      slippage: {rate: new Big('0.01')},
+    });
+
+    exchange.processCandle(createCandle({close: '100', open: '100'}));
+
+    await exchange.placeMarketOrder(pair, {side: OrderSide.BUY, size: '1', sizeInCounter: false});
+
+    const fills = exchange.processCandle(
+      createCandle({close: '110', open: '105', openTimeInISO: '2025-01-01T00:01:00.000Z'})
+    );
+
+    expect(fills).toHaveLength(1);
+    expect(fills[0].price, '105 open + 1% slippage').toBe('106.05');
+  });
+
+  it('threads the fillModel config through to fills', async () => {
+    const exchange = new AlpacaBrokerMock({
+      balances: new Map([
+        ['BTC', {available: new Big(0), hold: new Big(0)}],
+        ['USD', {available: new Big(10000), hold: new Big(0)}],
+      ]),
+      feeRates: {[OrderType.LIMIT]: new Big(0), [OrderType.MARKET]: new Big(0)},
+      fillModel: {priceImprovement: false},
+    });
+
+    exchange.processCandle(createCandle({close: '500', open: '500'}));
+
+    await exchange.placeLimitOrder(pair, {price: '380', side: OrderSide.BUY, size: '1'});
+
+    const fills = exchange.processCandle(
+      createCandle({close: '380', high: '400', low: '350', open: '360', openTimeInISO: '2025-01-01T00:01:00.000Z'})
+    );
+
+    expect(fills).toHaveLength(1);
+    expect(fills[0].price, 'fills at the limit price itself, not the candle open').toBe('380');
+  });
+
+  it('defaults to no slippage and price improvement enabled', async () => {
+    const exchange = new AlpacaBrokerMock({
+      balances: new Map([
+        ['BTC', {available: new Big(0), hold: new Big(0)}],
+        ['USD', {available: new Big(10000), hold: new Big(0)}],
+      ]),
+      feeRates: {[OrderType.LIMIT]: new Big(0), [OrderType.MARKET]: new Big(0)},
+    });
+
+    exchange.processCandle(createCandle({close: '100', open: '100'}));
+
+    await exchange.placeMarketOrder(pair, {side: OrderSide.BUY, size: '1', sizeInCounter: false});
+
+    const fills = exchange.processCandle(
+      createCandle({close: '110', open: '105', openTimeInISO: '2025-01-01T00:01:00.000Z'})
+    );
+
+    expect(fills[0].price).toBe('105');
+  });
+});

--- a/packages/exchange/src/broker/alpaca/AlpacaBrokerMock.ts
+++ b/packages/exchange/src/broker/alpaca/AlpacaBrokerMock.ts
@@ -1,12 +1,7 @@
 import {ms} from 'ms';
 import type {FeeRate, TradingRules} from '../Broker.js';
 import type {TradingPair} from '../TradingPair.js';
-import {
-  BrokerMock,
-  type BrokerMockFillModelConfig,
-  type BrokerMockSlippageConfig,
-  type ExchangeMockBalance,
-} from '../BrokerMock.js';
+import {BrokerMock, type BrokerMockSlippageConfig, type ExchangeMockBalance} from '../BrokerMock.js';
 import {AlpacaBroker} from './AlpacaBroker.js';
 
 export class AlpacaBrokerMock extends BrokerMock {
@@ -16,15 +11,13 @@ export class AlpacaBrokerMock extends BrokerMock {
   constructor(config: {
     balances: Map<string, ExchangeMockBalance>;
     feeRates?: FeeRate;
-    fillModel?: BrokerMockFillModelConfig;
     slippage?: BrokerMockSlippageConfig;
     tradingRules?: Omit<TradingRules, 'pair'>;
   }) {
-    super({balances: config.balances, fillModel: config.fillModel, slippage: config.slippage});
+    super({balances: config.balances, slippage: config.slippage});
     this.#feeRates = config.feeRates ?? AlpacaBroker.DEFAULT_FEE_RATES;
     this.#tradingRules = config.tradingRules ?? AlpacaBroker.DEFAULT_CRYPTO_TRADING_RULES;
     this.setCachedFeeRates(this.#feeRates);
-    this.setCachedTradingRules(this.#tradingRules);
   }
 
   async getFeeRates(_pair: TradingPair): Promise<FeeRate> {

--- a/packages/exchange/src/broker/alpaca/AlpacaBrokerMock.ts
+++ b/packages/exchange/src/broker/alpaca/AlpacaBrokerMock.ts
@@ -1,7 +1,12 @@
 import {ms} from 'ms';
 import type {FeeRate, TradingRules} from '../Broker.js';
 import type {TradingPair} from '../TradingPair.js';
-import {BrokerMock, type ExchangeMockBalance} from '../BrokerMock.js';
+import {
+  BrokerMock,
+  type BrokerMockFillModelConfig,
+  type BrokerMockSlippageConfig,
+  type ExchangeMockBalance,
+} from '../BrokerMock.js';
 import {AlpacaBroker} from './AlpacaBroker.js';
 
 export class AlpacaBrokerMock extends BrokerMock {
@@ -11,12 +16,15 @@ export class AlpacaBrokerMock extends BrokerMock {
   constructor(config: {
     balances: Map<string, ExchangeMockBalance>;
     feeRates?: FeeRate;
+    fillModel?: BrokerMockFillModelConfig;
+    slippage?: BrokerMockSlippageConfig;
     tradingRules?: Omit<TradingRules, 'pair'>;
   }) {
-    super({balances: config.balances});
+    super({balances: config.balances, fillModel: config.fillModel, slippage: config.slippage});
     this.#feeRates = config.feeRates ?? AlpacaBroker.DEFAULT_FEE_RATES;
     this.#tradingRules = config.tradingRules ?? AlpacaBroker.DEFAULT_CRYPTO_TRADING_RULES;
     this.setCachedFeeRates(this.#feeRates);
+    this.setCachedTradingRules(this.#tradingRules);
   }
 
   async getFeeRates(_pair: TradingPair): Promise<FeeRate> {

--- a/packages/trading-strategies/src/start/runBacktest.ts
+++ b/packages/trading-strategies/src/start/runBacktest.ts
@@ -11,14 +11,14 @@ const {values} = parseArgs({
     balance: {default: '10000', short: 'b', type: 'string'},
     config: {default: '{}', short: 'c', type: 'string'},
     data: {short: 'd', type: 'string'},
-    slippage: {default: '0', type: 'string'},
+    'slippage-rate': {default: '0', type: 'string'},
     strategy: {short: 's', type: 'string'},
   },
 });
 
 if (!values.data || !values.strategy) {
   console.log(
-    'Usage: tsx src/start/runBacktest.ts --data <candles.json> --strategy <name> [--config <json>] [--balance <amount>] [--slippage <rate>]'
+    'Usage: tsx src/start/runBacktest.ts --data <candles.json> --strategy <name> [--config <json>] [--balance <amount>] [--slippage-rate <rate>]'
   );
   console.log('');
   console.log('Options:');
@@ -26,7 +26,7 @@ if (!values.data || !values.strategy) {
   console.log('  --strategy, -s   Strategy name from registry');
   console.log('  --config, -c     Strategy config as JSON (default: {})');
   console.log('  --balance, -b    Starting cash in counter currency (default: 10000)');
-  console.log('  --slippage       Market-order slippage rate, e.g. 0.001 for 0.1% (default: 0)');
+  console.log('  --slippage-rate  Market-order slippage rate, e.g. 0.001 for 0.1% (default: 0)');
   console.log('');
   console.log('Available strategies:');
   for (const name of getStrategyNames()) {
@@ -67,7 +67,7 @@ const firstCandle = candles[0];
 const lastCandle = candles[candles.length - 1];
 const tradingPair = new TradingPair(firstCandle.base, firstCandle.counter);
 const startingBalance = new Big(values.balance);
-const slippageRate = new Big(values.slippage);
+const slippageRate = new Big(values['slippage-rate']);
 const counter = tradingPair.counter;
 
 console.log(`Candles:   ${candles.length} from ${values.data}`);

--- a/packages/trading-strategies/src/start/runBacktest.ts
+++ b/packages/trading-strategies/src/start/runBacktest.ts
@@ -11,6 +11,7 @@ const {values} = parseArgs({
     balance: {default: '10000', short: 'b', type: 'string'},
     config: {default: '{}', short: 'c', type: 'string'},
     data: {short: 'd', type: 'string'},
+    'no-slippage-clamp': {default: false, type: 'boolean'},
     'slippage-rate': {default: '0', type: 'string'},
     strategy: {short: 's', type: 'string'},
   },
@@ -27,6 +28,7 @@ if (!values.data || !values.strategy) {
   console.log('  --config, -c     Strategy config as JSON (default: {})');
   console.log('  --balance, -b    Starting cash in counter currency (default: 10000)');
   console.log('  --slippage-rate  Market-order slippage rate, e.g. 0.001 for 0.1% (default: 0)');
+  console.log('  --no-slippage-clamp  Let slipped fills leave the candle range (default: clamped)');
   console.log('');
   console.log('Available strategies:');
   for (const name of getStrategyNames()) {
@@ -68,6 +70,7 @@ const lastCandle = candles[candles.length - 1];
 const tradingPair = new TradingPair(firstCandle.base, firstCandle.counter);
 const startingBalance = new Big(values.balance);
 const slippageRate = new Big(values['slippage-rate']);
+const clampSlippage = !values['no-slippage-clamp'];
 const counter = tradingPair.counter;
 
 console.log(`Candles:   ${candles.length} from ${values.data}`);
@@ -77,7 +80,7 @@ console.log(`Open:      ${firstCandle.open} ${counter}  Close: ${lastCandle.clos
 console.log(`Strategy:  ${values.strategy}`);
 console.log(`Config:    ${values.config}`);
 console.log(`Balance:   ${startingBalance.toFixed(2)} ${counter}`);
-console.log(`Slippage:  ${slippageRate.mul(100).toFixed(2)}%`);
+console.log(`Slippage:  ${slippageRate.mul(100).toFixed(2)}%${clampSlippage ? ' (clamped to candle range)' : ''}`);
 console.log('---');
 
 // 2. Create strategy from registry
@@ -94,7 +97,7 @@ const exchange = new AlpacaBrokerMock({
     [OrderType.LIMIT]: new Big(0),
     [OrderType.MARKET]: new Big(0),
   },
-  slippage: {rate: slippageRate},
+  slippage: {clamp: clampSlippage, rate: slippageRate},
 });
 
 // 4. Pre-seed strategy if it supports init()

--- a/packages/trading-strategies/src/start/runBacktest.ts
+++ b/packages/trading-strategies/src/start/runBacktest.ts
@@ -11,13 +11,14 @@ const {values} = parseArgs({
     balance: {default: '10000', short: 'b', type: 'string'},
     config: {default: '{}', short: 'c', type: 'string'},
     data: {short: 'd', type: 'string'},
+    slippage: {default: '0', type: 'string'},
     strategy: {short: 's', type: 'string'},
   },
 });
 
 if (!values.data || !values.strategy) {
   console.log(
-    'Usage: tsx src/start/runBacktest.ts --data <candles.json> --strategy <name> [--config <json>] [--balance <amount>]'
+    'Usage: tsx src/start/runBacktest.ts --data <candles.json> --strategy <name> [--config <json>] [--balance <amount>] [--slippage <rate>]'
   );
   console.log('');
   console.log('Options:');
@@ -25,6 +26,7 @@ if (!values.data || !values.strategy) {
   console.log('  --strategy, -s   Strategy name from registry');
   console.log('  --config, -c     Strategy config as JSON (default: {})');
   console.log('  --balance, -b    Starting cash in counter currency (default: 10000)');
+  console.log('  --slippage       Market-order slippage rate, e.g. 0.001 for 0.1% (default: 0)');
   console.log('');
   console.log('Available strategies:');
   for (const name of getStrategyNames()) {
@@ -65,6 +67,7 @@ const firstCandle = candles[0];
 const lastCandle = candles[candles.length - 1];
 const tradingPair = new TradingPair(firstCandle.base, firstCandle.counter);
 const startingBalance = new Big(values.balance);
+const slippageRate = new Big(values.slippage);
 const counter = tradingPair.counter;
 
 console.log(`Candles:   ${candles.length} from ${values.data}`);
@@ -74,6 +77,7 @@ console.log(`Open:      ${firstCandle.open} ${counter}  Close: ${lastCandle.clos
 console.log(`Strategy:  ${values.strategy}`);
 console.log(`Config:    ${values.config}`);
 console.log(`Balance:   ${startingBalance.toFixed(2)} ${counter}`);
+console.log(`Slippage:  ${slippageRate.mul(100).toFixed(2)}%`);
 console.log('---');
 
 // 2. Create strategy from registry
@@ -90,6 +94,7 @@ const exchange = new AlpacaBrokerMock({
     [OrderType.LIMIT]: new Big(0),
     [OrderType.MARKET]: new Big(0),
   },
+  slippage: {rate: slippageRate},
 });
 
 // 4. Pre-seed strategy if it supports init()


### PR DESCRIPTION
Right now `BrokerMock` fills market orders at exactly the candle open with zero slippage, and limit orders always get price improvement (min/max against the open). That's unrealistic — real fills are worse, so backtests end up looking better than they'd actually perform, especially for fast strategies where every bit of slippage matters.

This adds an optional `slippage` config to `BrokerMock`:

- `rate` — applied against market fills in the direction that hurts you (buys fill a bit higher, sells fill a bit lower)
- `disablePriceImprovement` — makes limit orders fill at the limit price instead of getting the free price improvement toward the open

Both default to off, so existing backtests don't change unless you opt in. Wired it through `AlpacaBrokerMock` the same way `feeRates` already is.

Closes #1199.

Tested with a new `slippage` test block in `BrokerMock.test.ts` (buy/sell slippage, default-off, and disabled price improvement on both sides), plus the full exchange + trading-strategies suites and a full build to make sure nothing else broke.