### PR TITLE
refactor(trading-signals): extract zero-cross signal into shared base class

### DIFF
--- a/packages/trading-signals/src/base/Indicator.ts
+++ b/packages/trading-signals/src/base/Indicator.ts
@@ -172,7 +172,7 @@ export abstract class TrendIndicatorSeries<
  * different zero-line reading (e.g. treating zero itself as directional) implement their own
  * signal instead.
  */
-export abstract class ZeroCrossTrendIndicatorSeries<Input = number> extends TrendIndicatorSeries<Input> {
+export abstract class ZeroCrossSeries<Input = number> extends TrendIndicatorSeries<Input> {
   protected calculateSignalState(result: number | null | undefined) {
     if (result === null || result === undefined) {
       return TradingSignal.UNKNOWN;

--- a/packages/trading-signals/src/base/Indicator.ts
+++ b/packages/trading-signals/src/base/Indicator.ts
@@ -164,3 +164,28 @@ export abstract class TrendIndicatorSeries<
     };
   }
 }
+
+/**
+ * Many oscillators share the same established interpretation: the side of the zero line the
+ * reading sits on tells the direction of current pressure. This base class encodes that
+ * interpretation once, so an oscillator only implements its calculation. Indicators with a
+ * different zero-line reading (e.g. treating zero itself as directional) implement their own
+ * signal instead.
+ */
+export abstract class ZeroCrossTrendIndicatorSeries<Input = number> extends TrendIndicatorSeries<Input> {
+  protected calculateSignalState(result: number | null | undefined) {
+    if (result === null || result === undefined) {
+      return TradingSignal.UNKNOWN;
+    }
+
+    if (result > 0) {
+      return TradingSignal.BULLISH;
+    }
+
+    if (result < 0) {
+      return TradingSignal.BEARISH;
+    }
+
+    return TradingSignal.SIDEWAYS;
+  }
+}

--- a/packages/trading-signals/src/base/Indicator.ts
+++ b/packages/trading-signals/src/base/Indicator.ts
@@ -166,8 +166,8 @@ export abstract class TrendIndicatorSeries<
 }
 
 /**
- * Encodes the shared oscillator interpretation once: the side of the zero line tells the
- * direction of current pressure. Oscillators that read zero differently implement their own signal.
+ * Most oscillators share one reading of the zero line. Above it means bullish pressure, below it
+ * bearish. Oscillators that read the zero line differently implement their own signal.
  */
 export abstract class ZeroCrossSeries<Input = number> extends TrendIndicatorSeries<Input> {
   protected calculateSignalState(result: number | null | undefined) {

--- a/packages/trading-signals/src/base/Indicator.ts
+++ b/packages/trading-signals/src/base/Indicator.ts
@@ -166,11 +166,8 @@ export abstract class TrendIndicatorSeries<
 }
 
 /**
- * Many oscillators share the same established interpretation: the side of the zero line the
- * reading sits on tells the direction of current pressure. This base class encodes that
- * interpretation once, so an oscillator only implements its calculation. Indicators with a
- * different zero-line reading (e.g. treating zero itself as directional) implement their own
- * signal instead.
+ * Encodes the shared oscillator interpretation once: the side of the zero line tells the
+ * direction of current pressure. Oscillators that read zero differently implement their own signal.
  */
 export abstract class ZeroCrossSeries<Input = number> extends TrendIndicatorSeries<Input> {
   protected calculateSignalState(result: number | null | undefined) {

--- a/packages/trading-signals/src/momentum/AO/AO.ts
+++ b/packages/trading-signals/src/momentum/AO/AO.ts
@@ -2,7 +2,7 @@ import type {MovingAverage} from '../../trend/MA/MovingAverage.js';
 import type {MovingAverageTypes} from '../../trend/MA/MovingAverageTypes.js';
 import {SMA} from '../../trend/SMA/SMA.js';
 import type {HighLow} from '../../base/Candle.type.js';
-import {ZeroCrossTrendIndicatorSeries} from '../../base/Indicator.js';
+import {ZeroCrossSeries} from '../../base/Indicator.js';
 
 /**
  * Awesome Oscillator (AO)
@@ -20,7 +20,7 @@ import {ZeroCrossTrendIndicatorSeries} from '../../base/Indicator.js';
  * @see https://www.tradingview.com/support/solutions/43000501826-awesome-oscillator-ao/
  * @see https://tradingstrategyguides.com/bill-williams-awesome-oscillator-strategy/
  */
-export class AO extends ZeroCrossTrendIndicatorSeries<HighLow<number>> {
+export class AO extends ZeroCrossSeries<HighLow<number>> {
   public readonly long: MovingAverage;
   public readonly short: MovingAverage;
   public readonly shortInterval: number;

--- a/packages/trading-signals/src/momentum/AO/AO.ts
+++ b/packages/trading-signals/src/momentum/AO/AO.ts
@@ -2,7 +2,7 @@ import type {MovingAverage} from '../../trend/MA/MovingAverage.js';
 import type {MovingAverageTypes} from '../../trend/MA/MovingAverageTypes.js';
 import {SMA} from '../../trend/SMA/SMA.js';
 import type {HighLow} from '../../base/Candle.type.js';
-import {TrendIndicatorSeries, TradingSignal} from '../../base/Indicator.js';
+import {ZeroCrossTrendIndicatorSeries} from '../../base/Indicator.js';
 
 /**
  * Awesome Oscillator (AO)
@@ -20,7 +20,7 @@ import {TrendIndicatorSeries, TradingSignal} from '../../base/Indicator.js';
  * @see https://www.tradingview.com/support/solutions/43000501826-awesome-oscillator-ao/
  * @see https://tradingstrategyguides.com/bill-williams-awesome-oscillator-strategy/
  */
-export class AO extends TrendIndicatorSeries<HighLow<number>> {
+export class AO extends ZeroCrossTrendIndicatorSeries<HighLow<number>> {
   public readonly long: MovingAverage;
   public readonly short: MovingAverage;
   public readonly shortInterval: number;
@@ -49,22 +49,5 @@ export class AO extends TrendIndicatorSeries<HighLow<number>> {
     }
 
     return null;
-  }
-
-  protected calculateSignalState(result: number | null | undefined) {
-    const hasResult = result !== null && result !== undefined;
-    const isBullish = hasResult && result > 0;
-    const isBearish = hasResult && result < 0;
-
-    switch (true) {
-      case !hasResult:
-        return TradingSignal.UNKNOWN;
-      case isBullish:
-        return TradingSignal.BULLISH;
-      case isBearish:
-        return TradingSignal.BEARISH;
-      default:
-        return TradingSignal.SIDEWAYS;
-    }
   }
 }

--- a/packages/trading-signals/src/momentum/MOM/MOM.ts
+++ b/packages/trading-signals/src/momentum/MOM/MOM.ts
@@ -1,4 +1,4 @@
-import {ZeroCrossTrendIndicatorSeries} from '../../base/Indicator.js';
+import {ZeroCrossSeries} from '../../base/Indicator.js';
 import {pushUpdate} from '../../util/pushUpdate.js';
 
 /**
@@ -10,7 +10,7 @@ import {pushUpdate} from '../../util/pushUpdate.js';
  * @see https://en.wikipedia.org/wiki/Momentum_(technical_analysis)
  * @see https://www.warriortrading.com/momentum-indicator/
  */
-export class MOM extends ZeroCrossTrendIndicatorSeries {
+export class MOM extends ZeroCrossSeries {
   readonly #history: number[];
   readonly #historyLength: number;
 

--- a/packages/trading-signals/src/momentum/MOM/MOM.ts
+++ b/packages/trading-signals/src/momentum/MOM/MOM.ts
@@ -1,4 +1,4 @@
-import {TradingSignal, TrendIndicatorSeries} from '../../base/Indicator.js';
+import {ZeroCrossTrendIndicatorSeries} from '../../base/Indicator.js';
 import {pushUpdate} from '../../util/pushUpdate.js';
 
 /**
@@ -10,7 +10,7 @@ import {pushUpdate} from '../../util/pushUpdate.js';
  * @see https://en.wikipedia.org/wiki/Momentum_(technical_analysis)
  * @see https://www.warriortrading.com/momentum-indicator/
  */
-export class MOM extends TrendIndicatorSeries {
+export class MOM extends ZeroCrossTrendIndicatorSeries {
   readonly #history: number[];
   readonly #historyLength: number;
 
@@ -35,23 +35,5 @@ export class MOM extends TrendIndicatorSeries {
     }
 
     return null;
-  }
-
-  protected calculateSignalState(result?: number | null | undefined) {
-    const hasResult = result !== null && result !== undefined;
-
-    if (!hasResult) {
-      return TradingSignal.UNKNOWN;
-    }
-
-    if (result > 0) {
-      return TradingSignal.BULLISH;
-    }
-
-    if (result < 0) {
-      return TradingSignal.BEARISH;
-    }
-
-    return TradingSignal.SIDEWAYS;
   }
 }

--- a/packages/trading-signals/src/momentum/PPO/PPO.ts
+++ b/packages/trading-signals/src/momentum/PPO/PPO.ts
@@ -1,4 +1,4 @@
-import {ZeroCrossTrendIndicatorSeries} from '../../base/Indicator.js';
+import {ZeroCrossSeries} from '../../base/Indicator.js';
 import {EMA} from '../../trend/EMA/EMA.js';
 
 export type PPOConfig = {
@@ -20,7 +20,7 @@ export type PPOConfig = {
  * @see https://www.investopedia.com/terms/p/ppo.asp
  * @see https://tulipindicators.org/ppo
  */
-export class PPO extends ZeroCrossTrendIndicatorSeries {
+export class PPO extends ZeroCrossSeries {
   readonly #fast: EMA;
   readonly #slow: EMA;
 

--- a/packages/trading-signals/src/momentum/PPO/PPO.ts
+++ b/packages/trading-signals/src/momentum/PPO/PPO.ts
@@ -1,4 +1,4 @@
-import {TradingSignal, TrendIndicatorSeries} from '../../base/Indicator.js';
+import {ZeroCrossTrendIndicatorSeries} from '../../base/Indicator.js';
 import {EMA} from '../../trend/EMA/EMA.js';
 
 export type PPOConfig = {
@@ -20,7 +20,7 @@ export type PPOConfig = {
  * @see https://www.investopedia.com/terms/p/ppo.asp
  * @see https://tulipindicators.org/ppo
  */
-export class PPO extends TrendIndicatorSeries {
+export class PPO extends ZeroCrossTrendIndicatorSeries {
   readonly #fast: EMA;
   readonly #slow: EMA;
 
@@ -48,22 +48,5 @@ export class PPO extends TrendIndicatorSeries {
     }
 
     return null;
-  }
-
-  protected calculateSignalState(result: number | null | undefined) {
-    const hasResult = result !== null && result !== undefined;
-    const isBullish = hasResult && result > 0;
-    const isBearish = hasResult && result < 0;
-
-    switch (true) {
-      case !hasResult:
-        return TradingSignal.UNKNOWN;
-      case isBullish:
-        return TradingSignal.BULLISH;
-      case isBearish:
-        return TradingSignal.BEARISH;
-      default:
-        return TradingSignal.SIDEWAYS;
-    }
   }
 }

--- a/packages/trading-signals/src/momentum/TRIX/TRIX.ts
+++ b/packages/trading-signals/src/momentum/TRIX/TRIX.ts
@@ -1,4 +1,4 @@
-import {TradingSignal, TrendIndicatorSeries} from '../../base/Indicator.js';
+import {ZeroCrossTrendIndicatorSeries} from '../../base/Indicator.js';
 import {EMA} from '../../trend/EMA/EMA.js';
 
 /**
@@ -16,7 +16,7 @@ import {EMA} from '../../trend/EMA/EMA.js';
  * @see https://www.investopedia.com/terms/t/trix.asp
  * @see https://tulipindicators.org/trix
  */
-export class TRIX extends TrendIndicatorSeries {
+export class TRIX extends ZeroCrossTrendIndicatorSeries {
   readonly #single: EMA;
   readonly #double: EMA;
   readonly #triple: EMA;
@@ -63,22 +63,5 @@ export class TRIX extends TrendIndicatorSeries {
     }
 
     return null;
-  }
-
-  protected calculateSignalState(result: number | null | undefined) {
-    const hasResult = result !== null && result !== undefined;
-    const isBullish = hasResult && result > 0;
-    const isBearish = hasResult && result < 0;
-
-    switch (true) {
-      case !hasResult:
-        return TradingSignal.UNKNOWN;
-      case isBullish:
-        return TradingSignal.BULLISH;
-      case isBearish:
-        return TradingSignal.BEARISH;
-      default:
-        return TradingSignal.SIDEWAYS;
-    }
   }
 }

--- a/packages/trading-signals/src/momentum/TRIX/TRIX.ts
+++ b/packages/trading-signals/src/momentum/TRIX/TRIX.ts
@@ -1,4 +1,4 @@
-import {ZeroCrossTrendIndicatorSeries} from '../../base/Indicator.js';
+import {ZeroCrossSeries} from '../../base/Indicator.js';
 import {EMA} from '../../trend/EMA/EMA.js';
 
 /**
@@ -16,7 +16,7 @@ import {EMA} from '../../trend/EMA/EMA.js';
  * @see https://www.investopedia.com/terms/t/trix.asp
  * @see https://tulipindicators.org/trix
  */
-export class TRIX extends ZeroCrossTrendIndicatorSeries {
+export class TRIX extends ZeroCrossSeries {
   readonly #single: EMA;
   readonly #double: EMA;
   readonly #triple: EMA;

--- a/packages/trading-signals/src/volume/ADOSC/ADOSC.ts
+++ b/packages/trading-signals/src/volume/ADOSC/ADOSC.ts
@@ -1,5 +1,5 @@
 import type {HighLowCloseVolume} from '../../base/Candle.type.js';
-import {TradingSignal, TrendIndicatorSeries} from '../../base/Indicator.js';
+import {ZeroCrossTrendIndicatorSeries} from '../../base/Indicator.js';
 import {EMA} from '../../trend/EMA/EMA.js';
 import {AD} from '../AD/AD.js';
 
@@ -22,7 +22,7 @@ export type ADOSCConfig = {
  * @see https://www.investopedia.com/terms/c/chaikinoscillator.asp
  * @see https://tulipindicators.org/adosc
  */
-export class ADOSC extends TrendIndicatorSeries<HighLowCloseVolume> {
+export class ADOSC extends ZeroCrossTrendIndicatorSeries<HighLowCloseVolume> {
   readonly #ad = new AD();
   readonly #fast: EMA;
   readonly #slow: EMA;
@@ -52,22 +52,5 @@ export class ADOSC extends TrendIndicatorSeries<HighLowCloseVolume> {
     }
 
     return null;
-  }
-
-  protected calculateSignalState(result: number | null | undefined) {
-    const hasResult = result !== null && result !== undefined;
-    const isBullish = hasResult && result > 0;
-    const isBearish = hasResult && result < 0;
-
-    switch (true) {
-      case !hasResult:
-        return TradingSignal.UNKNOWN;
-      case isBullish:
-        return TradingSignal.BULLISH;
-      case isBearish:
-        return TradingSignal.BEARISH;
-      default:
-        return TradingSignal.SIDEWAYS;
-    }
   }
 }

--- a/packages/trading-signals/src/volume/ADOSC/ADOSC.ts
+++ b/packages/trading-signals/src/volume/ADOSC/ADOSC.ts
@@ -1,5 +1,5 @@
 import type {HighLowCloseVolume} from '../../base/Candle.type.js';
-import {ZeroCrossTrendIndicatorSeries} from '../../base/Indicator.js';
+import {ZeroCrossSeries} from '../../base/Indicator.js';
 import {EMA} from '../../trend/EMA/EMA.js';
 import {AD} from '../AD/AD.js';
 
@@ -22,7 +22,7 @@ export type ADOSCConfig = {
  * @see https://www.investopedia.com/terms/c/chaikinoscillator.asp
  * @see https://tulipindicators.org/adosc
  */
-export class ADOSC extends ZeroCrossTrendIndicatorSeries<HighLowCloseVolume> {
+export class ADOSC extends ZeroCrossSeries<HighLowCloseVolume> {
   readonly #ad = new AD();
   readonly #fast: EMA;
   readonly #slow: EMA;

--- a/packages/trading-signals/src/volume/CMF/CMF.ts
+++ b/packages/trading-signals/src/volume/CMF/CMF.ts
@@ -1,5 +1,5 @@
 import type {HighLowCloseVolume} from '../../base/Candle.type.js';
-import {TradingSignal, TrendIndicatorSeries} from '../../base/Indicator.js';
+import {ZeroCrossTrendIndicatorSeries} from '../../base/Indicator.js';
 import {pushUpdate} from '../../util/pushUpdate.js';
 
 /**
@@ -17,7 +17,7 @@ import {pushUpdate} from '../../util/pushUpdate.js';
  *
  * @see https://www.investopedia.com/terms/c/chaikinoscillator.asp
  */
-export class CMF extends TrendIndicatorSeries<HighLowCloseVolume> {
+export class CMF extends ZeroCrossTrendIndicatorSeries<HighLowCloseVolume> {
   readonly #candles: HighLowCloseVolume[] = [];
 
   public readonly interval: number;
@@ -56,21 +56,5 @@ export class CMF extends TrendIndicatorSeries<HighLowCloseVolume> {
     const cmf = sumVolume === 0 ? 0 : sumMoneyFlowVolume / sumVolume;
 
     return this.setResult(cmf, replace);
-  }
-
-  protected calculateSignalState(result: number | null | undefined) {
-    if (result === null || result === undefined) {
-      return TradingSignal.UNKNOWN;
-    }
-
-    if (result > 0) {
-      return TradingSignal.BULLISH;
-    }
-
-    if (result < 0) {
-      return TradingSignal.BEARISH;
-    }
-
-    return TradingSignal.SIDEWAYS;
   }
 }

--- a/packages/trading-signals/src/volume/CMF/CMF.ts
+++ b/packages/trading-signals/src/volume/CMF/CMF.ts
@@ -1,5 +1,5 @@
 import type {HighLowCloseVolume} from '../../base/Candle.type.js';
-import {ZeroCrossTrendIndicatorSeries} from '../../base/Indicator.js';
+import {ZeroCrossSeries} from '../../base/Indicator.js';
 import {pushUpdate} from '../../util/pushUpdate.js';
 
 /**
@@ -17,7 +17,7 @@ import {pushUpdate} from '../../util/pushUpdate.js';
  *
  * @see https://www.investopedia.com/terms/c/chaikinoscillator.asp
  */
-export class CMF extends ZeroCrossTrendIndicatorSeries<HighLowCloseVolume> {
+export class CMF extends ZeroCrossSeries<HighLowCloseVolume> {
   readonly #candles: HighLowCloseVolume[] = [];
 
   public readonly interval: number;

--- a/packages/trading-signals/src/volume/EMV/EMV.ts
+++ b/packages/trading-signals/src/volume/EMV/EMV.ts
@@ -1,5 +1,5 @@
 import type {HighLowCloseVolume} from '../../base/Candle.type.js';
-import {ZeroCrossTrendIndicatorSeries} from '../../base/Indicator.js';
+import {ZeroCrossSeries} from '../../base/Indicator.js';
 import {SMA} from '../../trend/SMA/SMA.js';
 import {pushUpdate} from '../../util/pushUpdate.js';
 
@@ -19,7 +19,7 @@ import {pushUpdate} from '../../util/pushUpdate.js';
  *
  * @see https://www.investopedia.com/terms/e/easeofmovement.asp
  */
-export class EMV extends ZeroCrossTrendIndicatorSeries<HighLowCloseVolume> {
+export class EMV extends ZeroCrossSeries<HighLowCloseVolume> {
   readonly #candles: HighLowCloseVolume[] = [];
   readonly #sma: SMA;
   readonly #scale: number;

--- a/packages/trading-signals/src/volume/EMV/EMV.ts
+++ b/packages/trading-signals/src/volume/EMV/EMV.ts
@@ -1,5 +1,5 @@
 import type {HighLowCloseVolume} from '../../base/Candle.type.js';
-import {TradingSignal, TrendIndicatorSeries} from '../../base/Indicator.js';
+import {ZeroCrossTrendIndicatorSeries} from '../../base/Indicator.js';
 import {SMA} from '../../trend/SMA/SMA.js';
 import {pushUpdate} from '../../util/pushUpdate.js';
 
@@ -19,7 +19,7 @@ import {pushUpdate} from '../../util/pushUpdate.js';
  *
  * @see https://www.investopedia.com/terms/e/easeofmovement.asp
  */
-export class EMV extends TrendIndicatorSeries<HighLowCloseVolume> {
+export class EMV extends ZeroCrossTrendIndicatorSeries<HighLowCloseVolume> {
   readonly #candles: HighLowCloseVolume[] = [];
   readonly #sma: SMA;
   readonly #scale: number;
@@ -62,21 +62,5 @@ export class EMV extends TrendIndicatorSeries<HighLowCloseVolume> {
     }
 
     return this.setResult(smaResult, replace);
-  }
-
-  protected calculateSignalState(result: number | null | undefined) {
-    if (result === null || result === undefined) {
-      return TradingSignal.UNKNOWN;
-    }
-
-    if (result > 0) {
-      return TradingSignal.BULLISH;
-    }
-
-    if (result < 0) {
-      return TradingSignal.BEARISH;
-    }
-
-    return TradingSignal.SIDEWAYS;
   }
 }

--- a/packages/trading-signals/src/volume/VROC/VROC.ts
+++ b/packages/trading-signals/src/volume/VROC/VROC.ts
@@ -1,4 +1,4 @@
-import {TradingSignal, TrendIndicatorSeries} from '../../base/Indicator.js';
+import {ZeroCrossTrendIndicatorSeries} from '../../base/Indicator.js';
 import {pushUpdate} from '../../util/pushUpdate.js';
 
 /**
@@ -14,7 +14,7 @@ import {pushUpdate} from '../../util/pushUpdate.js';
  *
  * @see https://www.investopedia.com/terms/v/volumerateofchange.asp
  */
-export class VROC extends TrendIndicatorSeries {
+export class VROC extends ZeroCrossTrendIndicatorSeries {
   readonly #volumes: number[] = [];
   readonly #historyLength: number;
 
@@ -46,21 +46,5 @@ export class VROC extends TrendIndicatorSeries {
     const vroc = ((volume - previousVolume) / previousVolume) * 100;
 
     return this.setResult(vroc, replace);
-  }
-
-  protected calculateSignalState(result: number | null | undefined) {
-    if (result === null || result === undefined) {
-      return TradingSignal.UNKNOWN;
-    }
-
-    if (result > 0) {
-      return TradingSignal.BULLISH;
-    }
-
-    if (result < 0) {
-      return TradingSignal.BEARISH;
-    }
-
-    return TradingSignal.SIDEWAYS;
   }
 }

--- a/packages/trading-signals/src/volume/VROC/VROC.ts
+++ b/packages/trading-signals/src/volume/VROC/VROC.ts
@@ -1,4 +1,4 @@
-import {ZeroCrossTrendIndicatorSeries} from '../../base/Indicator.js';
+import {ZeroCrossSeries} from '../../base/Indicator.js';
 import {pushUpdate} from '../../util/pushUpdate.js';
 
 /**
@@ -14,7 +14,7 @@ import {pushUpdate} from '../../util/pushUpdate.js';
  *
  * @see https://www.investopedia.com/terms/v/volumerateofchange.asp
  */
-export class VROC extends ZeroCrossTrendIndicatorSeries {
+export class VROC extends ZeroCrossSeries {
   readonly #volumes: number[] = [];
   readonly #historyLength: number;
 


### PR DESCRIPTION
## Summary

A jscpd scan flagged byte-identical `calculateSignalState` implementations across the volume indicators. A follow-up sweep (`grep "result > 0"`) showed the same zero-line logic duplicated across **8 oscillators** — half written in `if` style, half in `switch` style, which is why token-based clone detection only caught 3 of them.

This PR extracts the shared interpretation into a new `ZeroCrossSeries` base class in `src/base/Indicator.ts`:

- reading **> 0** → `BULLISH`
- reading **< 0** → `BEARISH`
- reading **= 0** → `SIDEWAYS`
- no result yet → `UNKNOWN`

**Migrated:** AO, TRIX, MOM, PPO, ADOSC, CMF, EMV, VROC — each drops its `calculateSignalState` copy and extends the new base class.

**Intentionally not migrated:** AC — it maps a reading of exactly zero to `BEARISH` and has no sideways state, so it keeps its own implementation (noted in the base class JSDoc).

Net: **+41 / −150 lines**. The class is exported through the existing `export *` chain, so it is available as a public building block for future oscillators.

## Verification

- `tsc` clean, `oxlint` clean
- 760/760 tests pass, coverage stays at 100% (statements/branches/functions/lines)
- jscpd: TypeScript clones 61 → 56, duplicated TS lines 3.92% → 3.45%