### PR TITLE
refactor(trading-signals): migrate object-result indicators to shared TrendTechnicalIndicator base

### DIFF
--- a/packages/trading-signals/src/base/Indicator.ts
+++ b/packages/trading-signals/src/base/Indicator.ts
@@ -164,3 +164,53 @@ export abstract class TrendIndicatorSeries<
     };
   }
 }
+
+/**
+ * Counterpart to {@link TrendIndicatorSeries} for indicators whose result is a composite object
+ * (e.g. multiple bands or lines) instead of a single number. Subclasses inherit previous-result
+ * caching and signal-change detection so they don't have to hand-roll it per indicator.
+ */
+export abstract class TrendTechnicalIndicator<
+  Result,
+  Input = number,
+  SignalState = TradingSignals,
+  State extends object = Record<string, never>,
+> extends TechnicalIndicator<Result, Input, State> {
+  protected abstract calculateSignalState(result?: Result | null | undefined): SignalState;
+  protected previousResult?: Result;
+  #previousSignalState?: SignalState;
+
+  protected setResult(value: Result, replace: boolean) {
+    // When replacing, restore the previous signal state
+    if (replace && this.previousResult !== undefined) {
+      this.#previousSignalState = this.calculateSignalState(this.previousResult);
+    } else if (!replace) {
+      // Cache the previous signal state before updating
+      this.#previousSignalState = this.calculateSignalState(this.result);
+    }
+
+    // When replacing the latest value, restore previous result first
+    if (replace) {
+      this.result = this.previousResult;
+    }
+
+    // Cache previous result
+    this.previousResult = this.result;
+
+    // Set new result
+    return (this.result = value);
+  }
+
+  getSignal(): {
+    state: SignalState;
+    hasChanged: boolean;
+  } {
+    const currentState = this.calculateSignalState(this.getResult());
+    const hasChanged = this.#previousSignalState !== undefined && this.#previousSignalState !== currentState;
+
+    return {
+      hasChanged,
+      state: currentState,
+    };
+  }
+}

--- a/packages/trading-signals/src/momentum/MACD/MACD.ts
+++ b/packages/trading-signals/src/momentum/MACD/MACD.ts
@@ -1,6 +1,6 @@
 import type {DEMA} from '../../trend/DEMA/DEMA.js';
 import type {EMA} from '../../trend/EMA/EMA.js';
-import {TechnicalIndicator, TradingSignal} from '../../base/Indicator.js';
+import {TradingSignal, TrendTechnicalIndicator} from '../../base/Indicator.js';
 import {pushUpdate} from '../../util/pushUpdate.js';
 
 export type MACDResult = {
@@ -18,9 +18,8 @@ export type MACDResult = {
  *
  * @see https://www.investopedia.com/terms/m/macd.asp
  */
-export class MACD extends TechnicalIndicator<MACDResult, number> {
+export class MACD extends TrendTechnicalIndicator<MACDResult> {
   public readonly prices: number[] = [];
-  #previousResult?: MACDResult;
 
   public readonly short: EMA | DEMA;
   public readonly long: EMA | DEMA;
@@ -47,22 +46,19 @@ export class MACD extends TechnicalIndicator<MACDResult, number> {
       const macd = short - long;
       const signal = this.signal.update(macd, replace);
 
-      if (replace) {
-        this.result = this.#previousResult;
-      }
-
-      this.#previousResult = this.result;
-
-      return (this.result = {
-        histogram: macd - signal,
-        macd,
-        signal,
-      });
+      return this.setResult(
+        {
+          histogram: macd - signal,
+          macd,
+          signal,
+        },
+        replace
+      );
     }
     return null;
   }
 
-  protected calculateSignal(result?: MACDResult | null | undefined) {
+  protected override calculateSignalState(result?: MACDResult | null | undefined) {
     const hasResult = result !== null && result !== undefined;
     const isBullish = hasResult && result.histogram > 0; // MACD above signal line
     const isBearish = hasResult && result.histogram < 0; // MACD below signal line
@@ -76,19 +72,5 @@ export class MACD extends TechnicalIndicator<MACDResult, number> {
       default:
         return TradingSignal.BEARISH;
     }
-  }
-
-  getSignal(): {
-    state: (typeof TradingSignal)[keyof typeof TradingSignal];
-    hasChanged: boolean;
-  } {
-    const previousState = this.calculateSignal(this.#previousResult);
-    const state = this.calculateSignal(this.getResult());
-    const hasChanged = previousState !== state;
-
-    return {
-      hasChanged,
-      state,
-    };
   }
 }

--- a/packages/trading-signals/src/momentum/STOCH/StochasticOscillator.test.ts
+++ b/packages/trading-signals/src/momentum/STOCH/StochasticOscillator.test.ts
@@ -30,6 +30,19 @@ describe('StochasticOscillator', () => {
       expect(stoch.getRequiredInputs()).toBe(9);
       expect(stoch.getResultOrThrow().stochK.toFixed(2)).toBe('91.09');
     });
+
+    it('keeps feeding the %D average when %K is zero', () => {
+      const stoch = new StochasticOscillator({dPeriod: 3, kPeriod: 5, kSlowingPeriod: 3});
+      // Closing on the window low keeps %K at exactly zero
+      const candle = {close: 10, high: 100, low: 10} as const;
+
+      const results = Array.from({length: stoch.getRequiredInputs()}, () => stoch.add(candle));
+
+      // %D averages three %K readings, so a result must not appear before the 9th candle
+      expect(results[6]).toBeNull();
+      expect(results[7]).toBeNull();
+      expect(results[8]).toEqual({stochD: 0, stochK: 0});
+    });
   });
 
   describe('replace', () => {

--- a/packages/trading-signals/src/momentum/STOCH/StochasticOscillator.ts
+++ b/packages/trading-signals/src/momentum/STOCH/StochasticOscillator.ts
@@ -1,6 +1,6 @@
 import {SMA} from '../../trend/SMA/SMA.js';
 import type {HighLowClose} from '../../base/Candle.type.js';
-import {TechnicalIndicator, TradingSignal} from '../../base/Indicator.js';
+import {TradingSignal, TrendTechnicalIndicator} from '../../base/Indicator.js';
 import type {SignalThresholds} from '../../base/SignalThresholds.type.js';
 import {pushUpdate} from '../../util/pushUpdate.js';
 
@@ -38,11 +38,10 @@ export type StochasticOscillatorConfig = {
  * @see https://www.investopedia.com/terms/s/stochasticoscillator.asp
  * @see https://tulipindicators.org/stoch
  */
-export class StochasticOscillator extends TechnicalIndicator<StochasticResult, HighLowClose<number>> {
+export class StochasticOscillator extends TrendTechnicalIndicator<StochasticResult, HighLowClose<number>> {
   public readonly candles: HighLowClose<number>[] = [];
   readonly #smoothK: SMA;
   readonly #smoothD: SMA;
-  #previousResult?: StochasticResult;
 
   public readonly kPeriod: number;
   public readonly kSlowingPeriod: number;
@@ -79,26 +78,24 @@ export class StochasticOscillator extends TechnicalIndicator<StochasticResult, H
       // Prevent division by zero
       fastK = fastK / (divisor === 0 ? 1 : divisor);
       const stochK = this.#smoothK.update(fastK, replace); // (stoch_k, %k)
-      const stochD = stochK && this.#smoothD.update(stochK, replace); // (stoch_d, %d)
+      // A %K of 0 (close at the window low) is a valid reading and must still feed the %D average
+      const stochD = stochK !== null ? this.#smoothD.update(stochK, replace) : null; // (stoch_d, %d)
 
       if (stochK !== null && stochD !== null) {
-        if (replace) {
-          this.result = this.#previousResult;
-        }
-
-        this.#previousResult = this.result;
-
-        return (this.result = {
-          stochD,
-          stochK,
-        });
+        return this.setResult(
+          {
+            stochD,
+            stochK,
+          },
+          replace
+        );
       }
     }
 
     return null;
   }
 
-  protected calculateSignal(result?: StochasticResult | null | undefined) {
+  protected override calculateSignalState(result?: StochasticResult | null | undefined) {
     const hasResult = result !== null && result !== undefined;
     const isOversold = hasResult && result.stochK <= this.#oversold;
     const isOverbought = hasResult && result.stochK >= this.#overbought;
@@ -113,19 +110,5 @@ export class StochasticOscillator extends TechnicalIndicator<StochasticResult, H
       default:
         return TradingSignal.SIDEWAYS;
     }
-  }
-
-  getSignal(): {
-    state: (typeof TradingSignal)[keyof typeof TradingSignal];
-    hasChanged: boolean;
-  } {
-    const previousState = this.calculateSignal(this.#previousResult);
-    const state = this.calculateSignal(this.getResult());
-    const hasChanged = previousState !== state;
-
-    return {
-      hasChanged,
-      state,
-    };
   }
 }

--- a/packages/trading-signals/src/volatility/ABANDS/AccelerationBands.test.ts
+++ b/packages/trading-signals/src/volatility/ABANDS/AccelerationBands.test.ts
@@ -44,10 +44,11 @@ describe('AccelerationBands', () => {
         {close: 192.13, high: 192.49, low: 189.82, open: 192.03},
       ];
 
-      for (const candle of candles) {
-        const {close, high, low} = candle;
+      candles.forEach(({close, high, low}, index) => {
         accBands.add({close, high, low});
-      }
+
+        expect(accBands.isStable).toBe(index >= interval - 1);
+      });
 
       let result = accBands.getResultOrThrow();
 
@@ -107,32 +108,38 @@ describe('AccelerationBands', () => {
       expect(signal.state).toBe(TradingSignal.UNKNOWN);
     });
 
-    it('returns BULLISH when close breaks above the previous upper band', () => {
+    it('returns BULLISH when the close breaks above the upper band', () => {
       const accBands = new AccelerationBands(5, 4);
-      // 5 stable candles for first result, then spike: signal compares against previous bands
+
+      // Fill the interval with flat candles so the bands stay narrow around 50
       for (let i = 0; i < 5; i++) {
         accBands.add({close: 50, high: 51, low: 49});
       }
+
       accBands.add({close: 80, high: 81, low: 79});
       const signal = accBands.getSignal();
       expect(signal.state).toBe(TradingSignal.BULLISH);
     });
 
-    it('returns BEARISH when close breaks below the previous lower band', () => {
+    it('returns BEARISH when the close breaks below the lower band', () => {
       const accBands = new AccelerationBands(5, 4);
+
       for (let i = 0; i < 5; i++) {
         accBands.add({close: 50, high: 51, low: 49});
       }
+
       accBands.add({close: 20, high: 21, low: 19});
       const signal = accBands.getSignal();
       expect(signal.state).toBe(TradingSignal.BEARISH);
     });
 
-    it('returns SIDEWAYS when close is between the previous bands', () => {
+    it('returns SIDEWAYS when the close stays between the bands', () => {
       const accBands = new AccelerationBands(5, 4);
+
       for (let i = 0; i < 5; i++) {
         accBands.add({close: 50, high: 51, low: 49});
       }
+
       accBands.add({close: 50, high: 51, low: 49});
       const signal = accBands.getSignal();
       expect(signal.state).toBe(TradingSignal.SIDEWAYS);
@@ -140,13 +147,15 @@ describe('AccelerationBands', () => {
 
     it('tracks signal state changes', () => {
       const accBands = new AccelerationBands(5, 4);
-      // 6 stable candles: need previous result to exist for non-UNKNOWN signal
+
+      // Flat candles keep the bands narrow around 50
       for (let i = 0; i < 6; i++) {
         accBands.add({close: 50, high: 51, low: 49});
       }
+
       expect(accBands.getSignal().state).toBe(TradingSignal.SIDEWAYS);
 
-      // Spike above previous upper band (BULLISH)
+      // Spike up: the close escapes the bands to the upside
       accBands.add({close: 80, high: 81, low: 79});
       const signal = accBands.getSignal();
       expect(signal.state).toBe(TradingSignal.BULLISH);
@@ -155,17 +164,23 @@ describe('AccelerationBands', () => {
 
     it('restores previous signal state on replace', () => {
       const accBands = new AccelerationBands(5, 4);
+
       for (let i = 0; i < 6; i++) {
         accBands.add({close: 50, high: 51, low: 49});
       }
+
       expect(accBands.getSignal().state).toBe(TradingSignal.SIDEWAYS);
 
       // Add a spike, then replace it with a normal value
       accBands.add({close: 80, high: 81, low: 79});
-      expect(accBands.getSignal().state).toBe(TradingSignal.BULLISH);
+      const signal = accBands.getSignal();
+      expect(signal.state).toBe(TradingSignal.BULLISH);
+      expect(signal.hasChanged).toBe(true);
 
       accBands.replace({close: 50, high: 51, low: 49});
-      expect(accBands.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+      const restoredSignal = accBands.getSignal();
+      expect(restoredSignal.state).toBe(TradingSignal.SIDEWAYS);
+      expect(restoredSignal.hasChanged).toBe(false);
     });
   });
 });

--- a/packages/trading-signals/src/volatility/ABANDS/AccelerationBands.ts
+++ b/packages/trading-signals/src/volatility/ABANDS/AccelerationBands.ts
@@ -1,4 +1,4 @@
-import {TechnicalIndicator, TradingSignal} from '../../base/Indicator.js';
+import {TradingSignal, TrendTechnicalIndicator} from '../../base/Indicator.js';
 import type {MovingAverage} from '../../trend/MA/MovingAverage.js';
 import type {MovingAverageTypes} from '../../trend/MA/MovingAverageTypes.js';
 import {SMA} from '../../trend/SMA/SMA.js';
@@ -23,12 +23,10 @@ import type {HighLowClose} from '../../base/Candle.type.js';
  * @see https://github.com/QuantConnect/Lean/blob/master/Indicators/AccelerationBands.cs
  * @see https://github.com/twopirllc/pandas-ta/blob/master/pandas_ta/volatility/accbands.py
  */
-export class AccelerationBands extends TechnicalIndicator<BandsResult, HighLowClose<number>> {
+export class AccelerationBands extends TrendTechnicalIndicator<BandsResult, HighLowClose<number>> {
   readonly #lowerBand: MovingAverage;
   readonly #middleBand: MovingAverage;
   readonly #upperBand: MovingAverage;
-  #previousResult?: BandsResult;
-  #twoPreviousResult?: BandsResult;
   #lastClose?: number;
   #previousClose?: number;
 
@@ -56,56 +54,51 @@ export class AccelerationBands extends TechnicalIndicator<BandsResult, HighLowCl
     this.#middleBand.update(close, replace);
     this.#upperBand.update(high * (1 + coefficient), replace);
 
+    /*
+     * Rewind the close history so the re-cached previous signal state pairs the previous
+     * bands with the close that belonged to them.
+     */
     if (replace) {
-      this.result = this.#previousResult;
-      this.#previousResult = this.#twoPreviousResult;
       this.#lastClose = this.#previousClose;
     }
 
-    this.#twoPreviousResult = this.#previousResult;
-    this.#previousResult = this.result;
-    this.#previousClose = this.#lastClose;
-    this.#lastClose = close;
+    let result: BandsResult | null = null;
 
-    if (this.isStable) {
-      return (this.result = {
-        lower: this.#lowerBand.getResultOrThrow(),
-        middle: this.#middleBand.getResultOrThrow(),
-        upper: this.#upperBand.getResultOrThrow(),
-      });
+    if (this.#middleBand.isStable) {
+      result = this.setResult(
+        {
+          lower: this.#lowerBand.getResultOrThrow(),
+          middle: this.#middleBand.getResultOrThrow(),
+          upper: this.#upperBand.getResultOrThrow(),
+        },
+        replace
+      );
     }
 
-    return null;
+    if (!replace) {
+      this.#previousClose = this.#lastClose;
+    }
+
+    this.#lastClose = close;
+
+    return result;
   }
 
-  override get isStable() {
-    return this.#middleBand.isStable;
-  }
+  protected override calculateSignalState(result?: BandsResult | null) {
+    const close = this.#lastClose;
 
-  protected calculateSignal(result?: BandsResult | null, close?: number) {
     if (!result || close === undefined) {
       return TradingSignal.UNKNOWN;
     }
+
     if (close > result.upper) {
       return TradingSignal.BULLISH;
     }
+
     if (close < result.lower) {
       return TradingSignal.BEARISH;
     }
+
     return TradingSignal.SIDEWAYS;
-  }
-
-  getSignal(): {
-    state: (typeof TradingSignal)[keyof typeof TradingSignal];
-    hasChanged: boolean;
-  } {
-    const previousState = this.calculateSignal(this.#twoPreviousResult, this.#previousClose);
-    const state = this.calculateSignal(this.#previousResult, this.#lastClose);
-    const hasChanged = previousState !== state;
-
-    return {
-      hasChanged,
-      state,
-    };
   }
 }

--- a/packages/trading-signals/src/volatility/BBANDS/BollingerBands.test.ts
+++ b/packages/trading-signals/src/volatility/BBANDS/BollingerBands.test.ts
@@ -194,33 +194,38 @@ describe('BollingerBands', () => {
       expect(signal.state).toBe(TradingSignal.UNKNOWN);
     });
 
-    it('returns BULLISH when price breaks above the previous upper band', () => {
+    it('returns BULLISH when the price breaks above the upper band', () => {
       const bb = new BollingerBands(10, 2);
-      // Need 12 adds: 10 for the first result, 12th to have a previous result to compare against
+
+      // Fill the interval with flat prices so the bands stay narrow around 50
       for (let i = 0; i < 11; i++) {
         bb.add(50);
       }
-      // Now spike: signal compares 100 against the previous bands (all 50s → narrow bands)
+
       bb.add(100);
       const signal = bb.getSignal();
       expect(signal.state).toBe(TradingSignal.BULLISH);
     });
 
-    it('returns BEARISH when price breaks below the previous lower band', () => {
+    it('returns BEARISH when the price breaks below the lower band', () => {
       const bb = new BollingerBands(10, 2);
+
       for (let i = 0; i < 11; i++) {
         bb.add(50);
       }
+
       bb.add(0);
       const signal = bb.getSignal();
       expect(signal.state).toBe(TradingSignal.BEARISH);
     });
 
-    it('returns SIDEWAYS when price is between the previous bands', () => {
+    it('returns SIDEWAYS when the price stays between the bands', () => {
       const bb = new BollingerBands(10, 2);
+
       for (let i = 0; i < 11; i++) {
         bb.add(50 + (i % 2));
       }
+
       bb.add(50);
       const signal = bb.getSignal();
       expect(signal.state).toBe(TradingSignal.SIDEWAYS);
@@ -228,13 +233,15 @@ describe('BollingerBands', () => {
 
     it('tracks signal state changes', () => {
       const bb = new BollingerBands(10, 2);
-      // Build up stable data: 12 adds to get a previous result for comparison
+
+      // Flat prices keep the bands narrow around 50
       for (let i = 0; i < 12; i++) {
         bb.add(50);
       }
+
       expect(bb.getSignal().state).toBe(TradingSignal.SIDEWAYS);
 
-      // Spike up: compared against previous narrow bands → BULLISH
+      // Spike up: the price escapes the bands to the upside
       bb.add(100);
       const signal = bb.getSignal();
       expect(signal.state).toBe(TradingSignal.BULLISH);
@@ -243,17 +250,23 @@ describe('BollingerBands', () => {
 
     it('restores previous signal state on replace', () => {
       const bb = new BollingerBands(10, 2);
+
       for (let i = 0; i < 12; i++) {
         bb.add(50);
       }
+
       expect(bb.getSignal().state).toBe(TradingSignal.SIDEWAYS);
 
       // Add a spike, then replace it with a normal value
       bb.add(100);
-      expect(bb.getSignal().state).toBe(TradingSignal.BULLISH);
+      const signal = bb.getSignal();
+      expect(signal.state).toBe(TradingSignal.BULLISH);
+      expect(signal.hasChanged).toBe(true);
 
       bb.replace(50);
-      expect(bb.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+      const restoredSignal = bb.getSignal();
+      expect(restoredSignal.state).toBe(TradingSignal.SIDEWAYS);
+      expect(restoredSignal.hasChanged).toBe(false);
     });
   });
 });

--- a/packages/trading-signals/src/volatility/BBANDS/BollingerBands.ts
+++ b/packages/trading-signals/src/volatility/BBANDS/BollingerBands.ts
@@ -1,4 +1,4 @@
-import {TechnicalIndicator, TradingSignal} from '../../base/Indicator.js';
+import {TradingSignal, TrendTechnicalIndicator} from '../../base/Indicator.js';
 import type {BandsResult} from '../../base/BandsResult.type.js';
 import {getAverage, getStandardDeviation, pushUpdate} from '../../util/index.js';
 
@@ -12,10 +12,8 @@ import {getAverage, getStandardDeviation, pushUpdate} from '../../util/index.js'
  *
  * @see https://www.investopedia.com/terms/b/bollingerbands.asp
  */
-export class BollingerBands extends TechnicalIndicator<BandsResult, number> {
+export class BollingerBands extends TrendTechnicalIndicator<BandsResult> {
   public readonly prices: number[] = [];
-  #previousResult?: BandsResult;
-  #twoPreviousResult?: BandsResult;
   #lastPrice?: number;
   #previousPrice?: number;
 
@@ -35,55 +33,54 @@ export class BollingerBands extends TechnicalIndicator<BandsResult, number> {
   update(price: number, replace: boolean) {
     pushUpdate({array: this.prices, item: price, maxLength: this.interval, replace: replace});
 
+    /*
+     * Rewind the price history so the re-cached previous signal state pairs the previous
+     * bands with the price that belonged to them.
+     */
     if (replace) {
-      this.result = this.#previousResult;
-      this.#previousResult = this.#twoPreviousResult;
       this.#lastPrice = this.#previousPrice;
     }
 
-    this.#twoPreviousResult = this.#previousResult;
-    this.#previousResult = this.result;
-    this.#previousPrice = this.#lastPrice;
-    this.#lastPrice = price;
+    let result: BandsResult | null = null;
 
     if (this.prices.length === this.interval) {
       const middle = getAverage(this.prices);
       const standardDeviation = getStandardDeviation(this.prices, middle);
 
-      return (this.result = {
-        lower: middle - standardDeviation * this.deviationMultiplier,
-        middle,
-        upper: middle + standardDeviation * this.deviationMultiplier,
-      });
+      result = this.setResult(
+        {
+          lower: middle - standardDeviation * this.deviationMultiplier,
+          middle,
+          upper: middle + standardDeviation * this.deviationMultiplier,
+        },
+        replace
+      );
     }
 
-    return null;
+    if (!replace) {
+      this.#previousPrice = this.#lastPrice;
+    }
+
+    this.#lastPrice = price;
+
+    return result;
   }
 
-  protected calculateSignal(result?: BandsResult | null, price?: number) {
+  protected override calculateSignalState(result?: BandsResult | null) {
+    const price = this.#lastPrice;
+
     if (!result || price === undefined) {
       return TradingSignal.UNKNOWN;
     }
+
     if (price > result.upper) {
       return TradingSignal.BULLISH;
     }
+
     if (price < result.lower) {
       return TradingSignal.BEARISH;
     }
+
     return TradingSignal.SIDEWAYS;
-  }
-
-  getSignal(): {
-    state: (typeof TradingSignal)[keyof typeof TradingSignal];
-    hasChanged: boolean;
-  } {
-    const previousState = this.calculateSignal(this.#twoPreviousResult, this.#previousPrice);
-    const state = this.calculateSignal(this.#previousResult, this.#lastPrice);
-    const hasChanged = previousState !== state;
-
-    return {
-      hasChanged,
-      state,
-    };
   }
 }


### PR DESCRIPTION
## Summary

Replaces the stale stacked PRs #1182 / #1183 with a single migration built on today's `main`. Those PRs introduced an object-result signal base against the old `src/types/Indicator.ts` layout; main has since restructured the base (`src/base/Indicator.ts`, `TrendIndicatorSeries`, contract tests), so they were closed and redone here.

- **`TrendTechnicalIndicator`** (`src/base/Indicator.ts`): object-result counterpart of `TrendIndicatorSeries` — previous-result caching via `setResult()`, a `calculateSignalState()` hook, and shared `getSignal()` with change detection.
- **`MACD`**, **`BollingerBands`**, **`StochasticOscillator`**, **`AccelerationBands`**: extend the new base and implement only `calculateSignalState()`; all hand-rolled `#previousResult` / `#twoPreviousResult` bookkeeping and per-indicator `getSignal()` implementations are gone. Exported names and result shapes are unchanged.
- The bands indicators rewind their close/price history on `replace()` so the re-cached previous signal state pairs the previous bands with the close that belonged to them (ported from #1182/#1183).
- `AccelerationBands` drops its redundant `isStable` override — the base's `result !== undefined` flips at the same input, pinned by a per-add `isStable` assertion against the QuantConnect fixture.

## Behavioral changes

- **Bands signals now evaluate the latest close against the current bands** instead of the previous candle's bands (deliberate, carried over from #1182/#1183; test descriptions updated accordingly).
- **STOCH: a %K of exactly 0 now feeds the %D average.** The previous falsy short-circuit (`stochK && …`) skipped the %D SMA and fabricated a result before %D had warmed up. New test pins the first emission to `getRequiredInputs()` candles when the close sits on the window low.

## Remaining `getSignal` implementations

`grep -rn "getSignal" src` now matches only the two shared implementations in `src/base/Indicator.ts` — no indicator hand-rolls signal tracking anymore.

## Test plan

- [x] `npm test` in `packages/trading-signals` — 78 files / 761 tests pass, coverage 100% statements/branches/functions/lines
- [x] Strengthened replace-tests: signal state *and* `hasChanged` restoration on `replace()` for BBANDS and ABANDS
- [x] New STOCH test for the %K = 0 warm-up fix
- [x] `tsc --noEmit`, root `oxlint`/`oxfmt`, `knip` — clean
- [x] Downstream: rebuilt all dists, `npm test` in `packages/trading-strategies` — 23 files / 261 tests pass
