### PR TITLE
feat(trading-signals): add six moving average variants (ALMA, FRAMA, T3, TRIMA, VIDYA, ZLEMA)

### DIFF
--- a/packages/trading-signals-docs/indicator-demos/trend/ALMA.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/ALMA.demo.tsx
@@ -1,0 +1,20 @@
+import {ALMA as ALMAClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const ALMA: IndicatorConfig = {
+  chartTitle: 'ALMA (9)',
+  color: '#6366f1',
+  createIndicator: () => new ALMAClass(9),
+  description: 'Arnaud Legoux Moving Average',
+  details:
+    'Weights the price window with a Gaussian bell whose peak is shifted toward the newest prices: prices near the peak dominate the average for low lag, while the tails of the bell still dampen outliers for smoothness. Offset steers the peak, sigma the width of the bell.',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
+  id: 'alma',
+  name: 'ALMA',
+  processData: makeProcessData({rowInputs: ['close']}),
+  requiredInputs: 9,
+  type: 'single',
+  yAxisLabel: 'Price',
+};

--- a/packages/trading-signals-docs/indicator-demos/trend/FRAMA.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/FRAMA.demo.tsx
@@ -1,0 +1,20 @@
+import {FRAMA as FRAMAClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const FRAMA: IndicatorConfig = {
+  chartTitle: 'FRAMA (16)',
+  color: '#0ea5e9',
+  createIndicator: () => new FRAMAClass(16),
+  description: 'Fractal Adaptive Moving Average',
+  details:
+    'Measures the fractal dimension of the price curve over the interval and adapts its smoothing accordingly: it hugs prices almost one-to-one when they travel in a straight line and turns as sluggish as a 200-period average in dense congestion, flattening out whipsaws.',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
+  id: 'frama',
+  name: 'FRAMA',
+  processData: makeProcessData({rowInputs: ['close']}),
+  requiredInputs: 16,
+  type: 'single',
+  yAxisLabel: 'Price',
+};

--- a/packages/trading-signals-docs/indicator-demos/trend/T3.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/T3.demo.tsx
@@ -1,0 +1,20 @@
+import {T3 as T3Class} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const T3: IndicatorConfig = {
+  chartTitle: 'T3 (5)',
+  color: '#22d3ee',
+  createIndicator: () => new T3Class(5),
+  description: 'Tillson T3 Moving Average',
+  details:
+    'Applies Tim Tillson’s "generalized DEMA" three times — a weighted blend of six cascaded EMAs — producing a curve that is smoother than an EMA yet turns with less lag. The volume factor (default 0.7) steers it between a plain EMA (0) and a full DEMA (1).',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
+  id: 't3',
+  name: 'T3',
+  processData: makeProcessData({rowInputs: ['close']}),
+  requiredInputs: 25,
+  type: 'single',
+  yAxisLabel: 'Price',
+};

--- a/packages/trading-signals-docs/indicator-demos/trend/TRIMA.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/TRIMA.demo.tsx
@@ -1,0 +1,20 @@
+import {TRIMA as TRIMAClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const TRIMA: IndicatorConfig = {
+  chartTitle: 'TRIMA (10)',
+  color: '#a855f7',
+  createIndicator: () => new TRIMAClass(10),
+  description: 'Triangular Moving Average',
+  details:
+    'Weights the middle of the interval most heavily, tapering off towards the oldest and newest prices — equivalent to smoothing an SMA with a second SMA. Filters out most short-lived noise at the cost of extra lag.',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
+  id: 'trima',
+  name: 'TRIMA',
+  processData: makeProcessData({rowInputs: ['close']}),
+  requiredInputs: 10,
+  type: 'single',
+  yAxisLabel: 'Price',
+};

--- a/packages/trading-signals-docs/indicator-demos/trend/VIDYA.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/VIDYA.demo.tsx
@@ -1,0 +1,20 @@
+import {VIDYA as VIDYAClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const VIDYA: IndicatorConfig = {
+  chartTitle: 'VIDYA (10)',
+  color: '#6366f1',
+  createIndicator: () => new VIDYAClass(10),
+  description: 'Variable Index Dynamic Average',
+  details:
+    'EMA variant that scales its smoothing weight by the absolute Chande Momentum Oscillator: strong one-directional momentum makes it track price closely, while choppy sideways action flattens it into a noise filter.',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
+  id: 'vidya',
+  name: 'VIDYA',
+  processData: makeProcessData({rowInputs: ['close']}),
+  requiredInputs: 11,
+  type: 'single',
+  yAxisLabel: 'Price',
+};

--- a/packages/trading-signals-docs/indicator-demos/trend/ZLEMA.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/ZLEMA.demo.tsx
@@ -1,0 +1,20 @@
+import {ZLEMA as ZLEMAClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const ZLEMA: IndicatorConfig = {
+  chartTitle: 'ZLEMA (5)',
+  color: '#6366f1',
+  createIndicator: () => new ZLEMAClass(5),
+  description: 'Zero-Lag Exponential Moving Average',
+  details:
+    'Cancels most of the EMA lag by amplifying the newest price with its gain over the price from half an interval ago before smoothing. Hugs turning points that a plain EMA reaches several bars later.',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
+  id: 'zlema',
+  name: 'ZLEMA',
+  processData: makeProcessData({rowInputs: ['close']}),
+  requiredInputs: 5,
+  type: 'single',
+  yAxisLabel: 'Price',
+};

--- a/packages/trading-signals-docs/indicator-demos/trend/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/index.tsx
@@ -6,6 +6,7 @@ import {DEMA} from './DEMA.demo';
 import {HMA} from './HMA.demo';
 import {KAMA} from './KAMA.demo';
 import {TEMA} from './TEMA.demo';
+import {TRIMA} from './TRIMA.demo';
 import {DMA} from './DMA.demo';
 import {DX} from './DX.demo';
 import {EMA} from './EMA.demo';
@@ -32,6 +33,7 @@ export const indicators: IndicatorConfig[] = [
   TEMA,
   HMA,
   KAMA,
+  TRIMA,
   Aroon,
   ChandelierExit,
   WMA,

--- a/packages/trading-signals-docs/indicator-demos/trend/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/index.tsx
@@ -9,6 +9,7 @@ import {KAMA} from './KAMA.demo';
 import {T3} from './T3.demo';
 import {TEMA} from './TEMA.demo';
 import {TRIMA} from './TRIMA.demo';
+import {VIDYA} from './VIDYA.demo';
 import {DMA} from './DMA.demo';
 import {DX} from './DX.demo';
 import {EMA} from './EMA.demo';
@@ -40,6 +41,7 @@ export const indicators: IndicatorConfig[] = [
   TRIMA,
   ALMA,
   ZLEMA,
+  VIDYA,
   Aroon,
   ChandelierExit,
   WMA,

--- a/packages/trading-signals-docs/indicator-demos/trend/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/index.tsx
@@ -1,4 +1,5 @@
 import {ADX} from './ADX.demo';
+import {ALMA} from './ALMA.demo';
 import {Aroon} from './Aroon.demo';
 import {BreakoutBarLow} from './BreakoutBarLow.demo';
 import {ChandelierExit} from './ChandelierExit.demo';
@@ -36,6 +37,7 @@ export const indicators: IndicatorConfig[] = [
   HMA,
   KAMA,
   TRIMA,
+  ALMA,
   Aroon,
   ChandelierExit,
   WMA,

--- a/packages/trading-signals-docs/indicator-demos/trend/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/index.tsx
@@ -4,6 +4,7 @@ import {Aroon} from './Aroon.demo';
 import {BreakoutBarLow} from './BreakoutBarLow.demo';
 import {ChandelierExit} from './ChandelierExit.demo';
 import {DEMA} from './DEMA.demo';
+import {FRAMA} from './FRAMA.demo';
 import {HMA} from './HMA.demo';
 import {KAMA} from './KAMA.demo';
 import {T3} from './T3.demo';
@@ -42,6 +43,7 @@ export const indicators: IndicatorConfig[] = [
   ALMA,
   ZLEMA,
   VIDYA,
+  FRAMA,
   Aroon,
   ChandelierExit,
   WMA,

--- a/packages/trading-signals-docs/indicator-demos/trend/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/index.tsx
@@ -26,6 +26,7 @@ import {VWAP} from './VWAP.demo';
 import {WMA} from './WMA.demo';
 import {WSMA} from './WSMA.demo';
 import {ZigZag} from './ZigZag.demo';
+import {ZLEMA} from './ZLEMA.demo';
 import type {IndicatorConfig} from '../../utils/types';
 
 export const indicators: IndicatorConfig[] = [
@@ -38,6 +39,7 @@ export const indicators: IndicatorConfig[] = [
   KAMA,
   TRIMA,
   ALMA,
+  ZLEMA,
   Aroon,
   ChandelierExit,
   WMA,

--- a/packages/trading-signals-docs/indicator-demos/trend/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/index.tsx
@@ -5,6 +5,7 @@ import {ChandelierExit} from './ChandelierExit.demo';
 import {DEMA} from './DEMA.demo';
 import {HMA} from './HMA.demo';
 import {KAMA} from './KAMA.demo';
+import {T3} from './T3.demo';
 import {TEMA} from './TEMA.demo';
 import {TRIMA} from './TRIMA.demo';
 import {DMA} from './DMA.demo';
@@ -31,6 +32,7 @@ export const indicators: IndicatorConfig[] = [
   EMA,
   DEMA,
   TEMA,
+  T3,
   HMA,
   KAMA,
   TRIMA,

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -83,6 +83,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Weighted Moving Average (WMA)
 1. Wilder's Smoothed Moving Average (WSMA / WWS / SMMA / MEMA)
 1. Williams %R (WILLR)
+1. Zero-Lag Exponential Moving Average (ZLEMA)
 1. Zig Zag Indicator (ZigZag)
 
 Utility Methods:

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -27,6 +27,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Acceleration Bands (ABANDS)
 1. Accelerator Oscillator (AC)
 1. Accumulation/Distribution (AD)
+1. Arnaud Legoux Moving Average (ALMA)
 1. Aroon (AROON)
 1. Average Directional Index (ADX)
 1. Average True Range (ATR)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -46,6 +46,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Ease of Movement (EMV)
 1. Exponential Moving Average (EMA)
 1. Efficiency Ratio (ER)
+1. Fractal Adaptive Moving Average (FRAMA)
 1. Hull Moving Average (HMA)
 1. Interquartile Range (IQR)
 1. Kaufman's Adaptive Moving Average (KAMA)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -76,6 +76,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Triple Smoothed EMA Rate of Change (TRIX)
 1. True Range (TR)
 1. Ultimate Oscillator (ULTOSC)
+1. Variable Index Dynamic Average (VIDYA)
 1. Volatility Stop (VSTOP)
 1. Volume Rate of Change (VROC)
 1. Volume-Weighted Average Price (VWAP)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -69,6 +69,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Stochastic RSI (STOCHRSI)
 1. SuperTrend (SUPERTREND)
 1. Tom Demark's Sequential Indicator (TDS)
+1. Triangular Moving Average (TRIMA)
 1. Triple Exponential Moving Average (TEMA)
 1. Triple Smoothed EMA Rate of Change (TRIX)
 1. True Range (TR)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -68,6 +68,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Stochastic Oscillator (STOCH)
 1. Stochastic RSI (STOCHRSI)
 1. SuperTrend (SUPERTREND)
+1. Tillson T3 Moving Average (T3)
 1. Tom Demark's Sequential Indicator (TDS)
 1. Triangular Moving Average (TRIMA)
 1. Triple Exponential Moving Average (TEMA)

--- a/packages/trading-signals/src/trend/ALMA/ALMA.test.ts
+++ b/packages/trading-signals/src/trend/ALMA/ALMA.test.ts
@@ -1,0 +1,148 @@
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {ALMA} from './ALMA.js';
+
+describe('ALMA', () => {
+  /*
+   * Test data verified with the ALMA(9, 0.85, 6) baseline of "Skender.Stock.Indicators" v3.0.0.
+   * Prices are the first 20 closes of its reference quote history:
+   * https://github.com/DaveSkender/Stock.Indicators/blob/3.0.0/tests/indicators/_testdata/quotes/default.csv#L2-L21
+   * Expectations are its committed baseline results, rounded to 7 decimal places:
+   * https://github.com/DaveSkender/Stock.Indicators/blob/3.0.0/tests/indicators/_testdata/results/alma.standard.json#L36-L80
+   */
+  const prices = [
+    212.8, 214.06, 213.89, 214.66, 213.95, 213.95, 214.55, 214.02, 214.51, 213.75, 214.22, 213.43, 214.21, 213.66,
+    215.03, 216.89, 216.66, 216.32, 214.98, 214.96,
+  ] as const;
+  const expectations = [
+    '214.2611591',
+    '214.1828154',
+    '214.1391983',
+    '213.9577828',
+    '213.9241142',
+    '213.8637213',
+    '214.1054047',
+    '214.8606438',
+    '215.6817140',
+    '216.2088357',
+    '216.0927793',
+    '215.6764184',
+  ] as const;
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const alma = new ALMA(9);
+
+      alma.updates(prices, false);
+
+      const originalValue = 220;
+      const replacedValue = 210;
+
+      const originalResult = alma.add(originalValue);
+
+      expect(originalResult?.toFixed(2)).toBe('216.39');
+
+      const replacedResult = alma.replace(replacedValue);
+
+      expect(replacedResult?.toFixed(2)).toBe('214.19');
+      expect(replacedResult).not.toBe(originalResult);
+
+      const restoredResult = alma.replace(originalValue);
+
+      expect(restoredResult).toBe(originalResult);
+    });
+  });
+
+  describe('getResultOrThrow', () => {
+    it('is compatible with results from Skender.Stock.Indicators', () => {
+      const interval = 9;
+      const alma = new ALMA(interval);
+      const offset = alma.getRequiredInputs() - 1;
+
+      prices.forEach((price, i) => {
+        const result = alma.add(price);
+
+        if (result) {
+          expect(result.toFixed(7)).toBe(expectations[i - offset]);
+        }
+      });
+
+      expect(alma.isStable).toBe(true);
+      expect(alma.getRequiredInputs()).toBe(interval);
+    });
+
+    it('supports a custom offset and sigma', () => {
+      /*
+       * Hand-derived: with an interval of 3, offset 0.9 and sigma 3, the bell peaks at
+       * m = 0.9 * (3 - 1) = 1.8 with spread s = 3 / 3 = 1, so the weights are:
+       * w0 = exp(-(0 - 1.8)^2 / 2) = exp(-1.62) = 0.19789869908361465
+       * w1 = exp(-(1 - 1.8)^2 / 2) = exp(-0.32) = 0.72614903707369090
+       * w2 = exp(-(2 - 1.8)^2 / 2) = exp(-0.02) = 0.98019867330675540
+       * ALMA = (10 * w0 + 20 * w1 + 40 * w2) / (w0 + w1 + w2)
+       *      = 55.70991466458018 / 1.904246409464061 = 29.25562279529749
+       */
+      const alma = new ALMA(3, 0.9, 3);
+
+      alma.add(10);
+      alma.add(20);
+      alma.add(40);
+
+      expect(alma.getResultOrThrow().toFixed(4)).toBe('29.2556');
+    });
+
+    it('stays on the price level when the market is completely flat', () => {
+      const alma = new ALMA(5);
+
+      for (let i = 0; i < 8; i++) {
+        alma.add(100);
+      }
+
+      /*
+       * The weighted price sum is normalized by the weight total, so a flat market reproduces
+       * the price level up to one ulp of floating-point rounding.
+       */
+      expect(alma.getResultOrThrow()).toBeCloseTo(100, 12);
+    });
+
+    it('returns the window midpoint of a linear ramp when the bell is centered', () => {
+      /*
+       * With offset 0.5 the bell is symmetric around the window middle, so on a linear ramp
+       * every paired deviation cancels and the average lands on the midpoint price. The math
+       * is exact; summation order leaves at most one ulp of floating-point rounding.
+       */
+      const rampPrices = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11] as const;
+      const midpoints = [5, 6, 7] as const;
+      const alma = new ALMA(9, 0.5, 6);
+      const offset = alma.getRequiredInputs() - 1;
+
+      rampPrices.forEach((price, i) => {
+        const result = alma.add(price);
+
+        if (result) {
+          expect(result).toBeCloseTo(midpoints[i - offset], 12);
+        }
+      });
+
+      expect(alma.isStable).toBe(true);
+    });
+  });
+
+  describe('prices', () => {
+    it('does not cache more prices than necessary to fill the interval', () => {
+      const alma = new ALMA(3);
+
+      alma.add(1);
+      alma.add(2);
+      expect(alma.prices.length).toBe(2);
+      alma.add(3);
+      expect(alma.prices.length).toBe(3);
+      alma.add(4);
+      expect(alma.prices.length).toBe(3);
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new ALMA(5),
+  divergentInput: 1_000,
+  inputs: [81.59, 81.06, 82.87, 83.0, 83.61, 83.15],
+});

--- a/packages/trading-signals/src/trend/ALMA/ALMA.ts
+++ b/packages/trading-signals/src/trend/ALMA/ALMA.ts
@@ -1,0 +1,59 @@
+import {MovingAverage} from '../MA/MovingAverage.js';
+import {pushUpdate} from '../../util/pushUpdate.js';
+
+/**
+ * Arnaud Legoux Moving Average (ALMA)
+ * Type: Trend
+ *
+ * Weights the price window with a Gaussian bell whose peak is shifted toward the newest prices,
+ * tackling the classic moving average trade-off between responsiveness and smoothness: prices
+ * near the peak dominate the average (low lag) while the bell's tails still dampen outliers
+ * (smoothness). The offset (0 to 1) positions the peak within the window — higher values hug
+ * recent price action more closely — and sigma controls the bell's width — larger values spread
+ * the weight for a smoother line. Arnaud Legoux and Dimitrios Kouzis-Loukas proposed offset 0.85
+ * and sigma 6 as a balanced default in 2009.
+ *
+ * @see https://www.tradingview.com/support/solutions/43000594683-arnaud-legoux-moving-average/
+ * @see https://dotnet.stockindicators.dev/indicators/Alma/
+ */
+export class ALMA extends MovingAverage {
+  public readonly prices: number[] = [];
+  readonly #weights: number[] = [];
+  readonly #totalWeight: number;
+
+  constructor(interval: number, offset: number = 0.85, sigma: number = 6) {
+    super(interval);
+
+    /*
+     * The bell never changes once configured, so its weights are laid out up front:
+     * the peak sits at the offset position within the window and sigma sets the spread.
+     */
+    const peak = offset * (interval - 1);
+    const spread = interval / sigma;
+    let totalWeight = 0;
+
+    for (let i = 0; i < interval; i++) {
+      const weight = Math.exp(-((i - peak) ** 2) / (2 * spread ** 2));
+      this.#weights.push(weight);
+      totalWeight += weight;
+    }
+
+    this.#totalWeight = totalWeight;
+  }
+
+  override getRequiredInputs() {
+    return this.interval;
+  }
+
+  update(price: number, replace: boolean) {
+    pushUpdate({array: this.prices, item: price, maxLength: this.interval, replace: replace});
+
+    if (this.prices.length === this.interval) {
+      const weightedSum = this.prices.reduce((sum, value, index) => sum + value * this.#weights[index], 0);
+
+      return this.setResult(weightedSum / this.#totalWeight, replace);
+    }
+
+    return null;
+  }
+}

--- a/packages/trading-signals/src/trend/FRAMA/FRAMA.test.ts
+++ b/packages/trading-signals/src/trend/FRAMA/FRAMA.test.ts
@@ -1,0 +1,134 @@
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {FRAMA} from './FRAMA.js';
+
+describe('FRAMA', () => {
+  /*
+   * FRAMA is not part of Tulip Indicators, so the reference values are hand-derived from the formulas in
+   * Ehlers' paper (http://www.mesasoftware.com/papers/FRAMA.pdf) with interval N = 4 (window halves of 2):
+   *
+   * Prices 82, 88, 84 fill the window; price 90 completes it and seeds FRAMA = 90.
+   *
+   * Price 86 — window [88, 84, 90, 86]:
+   *   N1 = (88 - 84) / 2 = 2 (older half), N2 = (90 - 86) / 2 = 2 (newer half), N3 = (90 - 84) / 4 = 1.5
+   *   D = (ln(2 + 2) - ln(1.5)) / ln(2) = 1.415037
+   *   alpha = exp(-4.6 * (D - 1)) = 0.148203
+   *   FRAMA = 0.148203 * 86 + 0.851797 * 90 = 89.407
+   *
+   * Price 89 — window [84, 90, 86, 89]:
+   *   N1 = (90 - 84) / 2 = 3, N2 = (89 - 86) / 2 = 1.5, N3 = (90 - 84) / 4 = 1.5
+   *   D = (ln(4.5) - ln(1.5)) / ln(2) = ln(3) / ln(2) = 1.584963
+   *   alpha = exp(-4.6 * 0.584963) = 0.067825
+   *   FRAMA = 0.067825 * 89 + 0.932175 * 89.407188 = 89.380
+   *
+   * Price 87 — window [90, 86, 89, 87]:
+   *   N1 = (90 - 86) / 2 = 2, N2 = (89 - 87) / 2 = 1, N3 = (90 - 86) / 4 = 1
+   *   D = (ln(3) - ln(1)) / ln(2) = 1.584963
+   *   alpha = 0.067825
+   *   FRAMA = 0.067825 * 87 + 0.932175 * 89.379571 = 89.218
+   */
+  const prices = [82, 88, 84, 90, 86, 89, 87] as const;
+  const expectations = ['90.000', '89.407', '89.380', '89.218'] as const;
+
+  describe('constructor', () => {
+    it('throws when the interval is odd, because the fractal dimension is measured over two equal window halves', () => {
+      expect(() => new FRAMA(5)).toThrowError(
+        'The interval has to be an even number of at least 2, but "5" was given.'
+      );
+    });
+
+    it('throws when the interval is smaller than 2', () => {
+      expect(() => new FRAMA(0)).toThrowError(
+        'The interval has to be an even number of at least 2, but "0" was given.'
+      );
+    });
+  });
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const frama = new FRAMA(4);
+
+      frama.updates(prices, false);
+
+      const originalValue = 95;
+      const replacedValue = 80;
+
+      const originalResult = frama.add(originalValue);
+
+      expect(originalResult?.toFixed(2)).toBe('90.74');
+
+      const replacedResult = frama.replace(replacedValue);
+
+      expect(replacedResult?.toFixed(2)).toBe('84.64');
+      expect(replacedResult).not.toBe(originalResult);
+
+      const restoredResult = frama.replace(originalValue);
+
+      expect(restoredResult).toBe(originalResult);
+    });
+  });
+
+  describe('getResultOrThrow', () => {
+    it('matches the reference calculation hand-derived from the Ehlers paper', () => {
+      const interval = 4;
+      const frama = new FRAMA(interval);
+      const offset = frama.getRequiredInputs() - 1;
+
+      prices.forEach((price, i) => {
+        const result = frama.add(price);
+
+        if (result) {
+          expect(result.toFixed(3)).toBe(expectations[i - offset]);
+        }
+      });
+
+      expect(frama.isStable).toBe(true);
+      expect(frama.getRequiredInputs()).toBe(interval);
+    });
+
+    it('stays on the price level when the market is completely flat', () => {
+      const frama = new FRAMA(4);
+
+      for (let i = 0; i < 8; i++) {
+        frama.add(100);
+      }
+
+      expect(frama.getResultOrThrow()).toBe(100);
+    });
+
+    it('snaps to the latest price when only the older window half is flat', () => {
+      const frama = new FRAMA(4);
+
+      frama.updates([50, 50, 50, 60, 70], false);
+
+      expect(frama.getResultOrThrow()).toBe(70);
+    });
+
+    it('snaps to the latest price when only the newer window half is flat', () => {
+      const frama = new FRAMA(4);
+
+      frama.updates([40, 60, 70, 50, 50], false);
+
+      expect(frama.getResultOrThrow()).toBe(50);
+    });
+
+    it('clamps the smoothing at the latest price when the window is wildly volatile', () => {
+      /*
+       * The final window [10, 11, 100, 101] gapped up between its halves:
+       * N1 = 0.5, N2 = 0.5, N3 = 22.75 make D = -4.507795, so the raw smoothing
+       * exp(-4.6 * (D - 1)) = 1.007e11 hits the upper bound of 1.
+       */
+      const frama = new FRAMA(4);
+
+      frama.updates([10, 11, 10, 11, 100], false);
+
+      expect(frama.getResultOrThrow()).not.toBe(101);
+      expect(frama.add(101)).toBe(101);
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new FRAMA(4),
+  divergentInput: 1_000,
+  inputs: [82, 88, 84, 90, 86, 89],
+});

--- a/packages/trading-signals/src/trend/FRAMA/FRAMA.ts
+++ b/packages/trading-signals/src/trend/FRAMA/FRAMA.ts
@@ -1,0 +1,76 @@
+import {getMaximum} from '../../util/getMaximum.js';
+import {getMinimum} from '../../util/getMinimum.js';
+import {pushUpdate} from '../../util/pushUpdate.js';
+import {MovingAverage} from '../MA/MovingAverage.js';
+
+/**
+ * Fractal Adaptive Moving Average (FRAMA)
+ * Type: Trend
+ *
+ * FRAMA was developed by John Ehlers to resolve the fixed tradeoff between smoothness and lag of ordinary moving
+ * averages. It estimates the fractal dimension of the price curve — how densely price filled its range over the
+ * interval, measured by comparing the ranges of the two window halves against the range of the full window — and
+ * turns that roughness into the smoothing of an exponential moving average. Near a fractal dimension of 1 (prices
+ * traveled in a straight line) it follows price almost one-to-one; near 2 (dense congestion) it becomes as sluggish
+ * as a 200-period moving average, flattening out whipsaws in congestion zones.
+ *
+ * The interval must be an even number of at least 2, because the fractal dimension is measured over two equal
+ * window halves; anything else throws an error. The first result seeds with the price that completes the first
+ * full window, matching the paper. When either window half is flat, a straight line (fractal dimension 1) is
+ * assumed, so the average snaps to the current price — the same "a flat window is perfectly efficient" convention
+ * KAMA follows.
+ *
+ * Ehlers feeds the median price `(high + low) / 2` into FRAMA; this implementation works on whatever price series
+ * it is fed.
+ *
+ * @see http://www.mesasoftware.com/papers/FRAMA.pdf
+ */
+export class FRAMA extends MovingAverage {
+  readonly #prices: number[] = [];
+
+  constructor(interval: number) {
+    super(interval);
+
+    if (interval < 2 || interval % 2 !== 0) {
+      throw new Error(`The interval has to be an even number of at least 2, but "${interval}" was given.`);
+    }
+  }
+
+  override getRequiredInputs() {
+    return this.interval;
+  }
+
+  update(price: number, replace: boolean) {
+    pushUpdate({array: this.#prices, item: price, maxLength: this.interval + 1, replace: replace});
+
+    if (this.#prices.length < this.interval) {
+      return null;
+    }
+
+    if (this.#prices.length === this.interval) {
+      return this.setResult(price, replace);
+    }
+
+    const half = this.interval / 2;
+    const window = this.#prices.slice(-this.interval);
+    const olderHalf = window.slice(0, half);
+    const newerHalf = window.slice(half);
+    const n1 = (getMaximum(olderHalf) - getMinimum(olderHalf)) / half;
+    const n2 = (getMaximum(newerHalf) - getMinimum(newerHalf)) / half;
+    const n3 = (getMaximum(window) - getMinimum(window)) / this.interval;
+
+    /*
+     * A flat half reads as a straight line (fractal dimension 1). This also rules out taking the
+     * logarithm of zero: a fully flat window always contains a flat half.
+     */
+    const dimension = n1 === 0 || n2 === 0 ? 1 : (Math.log(n1 + n2) - Math.log(n3)) / Math.log(2);
+
+    // Ehlers bounds the smoothing between following the price one-to-one and a very slow average
+    const alpha = Math.min(Math.max(Math.exp(-4.6 * (dimension - 1)), 0.01), 1);
+
+    // Guaranteed to exist: the seed result was set as soon as the first window filled up
+    const previous = (replace ? this.previousResult : this.result) as number;
+
+    return this.setResult(alpha * price + (1 - alpha) * previous, replace);
+  }
+}

--- a/packages/trading-signals/src/trend/MA/MovingAverageTypes.ts
+++ b/packages/trading-signals/src/trend/MA/MovingAverageTypes.ts
@@ -1,3 +1,4 @@
+import type {ALMA} from '../ALMA/ALMA.js';
 import type {EMA} from '../EMA/EMA.js';
 import type {HMA} from '../HMA/HMA.js';
 import type {RMA} from '../RMA/RMA.js';
@@ -8,6 +9,7 @@ import type {WMA} from '../WMA/WMA.js';
 import type {WSMA} from '../WSMA/WSMA.js';
 
 export type MovingAverageTypes =
+  | typeof ALMA
   | typeof EMA
   | typeof HMA
   | typeof RMA

--- a/packages/trading-signals/src/trend/MA/MovingAverageTypes.ts
+++ b/packages/trading-signals/src/trend/MA/MovingAverageTypes.ts
@@ -1,5 +1,6 @@
 import type {ALMA} from '../ALMA/ALMA.js';
 import type {EMA} from '../EMA/EMA.js';
+import type {FRAMA} from '../FRAMA/FRAMA.js';
 import type {HMA} from '../HMA/HMA.js';
 import type {RMA} from '../RMA/RMA.js';
 import type {SMA} from '../SMA/SMA.js';
@@ -13,6 +14,7 @@ import type {ZLEMA} from '../ZLEMA/ZLEMA.js';
 export type MovingAverageTypes =
   | typeof ALMA
   | typeof EMA
+  | typeof FRAMA
   | typeof HMA
   | typeof RMA
   | typeof SMA

--- a/packages/trading-signals/src/trend/MA/MovingAverageTypes.ts
+++ b/packages/trading-signals/src/trend/MA/MovingAverageTypes.ts
@@ -7,6 +7,7 @@ import type {T3} from '../T3/T3.js';
 import type {TRIMA} from '../TRIMA/TRIMA.js';
 import type {WMA} from '../WMA/WMA.js';
 import type {WSMA} from '../WSMA/WSMA.js';
+import type {ZLEMA} from '../ZLEMA/ZLEMA.js';
 
 export type MovingAverageTypes =
   | typeof ALMA
@@ -17,4 +18,5 @@ export type MovingAverageTypes =
   | typeof T3
   | typeof TRIMA
   | typeof WMA
-  | typeof WSMA;
+  | typeof WSMA
+  | typeof ZLEMA;

--- a/packages/trading-signals/src/trend/MA/MovingAverageTypes.ts
+++ b/packages/trading-signals/src/trend/MA/MovingAverageTypes.ts
@@ -5,6 +5,7 @@ import type {RMA} from '../RMA/RMA.js';
 import type {SMA} from '../SMA/SMA.js';
 import type {T3} from '../T3/T3.js';
 import type {TRIMA} from '../TRIMA/TRIMA.js';
+import type {VIDYA} from '../VIDYA/VIDYA.js';
 import type {WMA} from '../WMA/WMA.js';
 import type {WSMA} from '../WSMA/WSMA.js';
 import type {ZLEMA} from '../ZLEMA/ZLEMA.js';
@@ -17,6 +18,7 @@ export type MovingAverageTypes =
   | typeof SMA
   | typeof T3
   | typeof TRIMA
+  | typeof VIDYA
   | typeof WMA
   | typeof WSMA
   | typeof ZLEMA;

--- a/packages/trading-signals/src/trend/MA/MovingAverageTypes.ts
+++ b/packages/trading-signals/src/trend/MA/MovingAverageTypes.ts
@@ -2,6 +2,7 @@ import type {EMA} from '../EMA/EMA.js';
 import type {HMA} from '../HMA/HMA.js';
 import type {RMA} from '../RMA/RMA.js';
 import type {SMA} from '../SMA/SMA.js';
+import type {T3} from '../T3/T3.js';
 import type {TRIMA} from '../TRIMA/TRIMA.js';
 import type {WMA} from '../WMA/WMA.js';
 import type {WSMA} from '../WSMA/WSMA.js';
@@ -11,6 +12,7 @@ export type MovingAverageTypes =
   | typeof HMA
   | typeof RMA
   | typeof SMA
+  | typeof T3
   | typeof TRIMA
   | typeof WMA
   | typeof WSMA;

--- a/packages/trading-signals/src/trend/MA/MovingAverageTypes.ts
+++ b/packages/trading-signals/src/trend/MA/MovingAverageTypes.ts
@@ -2,7 +2,15 @@ import type {EMA} from '../EMA/EMA.js';
 import type {HMA} from '../HMA/HMA.js';
 import type {RMA} from '../RMA/RMA.js';
 import type {SMA} from '../SMA/SMA.js';
+import type {TRIMA} from '../TRIMA/TRIMA.js';
 import type {WMA} from '../WMA/WMA.js';
 import type {WSMA} from '../WSMA/WSMA.js';
 
-export type MovingAverageTypes = typeof EMA | typeof HMA | typeof RMA | typeof SMA | typeof WMA | typeof WSMA;
+export type MovingAverageTypes =
+  | typeof EMA
+  | typeof HMA
+  | typeof RMA
+  | typeof SMA
+  | typeof TRIMA
+  | typeof WMA
+  | typeof WSMA;

--- a/packages/trading-signals/src/trend/T3/T3.test.ts
+++ b/packages/trading-signals/src/trend/T3/T3.test.ts
@@ -1,0 +1,166 @@
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {EMA} from '../EMA/EMA.js';
+import {T3} from './T3.js';
+
+describe('T3', () => {
+  const prices = [
+    81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84, 83.99, 84.55, 84.36, 85.53, 86.54, 86.89, 87.77, 87.29,
+  ] as const;
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const t3 = new T3(3);
+
+      t3.updates(prices, false);
+
+      const originalValue = 90;
+      const replacedValue = 83;
+
+      const originalResult = t3.add(originalValue);
+
+      expect(originalResult?.toFixed(2)).toBe('88.35');
+
+      const replacedResult = t3.replace(replacedValue);
+
+      expect(replacedResult?.toFixed(2)).toBe('86.20');
+      expect(replacedResult).not.toBe(originalResult);
+
+      const restoredResult = t3.replace(originalValue);
+
+      expect(restoredResult).toBe(originalResult);
+    });
+  });
+
+  describe('getResultOrThrow', () => {
+    /*
+     * Hand-derived from Tillson's definition, because no external fixture matches this seeding:
+     * Tulip Indicators does not implement T3, and TA-Lib seeds each cascade stage with an SMA
+     * while this cascade seeds every stage with its first input (the TEMA convention), so
+     * published TA-Lib values cannot agree on the early readings.
+     *
+     * Interval 2 means every stage weights its newest input with k = 2 / (2 + 1) = 2/3 and its
+     * previous reading with 1/3. A stage emits its first reading as a copy of its first input
+     * and starts feeding the next stage one bar later, once it has seen two inputs.
+     *
+     * Cascade for the rising series (columns are the six smoothing stages e1..e6):
+     *
+     * 10 -> 10
+     * 11 -> 10.666666667 | 10.666666667
+     * 12 -> 11.555555556 | 11.259259259 | 11.259259259
+     * 13 -> 12.518518519 | 12.098765432 | 11.818930041 | 11.818930041
+     * 14 -> 13.506172840 | 13.037037037 | 12.631001372 | 12.360310928 | 12.360310928
+     * 15 -> 14.502057613 | 14.013717421 | 13.552812071 | 13.155311690 | 12.890311436 | 12.890311436
+     * 16 -> 15.500685871 | 15.005029721 | 14.520957171 | 14.065742011 | 13.673931819 | 13.412725025
+     * 17 -> 16.500228624 | 16.001828989 | 15.508205050 | 15.027384037 | 14.576233298 | 14.188397207
+     *
+     * Weights for the default volume factor a = 0.7:
+     *
+     * c1 = -a^3                  = -0.343
+     * c2 = 3a^2 + 3a^3           =  2.499
+     * c3 = -6a^2 - 3a - 3a^3     = -6.069
+     * c4 = 1 + 3a + a^3 + 3a^2   =  4.913
+     *
+     * First reading (bar 7, all six stages warmed up), T3 = c1*e6 + c2*e5 + c3*e4 + c4*e3:
+     *
+     * T3 = -0.343 * 13.412725025 + 2.499 * 13.673931819 - 6.069 * 14.065742011 + 4.913 * 14.520957171
+     *    = 15.547065251
+     *
+     * Bar 8:
+     *
+     * T3 = -0.343 * 14.188397207 + 2.499 * 14.576233298 - 6.069 * 15.027384037 + 4.913 * 15.508205050
+     *    = 16.550004460
+     */
+    const risingPrices = [10, 11, 12, 13, 14, 15, 16, 17] as const;
+
+    it('matches the hand-derived cascade with the default volume factor', () => {
+      const expectations = ['15.547065251', '16.550004460'] as const;
+      const t3 = new T3(2);
+      const offset = t3.getRequiredInputs() - 1;
+
+      risingPrices.forEach((price, i) => {
+        const result = t3.add(price);
+
+        if (result) {
+          expect(result.toFixed(9)).toBe(expectations[i - offset]);
+        }
+      });
+
+      expect(t3.isStable).toBe(true);
+      expect(t3.getRequiredInputs()).toBe(7);
+    });
+
+    /*
+     * Same cascade as above (the six smoothing stages ignore the volume factor), only the
+     * weights change for a = 0.5:
+     *
+     * c1 = -0.125, c2 = 1.125, c3 = -3.375, c4 = 3.375
+     *
+     * Bar 7: -0.125 * 13.412725025 + 1.125 * 13.673931819 - 3.375 * 14.065742011 + 3.375 * 14.520957171 = 15.242933835
+     * Bar 8: -0.125 * 14.188397207 + 1.125 * 14.576233298 - 3.375 * 15.027384037 + 3.375 * 15.508205050 = 16.247483728
+     */
+    it('weights the cascade differently with an explicit volume factor', () => {
+      const expectations = ['15.242933835', '16.247483728'] as const;
+      const t3 = new T3(2, 0.5);
+      const offset = t3.getRequiredInputs() - 1;
+
+      risingPrices.forEach((price, i) => {
+        const result = t3.add(price);
+
+        if (result) {
+          expect(result.toFixed(9)).toBe(expectations[i - offset]);
+        }
+      });
+
+      expect(t3.isStable).toBe(true);
+    });
+
+    it("defaults to Tillson's recommended volume factor of 0.7", () => {
+      const defaultT3 = new T3(2);
+      const explicitT3 = new T3(2, 0.7);
+
+      expect(defaultT3.volumeFactor).toBe(0.7);
+
+      for (const price of risingPrices) {
+        expect(defaultT3.add(price)).toBe(explicitT3.add(price));
+      }
+    });
+
+    it('equals a triple-smoothed EMA when the volume factor is zero', () => {
+      const t3 = new T3(3, 0);
+      const singleEMA = new EMA(3);
+      const doubleEMA = new EMA(3);
+      const tripleEMA = new EMA(3);
+
+      for (const price of prices) {
+        t3.add(price);
+        singleEMA.add(price);
+
+        if (singleEMA.isStable) {
+          doubleEMA.add(singleEMA.getResultOrThrow());
+
+          if (doubleEMA.isStable) {
+            tripleEMA.add(doubleEMA.getResultOrThrow());
+          }
+        }
+      }
+
+      expect(t3.getResultOrThrow()).toBe(tripleEMA.getResultOrThrow());
+    });
+
+    it('converges to the price level when the market is completely flat', () => {
+      const t3 = new T3(5);
+
+      for (let i = 0; i < 25; i++) {
+        t3.add(100);
+      }
+
+      expect(t3.getResultOrThrow()).toBeCloseTo(100, 12);
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new T3(3),
+  divergentInput: 1_000,
+  inputs: [81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84, 83.99, 84.55, 84.36, 85.53, 86.54, 86.89, 87.77, 87.29],
+});

--- a/packages/trading-signals/src/trend/T3/T3.ts
+++ b/packages/trading-signals/src/trend/T3/T3.ts
@@ -1,0 +1,96 @@
+import {EMA} from '../EMA/EMA.js';
+import {MovingAverage} from '../MA/MovingAverage.js';
+
+/**
+ * Tillson T3 Moving Average (T3)
+ * Type: Trend
+ *
+ * The T3 was developed by Tim Tillson to give trend followers a smooth curve that still turns quickly:
+ * it applies his "generalized DEMA" three times, which expands into a weighted blend of six cascaded
+ * EMAs. The volume factor (unrelated to trade volume) steers each stage between a plain EMA (0) and a
+ * full DEMA (1) — higher values hug price more closely at the cost of overshoot. Tillson recommends 0.7.
+ *
+ * The chain is staged — each EMA starts only once the previous one is stable, seeding itself with that
+ * EMA's first stable value — following the same convention as TEMA. TA-Lib seeds each stage with an SMA
+ * instead, so early readings differ slightly from TA-Lib until the seed influence decays.
+ *
+ * @see Tim Tillson, "Smoothing Techniques for More Accurate Signals", Technical Analysis of Stocks & Commodities (January 1998)
+ * @see https://www.fmlabs.com/reference/default.htm?url=T3.htm
+ * @see https://www.tadoc.org/indicator/T3.htm
+ */
+export class T3 extends MovingAverage {
+  readonly #ema1: EMA;
+  readonly #ema2: EMA;
+  readonly #ema3: EMA;
+  readonly #ema4: EMA;
+  readonly #ema5: EMA;
+  readonly #ema6: EMA;
+
+  readonly #c1: number;
+  readonly #c2: number;
+  readonly #c3: number;
+  readonly #c4: number;
+
+  public readonly volumeFactor: number;
+
+  constructor(interval: number, volumeFactor: number = 0.7) {
+    super(interval);
+    this.volumeFactor = volumeFactor;
+    this.#ema1 = new EMA(interval);
+    this.#ema2 = new EMA(interval);
+    this.#ema3 = new EMA(interval);
+    this.#ema4 = new EMA(interval);
+    this.#ema5 = new EMA(interval);
+    this.#ema6 = new EMA(interval);
+
+    const a = volumeFactor;
+    this.#c1 = -(a ** 3);
+    this.#c2 = 3 * a ** 2 + 3 * a ** 3;
+    this.#c3 = -6 * a ** 2 - 3 * a - 3 * a ** 3;
+    this.#c4 = 1 + 3 * a + a ** 3 + 3 * a ** 2;
+  }
+
+  override getRequiredInputs() {
+    return 6 * (this.interval - 1) + 1;
+  }
+
+  update(price: number, replace: boolean) {
+    const ema1 = this.#ema1.update(price, replace);
+
+    if (!this.#ema1.isStable) {
+      return null;
+    }
+
+    const ema2 = this.#ema2.update(ema1, replace);
+
+    if (!this.#ema2.isStable) {
+      return null;
+    }
+
+    const ema3 = this.#ema3.update(ema2, replace);
+
+    if (!this.#ema3.isStable) {
+      return null;
+    }
+
+    const ema4 = this.#ema4.update(ema3, replace);
+
+    if (!this.#ema4.isStable) {
+      return null;
+    }
+
+    const ema5 = this.#ema5.update(ema4, replace);
+
+    if (!this.#ema5.isStable) {
+      return null;
+    }
+
+    const ema6 = this.#ema6.update(ema5, replace);
+
+    if (!this.#ema6.isStable) {
+      return null;
+    }
+
+    return this.setResult(this.#c1 * ema6 + this.#c2 * ema5 + this.#c3 * ema4 + this.#c4 * ema3, replace);
+  }
+}

--- a/packages/trading-signals/src/trend/TRIMA/TRIMA.test.ts
+++ b/packages/trading-signals/src/trend/TRIMA/TRIMA.test.ts
@@ -1,0 +1,114 @@
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {TRIMA} from './TRIMA.js';
+
+describe('TRIMA', () => {
+  /*
+   * Test data verified with:
+   * https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt#L418-L420
+   */
+  const prices = [
+    81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84, 83.99, 84.55, 84.36, 85.53, 86.54, 86.89, 87.77, 87.29,
+  ] as const;
+  const expectations = [
+    '82.437',
+    '82.908',
+    '83.204',
+    '83.260',
+    '83.440',
+    '83.807',
+    '84.302',
+    '84.863',
+    '85.537',
+    '86.288',
+    '86.901',
+  ] as const;
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const trima = new TRIMA(5);
+
+      trima.updates(prices, false);
+
+      const originalValue = 90;
+      const replacedValue = 83;
+
+      const originalResult = trima.add(originalValue);
+
+      expect(originalResult?.toFixed(2)).toBe('87.58');
+
+      const replacedResult = trima.replace(replacedValue);
+
+      expect(replacedResult?.toFixed(2)).toBe('86.80');
+      expect(replacedResult).not.toBe(originalResult);
+
+      const restoredResult = trima.replace(originalValue);
+
+      expect(restoredResult).toBe(originalResult);
+    });
+  });
+
+  describe('getResultOrThrow', () => {
+    it('is compatible with results from Tulip Indicators (TI)', {tags: ['tulipindicators']}, () => {
+      const interval = 5;
+      const trima = new TRIMA(interval);
+      const offset = trima.getRequiredInputs() - 1;
+
+      prices.forEach((price, i) => {
+        const result = trima.add(price);
+
+        if (result) {
+          expect(result.toFixed(3)).toBe(expectations[i - offset]);
+        }
+      });
+
+      expect(trima.isStable).toBe(true);
+      expect(trima.getRequiredInputs()).toBe(interval);
+    });
+
+    it('repeats the peak weight when the interval is even', () => {
+      const evenExpectations = [
+        '82.641',
+        '82.981',
+        '83.235',
+        '83.393',
+        '83.655',
+        '84.058',
+        '84.596',
+        '85.228',
+        '85.919',
+        '86.545',
+      ] as const;
+      const trima = new TRIMA(6);
+      const offset = trima.getRequiredInputs() - 1;
+
+      prices.forEach((price, i) => {
+        const result = trima.add(price);
+
+        if (result) {
+          expect(result.toFixed(3)).toBe(evenExpectations[i - offset]);
+        }
+      });
+
+      expect(trima.isStable).toBe(true);
+    });
+
+    it('weights all prices equally when the interval is too short to form a triangle', () => {
+      const trima = new TRIMA(2);
+
+      trima.add(3);
+      trima.add(5);
+
+      expect(trima.getResultOrThrow()).toBe(4);
+
+      trima.add(9);
+
+      expect(trima.getResultOrThrow()).toBe(7);
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new TRIMA(5),
+  divergentInput: 1_000,
+  inputs: [81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84, 83.99, 84.55, 84.36, 85.53, 86.54, 86.89, 87.77, 87.29],
+});

--- a/packages/trading-signals/src/trend/TRIMA/TRIMA.ts
+++ b/packages/trading-signals/src/trend/TRIMA/TRIMA.ts
@@ -1,0 +1,46 @@
+import {MovingAverage} from '../MA/MovingAverage.js';
+import {pushUpdate} from '../../util/pushUpdate.js';
+
+/**
+ * Triangular Moving Average (TRIMA)
+ * Type: Trend
+ *
+ * The Triangular Moving Average weights the middle of the interval most heavily, tapering off symmetrically towards both the oldest and the newest price. This is equivalent to smoothing a Simple Moving Average with a second Simple Moving Average, which makes the TRIMA noticeably smoother — and slower to react — than an SMA over the same interval. Traders reach for it when reading the underlying trend direction matters more than reacting quickly, since the double smoothing filters out most short-lived noise.
+ *
+ * @see https://tulipindicators.org/trima
+ * @see https://www.fmlabs.com/reference/default.htm?url=TriangularMA.htm
+ */
+export class TRIMA extends MovingAverage {
+  public readonly prices: number[] = [];
+  readonly #divisor: number;
+
+  constructor(interval: number) {
+    super(interval);
+
+    /*
+     * Total triangular weight in closed form: an even interval repeats the peak weight
+     * (e.g. 1-2-3-3-2-1), an odd interval peaks once (e.g. 1-2-3-2-1).
+     */
+    const half = Math.trunc(interval / 2);
+    this.#divisor = interval % 2 === 0 ? (half + 1) * half : (half + 1) ** 2;
+  }
+
+  override getRequiredInputs() {
+    return this.interval;
+  }
+
+  update(price: number, replace: boolean) {
+    pushUpdate({array: this.prices, item: price, maxLength: this.interval, replace: replace});
+
+    if (this.prices.length === this.interval) {
+      const weightedSum = this.prices.reduce(
+        (sum, value, index) => sum + value * Math.min(index + 1, this.interval - index),
+        0
+      );
+
+      return this.setResult(weightedSum / this.#divisor, replace);
+    }
+
+    return null;
+  }
+}

--- a/packages/trading-signals/src/trend/VIDYA/VIDYA.test.ts
+++ b/packages/trading-signals/src/trend/VIDYA/VIDYA.test.ts
@@ -1,0 +1,136 @@
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {EMA} from '../EMA/EMA.js';
+import {VIDYA} from './VIDYA.js';
+
+describe('VIDYA', () => {
+  /*
+   * No published fixture exists for this VIDYA variant with first-price seeding: Tulip Indicators
+   * (https://tulipindicators.org/vidya) implements Chande's older 1992 standard-deviation variant, and pandas-ta
+   * seeds its CMO-based recursion with zero, which skews all early values. The expectations below are therefore
+   * derived by hand from the CMO-based definition
+   * (https://www.metatrader5.com/en/terminal/help/indicators/trend_indicators/vida) with alpha = 2 / (2 + 1) = 2/3
+   * and the seed being the first price (10):
+   *
+   * Price 11: changes +2 / -1 over (10, 12, 11) => CMO = 100 * (2 - 1) / 3 = 33.33 => k = 1/3
+   *           VIDYA = (2/3 * 1/3) * 11 + (1 - 2/9) * 10      = 92/9   = 10.2222
+   * Price 14: changes -1 / +3 over (12, 11, 14) => CMO = 100 * (3 - 1) / 4 = 50    => k = 1/2
+   *           VIDYA = (2/3 * 1/2) * 14 + (1 - 1/3) * 92/9    = 310/27 = 11.4815
+   * Price 13: changes +3 / -1 over (11, 14, 13) => CMO = 100 * (3 - 1) / 4 = 50    => k = 1/2
+   *           VIDYA = (2/3 * 1/2) * 13 + (1 - 1/3) * 310/27  = 971/81 = 11.9877
+   */
+  const prices = [10, 12, 11, 14, 13] as const;
+  const expectations = ['10.2222', '11.4815', '11.9877'] as const;
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const vidya = new VIDYA(2);
+
+      vidya.updates([10, 12, 11, 14], false);
+
+      const originalValue = 13;
+      const replacedValue = 8;
+
+      const originalResult = vidya.add(originalValue);
+
+      expect(originalResult?.toFixed(4)).toBe('11.9877');
+
+      /*
+       * The replacement flips the momentum reading: changes +3 / -6 over (11, 14, 8) give
+       * CMO = 100 * (3 - 6) / 9 = -33.33 => k = 1/3, and the recursion resumes from the result
+       * before the replaced price (310/27):
+       * VIDYA = (2/3 * 1/3) * 8 + (1 - 2/9) * 310/27 = 2602/243 = 10.7078
+       */
+      const replacedResult = vidya.replace(replacedValue);
+
+      expect(replacedResult?.toFixed(4)).toBe('10.7078');
+      expect(replacedResult).not.toBe(originalResult);
+
+      const restoredResult = vidya.replace(originalValue);
+
+      expect(restoredResult).toBe(originalResult);
+    });
+
+    it('treats a replacement before any values as the first value', () => {
+      const vidya = new VIDYA(2);
+
+      expect(vidya.replace(10)).toBeNull();
+      expect(vidya.add(12)).toBeNull();
+      expect(vidya.add(11)?.toFixed(4)).toBe('10.2222');
+    });
+
+    it('re-seeds when the very first price is replaced', () => {
+      const reference = new VIDYA(2);
+
+      reference.updates([9, 12, 11], false);
+
+      const vidya = new VIDYA(2);
+
+      vidya.add(10);
+      vidya.replace(9);
+      vidya.add(12);
+      vidya.add(11);
+
+      expect(vidya.getResultOrThrow()).toBe(reference.getResultOrThrow());
+      expect(vidya.getResultOrThrow().toFixed(4)).toBe('9.6667');
+    });
+  });
+
+  describe('getResultOrThrow', () => {
+    it('matches a hand-derived reference series', () => {
+      const interval = 2;
+      const vidya = new VIDYA(interval);
+      const offset = vidya.getRequiredInputs() - 1;
+
+      prices.forEach((price, i) => {
+        const result = vidya.add(price);
+
+        if (result) {
+          expect(result.toFixed(4)).toBe(expectations[i - offset]);
+        }
+      });
+
+      expect(vidya.isStable).toBe(true);
+      expect(vidya.getRequiredInputs()).toBe(interval + 1);
+    });
+
+    it('stays on the price level when the market is completely flat', () => {
+      const vidya = new VIDYA(5);
+
+      for (let i = 0; i < 8; i++) {
+        vidya.add(100);
+      }
+
+      expect(vidya.getResultOrThrow()).toBe(100);
+    });
+
+    it('matches a plain EMA when every bar moves in the same direction', () => {
+      /*
+       * On a strictly rising series the absolute CMO is pinned at 100, so the adaptive weight collapses to the
+       * plain EMA weight. The EMA twin seeds on the first price — exactly like VIDYA — and afterwards only sees
+       * the prices for which VIDYA produces results.
+       */
+      const risingPrices = [10, 11, 13, 16, 20, 21, 23, 26, 30, 31] as const;
+      const vidya = new VIDYA(3);
+      const ema = new EMA(3);
+      const offset = vidya.getRequiredInputs() - 1;
+
+      ema.add(risingPrices[0]);
+
+      risingPrices.forEach((price, i) => {
+        const result = vidya.add(price);
+
+        if (i >= offset) {
+          expect(result).toBe(ema.add(price));
+        }
+      });
+
+      expect(vidya.isStable).toBe(true);
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new VIDYA(5),
+  divergentInput: 1_000,
+  inputs: [81.59, 81.06, 82.87, 83.0, 83.61, 83.15],
+});

--- a/packages/trading-signals/src/trend/VIDYA/VIDYA.ts
+++ b/packages/trading-signals/src/trend/VIDYA/VIDYA.ts
@@ -1,0 +1,65 @@
+import {CMO} from '../../momentum/CMO/CMO.js';
+import {MovingAverage} from '../MA/MovingAverage.js';
+
+/**
+ * Variable Index Dynamic Average (VIDYA)
+ * Type: Trend
+ *
+ * VIDYA was developed by Tushar Chande. It behaves like an EMA whose speed is not fixed: the smoothing weight is
+ * scaled by the absolute Chande Momentum Oscillator over the same interval, so the average hugs price in strong
+ * trends and flattens into a noise filter when the market chops sideways.
+ *
+ * Chande published two variants. His original from 1992 derives its volatility index from a ratio of standard
+ * deviations — that is the variant Tulip Indicators implements. This class implements the later CMO-based
+ * definition from Chande & Kroll's book "The New Technical Trader" (1994), which TradingView, MetaTrader and most
+ * modern libraries use. Results of the two variants are not comparable.
+ *
+ * Seeding: the recursion starts from the very first price, so once the internal momentum window has filled up, the
+ * first result blends the current price with that seed. Libraries disagree on this choice (pandas-ta seeds with
+ * zero), which makes early values differ between implementations even when the formula matches.
+ *
+ * @see https://www.metatrader5.com/en/terminal/help/indicators/trend_indicators/vida
+ * @see https://tulipindicators.org/vidya
+ */
+export class VIDYA extends MovingAverage {
+  readonly #cmo: CMO;
+  readonly #weightFactor: number;
+  #pricesCounter = 0;
+  #seedPrice?: number;
+
+  constructor(interval: number) {
+    super(interval);
+    this.#cmo = new CMO(interval);
+    this.#weightFactor = 2 / (interval + 1);
+  }
+
+  override getRequiredInputs() {
+    return this.#cmo.getRequiredInputs();
+  }
+
+  update(price: number, replace: boolean) {
+    if (!replace) {
+      this.#pricesCounter++;
+    } else if (this.#pricesCounter === 0) {
+      // A replacement before any input counts as the first input
+      this.#pricesCounter++;
+    }
+
+    // Only the very first price defines the seed, so replacing that price re-seeds the recursion
+    if (this.#pricesCounter === 1) {
+      this.#seedPrice = price;
+    }
+
+    const cmo = this.#cmo.update(price, replace);
+
+    if (cmo === null) {
+      return null;
+    }
+
+    const smoothing = this.#weightFactor * (Math.abs(cmo) / 100);
+    // The fallback is guaranteed to exist: the seed was captured with the very first price, long before the momentum window fills up
+    const previous = ((replace ? this.previousResult : this.result) ?? this.#seedPrice) as number;
+
+    return this.setResult(smoothing * price + (1 - smoothing) * previous, replace);
+  }
+}

--- a/packages/trading-signals/src/trend/ZLEMA/ZLEMA.test.ts
+++ b/packages/trading-signals/src/trend/ZLEMA/ZLEMA.test.ts
@@ -1,0 +1,125 @@
+import {NotEnoughDataError} from '../../error/index.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {EMA} from '../EMA/EMA.js';
+import {ZLEMA} from './ZLEMA.js';
+
+describe('ZLEMA', () => {
+  /*
+   * Test data verified with:
+   * https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt#L497-L499
+   */
+  const prices = [
+    81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84, 83.99, 84.55, 84.36, 85.53, 86.54, 86.89, 87.77, 87.29,
+  ] as const;
+  const expectations = [
+    '83.477',
+    '83.418',
+    '82.969',
+    '83.589',
+    '84.479',
+    '84.563',
+    '85.212',
+    '86.381',
+    '87.004',
+    '87.669',
+    '87.676',
+  ] as const;
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const zlema = new ZLEMA(5);
+
+      zlema.updates(prices, false);
+
+      const originalValue = 90;
+      const replacedValue = 80;
+
+      const originalResult = zlema.add(originalValue);
+
+      expect(originalResult?.toFixed(2)).toBe('89.19');
+
+      const replacedResult = zlema.replace(replacedValue);
+
+      expect(replacedResult?.toFixed(2)).toBe('82.53');
+      expect(replacedResult).not.toBe(originalResult);
+
+      const restoredResult = zlema.replace(originalValue);
+
+      expect(restoredResult).toBe(originalResult);
+    });
+
+    it('simply adds a price when there is no price to replace', () => {
+      const zlema = new ZLEMA(5);
+
+      zlema.replace(prices[0]);
+
+      for (const price of prices.slice(1, 5)) {
+        zlema.add(price);
+      }
+
+      expect(zlema.getResultOrThrow().toFixed(3)).toBe('83.477');
+    });
+  });
+
+  describe('getResultOrThrow', () => {
+    it('is compatible with results from Tulip Indicators (TI)', {tags: ['tulipindicators']}, () => {
+      const interval = 5;
+      const zlema = new ZLEMA(interval);
+      const offset = zlema.getRequiredInputs() - 1;
+
+      prices.forEach((price, i) => {
+        const result = zlema.add(price);
+
+        if (result) {
+          expect(result.toFixed(3)).toBe(expectations[i - offset]);
+        }
+      });
+
+      expect(zlema.isStable).toBe(true);
+      expect(zlema.getRequiredInputs()).toBe(interval);
+    });
+
+    it('throws an error when the smoothing has started but the interval is not yet filled', () => {
+      const zlema = new ZLEMA(5);
+
+      zlema.add(prices[0]);
+      zlema.add(prices[1]);
+
+      expect(zlema.isStable).toBe(false);
+      expect(() => zlema.getResultOrThrow()).toThrow(NotEnoughDataError);
+    });
+
+    it('tracks the price itself when the interval is 1', () => {
+      const zlema = new ZLEMA(1);
+
+      expect(zlema.add(81.59)?.toFixed(2)).toBe('81.59');
+      expect(zlema.add(82.87)?.toFixed(2)).toBe('82.87');
+      expect(zlema.getResultOrThrow().toFixed(2)).toBe('82.87');
+    });
+
+    it('tracks a steadily trending price more closely than a classic EMA', () => {
+      const interval = 5;
+      const zlema = new ZLEMA(interval);
+      const ema = new EMA(interval);
+
+      let price = 100;
+
+      for (let i = 0; i < 20; i++) {
+        price += 1;
+        zlema.add(price);
+        ema.add(price);
+      }
+
+      const zlemaLag = price - zlema.getResultOrThrow();
+      const emaLag = price - ema.getResultOrThrow();
+
+      expect(zlemaLag).toBeLessThan(emaLag);
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new ZLEMA(5),
+  divergentInput: 1_000,
+  inputs: [81.59, 81.06, 82.87, 83.0, 83.61, 83.15],
+});

--- a/packages/trading-signals/src/trend/ZLEMA/ZLEMA.ts
+++ b/packages/trading-signals/src/trend/ZLEMA/ZLEMA.ts
@@ -1,0 +1,77 @@
+import {MovingAverage} from '../MA/MovingAverage.js';
+import {NotEnoughDataError} from '../../error/index.js';
+import {pushUpdate} from '../../util/pushUpdate.js';
+
+/**
+ * Zero-Lag Exponential Moving Average (ZLEMA)
+ * Type: Trend
+ *
+ * Proposed by John Ehlers and Ric Way, the ZLEMA strips most of the lag from a classic EMA by
+ * amplifying the newest price with its gain over the price from half an interval ago, and only then
+ * smoothing that de-lagged price. The average therefore hugs turning points that a plain EMA
+ * reaches several bars later.
+ *
+ * Seeding of the smoothing matches Tulip Indicators.
+ *
+ * @see https://en.wikipedia.org/wiki/Zero_lag_exponential_moving_average
+ * @see https://tulipindicators.org/zlema
+ */
+export class ZLEMA extends MovingAverage {
+  #pricesCounter = 0;
+  readonly #lag: number;
+  readonly #prices: number[] = [];
+  readonly #weightFactor: number;
+
+  constructor(interval: number) {
+    super(interval);
+    this.#lag = Math.floor((interval - 1) / 2);
+    this.#weightFactor = 2 / (interval + 1);
+  }
+
+  override getRequiredInputs() {
+    return this.interval;
+  }
+
+  update(price: number, replace: boolean) {
+    if (!replace || this.#pricesCounter === 0) {
+      this.#pricesCounter++;
+    }
+
+    pushUpdate({array: this.#prices, item: price, maxLength: this.#lag + 1, replace});
+
+    if (this.#pricesCounter < this.#lag) {
+      return null;
+    }
+
+    const previousSmoothed = replace ? this.previousResult : this.result;
+    const deLaggedPrice = 2 * price - this.#prices[0];
+
+    let smoothed: number;
+
+    if (this.#pricesCounter === this.#lag) {
+      // Tulip Indicators seeds the smoothing with the raw price of the last bar for which no de-lagged price exists yet
+      smoothed = price;
+    } else if (previousSmoothed === undefined) {
+      // Without lag to compensate (interval <= 2), the very first de-lagged price seeds the smoothing
+      smoothed = deLaggedPrice;
+    } else {
+      smoothed = (deLaggedPrice - previousSmoothed) * this.#weightFactor + previousSmoothed;
+    }
+
+    this.setResult(smoothed, replace);
+
+    return this.#pricesCounter < this.interval ? null : smoothed;
+  }
+
+  override getResultOrThrow() {
+    if (this.#pricesCounter < this.interval) {
+      throw new NotEnoughDataError(this.getRequiredInputs());
+    }
+
+    return super.getResultOrThrow();
+  }
+
+  override get isStable() {
+    return this.#pricesCounter >= this.interval;
+  }
+}

--- a/packages/trading-signals/src/trend/index.ts
+++ b/packages/trading-signals/src/trend/index.ts
@@ -20,6 +20,7 @@ export * from './SWING_HIGH/SwingHigh.js';
 export * from './SWING_LOW/SwingLookback.js';
 export * from './SWING_LOW/SwingLow.js';
 export * from './TEMA/TEMA.js';
+export * from './TRIMA/TRIMA.js';
 export * from './VSTOP/VolatilityStop.js';
 export * from './VWAP/VWAP.js';
 export * from './WMA/WMA.js';

--- a/packages/trading-signals/src/trend/index.ts
+++ b/packages/trading-signals/src/trend/index.ts
@@ -1,4 +1,5 @@
 export * from './ADX/ADX.js';
+export * from './ALMA/ALMA.js';
 export * from './AROON/Aroon.js';
 export * from './BREAKOUT_BAR_LOW/BreakoutBarLow.js';
 export * from './CE/ChandelierExit.js';

--- a/packages/trading-signals/src/trend/index.ts
+++ b/packages/trading-signals/src/trend/index.ts
@@ -28,3 +28,4 @@ export * from './VWAP/VWAP.js';
 export * from './WMA/WMA.js';
 export * from './WSMA/WSMA.js';
 export * from './ZIGZAG/ZigZag.js';
+export * from './ZLEMA/ZLEMA.js';

--- a/packages/trading-signals/src/trend/index.ts
+++ b/packages/trading-signals/src/trend/index.ts
@@ -23,6 +23,7 @@ export * from './SWING_LOW/SwingLow.js';
 export * from './T3/T3.js';
 export * from './TEMA/TEMA.js';
 export * from './TRIMA/TRIMA.js';
+export * from './VIDYA/VIDYA.js';
 export * from './VSTOP/VolatilityStop.js';
 export * from './VWAP/VWAP.js';
 export * from './WMA/WMA.js';

--- a/packages/trading-signals/src/trend/index.ts
+++ b/packages/trading-signals/src/trend/index.ts
@@ -7,6 +7,7 @@ export * from './DEMA/DEMA.js';
 export * from './DMA/DMA.js';
 export * from './DX/DX.js';
 export * from './EMA/EMA.js';
+export * from './FRAMA/FRAMA.js';
 export * from './HIGHER_LOW_TRAIL/HigherLowTrail.js';
 export * from './HMA/HMA.js';
 export * from './KAMA/KAMA.js';

--- a/packages/trading-signals/src/trend/index.ts
+++ b/packages/trading-signals/src/trend/index.ts
@@ -19,6 +19,7 @@ export * from './SUPERTREND/SuperTrend.js';
 export * from './SWING_HIGH/SwingHigh.js';
 export * from './SWING_LOW/SwingLookback.js';
 export * from './SWING_LOW/SwingLow.js';
+export * from './T3/T3.js';
 export * from './TEMA/TEMA.js';
 export * from './TRIMA/TRIMA.js';
 export * from './VSTOP/VolatilityStop.js';


### PR DESCRIPTION
## Summary

Adds six moving average variants, each as its own commit with implementation, 100%-covered tests, docs demo, and README/barrel/`MovingAverageTypes` wiring:

| Indicator | Class | Reference verification |
|---|---|---|
| Triangular Moving Average | `TRIMA` | Tulip Indicators `untest.txt` L418–420 (odd, even + degenerate intervals) |
| Tillson T3 | `T3` | Hand-derived cascade table + properties (TA-Lib seeds stages with SMA, structurally incompatible with this repo's EMA seeding — documented in test) |
| Arnaud Legoux MA | `ALMA` | Skender.Stock.Indicators v3.0.0 committed baseline (formula reproduced to 5.7e-14) |
| Zero-Lag EMA | `ZLEMA` | Tulip Indicators `untest.txt` L497–499, `zlema.c` seeding semantics |
| Variable Index Dynamic Average | `VIDYA` | CMO-based variant (Chande & Kroll 1994; MetaTrader/TradingView convention) — hand-derived + bitwise EMA-equivalence property. Tulip's 1992 stddev variant intentionally not implemented (documented in JSDoc) |
| Fractal Adaptive MA | `FRAMA` | Ehlers paper (mesasoftware.com/papers/FRAMA.pdf) — hand-derived N1/N2/N3/D/alpha steps + flat/clamp properties |

## Notes

- All six extend `MovingAverage` and are added to the `MovingAverageTypes` union, so they are injectable as smoothing into every indicator that accepts one.
- `FRAMA` throws on odd/`< 2` intervals (fractal dimension needs two equal window halves).
- Every indicator registers the shared `testIndicatorContract` fixture (warm-up + replace-state contracts) plus bidirectional exact-value `replace()` tests.
- Docs demos added and registered for all six.

Part 1/3 of the indicator expansion (next: zero-cross oscillators, then channel/multi-value indicators — stacked PRs).