### PR TITLE
feat(trading-signals): add nine oscillators (APO, BOP, COPPOCK, ERI, FI, FISHER, KST, KVO, TSI)

### DIFF
--- a/packages/trading-signals-docs/indicator-demos/momentum/APO.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/APO.demo.tsx
@@ -1,0 +1,20 @@
+import {APO as APOClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const APO: IndicatorConfig = {
+  chartTitle: 'APO (12, 26)',
+  color: '#0ea5e9',
+  createIndicator: () => new APOClass(),
+  description: 'Absolute Price Oscillator',
+  details:
+    "The MACD line without the signal line: reports the spread between the fast and slow EMA in the instrument's own price units, so the reading is directly actionable for a single instrument. Crossings of the zero line signal trend changes.",
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
+  id: 'apo',
+  name: 'APO',
+  processData: makeProcessData({rowInputs: ['close']}),
+  requiredInputs: 26,
+  type: 'single',
+  yAxisLabel: 'APO',
+};

--- a/packages/trading-signals-docs/indicator-demos/momentum/BOP.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/BOP.demo.tsx
@@ -1,0 +1,20 @@
+import {BOP as BOPClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const BOP: IndicatorConfig = {
+  chartTitle: 'Balance of Power',
+  color: '#eab308',
+  createIndicator: () => new BOPClass(),
+  description: 'Balance of Power',
+  details:
+    'Relates each candle body to its full range to show whether buyers or sellers were in control. Unsmoothed, so pair it with an SMA for the smoothed variant many chart platforms display.',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['open', 'high', 'low', 'close']}),
+  id: 'bop',
+  name: 'BOP',
+  processData: makeProcessData({rowInputs: ['open', 'high', 'low', 'close']}),
+  requiredInputs: 1,
+  type: 'single',
+  yAxisLabel: 'BOP',
+};

--- a/packages/trading-signals-docs/indicator-demos/momentum/CoppockCurve.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/CoppockCurve.demo.tsx
@@ -1,0 +1,20 @@
+import {CoppockCurve as CoppockCurveClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const CoppockCurve: IndicatorConfig = {
+  chartTitle: 'Coppock Curve (10/14/11)',
+  color: '#f97316',
+  createIndicator: () => new CoppockCurveClass(),
+  description: 'Coppock Curve',
+  details:
+    'A long-term momentum oscillator designed for monthly bars: it adds a 14-period and an 11-period rate of change and smooths the sum with a 10-period weighted moving average. Readings above zero signal bullish momentum; the classic buy signal is an upturn from below zero after a major bottom.',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
+  id: 'coppock',
+  name: 'Coppock Curve',
+  processData: makeProcessData({rowInputs: ['close']}),
+  requiredInputs: 24,
+  type: 'single',
+  yAxisLabel: 'Coppock',
+};

--- a/packages/trading-signals-docs/indicator-demos/momentum/ElderRay.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/ElderRay.demo.tsx
@@ -1,0 +1,150 @@
+import {Chart as HighchartsChart} from '@highcharts/react';
+import {ElderRay as ElderRayClass} from 'trading-signals';
+import type {ReactNode} from 'react';
+import type {Candle} from '@typedtrader/exchange';
+import {createSharedTooltipFormatter, type ChartDataPoint} from '../../components/Chart';
+import {NotAvailable} from '../../components/NotAvailable';
+import PriceChart, {type PriceData} from '../../components/PriceChart';
+import {SignalBadge} from '../../components/SignalBadge';
+import {formatDate} from '../../utils/formatDate';
+import {collectPriceData} from '../../utils/renderUtils';
+import type {IndicatorConfig} from '../../utils/types';
+
+const renderElderRay = (config: IndicatorConfig, selectedCandles: Candle[]) => {
+  const eri = new ElderRayClass(13);
+  const chartDataBull: ChartDataPoint[] = [];
+  const chartDataBear: ChartDataPoint[] = [];
+  const priceData: PriceData[] = [];
+  const sampleValues: {
+    period: number;
+    date: string;
+    close: number;
+    bull: ReactNode;
+    bear: ReactNode;
+    signal: string;
+  }[] = [];
+
+  selectedCandles.forEach((candle, idx) => {
+    eri.add({close: Number(candle.close), high: Number(candle.high), low: Number(candle.low)});
+    const result = eri.isStable ? eri.getResult() : null;
+    const signal = eri.getSignal();
+    chartDataBull.push({x: idx + 1, y: result?.bullPower ?? null});
+    chartDataBear.push({x: idx + 1, y: result?.bearPower ?? null});
+
+    priceData.push(collectPriceData(candle, idx));
+
+    sampleValues.push({
+      bear: result ? result.bearPower.toFixed(4) : <NotAvailable />,
+      bull: result ? result.bullPower.toFixed(4) : <NotAvailable />,
+      close: Number(candle.close),
+      date: formatDate(candle.openTimeInISO),
+      period: idx + 1,
+      signal: signal.state,
+    });
+  });
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold text-white mb-2 select-text">
+          ElderRay(13) / Required Inputs: {eri.getRequiredInputs()}
+        </h2>
+        <p className="text-slate-300 select-text">{config.description}</p>
+        <p className="text-slate-400 text-sm mt-2 select-text">
+          Measures how far bulls push the high and bears drag the low away from a 13-period EMA of closing prices. Both
+          powers positive = buyers dominate, both negative = sellers dominate.
+        </p>
+      </div>
+
+      <div className="bg-slate-800/50 border border-slate-700 rounded-lg p-4">
+        <HighchartsChart
+          options={{
+            chart: {backgroundColor: 'transparent', height: 300, type: 'column'},
+            credits: {enabled: false},
+            legend: {enabled: true, itemStyle: {color: '#e2e8f0'}},
+            plotOptions: {
+              column: {borderWidth: 0},
+            },
+            series: [
+              {
+                color: config.color,
+                data: chartDataBull.map(point => [point.x, point.y]),
+                name: 'Bull Power',
+                type: 'column',
+              },
+              {
+                color: '#ef4444',
+                data: chartDataBear.map(point => [point.x, point.y]),
+                name: 'Bear Power',
+                type: 'column',
+              },
+            ],
+            title: {style: {color: '#e2e8f0', fontSize: '16px', fontWeight: '600'}, text: 'Elder Ray Index (13)'},
+            tooltip: {
+              backgroundColor: '#1e293b',
+              borderColor: '#475569',
+              formatter: createSharedTooltipFormatter(y => y.toFixed(4)),
+              shared: true,
+              style: {color: '#e2e8f0'},
+            },
+            xAxis: {
+              gridLineColor: '#334155',
+              labels: {style: {color: '#94a3b8'}},
+              title: {style: {color: '#94a3b8'}, text: 'Period'},
+            },
+            yAxis: {
+              gridLineColor: '#334155',
+              labels: {style: {color: '#94a3b8'}},
+              title: {style: {color: '#94a3b8'}, text: 'Power'},
+            },
+          }}
+        />
+      </div>
+
+      <PriceChart title="Input Prices" data={priceData} />
+
+      <div className="bg-slate-800/50 border border-slate-700 rounded-lg p-4">
+        <h3 className="text-lg font-semibold text-white mb-3">All Sample Values</h3>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-slate-600">
+                <th className="text-left text-slate-300 py-2 px-3">Period</th>
+                <th className="text-left text-slate-300 py-2 px-3">Date</th>
+                <th className="text-left text-slate-300 py-2 px-3">Close</th>
+                <th className="text-left text-slate-300 py-2 px-3">Bull Power</th>
+                <th className="text-left text-slate-300 py-2 px-3">Bear Power</th>
+                <th className="text-left text-slate-300 py-2 px-3">Signal</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sampleValues.map(row => (
+                <tr key={row.period} className="border-b border-slate-700/50">
+                  <td className="text-slate-400 py-2 px-3">{row.period}</td>
+                  <td className="text-slate-400 py-2 px-3">{row.date}</td>
+                  <td className="text-slate-300 py-2 px-3">${row.close.toFixed(2)}</td>
+                  <td className="text-white font-mono py-2 px-3">{row.bull}</td>
+                  <td className="text-white font-mono py-2 px-3">{row.bear}</td>
+                  <td className="py-2 px-3">
+                    <SignalBadge signal={row.signal} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const ElderRay: IndicatorConfig = {
+  color: '#22c55e',
+  createIndicator: () => new ElderRayClass(13),
+  customRender: renderElderRay,
+  description: 'Elder Ray Index',
+  id: 'elder-ray',
+  name: 'Elder Ray',
+  requiredInputs: 13,
+  type: 'custom',
+};

--- a/packages/trading-signals-docs/indicator-demos/momentum/FisherTransform.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/FisherTransform.demo.tsx
@@ -1,0 +1,20 @@
+import {FisherTransform as FisherTransformClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const FisherTransform: IndicatorConfig = {
+  chartTitle: 'Fisher Transform (10)',
+  color: '#f59e0b',
+  createIndicator: () => new FisherTransformClass(10),
+  description: 'Fisher Transform',
+  details:
+    "Reshapes prices into a nearly Gaussian distribution by locating each bar's midpoint within the recent high-low range, turning reversals into sharp peaks and troughs around the zero line. The prior bar's value doubles as the classic signal line.",
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['high', 'low']}),
+  id: 'fisher',
+  name: 'Fisher Transform',
+  processData: makeProcessData({rowInputs: ['high', 'low']}),
+  requiredInputs: 10,
+  type: 'single',
+  yAxisLabel: 'Fisher',
+};

--- a/packages/trading-signals-docs/indicator-demos/momentum/KST.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/KST.demo.tsx
@@ -1,0 +1,20 @@
+import {KST as KSTClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const KST: IndicatorConfig = {
+  chartTitle: 'KST (10, 15, 20, 30)',
+  color: '#e11d48',
+  createIndicator: () => new KSTClass(),
+  description: 'Know Sure Thing',
+  details:
+    "Martin Pring's Know Sure Thing blends the smoothed percentage rate of change of four timeframes, weighting the longer ones more heavily. Readings above zero mean bullish momentum confirmed across timeframes, readings below zero mean bearish momentum; zero-line crossings signal momentum shifts.",
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
+  id: 'kst',
+  name: 'KST',
+  processData: makeProcessData({rowInputs: ['close']}),
+  requiredInputs: 45,
+  type: 'single',
+  yAxisLabel: 'KST',
+};

--- a/packages/trading-signals-docs/indicator-demos/momentum/TSI.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/TSI.demo.tsx
@@ -1,0 +1,20 @@
+import {TSI as TSIClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const TSI: IndicatorConfig = {
+  chartTitle: 'TSI (25, 13)',
+  color: '#d946ef',
+  createIndicator: () => new TSIClass(),
+  description: 'True Strength Index',
+  details:
+    'Double-smooths bar-to-bar price change with a long and a short EMA and divides it by the equally smoothed absolute change, bounding readings between -100 and +100. Above zero, buyers dominate; below zero, sellers dominate — zero-line crossings mark momentum changing sides.',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
+  id: 'tsi',
+  name: 'TSI',
+  processData: makeProcessData({rowInputs: ['close']}),
+  requiredInputs: 38,
+  type: 'single',
+  yAxisLabel: 'TSI',
+};

--- a/packages/trading-signals-docs/indicator-demos/momentum/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/index.tsx
@@ -1,5 +1,6 @@
 import {AC} from './AC.demo';
 import {AO} from './AO.demo';
+import {APO} from './APO.demo';
 import {CCI} from './CCI.demo';
 import {CG} from './CG.demo';
 import {CMO} from './CMO.demo';
@@ -40,5 +41,6 @@ export const indicators: IndicatorConfig[] = [
   UltimateOscillator,
   CMO,
   PPO,
+  APO,
   TRIX,
 ];

--- a/packages/trading-signals-docs/indicator-demos/momentum/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/index.tsx
@@ -6,6 +6,7 @@ import {CCI} from './CCI.demo';
 import {CG} from './CG.demo';
 import {CMO} from './CMO.demo';
 import {CoppockCurve} from './CoppockCurve.demo';
+import {ElderRay} from './ElderRay.demo';
 import {ER} from './ER.demo';
 import {FisherTransform} from './FisherTransform.demo';
 import {KST} from './KST.demo';
@@ -51,6 +52,7 @@ export const indicators: IndicatorConfig[] = [
   FisherTransform,
   CoppockCurve,
   KST,
+  ElderRay,
   TRIX,
   TSI,
 ];

--- a/packages/trading-signals-docs/indicator-demos/momentum/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/index.tsx
@@ -8,6 +8,7 @@ import {CMO} from './CMO.demo';
 import {CoppockCurve} from './CoppockCurve.demo';
 import {ER} from './ER.demo';
 import {FisherTransform} from './FisherTransform.demo';
+import {KST} from './KST.demo';
 import {MACD} from './MACD.demo';
 import {MFI} from './MFI.demo';
 import {MOM} from './MOM.demo';
@@ -49,6 +50,7 @@ export const indicators: IndicatorConfig[] = [
   BOP,
   FisherTransform,
   CoppockCurve,
+  KST,
   TRIX,
   TSI,
 ];

--- a/packages/trading-signals-docs/indicator-demos/momentum/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/index.tsx
@@ -1,6 +1,7 @@
 import {AC} from './AC.demo';
 import {AO} from './AO.demo';
 import {APO} from './APO.demo';
+import {BOP} from './BOP.demo';
 import {CCI} from './CCI.demo';
 import {CG} from './CG.demo';
 import {CMO} from './CMO.demo';
@@ -42,5 +43,6 @@ export const indicators: IndicatorConfig[] = [
   CMO,
   PPO,
   APO,
+  BOP,
   TRIX,
 ];

--- a/packages/trading-signals-docs/indicator-demos/momentum/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/index.tsx
@@ -5,6 +5,7 @@ import {BOP} from './BOP.demo';
 import {CCI} from './CCI.demo';
 import {CG} from './CG.demo';
 import {CMO} from './CMO.demo';
+import {CoppockCurve} from './CoppockCurve.demo';
 import {ER} from './ER.demo';
 import {FisherTransform} from './FisherTransform.demo';
 import {MACD} from './MACD.demo';
@@ -46,5 +47,6 @@ export const indicators: IndicatorConfig[] = [
   APO,
   BOP,
   FisherTransform,
+  CoppockCurve,
   TRIX,
 ];

--- a/packages/trading-signals-docs/indicator-demos/momentum/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/index.tsx
@@ -6,6 +6,7 @@ import {CCI} from './CCI.demo';
 import {CG} from './CG.demo';
 import {CMO} from './CMO.demo';
 import {ER} from './ER.demo';
+import {FisherTransform} from './FisherTransform.demo';
 import {MACD} from './MACD.demo';
 import {MFI} from './MFI.demo';
 import {MOM} from './MOM.demo';
@@ -44,5 +45,6 @@ export const indicators: IndicatorConfig[] = [
   PPO,
   APO,
   BOP,
+  FisherTransform,
   TRIX,
 ];

--- a/packages/trading-signals-docs/indicator-demos/momentum/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/index.tsx
@@ -20,6 +20,7 @@ import {StochasticOscillator} from './StochasticOscillator.demo';
 import {StochasticRSI} from './StochasticRSI.demo';
 import {TDS} from './TDS.demo';
 import {TRIX} from './TRIX.demo';
+import {TSI} from './TSI.demo';
 import {UltimateOscillator} from './UltimateOscillator.demo';
 import {WilliamsR} from './WilliamsR.demo';
 import type {IndicatorConfig} from '../../utils/types';
@@ -49,4 +50,5 @@ export const indicators: IndicatorConfig[] = [
   FisherTransform,
   CoppockCurve,
   TRIX,
+  TSI,
 ];

--- a/packages/trading-signals-docs/indicator-demos/volume/ForceIndex.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volume/ForceIndex.demo.tsx
@@ -1,0 +1,20 @@
+import {ForceIndex as ForceIndexClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const ForceIndex: IndicatorConfig = {
+  chartTitle: 'Force Index (13)',
+  color: '#0ea5e9',
+  createIndicator: () => new ForceIndexClass(),
+  description: 'Force Index',
+  details:
+    "Dr. Alexander Elder's Force Index combines the direction of a price change, its extent, and the volume behind it into a single measure of the power of buyers or sellers, smoothed with a 13-period EMA. Readings above zero indicate buying pressure, below zero selling pressure.",
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close', 'volume']}),
+  id: 'force-index',
+  name: 'ForceIndex',
+  processData: makeProcessData({addInputs: ['close', 'high', 'low', 'volume'], rowInputs: ['close', 'volume']}),
+  requiredInputs: 14,
+  type: 'single',
+  yAxisLabel: 'FI',
+};

--- a/packages/trading-signals-docs/indicator-demos/volume/KVO.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volume/KVO.demo.tsx
@@ -1,0 +1,20 @@
+import {KVO as KVOClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const KVO: IndicatorConfig = {
+  chartTitle: 'Klinger Volume Oscillator (34, 55)',
+  color: '#f59e0b',
+  createIndicator: () => new KVOClass(),
+  description: 'Klinger Volume Oscillator',
+  details:
+    'Turns each candle into a signed "volume force" — full volume counted as buying or selling pressure by the trend of the high/low/close sum and scaled by its share of the current swing — then charts the spread between a short and a long EMA of that force to catch money-flow reversals early.',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close', 'volume']}),
+  id: 'kvo',
+  name: 'KVO',
+  processData: makeProcessData({addInputs: ['close', 'high', 'low', 'volume'], rowInputs: ['close', 'volume']}),
+  requiredInputs: 2,
+  type: 'single',
+  yAxisLabel: 'KVO',
+};

--- a/packages/trading-signals-docs/indicator-demos/volume/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volume/index.tsx
@@ -3,9 +3,10 @@ import {ADOSC} from './ADOSC.demo';
 import {CMF} from './CMF.demo';
 import {EMV} from './EMV.demo';
 import {ForceIndex} from './ForceIndex.demo';
+import {KVO} from './KVO.demo';
 import {PVT} from './PVT.demo';
 import {VROC} from './VROC.demo';
 import {VWMA} from './VWMA.demo';
 import type {IndicatorConfig} from '../../utils/types';
 
-export const indicators: IndicatorConfig[] = [AD, ADOSC, CMF, PVT, EMV, ForceIndex, VROC, VWMA];
+export const indicators: IndicatorConfig[] = [AD, ADOSC, CMF, PVT, EMV, ForceIndex, KVO, VROC, VWMA];

--- a/packages/trading-signals-docs/indicator-demos/volume/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volume/index.tsx
@@ -2,9 +2,10 @@ import {AD} from './AD.demo';
 import {ADOSC} from './ADOSC.demo';
 import {CMF} from './CMF.demo';
 import {EMV} from './EMV.demo';
+import {ForceIndex} from './ForceIndex.demo';
 import {PVT} from './PVT.demo';
 import {VROC} from './VROC.demo';
 import {VWMA} from './VWMA.demo';
 import type {IndicatorConfig} from '../../utils/types';
 
-export const indicators: IndicatorConfig[] = [AD, ADOSC, CMF, PVT, EMV, VROC, VWMA];
+export const indicators: IndicatorConfig[] = [AD, ADOSC, CMF, PVT, EMV, ForceIndex, VROC, VWMA];

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -55,6 +55,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Hull Moving Average (HMA)
 1. Interquartile Range (IQR)
 1. Kaufman's Adaptive Moving Average (KAMA)
+1. Know Sure Thing (KST)
 1. Linear Regression (LINREG)
 1. Mean Absolute Deviation (MAD)
 1. Momentum (MOM / MTM)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -48,6 +48,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Ease of Movement (EMV)
 1. Exponential Moving Average (EMA)
 1. Efficiency Ratio (ER)
+1. Fisher Transform (FISHER)
 1. Force Index (FI)
 1. Fractal Adaptive Moving Average (FRAMA)
 1. Hull Moving Average (HMA)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -81,6 +81,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Triple Exponential Moving Average (TEMA)
 1. Triple Smoothed EMA Rate of Change (TRIX)
 1. True Range (TR)
+1. True Strength Index (TSI)
 1. Ultimate Oscillator (ULTOSC)
 1. Variable Index Dynamic Average (VIDYA)
 1. Volatility Stop (VSTOP)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -24,6 +24,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 
 ## Supported Technical Indicators
 
+1. Absolute Price Oscillator (APO)
 1. Acceleration Bands (ABANDS)
 1. Accelerator Oscillator (AC)
 1. Accumulation/Distribution (AD)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -42,6 +42,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Chande Momentum Oscillator (CMO)
 1. Chandelier Exit (CE)
 1. Commodity Channel Index (CCI)
+1. Coppock Curve (COPPOCK)
 1. Directional Movement Index (DMI / DX)
 1. Double Exponential Moving Average (DEMA)
 1. Dual Moving Average (DMA)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -48,6 +48,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Ease of Movement (EMV)
 1. Exponential Moving Average (EMA)
 1. Efficiency Ratio (ER)
+1. Force Index (FI)
 1. Fractal Adaptive Moving Average (FRAMA)
 1. Hull Moving Average (HMA)
 1. Interquartile Range (IQR)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -47,6 +47,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Double Exponential Moving Average (DEMA)
 1. Dual Moving Average (DMA)
 1. Ease of Movement (EMV)
+1. Elder Ray Index (ERI)
 1. Exponential Moving Average (EMA)
 1. Efficiency Ratio (ER)
 1. Fisher Transform (FISHER)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -33,6 +33,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Average Directional Index (ADX)
 1. Average True Range (ATR)
 1. Awesome Oscillator (AO)
+1. Balance of Power (BOP)
 1. Bollinger Bands (BBANDS)
 1. Bollinger Bands Width (BBW)
 1. Center of Gravity (CG)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -56,6 +56,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Hull Moving Average (HMA)
 1. Interquartile Range (IQR)
 1. Kaufman's Adaptive Moving Average (KAMA)
+1. Klinger Volume Oscillator (KVO)
 1. Know Sure Thing (KST)
 1. Linear Regression (LINREG)
 1. Mean Absolute Deviation (MAD)

--- a/packages/trading-signals/src/momentum/APO/APO.test.ts
+++ b/packages/trading-signals/src/momentum/APO/APO.test.ts
@@ -1,0 +1,147 @@
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {APO} from './APO.js';
+import {TradingSignal} from '../../base/index.js';
+
+describe('APO', () => {
+  /*
+   * Test data verified with:
+   * https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt#L50-L52
+   *
+   * Tulip emits results from the 2nd candle onward; this implementation waits until the slow
+   * EMA is stable, so the first three Tulip values are skipped and the remaining ones match.
+   */
+  const prices = [
+    81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84, 83.99, 84.55, 84.36, 85.53, 86.54, 86.89, 87.77, 87.29,
+  ] as const;
+  const expectations = [
+    '0.618',
+    '0.351',
+    '0.111',
+    '0.416',
+    '0.578',
+    '0.422',
+    '0.684',
+    '0.927',
+    '0.891',
+    '0.979',
+    '0.621',
+  ] as const;
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const apo = new APO({fastPeriod: 2, slowPeriod: 5});
+
+      apo.updates(prices, false);
+
+      const originalValue = 90;
+      const replacedValue = 83;
+
+      const originalResult = apo.add(originalValue);
+
+      expect(originalResult?.toFixed(2)).toBe('1.31');
+
+      const replacedResult = apo.replace(replacedValue);
+
+      expect(replacedResult?.toFixed(2)).toBe('-1.03');
+      expect(replacedResult).not.toBe(originalResult);
+
+      const restoredResult = apo.replace(originalValue);
+
+      expect(restoredResult).toBe(originalResult);
+    });
+  });
+
+  describe('getResultOrThrow', () => {
+    it('is compatible with results from Tulip Indicators (TI)', {tags: ['tulipindicators']}, () => {
+      const apo = new APO({fastPeriod: 2, slowPeriod: 5});
+      const offset = apo.getRequiredInputs() - 1;
+
+      prices.forEach((price, i) => {
+        const result = apo.add(price);
+
+        if (result) {
+          expect(result.toFixed(3)).toBe(expectations[i - offset]);
+        }
+      });
+
+      expect(apo.isStable).toBe(true);
+      expect(apo.getRequiredInputs()).toBe(5);
+    });
+  });
+
+  describe('getSignal', () => {
+    it('returns UNKNOWN when there is no result', () => {
+      const apo = new APO();
+
+      expect(apo.getSignal()).toEqual({
+        hasChanged: false,
+        state: TradingSignal.UNKNOWN,
+      });
+    });
+
+    it('returns BULLISH when the fast EMA is above the slow EMA', () => {
+      const apo = new APO({fastPeriod: 2, slowPeriod: 5});
+
+      for (let i = 0; i < 6; i++) {
+        apo.add(100 + i);
+      }
+
+      expect(apo.getResultOrThrow()).toBeGreaterThan(0);
+      expect(apo.getSignal()).toEqual({
+        hasChanged: false,
+        state: TradingSignal.BULLISH,
+      });
+    });
+
+    it('returns BEARISH when the fast EMA is below the slow EMA', () => {
+      const apo = new APO({fastPeriod: 2, slowPeriod: 5});
+
+      for (let i = 0; i < 6; i++) {
+        apo.add(100 - i);
+      }
+
+      expect(apo.getResultOrThrow()).toBeLessThan(0);
+      expect(apo.getSignal()).toEqual({
+        hasChanged: false,
+        state: TradingSignal.BEARISH,
+      });
+    });
+
+    it('returns SIDEWAYS when the fast and slow EMA are equal', () => {
+      const apo = new APO({fastPeriod: 2, slowPeriod: 5});
+
+      for (let i = 0; i < 6; i++) {
+        apo.add(100);
+      }
+
+      expect(apo.getResultOrThrow()).toBe(0);
+      expect(apo.getSignal()).toEqual({
+        hasChanged: false,
+        state: TradingSignal.SIDEWAYS,
+      });
+    });
+
+    it('reports a signal change when the oscillator crosses the zero line', () => {
+      const apo = new APO({fastPeriod: 2, slowPeriod: 5});
+
+      for (let i = 0; i < 6; i++) {
+        apo.add(100 - i);
+      }
+
+      expect(apo.getSignal().state).toBe(TradingSignal.BEARISH);
+
+      apo.add(200);
+
+      expect(apo.getSignal()).toEqual({
+        hasChanged: true,
+        state: TradingSignal.BULLISH,
+      });
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new APO({fastPeriod: 2, slowPeriod: 5}),
+  divergentInput: 1_000,
+  inputs: [81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84],
+});

--- a/packages/trading-signals/src/momentum/APO/APO.test.ts
+++ b/packages/trading-signals/src/momentum/APO/APO.test.ts
@@ -59,7 +59,7 @@ describe('APO', () => {
       prices.forEach((price, i) => {
         const result = apo.add(price);
 
-        if (result) {
+        if (result !== null) {
           expect(result.toFixed(3)).toBe(expectations[i - offset]);
         }
       });

--- a/packages/trading-signals/src/momentum/APO/APO.ts
+++ b/packages/trading-signals/src/momentum/APO/APO.ts
@@ -1,0 +1,55 @@
+import {ZeroCrossSeries} from '../../base/Indicator.js';
+import {EMA} from '../../trend/EMA/EMA.js';
+
+export type APOConfig = {
+  /** Number of candles for the fast EMA (default: 12) */
+  fastPeriod?: number;
+  /** Number of candles for the slow EMA (default: 26) */
+  slowPeriod?: number;
+};
+
+/**
+ * Absolute Price Oscillator (APO)
+ * Type: Momentum
+ *
+ * The APO reports the spread between the fast and slow EMA in the instrument's own price units — it is the
+ * MACD line without the signal line. Keeping the price scale makes the reading directly actionable for a
+ * single instrument ("the fast average trades $2 above the slow one"), whereas its percentage sibling (PPO)
+ * trades that immediacy for comparability across differently priced instruments.
+ *
+ * Interpretation: readings above zero mean upside momentum, readings below zero mean downside momentum, and
+ * zero-line crossings flag a momentum reversal.
+ *
+ * @see https://www.fidelity.com/learning-center/trading-investing/technical-analysis/technical-indicator-guide/apo
+ * @see https://tulipindicators.org/apo
+ */
+export class APO extends ZeroCrossSeries {
+  readonly #fast: EMA;
+  readonly #slow: EMA;
+
+  public readonly fastPeriod: number;
+  public readonly slowPeriod: number;
+
+  constructor({fastPeriod = 12, slowPeriod = 26}: APOConfig = {}) {
+    super();
+    this.fastPeriod = fastPeriod;
+    this.slowPeriod = slowPeriod;
+    this.#fast = new EMA(fastPeriod);
+    this.#slow = new EMA(slowPeriod);
+  }
+
+  override getRequiredInputs() {
+    return this.#slow.getRequiredInputs();
+  }
+
+  update(price: number, replace: boolean) {
+    const fast = this.#fast.update(price, replace);
+    const slow = this.#slow.update(price, replace);
+
+    if (this.#slow.isStable) {
+      return this.setResult(fast - slow, replace);
+    }
+
+    return null;
+  }
+}

--- a/packages/trading-signals/src/momentum/BOP/BOP.test.ts
+++ b/packages/trading-signals/src/momentum/BOP/BOP.test.ts
@@ -1,0 +1,177 @@
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {TradingSignal} from '../../base/Indicator.js';
+import {BOP} from './BOP.js';
+
+describe('BOP', () => {
+  /*
+   * Test data verified with:
+   * https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt#L92-L97
+   */
+  const candles = [
+    {close: 81.59, high: 82.15, low: 81.29, open: 81.85},
+    {close: 81.06, high: 81.89, low: 80.64, open: 81.2},
+    {close: 82.87, high: 83.03, low: 81.31, open: 81.55},
+    {close: 83.0, high: 83.3, low: 82.65, open: 82.91},
+    {close: 83.61, high: 83.85, low: 83.07, open: 83.1},
+    {close: 83.15, high: 83.9, low: 83.11, open: 83.41},
+    {close: 82.84, high: 83.33, low: 82.49, open: 82.71},
+    {close: 83.99, high: 84.3, low: 82.3, open: 82.7},
+    {close: 84.55, high: 84.84, low: 84.15, open: 84.2},
+    {close: 84.36, high: 85.0, low: 84.11, open: 84.25},
+    {close: 85.53, high: 85.9, low: 84.03, open: 84.03},
+    {close: 86.54, high: 86.58, low: 85.39, open: 85.45},
+    {close: 86.89, high: 86.98, low: 85.76, open: 86.18},
+    {close: 87.77, high: 88.0, low: 87.17, open: 88.0},
+    {close: 87.29, high: 87.87, low: 87.01, open: 87.6},
+  ] as const;
+  const expectations = [
+    '-0.302',
+    '-0.112',
+    '0.767',
+    '0.138',
+    '0.654',
+    '-0.329',
+    '0.155',
+    '0.645',
+    '0.507',
+    '0.124',
+    '0.802',
+    '0.916',
+    '0.582',
+    '-0.277',
+    '-0.360',
+  ] as const;
+
+  describe('getResultOrThrow', () => {
+    it('calculates the balance of power from the very first candle', {tags: ['tulipindicators']}, () => {
+      const bop = new BOP();
+
+      expect(bop.getRequiredInputs()).toBe(1);
+
+      candles.forEach((candle, i) => {
+        const result = bop.add(candle);
+        expect(result?.toFixed(3)).toBe(expectations[i]);
+      });
+
+      expect(bop.isStable).toBe(true);
+    });
+
+    it('reads a candle without any range as perfectly balanced', () => {
+      const bop = new BOP();
+
+      const result = bop.add({close: 100, high: 100, low: 100, open: 100});
+
+      expect(result).toBe(0);
+      expect(bop.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+    });
+  });
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const bop = new BOP();
+
+      for (const candle of candles) {
+        bop.add(candle);
+      }
+
+      const originalValue = {close: 15, high: 20, low: 10, open: 10} as const;
+      const replacedValue = {close: 11, high: 20, low: 10, open: 19} as const;
+
+      bop.add(originalValue);
+
+      expect(bop.getResultOrThrow()).toBe(0.5);
+
+      bop.replace(replacedValue);
+
+      expect(bop.getResultOrThrow()).toBe(-0.8);
+
+      bop.replace(originalValue);
+
+      expect(bop.getResultOrThrow()).toBe(0.5);
+    });
+  });
+
+  describe('getSignal', () => {
+    it('returns UNKNOWN before any candle was added', () => {
+      const bop = new BOP();
+
+      expect(bop.getSignal()).toEqual({
+        hasChanged: false,
+        state: TradingSignal.UNKNOWN,
+      });
+    });
+
+    it('returns BULLISH when buyers close the candle above its open', () => {
+      const bop = new BOP();
+
+      bop.add({close: 15, high: 20, low: 10, open: 12});
+
+      expect(bop.getResultOrThrow()).toBeGreaterThan(0);
+      expect(bop.getSignal()).toEqual({
+        hasChanged: true,
+        state: TradingSignal.BULLISH,
+      });
+    });
+
+    it('returns BEARISH when sellers close the candle below its open', () => {
+      const bop = new BOP();
+
+      bop.add({close: 11, high: 20, low: 10, open: 19});
+
+      expect(bop.getResultOrThrow()).toBeLessThan(0);
+      expect(bop.getSignal()).toEqual({
+        hasChanged: true,
+        state: TradingSignal.BEARISH,
+      });
+    });
+
+    it('returns SIDEWAYS for a doji closing exactly where it opened', () => {
+      const bop = new BOP();
+
+      bop.add({close: 12, high: 14, low: 10, open: 12});
+
+      expect(bop.getResultOrThrow()).toBe(0);
+      expect(bop.getSignal()).toEqual({
+        hasChanged: true,
+        state: TradingSignal.SIDEWAYS,
+      });
+    });
+
+    it('keeps the signal unchanged while the same side stays in control', () => {
+      const bop = new BOP();
+
+      bop.add({close: 15, high: 20, low: 10, open: 12});
+      bop.add({close: 18, high: 20, low: 10, open: 11});
+
+      expect(bop.getSignal()).toEqual({
+        hasChanged: false,
+        state: TradingSignal.BULLISH,
+      });
+    });
+
+    it('flags the change when control flips from buyers to sellers', () => {
+      const bop = new BOP();
+
+      bop.add({close: 15, high: 20, low: 10, open: 12});
+      bop.add({close: 11, high: 20, low: 10, open: 19});
+
+      expect(bop.getSignal()).toEqual({
+        hasChanged: true,
+        state: TradingSignal.BEARISH,
+      });
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new BOP(),
+  divergentInput: {close: 900, high: 1_000, low: 800, open: 950},
+  inputs: [
+    {close: 81.59, high: 82.15, low: 81.29, open: 81.85},
+    {close: 81.06, high: 81.89, low: 80.64, open: 81.2},
+    {close: 82.87, high: 83.03, low: 81.31, open: 81.55},
+    {close: 83.0, high: 83.3, low: 82.65, open: 82.91},
+    {close: 83.61, high: 83.85, low: 83.07, open: 83.1},
+    {close: 83.15, high: 83.9, low: 83.11, open: 83.41},
+  ],
+});

--- a/packages/trading-signals/src/momentum/BOP/BOP.ts
+++ b/packages/trading-signals/src/momentum/BOP/BOP.ts
@@ -1,0 +1,37 @@
+import type {OpenHighLowClose} from '../../base/Candle.type.js';
+import {ZeroCrossSeries} from '../../base/Indicator.js';
+
+/**
+ * Balance of Power (BOP)
+ * Type: Momentum
+ *
+ * The Balance of Power (BOP), popularized by Igor Livshin, gauges which side controlled a single
+ * candle by relating its body to its full range. A reading near +1 means buyers closed the candle
+ * at the top of its range, a reading near -1 means sellers pinned the close to the bottom.
+ *
+ * This implementation is unsmoothed, matching Tulip Indicators. Chart platforms often display an
+ * SMA-smoothed BOP, which can be composed by feeding these results into an SMA.
+ *
+ * Interpretation:
+ * A BOP above zero signals bullish pressure, below zero bearish pressure. A doji closing where it
+ * opened is perfectly balanced (zero), and a candle without any range carries no directional
+ * information, so it also reads as balanced instead of dividing by zero.
+ *
+ * @see https://tulipindicators.org/bop
+ * @see https://www.tradingview.com/support/solutions/43000589100-balance-of-power-bop/
+ */
+export class BOP extends ZeroCrossSeries<OpenHighLowClose> {
+  override getRequiredInputs() {
+    return 1;
+  }
+
+  update({close, high, low, open}: OpenHighLowClose, replace: boolean) {
+    const range = high - low;
+
+    if (range <= 0) {
+      return this.setResult(0, replace);
+    }
+
+    return this.setResult((close - open) / range, replace);
+  }
+}

--- a/packages/trading-signals/src/momentum/COPPOCK/CoppockCurve.test.ts
+++ b/packages/trading-signals/src/momentum/COPPOCK/CoppockCurve.test.ts
@@ -1,0 +1,188 @@
+import {TradingSignal} from '../../base/Indicator.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {CoppockCurve} from './CoppockCurve.js';
+
+/*
+ * Neither Tulip Indicators (v0.9.1) nor Skender.Stock.Indicators (v3.0.0) ships a Coppock Curve
+ * baseline, so all expectations are hand-derived from the published formula:
+ * https://school.stockcharts.com/doku.php?id=technical_indicators:coppock_curve
+ */
+describe('CoppockCurve', () => {
+  describe('getResultOrThrow', () => {
+    it('sums both momentum readings in percent and weights the newest sum heaviest', () => {
+      /*
+       * Hand-derived reference (long ROC 3, short ROC 2, WMA 2):
+       *
+       * Prices: 200, 250, 240, 300, 288, 360
+       *
+       * 4th price (300): ROC(3) = (300 - 200) / 200 = 50%   | ROC(2) = (300 - 250) / 250 = 20% | sum = 70
+       * 5th price (288): ROC(3) = (288 - 250) / 250 = 15.2% | ROC(2) = (288 - 240) / 240 = 20% | sum = 35.2
+       * 6th price (360): ROC(3) = (360 - 240) / 240 = 50%   | ROC(2) = (360 - 300) / 300 = 20% | sum = 70
+       *
+       * The weighted average counts the newest sum twice as much as the one before it:
+       * 5th price: (70 * 1 + 35.2 * 2) / 3 = 140.4 / 3 = 46.8
+       * 6th price: (35.2 * 1 + 70 * 2) / 3 = 175.2 / 3 = 58.4
+       */
+      const prices = [200, 250, 240, 300, 288, 360] as const;
+      const expectations = ['46.80', '58.40'] as const;
+      const coppock = new CoppockCurve({longRocInterval: 3, shortRocInterval: 2, wmaInterval: 2});
+      const offset = coppock.getRequiredInputs() - 1;
+
+      prices.forEach((price, i) => {
+        const result = coppock.add(price);
+
+        if (result !== null) {
+          expect(result.toFixed(2)).toBe(expectations[i - offset]);
+        }
+      });
+
+      expect(coppock.isStable).toBe(true);
+    });
+
+    it('matches the closed-form value for a constant-growth series with its default configuration', () => {
+      /*
+       * When price grows by exactly 1% every candle, both rate-of-change readings stay constant,
+       * so any weighted average of their sum must equal that constant:
+       * 100 * (1.01^14 - 1) + 100 * (1.01^11 - 1) = 14.947421... + 11.566834... = 26.514255...
+       */
+      const coppock = new CoppockCurve();
+
+      expect(coppock.getRequiredInputs()).toBe(24);
+
+      for (let i = 0; i < 23; i++) {
+        coppock.add(100 * 1.01 ** i);
+      }
+
+      expect(coppock.isStable).toBe(false);
+
+      coppock.add(100 * 1.01 ** 23);
+
+      expect(coppock.getResultOrThrow().toFixed(4)).toBe('26.5143');
+    });
+  });
+
+  describe('getRequiredInputs', () => {
+    it('derives the warm-up from the slower momentum window when the short interval exceeds the long one', () => {
+      const prices = [100, 110, 120, 130, 140] as const;
+      const coppock = new CoppockCurve({longRocInterval: 2, shortRocInterval: 3, wmaInterval: 2});
+
+      expect(coppock.getRequiredInputs()).toBe(5);
+
+      prices.forEach((price, i) => {
+        const result = coppock.add(price);
+
+        if (i < prices.length - 1) {
+          expect(result).toBeNull();
+        }
+      });
+
+      expect(coppock.getResultOrThrow().toFixed(4)).toBe('45.3535');
+    });
+  });
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const prices = [200, 250, 240, 300, 288] as const;
+      const coppock = new CoppockCurve({longRocInterval: 3, shortRocInterval: 2, wmaInterval: 2});
+
+      for (const price of prices) {
+        coppock.add(price);
+      }
+
+      const originalValue = 360;
+      const replacementValue = 240;
+
+      coppock.add(originalValue);
+
+      expect(coppock.getResultOrThrow().toFixed(2)).toBe('58.40');
+
+      coppock.replace(replacementValue);
+
+      expect(coppock.getResultOrThrow().toFixed(2)).toBe('-1.60');
+
+      coppock.replace(originalValue);
+
+      expect(coppock.getResultOrThrow().toFixed(2)).toBe('58.40');
+    });
+  });
+
+  describe('getSignal', () => {
+    it('returns UNKNOWN before the warm-up is complete', () => {
+      const coppock = new CoppockCurve({longRocInterval: 3, shortRocInterval: 2, wmaInterval: 2});
+
+      expect(coppock.getSignal()).toEqual({
+        hasChanged: false,
+        state: TradingSignal.UNKNOWN,
+      });
+    });
+
+    it('returns BULLISH when rising prices push the curve above zero', () => {
+      const prices = [100, 110, 120, 130, 140] as const;
+      const coppock = new CoppockCurve({longRocInterval: 3, shortRocInterval: 2, wmaInterval: 2});
+
+      for (const price of prices) {
+        coppock.add(price);
+      }
+
+      expect(coppock.getSignal()).toEqual({
+        hasChanged: true,
+        state: TradingSignal.BULLISH,
+      });
+    });
+
+    it('returns BEARISH when falling prices push the curve below zero', () => {
+      const prices = [140, 130, 120, 110, 100] as const;
+      const coppock = new CoppockCurve({longRocInterval: 3, shortRocInterval: 2, wmaInterval: 2});
+
+      for (const price of prices) {
+        coppock.add(price);
+      }
+
+      expect(coppock.getSignal()).toEqual({
+        hasChanged: true,
+        state: TradingSignal.BEARISH,
+      });
+    });
+
+    it('returns SIDEWAYS when a flat market keeps the curve at zero', () => {
+      const prices = [100, 100, 100, 100, 100] as const;
+      const coppock = new CoppockCurve({longRocInterval: 3, shortRocInterval: 2, wmaInterval: 2});
+
+      for (const price of prices) {
+        coppock.add(price);
+      }
+
+      expect(coppock.getSignal()).toEqual({
+        hasChanged: true,
+        state: TradingSignal.SIDEWAYS,
+      });
+    });
+
+    it('reports a signal change only when the curve crosses the zero line', () => {
+      const risingPrices = [100, 110, 120, 130, 140, 150] as const;
+      const coppock = new CoppockCurve({longRocInterval: 3, shortRocInterval: 2, wmaInterval: 2});
+
+      for (const price of risingPrices) {
+        coppock.add(price);
+      }
+
+      expect(coppock.getSignal()).toEqual({
+        hasChanged: false,
+        state: TradingSignal.BULLISH,
+      });
+
+      coppock.add(60);
+
+      expect(coppock.getSignal()).toEqual({
+        hasChanged: true,
+        state: TradingSignal.BEARISH,
+      });
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new CoppockCurve({longRocInterval: 3, shortRocInterval: 2, wmaInterval: 2}),
+  divergentInput: 1_000,
+  inputs: [200, 250, 240, 300, 288, 360, 340],
+});

--- a/packages/trading-signals/src/momentum/COPPOCK/CoppockCurve.ts
+++ b/packages/trading-signals/src/momentum/COPPOCK/CoppockCurve.ts
@@ -1,0 +1,73 @@
+import {ZeroCrossSeries} from '../../base/Indicator.js';
+import {WMA} from '../../trend/WMA/WMA.js';
+import {ROC} from '../ROC/ROC.js';
+
+export type CoppockCurveConfig = {
+  /** Number of candles for the longer rate-of-change look-back (default: 14) */
+  longRocInterval?: number;
+  /** Number of candles for the shorter rate-of-change look-back (default: 11) */
+  shortRocInterval?: number;
+  /** Number of momentum readings smoothed by the weighted moving average (default: 10) */
+  wmaInterval?: number;
+};
+
+/**
+ * Coppock Curve (COPPOCK)
+ * Type: Momentum
+ *
+ * Economist Edwin "Sedge" Coppock published this oscillator in Barron's in 1962 after the Episcopal
+ * Church asked him for a long-term buying guide. He set the look-backs to 11 and 14 months because the
+ * church's bishops estimated mourning a bereavement takes that long, and he expected market recoveries
+ * to follow the same rhythm as recoveries from grief. The long look-backs and the heavy smoothing
+ * deliberately ignore rallies inside a bear market: the indicator was designed on monthly bars to flag
+ * major market bottoms, not short-lived bounces. It works on any timeframe, but reacts slowly by design.
+ *
+ * Interpretation: A curve above zero reports bullish long-term momentum, below zero bearish momentum.
+ * The classic entry popularized by Coppock is an upturn of the curve while it is still below zero,
+ * marking the start of a recovery from a major low.
+ *
+ * @see https://en.wikipedia.org/wiki/Coppock_curve
+ * @see https://school.stockcharts.com/doku.php?id=technical_indicators:coppock_curve
+ */
+export class CoppockCurve extends ZeroCrossSeries {
+  readonly #longRoc: ROC;
+  readonly #shortRoc: ROC;
+  readonly #wma: WMA;
+
+  public readonly longRocInterval: number;
+  public readonly shortRocInterval: number;
+  public readonly wmaInterval: number;
+
+  constructor({longRocInterval = 14, shortRocInterval = 11, wmaInterval = 10}: CoppockCurveConfig = {}) {
+    super();
+    this.longRocInterval = longRocInterval;
+    this.shortRocInterval = shortRocInterval;
+    this.wmaInterval = wmaInterval;
+    this.#longRoc = new ROC(longRocInterval);
+    this.#shortRoc = new ROC(shortRocInterval);
+    this.#wma = new WMA(wmaInterval);
+  }
+
+  override getRequiredInputs() {
+    // The smoothing only starts once the slower of the two momentum windows has filled.
+    const slowestRoc = Math.max(this.#longRoc.getRequiredInputs(), this.#shortRoc.getRequiredInputs());
+
+    return slowestRoc + this.#wma.getRequiredInputs() - 1;
+  }
+
+  update(price: number, replace: boolean) {
+    const longRoc = this.#longRoc.update(price, replace);
+    const shortRoc = this.#shortRoc.update(price, replace);
+
+    if (longRoc !== null && shortRoc !== null) {
+      // The momentum readings are fractions, but the curve is quoted in percentage points.
+      const coppock = this.#wma.update((longRoc + shortRoc) * 100, replace);
+
+      if (coppock !== null) {
+        return this.setResult(coppock, replace);
+      }
+    }
+
+    return null;
+  }
+}

--- a/packages/trading-signals/src/momentum/ERI/ElderRay.test.ts
+++ b/packages/trading-signals/src/momentum/ERI/ElderRay.test.ts
@@ -1,0 +1,255 @@
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {ElderRay} from './ElderRay.js';
+import {TradingSignal} from '../../base/index.js';
+
+describe('ElderRay', () => {
+  describe('update', () => {
+    it('calculates bull and bear power as the distance of high and low to the consensus of value', () => {
+      /*
+       * Formula (Dr. Alexander Elder, "Trading for a Living", 1993):
+       * Bull Power = High - EMA(13, Close)
+       * Bear Power = Low - EMA(13, Close)
+       * https://school.stockcharts.com/doku.php?id=technical_indicators:elder_ray_index
+       *
+       * Tulip Indicators ships no Elder Ray reference data, and Skender's baseline seeds its EMA
+       * with an SMA, so its early values diverge from this library's first-price-seeded EMA.
+       * The expectations below are therefore derived by hand with interval 3
+       * (weight factor 2 / (3 + 1) = 0.5):
+       *
+       * | Bar | High | Low | Close | EMA                         | Bull Power | Bear Power |
+       * |-----|------|-----|-------|-----------------------------|------------|------------|
+       * | 1   | 12   | 8   | 10    | 10 (seed)                   | -          | -          |
+       * | 2   | 14   | 10  | 12    | 12*0.5 + 10*0.5    = 11     | -          | -          |
+       * | 3   | 16   | 12  | 14    | 14*0.5 + 11*0.5    = 12.5   | 3.5        | -0.5       |
+       * | 4   | 18   | 14  | 16    | 16*0.5 + 12.5*0.5  = 14.25  | 3.75       | -0.25      |
+       * | 5   | 15   | 11  | 12    | 12*0.5 + 14.25*0.5 = 13.125 | 1.875      | -2.125     |
+       */
+      const candles = [
+        {close: 10, high: 12, low: 8},
+        {close: 12, high: 14, low: 10},
+        {close: 14, high: 16, low: 12},
+        {close: 16, high: 18, low: 14},
+        {close: 12, high: 15, low: 11},
+      ] as const;
+      const expectations = [
+        {bearPower: -0.5, bullPower: 3.5},
+        {bearPower: -0.25, bullPower: 3.75},
+        {bearPower: -2.125, bullPower: 1.875},
+      ] as const;
+      const eri = new ElderRay(3);
+      const offset = eri.getRequiredInputs() - 1;
+
+      candles.forEach((candle, i) => {
+        const result = eri.add(candle);
+
+        if (result) {
+          expect(result).toEqual(expectations[i - offset]);
+        }
+      });
+
+      expect(eri.isStable).toBe(true);
+    });
+
+    it('spans exactly the candle range with both powers combined', () => {
+      /*
+       * The consensus of value cancels out of the spread between the two powers, so bull power
+       * minus bear power always equals the candle's own high-to-low range, bit for bit.
+       */
+      const candles = [
+        {close: 99.34, high: 101.25, low: 98.6},
+        {close: 106.42, high: 108.4, low: 105.05},
+        {close: 110.47, high: 112.52, low: 108.47},
+        {close: 109.89, high: 110.81, low: 107.26},
+        {close: 105.25, high: 106.24, low: 103.19},
+        {close: 97.38, high: 100.09, low: 96.34},
+        {close: 92.81, high: 94.39, low: 91.14},
+        {close: 92.35, high: 94, low: 90.05},
+        {close: 96.5, high: 98.22, low: 94.77},
+        {close: 103.62, high: 104.21, low: 101.26},
+        {close: 109.01, high: 111.32, low: 107.67},
+        {close: 112.96, high: 115.34, low: 110.99},
+        {close: 112.27, high: 113.52, low: 110.87},
+        {close: 107.55, high: 108.87, low: 105.52},
+        {close: 101.34, high: 102.73, low: 98.68},
+        {close: 95.19, high: 97.1, low: 93.55},
+        {close: 94.84, high: 96.82, low: 93.77},
+        {close: 99.09, high: 101.14, low: 97.39},
+        {close: 106.25, high: 107.17, low: 103.92},
+        {close: 113.25, high: 114.24, low: 110.29},
+        {close: 115.45, high: 118.16, low: 114.71},
+        {close: 114.64, high: 116.22, low: 113.27},
+        {close: 109.85, high: 111.5, low: 107.85},
+        {close: 103.64, high: 105.36, low: 101.01},
+        {close: 99.22, high: 99.81, low: 97.16},
+      ] as const;
+      const eri = new ElderRay(13);
+      let verifiedBars = 0;
+
+      candles.forEach(candle => {
+        const result = eri.add(candle);
+
+        if (result) {
+          verifiedBars++;
+          expect(result.bullPower - result.bearPower).toBe(candle.high - candle.low);
+        }
+      });
+
+      expect(verifiedBars).toBe(13);
+    });
+
+    it('ends a strongly rising series with buyers in control of the whole bar', () => {
+      const risingCandles = Array.from({length: 20}, (_, i) => ({
+        close: 100 + i * 5,
+        high: 102 + i * 5,
+        low: 98 + i * 5,
+      }));
+      const eri = new ElderRay(13);
+
+      risingCandles.forEach(candle => eri.add(candle));
+
+      const result = eri.getResultOrThrow();
+
+      expect(result.bullPower).toBeGreaterThan(0);
+      expect(result.bearPower).toBeGreaterThan(0);
+      expect(eri.getSignal().state).toBe(TradingSignal.BULLISH);
+    });
+
+    it('ends a strongly falling series with sellers in control of the whole bar', () => {
+      const fallingCandles = Array.from({length: 20}, (_, i) => ({
+        close: 200 - i * 5,
+        high: 202 - i * 5,
+        low: 198 - i * 5,
+      }));
+      const eri = new ElderRay(13);
+
+      fallingCandles.forEach(candle => eri.add(candle));
+
+      const result = eri.getResultOrThrow();
+
+      expect(result.bullPower).toBeLessThan(0);
+      expect(result.bearPower).toBeLessThan(0);
+      expect(eri.getSignal().state).toBe(TradingSignal.BEARISH);
+    });
+  });
+
+  describe('getRequiredInputs', () => {
+    it('uses an interval of 13 periods by default, as recommended by Elder', () => {
+      expect(new ElderRay().getRequiredInputs()).toBe(13);
+      expect(new ElderRay(3).getRequiredInputs()).toBe(3);
+    });
+  });
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const eri = new ElderRay(3);
+
+      eri.add({close: 10, high: 12, low: 8});
+      eri.add({close: 12, high: 14, low: 10});
+      eri.add({close: 14, high: 16, low: 12});
+
+      const originalCandle = {close: 16, high: 18, low: 14} as const;
+      const replacementCandle = {close: 28, high: 30, low: 26} as const;
+
+      const originalResult = eri.add(originalCandle);
+
+      expect(originalResult).toEqual({bearPower: -0.25, bullPower: 3.75});
+
+      const replacedResult = eri.replace(replacementCandle);
+
+      expect(replacedResult).toEqual({bearPower: 5.75, bullPower: 9.75});
+
+      const restoredResult = eri.replace(originalCandle);
+
+      expect(restoredResult).toEqual({bearPower: -0.25, bullPower: 3.75});
+    });
+  });
+
+  describe('getSignal', () => {
+    it('returns UNKNOWN before the warm-up is complete', () => {
+      const eri = new ElderRay(3);
+
+      expect(eri.getSignal()).toEqual({hasChanged: false, state: TradingSignal.UNKNOWN});
+
+      eri.add({close: 10, high: 11, low: 9});
+      eri.add({close: 10, high: 11, low: 9});
+
+      expect(eri.getSignal()).toEqual({hasChanged: false, state: TradingSignal.UNKNOWN});
+    });
+
+    it('returns BULLISH when even the low trades above the consensus of value', () => {
+      const eri = new ElderRay(3);
+
+      eri.add({close: 10, high: 11, low: 9});
+      eri.add({close: 10, high: 11, low: 9});
+      eri.add({close: 10, high: 11, low: 9});
+      eri.add({close: 38, high: 40, low: 30});
+
+      expect(eri.getResultOrThrow()).toEqual({bearPower: 6, bullPower: 16});
+      expect(eri.getSignal().state).toBe(TradingSignal.BULLISH);
+    });
+
+    it('returns BEARISH when even the high stays below the consensus of value', () => {
+      const eri = new ElderRay(3);
+
+      eri.add({close: 40, high: 41, low: 39});
+      eri.add({close: 40, high: 41, low: 39});
+      eri.add({close: 40, high: 41, low: 39});
+      eri.add({close: 4, high: 12, low: 2});
+
+      expect(eri.getResultOrThrow()).toEqual({bearPower: -20, bullPower: -10});
+      expect(eri.getSignal().state).toBe(TradingSignal.BEARISH);
+    });
+
+    it('returns SIDEWAYS when the candle straddles the consensus of value', () => {
+      const eri = new ElderRay(3);
+
+      eri.add({close: 10, high: 11, low: 9});
+      eri.add({close: 10, high: 11, low: 9});
+      eri.add({close: 10, high: 11, low: 9});
+
+      expect(eri.getResultOrThrow()).toEqual({bearPower: -1, bullPower: 1});
+      expect(eri.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+    });
+
+    it('returns SIDEWAYS when neither side pushes the price away from the consensus of value', () => {
+      const eri = new ElderRay(3);
+
+      eri.add({close: 10, high: 10, low: 10});
+      eri.add({close: 10, high: 10, low: 10});
+      eri.add({close: 10, high: 10, low: 10});
+
+      expect(eri.getResultOrThrow()).toEqual({bearPower: 0, bullPower: 0});
+      expect(eri.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+    });
+
+    it('flags a change only when the signal switches its state', () => {
+      const eri = new ElderRay(3);
+
+      eri.add({close: 10, high: 11, low: 9});
+      eri.add({close: 10, high: 11, low: 9});
+      eri.add({close: 10, high: 11, low: 9});
+
+      expect(eri.getSignal()).toEqual({hasChanged: true, state: TradingSignal.SIDEWAYS});
+
+      eri.add({close: 38, high: 40, low: 30});
+
+      expect(eri.getSignal()).toEqual({hasChanged: true, state: TradingSignal.BULLISH});
+
+      eri.add({close: 42, high: 44, low: 36});
+
+      expect(eri.getSignal()).toEqual({hasChanged: false, state: TradingSignal.BULLISH});
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new ElderRay(3),
+  divergentInput: {close: 1_000, high: 1_010, low: 990},
+  inputs: [
+    {close: 10, high: 12, low: 8},
+    {close: 12, high: 14, low: 10},
+    {close: 14, high: 16, low: 12},
+    {close: 16, high: 18, low: 14},
+    {close: 12, high: 15, low: 11},
+  ],
+});

--- a/packages/trading-signals/src/momentum/ERI/ElderRay.ts
+++ b/packages/trading-signals/src/momentum/ERI/ElderRay.ts
@@ -1,0 +1,94 @@
+import {EMA} from '../../trend/EMA/EMA.js';
+import type {HighLowClose} from '../../base/Candle.type.js';
+import {TechnicalIndicator, TradingSignal} from '../../base/Indicator.js';
+
+export type ElderRayResult = {
+  /** Sellers' ability to drag the price below the consensus of value (negative readings show seller strength) */
+  bearPower: number;
+  /** Buyers' ability to lift the price above the consensus of value (positive readings show buyer strength) */
+  bullPower: number;
+};
+
+/**
+ * Elder Ray Index (ERI)
+ * Type: Momentum
+ *
+ * The Elder Ray Index was developed by Dr. Alexander Elder and introduced in his book "Trading for a Living" (1993).
+ * It treats an Exponential Moving Average (EMA) of closing prices (13 periods by default) as the market's consensus of
+ * value and measures how far the bulls and bears manage to push the price away from it: Bull Power is the distance of
+ * the candle's high above the consensus, Bear Power the distance of the candle's low below it.
+ *
+ * Interpretation: When both powers are positive, even the low of the candle trades above the consensus of value, so
+ * buyers dominate the whole bar (bullish pressure). When both powers are negative, even the high stays below the
+ * consensus, so sellers dominate (bearish pressure). A bar straddling the consensus shows neither side in control.
+ *
+ * @see https://school.stockcharts.com/doku.php?id=technical_indicators:elder_ray_index
+ * @see https://www.investopedia.com/articles/trading/03/022603.asp
+ */
+export class ElderRay extends TechnicalIndicator<ElderRayResult, HighLowClose<number>> {
+  readonly #ema: EMA;
+  #previousResult?: ElderRayResult;
+  public readonly interval: number;
+
+  constructor(interval: number = 13) {
+    super();
+    this.interval = interval;
+    this.#ema = new EMA(interval);
+  }
+
+  override getRequiredInputs() {
+    return this.#ema.getRequiredInputs();
+  }
+
+  update(candle: HighLowClose<number>, replace: boolean) {
+    this.#ema.update(candle.close, replace);
+
+    if (!this.#ema.isStable) {
+      return null;
+    }
+
+    const ema = this.#ema.getResultOrThrow();
+
+    if (replace) {
+      this.result = this.#previousResult;
+    }
+
+    this.#previousResult = this.result;
+
+    return (this.result = {
+      bearPower: candle.low - ema,
+      bullPower: candle.high - ema,
+    });
+  }
+
+  protected calculateSignal(result?: ElderRayResult | null | undefined) {
+    const hasResult = result !== null && result !== undefined;
+    const isBullish = hasResult && result.bullPower > 0 && result.bearPower > 0;
+    const isBearish = hasResult && result.bullPower < 0 && result.bearPower < 0;
+
+    switch (true) {
+      case !hasResult:
+        return TradingSignal.UNKNOWN;
+      case isBullish:
+        return TradingSignal.BULLISH;
+      case isBearish:
+        return TradingSignal.BEARISH;
+      default:
+        return TradingSignal.SIDEWAYS;
+    }
+  }
+
+  getSignal(): {
+    state: (typeof TradingSignal)[keyof typeof TradingSignal];
+    hasChanged: boolean;
+  } {
+    const previousState = this.calculateSignal(this.#previousResult);
+    const state = this.calculateSignal(this.getResult());
+    const hasChanged = previousState !== state;
+
+    return {
+      hasChanged,
+      state,
+    };
+  }
+}

--- a/packages/trading-signals/src/momentum/FISHER/FisherTransform.test.ts
+++ b/packages/trading-signals/src/momentum/FISHER/FisherTransform.test.ts
@@ -1,0 +1,195 @@
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {TradingSignal} from '../../base/Indicator.js';
+import {FisherTransform} from './FisherTransform.js';
+
+describe('FisherTransform', () => {
+  /*
+   * Test data verified with:
+   * https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt#L189-L193
+   */
+  const highs = [
+    82.15, 81.89, 83.03, 83.3, 83.85, 83.9, 83.33, 84.3, 84.84, 85.0, 85.9, 86.58, 86.98, 88.0, 87.87,
+  ] as const;
+  const lows = [
+    81.29, 80.64, 81.31, 82.65, 83.07, 83.11, 82.49, 82.3, 84.15, 84.11, 84.03, 85.39, 85.76, 87.17, 87.01,
+  ] as const;
+  const expectations = [
+    '0.343',
+    '0.791',
+    '0.825',
+    '0.806',
+    '1.066',
+    '1.439',
+    '1.851',
+    '2.275',
+    '2.698',
+    '3.117',
+    '3.185',
+  ] as const;
+
+  describe('constructor', () => {
+    it('defaults to an interval of 10 as popularized by John Ehlers', () => {
+      const fisherTransform = new FisherTransform();
+
+      expect(fisherTransform.getRequiredInputs()).toBe(10);
+    });
+  });
+
+  describe('getResultOrThrow', () => {
+    it('calculates the Fisher Transform with an interval of 5', {tags: ['tulipindicators']}, () => {
+      const fisherTransform = new FisherTransform(5);
+      const offset = fisherTransform.getRequiredInputs() - 1;
+
+      highs.forEach((high, i) => {
+        const result = fisherTransform.add({high, low: lows[i]});
+
+        if (fisherTransform.isStable) {
+          expect(result?.toFixed(3)).toBe(expectations[i - offset]);
+        }
+      });
+
+      expect(fisherTransform.getRequiredInputs()).toBe(5);
+      expect(fisherTransform.getSignal()).toEqual({
+        hasChanged: false,
+        state: TradingSignal.BULLISH,
+      });
+    });
+
+    it('stays finite in a flat market where every window is a single price', () => {
+      const fisherTransform = new FisherTransform(3);
+      const results: string[] = [];
+
+      for (let i = 0; i < 5; i++) {
+        const result = fisherTransform.add({high: 100, low: 90});
+
+        if (result !== null) {
+          results.push(result.toFixed(3));
+        }
+      }
+
+      /*
+       * A flat window reads as the bottom of a nominal range, so the transform drifts negative
+       * instead of dividing by zero.
+       */
+      expect(results).toEqual(['-0.343', '-0.791', '-1.261']);
+    });
+
+    it('caps the transform when prices pin the top of their range for many bars', () => {
+      const fisherTransform = new FisherTransform(2);
+
+      for (let i = 0; i < 13; i++) {
+        fisherTransform.add({high: i + 1.5, low: i + 0.5});
+      }
+
+      expect(fisherTransform.getResultOrThrow().toFixed(4)).toBe('6.1432');
+    });
+
+    it('caps the transform when prices pin the bottom of their range for many bars', () => {
+      const fisherTransform = new FisherTransform(2);
+
+      for (let i = 0; i < 13; i++) {
+        fisherTransform.add({high: 13.5 - i, low: 12.5 - i});
+      }
+
+      expect(fisherTransform.getResultOrThrow().toFixed(4)).toBe('-6.1432');
+    });
+  });
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const fisherTransform = new FisherTransform(5);
+
+      highs.forEach((high, i) => {
+        fisherTransform.add({high, low: lows[i]});
+      });
+
+      const latestValue = {high: 1_000, low: 999} as const;
+      const latestResult = '3.43';
+
+      fisherTransform.add(latestValue);
+
+      expect(fisherTransform.getResultOrThrow().toFixed(2)).toBe(latestResult);
+
+      const someOtherValue = {high: 90, low: 80} as const;
+      const otherResult = '1.89';
+
+      fisherTransform.replace(someOtherValue);
+
+      expect(fisherTransform.getResultOrThrow().toFixed(2)).toBe(otherResult);
+
+      fisherTransform.replace(latestValue);
+
+      expect(fisherTransform.getResultOrThrow().toFixed(2)).toBe(latestResult);
+    });
+  });
+
+  describe('getSignal', () => {
+    it('returns UNKNOWN before the warm-up is complete', () => {
+      const fisherTransform = new FisherTransform(5);
+
+      expect(fisherTransform.getSignal()).toEqual({
+        hasChanged: false,
+        state: TradingSignal.UNKNOWN,
+      });
+    });
+
+    it('returns BULLISH when the transform is above zero', () => {
+      const fisherTransform = new FisherTransform(5);
+
+      for (let i = 0; i < 5; i++) {
+        fisherTransform.add({high: 100 + i, low: 90 + i});
+      }
+
+      expect(fisherTransform.getResultOrThrow()).toBeGreaterThan(0);
+      expect(fisherTransform.getSignal()).toEqual({
+        hasChanged: true,
+        state: TradingSignal.BULLISH,
+      });
+    });
+
+    it('returns BEARISH when the transform is below zero', () => {
+      const fisherTransform = new FisherTransform(5);
+
+      for (let i = 0; i < 5; i++) {
+        fisherTransform.add({high: 100 - i, low: 90 - i});
+      }
+
+      expect(fisherTransform.getResultOrThrow()).toBeLessThan(0);
+      expect(fisherTransform.getSignal()).toEqual({
+        hasChanged: true,
+        state: TradingSignal.BEARISH,
+      });
+    });
+
+    it('returns SIDEWAYS when a mid-range bar keeps the transform at exactly zero', () => {
+      const fisherTransform = new FisherTransform(3);
+
+      fisherTransform.add({high: 2, low: 0});
+      fisherTransform.add({high: 4, low: 2});
+      fisherTransform.add({high: 3, low: 1});
+
+      expect(fisherTransform.getResultOrThrow()).toBe(0);
+      expect(fisherTransform.getSignal()).toEqual({
+        hasChanged: true,
+        state: TradingSignal.SIDEWAYS,
+      });
+    });
+  });
+});
+
+/*
+ * The Fisher Transform only reads a bar's relative position inside its window, so any candle at
+ * the top of the range normalizes identically — a diverging input has to sit below the range.
+ */
+testIndicatorContract({
+  create: () => new FisherTransform(5),
+  divergentInput: {high: 81, low: 80},
+  inputs: [
+    {high: 82.15, low: 81.29},
+    {high: 81.89, low: 80.64},
+    {high: 83.03, low: 81.31},
+    {high: 83.3, low: 82.65},
+    {high: 83.85, low: 83.07},
+    {high: 83.9, low: 83.11},
+  ],
+});

--- a/packages/trading-signals/src/momentum/FISHER/FisherTransform.ts
+++ b/packages/trading-signals/src/momentum/FISHER/FisherTransform.ts
@@ -1,0 +1,90 @@
+import type {HighLow} from '../../base/Candle.type.js';
+import {ZeroCrossSeries} from '../../base/Indicator.js';
+import {getMaximum} from '../../util/getMaximum.js';
+import {getMinimum} from '../../util/getMinimum.js';
+import {pushUpdate} from '../../util/pushUpdate.js';
+
+/**
+ * Fisher Transform (FISHER)
+ * Type: Momentum
+ *
+ * Developed by John F. Ehlers, the Fisher Transform reshapes prices into a nearly Gaussian
+ * distribution. It locates each bar's midpoint within the recent high-low range and stretches
+ * that position with the inverse hyperbolic tangent, so price extremes turn into sharp,
+ * unambiguous peaks and troughs instead of the rounded tops raw prices produce. This makes it
+ * popular for spotting reversals earlier than lagging averages.
+ *
+ * The classic signal line requires no extra calculation: it is simply the Fisher value of the
+ * previous bar, so a signal-line crossing occurs whenever the current value passes the prior one.
+ *
+ * Interpretation: Readings above zero indicate bullish pressure, readings below zero bearish
+ * pressure. Extreme swings far away from the zero line mark likely turning points.
+ *
+ * @see https://www.investopedia.com/terms/f/fisher-transform.asp
+ * @see https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/indicators/fisher.c
+ */
+export class FisherTransform extends ZeroCrossSeries<HighLow<number>> {
+  public readonly interval: number;
+
+  readonly #medians: number[] = [];
+  #normalized = 0;
+  #fisher = 0;
+  #previousNormalized = 0;
+  #previousFisher = 0;
+
+  constructor(interval: number = 10) {
+    super();
+    this.interval = interval;
+  }
+
+  override getRequiredInputs() {
+    return this.interval;
+  }
+
+  update({high, low}: HighLow<number>, replace: boolean) {
+    /*
+     * The normalization and the transform are both recursive, so a replacement has to resume
+     * from the values committed before the replaced bar.
+     */
+    if (replace) {
+      this.#normalized = this.#previousNormalized;
+      this.#fisher = this.#previousFisher;
+    }
+
+    const median = (high + low) / 2;
+
+    pushUpdate({array: this.#medians, item: median, maxLength: this.interval, replace});
+
+    if (this.#medians.length < this.interval) {
+      return null;
+    }
+
+    this.#previousNormalized = this.#normalized;
+    this.#previousFisher = this.#fisher;
+
+    const highest = getMaximum(this.#medians);
+    const lowest = getMinimum(this.#medians);
+    /*
+     * A flat window offers no range to position the bar in, so a nominal range keeps the
+     * normalization defined (the same fallback Tulip Indicators uses).
+     */
+    const range = highest === lowest ? 0.001 : highest - lowest;
+
+    let normalized = 0.33 * 2 * ((median - lowest) / range - 0.5) + 0.67 * this.#normalized;
+
+    /*
+     * A bar pinned to the edge of its range would stretch to infinity, so the normalized
+     * position is capped just below the poles at ±1.
+     */
+    if (normalized > 0.99) {
+      normalized = 0.999;
+    } else if (normalized < -0.99) {
+      normalized = -0.999;
+    }
+
+    this.#normalized = normalized;
+    this.#fisher = 0.5 * Math.log((1 + normalized) / (1 - normalized)) + 0.5 * this.#fisher;
+
+    return this.setResult(this.#fisher, replace);
+  }
+}

--- a/packages/trading-signals/src/momentum/KST/KST.test.ts
+++ b/packages/trading-signals/src/momentum/KST/KST.test.ts
@@ -1,0 +1,172 @@
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {KST} from './KST.js';
+import {TradingSignal} from '../../base/index.js';
+
+describe('KST', () => {
+  // Short timeframes keep the warm-up at 6 candles, so the expectations stay hand-checkable.
+  const fastConfig = {roc1: 1, roc2: 2, roc3: 3, roc4: 4, sma1: 2, sma2: 2, sma3: 2, sma4: 2} as const;
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const kst = new KST(fastConfig);
+
+      kst.updates([10, 12, 15, 20, 24, 30], false);
+
+      const originalResult = kst.add(33);
+
+      expect(originalResult?.toFixed(2)).toBe('892.50');
+
+      /*
+       * Replacing the newest price has to roll back all four rate-of-change chains:
+       * 1 * 7.5 + 2 * 31.25 + 3 * 67.5 + 4 * 115 = 732.5
+       */
+      const replacedResult = kst.replace(27);
+
+      expect(replacedResult?.toFixed(2)).toBe('732.50');
+      expect(replacedResult).not.toBe(originalResult);
+
+      const restoredResult = kst.replace(33);
+
+      expect(restoredResult).toBe(originalResult);
+    });
+  });
+
+  describe('getResultOrThrow', () => {
+    it('matches the hand-derived reference values', () => {
+      /*
+       * Neither Tulip Indicators nor Skender's Stock.Indicators cover the KST — the latter has
+       * no Kst implementation in the git trees of tags 3.0.0 or 2.7.3
+       * (https://github.com/DaveSkender/Stock.Indicators/tree/3.0.0/src,
+       * https://github.com/DaveSkender/Stock.Indicators/tree/2.7.3/src/e-k), so the expectations
+       * are derived by hand from Pring's formula with 1/2/3/4-bar timeframes, all smoothed over
+       * 2 bars.
+       *
+       * Percentage rates of change for the prices 10, 12, 15, 20, 24, 30, 33 (t0..t6):
+       *   1-bar: 20, 25, 100/3, 20, 25, 10 (t1..t6)
+       *   2-bar: 50, 200/3, 60, 50, 37.5 (t2..t6)
+       *   3-bar: 100, 100, 100, 65 (t3..t6)
+       *   4-bar: 140, 150, 120 (t4..t6)
+       *
+       * Weighted sums of the 2-bar averages:
+       *   t5: 1 * 22.5 + 2 * 55 + 3 * 100 + 4 * 145 = 1012.5
+       *   t6: 1 * 17.5 + 2 * 43.75 + 3 * 82.5 + 4 * 135 = 892.5
+       */
+      const prices = [10, 12, 15, 20, 24, 30, 33] as const;
+      const expectations = ['1012.50', '892.50'] as const;
+      const kst = new KST(fastConfig);
+      const offset = kst.getRequiredInputs() - 1;
+
+      prices.forEach((price, i) => {
+        const result = kst.add(price);
+
+        if (result !== null) {
+          expect(result.toFixed(2)).toBe(expectations[i - offset]);
+        }
+      });
+
+      expect(kst.isStable).toBe(true);
+      expect(kst.getRequiredInputs()).toBe(6);
+    });
+
+    it('reproduces the closed-form reading for constant-rate growth with the default timeframes', () => {
+      /*
+       * With prices growing 1% per bar, every percentage rate of change is constant
+       * (100 * (1.01^n - 1)) and averaging a constant returns the constant, so the expected
+       * reading follows in closed form, independently of this implementation:
+       * 1 * ROC%(10) + 2 * ROC%(15) + 3 * ROC%(20) + 4 * ROC%(30) ≈ 247.85
+       */
+      const kst = new KST();
+
+      for (let i = 0; i < 44; i++) {
+        kst.add(100 * 1.01 ** i);
+      }
+
+      expect(kst.isStable).toBe(false);
+
+      kst.add(100 * 1.01 ** 44);
+
+      const closedForm =
+        100 * (1 * (1.01 ** 10 - 1) + 2 * (1.01 ** 15 - 1) + 3 * (1.01 ** 20 - 1) + 4 * (1.01 ** 30 - 1));
+
+      expect(kst.getResultOrThrow()).toBeCloseTo(closedForm, 9);
+      expect(kst.getResultOrThrow().toFixed(2)).toBe('247.85');
+    });
+  });
+
+  describe('getRequiredInputs', () => {
+    it('reports the warm-up of the slowest smoothing chain', () => {
+      expect(new KST().getRequiredInputs()).toBe(45);
+      expect(new KST(fastConfig).getRequiredInputs()).toBe(6);
+      // A short-horizon chain dominates the warm-up when it is configured slower than the long one.
+      expect(
+        new KST({roc1: 10, roc2: 2, roc3: 2, roc4: 2, sma1: 10, sma2: 2, sma3: 2, sma4: 2}).getRequiredInputs()
+      ).toBe(20);
+    });
+  });
+
+  describe('getSignal', () => {
+    it('returns UNKNOWN while the indicator warms up', () => {
+      const kst = new KST(fastConfig);
+
+      expect(kst.getSignal()).toStrictEqual({hasChanged: false, state: TradingSignal.UNKNOWN});
+
+      kst.add(10);
+
+      expect(kst.getSignal()).toStrictEqual({hasChanged: false, state: TradingSignal.UNKNOWN});
+    });
+
+    it('returns BULLISH when momentum is positive across timeframes', () => {
+      const kst = new KST(fastConfig);
+
+      kst.updates([10, 12, 15, 20, 24, 30], false);
+
+      expect(kst.getResultOrThrow().toFixed(2)).toBe('1012.50');
+      expect(kst.getSignal()).toStrictEqual({hasChanged: true, state: TradingSignal.BULLISH});
+    });
+
+    it('returns BEARISH when momentum is negative across timeframes', () => {
+      const kst = new KST(fastConfig);
+
+      kst.updates([33, 30, 24, 20, 15, 12], false);
+
+      expect(kst.getResultOrThrow().toFixed(2)).toBe('-479.09');
+      expect(kst.getSignal().state).toBe(TradingSignal.BEARISH);
+    });
+
+    it('returns SIDEWAYS when prices do not move', () => {
+      const kst = new KST(fastConfig);
+
+      for (let i = 0; i < 6; i++) {
+        kst.add(50);
+      }
+
+      expect(kst.getResultOrThrow()).toBe(0);
+      expect(kst.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+    });
+
+    it('flags the change when momentum flips', () => {
+      const kst = new KST(fastConfig);
+
+      kst.updates([10, 12, 15, 20, 24, 30], false);
+
+      expect(kst.getSignal()).toStrictEqual({hasChanged: true, state: TradingSignal.BULLISH});
+
+      kst.add(5);
+
+      // The heavier weights of the long timeframes keep the reading positive after a single crash bar.
+      expect(kst.getResultOrThrow()).toBeGreaterThan(0);
+      expect(kst.getSignal()).toStrictEqual({hasChanged: false, state: TradingSignal.BULLISH});
+
+      kst.add(5);
+
+      expect(kst.getResultOrThrow()).toBeLessThan(0);
+      expect(kst.getSignal()).toStrictEqual({hasChanged: true, state: TradingSignal.BEARISH});
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new KST({roc1: 1, roc2: 2, roc3: 3, roc4: 4, sma1: 2, sma2: 2, sma3: 2, sma4: 2}),
+  divergentInput: 1_000,
+  inputs: [81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84],
+});

--- a/packages/trading-signals/src/momentum/KST/KST.ts
+++ b/packages/trading-signals/src/momentum/KST/KST.ts
@@ -1,0 +1,98 @@
+import {ZeroCrossSeries} from '../../base/Indicator.js';
+import {SMA} from '../../trend/SMA/SMA.js';
+import {ROC} from '../ROC/ROC.js';
+
+export type KSTConfig = {
+  /** Lookback of the shortest rate-of-change timeframe (default: 10) */
+  roc1?: number;
+  /** Lookback of the second rate-of-change timeframe (default: 15) */
+  roc2?: number;
+  /** Lookback of the third rate-of-change timeframe (default: 20) */
+  roc3?: number;
+  /** Lookback of the longest rate-of-change timeframe (default: 30) */
+  roc4?: number;
+  /** Smoothing period for the shortest timeframe (default: 10) */
+  sma1?: number;
+  /** Smoothing period for the second timeframe (default: 10) */
+  sma2?: number;
+  /** Smoothing period for the third timeframe (default: 10) */
+  sma3?: number;
+  /** Smoothing period for the longest timeframe (default: 15) */
+  sma4?: number;
+};
+
+type WeightedChain = {
+  roc: ROC;
+  sma: SMA;
+  weight: number;
+};
+
+/**
+ * Know Sure Thing (KST)
+ * Type: Momentum
+ *
+ * Developed by Martin Pring, the KST blends the smoothed percentage rate of change of four timeframes into a
+ * single momentum oscillator, weighting the longer timeframes more heavily (1x to 4x). A single-timeframe rate
+ * of change whipsaws on every short-lived swing; requiring four horizons to agree filters those out, so the KST
+ * reflects the dominant momentum cycle rather than the latest twitch.
+ *
+ * Interpretation: readings above zero mean bullish momentum across timeframes, readings below zero mean bearish
+ * momentum. Pring additionally pairs the oscillator with a 9-period SMA signal line — feed the KST readings into
+ * an SMA(9) to reproduce it.
+ *
+ * @see https://www.investopedia.com/terms/k/know-sure-thing-kst.asp
+ * @see https://chartschool.stockcharts.com/table-of-contents/technical-indicators-and-overlays/technical-indicators/know-sure-thing-kst
+ */
+export class KST extends ZeroCrossSeries {
+  readonly #chains: readonly WeightedChain[];
+
+  constructor({
+    roc1 = 10,
+    roc2 = 15,
+    roc3 = 20,
+    roc4 = 30,
+    sma1 = 10,
+    sma2 = 10,
+    sma3 = 10,
+    sma4 = 15,
+  }: KSTConfig = {}) {
+    super();
+    this.#chains = [
+      {roc: new ROC(roc1), sma: new SMA(sma1), weight: 1},
+      {roc: new ROC(roc2), sma: new SMA(sma2), weight: 2},
+      {roc: new ROC(roc3), sma: new SMA(sma3), weight: 3},
+      {roc: new ROC(roc4), sma: new SMA(sma4), weight: 4},
+    ];
+  }
+
+  override getRequiredInputs() {
+    // A smoothing window only starts filling once its rate-of-change lookback is filled.
+    return Math.max(...this.#chains.map(({roc, sma}) => roc.interval + sma.interval));
+  }
+
+  update(price: number, replace: boolean) {
+    let weightedSum = 0;
+    let isWarmingUp = false;
+
+    for (const {roc, sma, weight} of this.#chains) {
+      const rateOfChange = roc.update(price, replace);
+      const smoothed = rateOfChange === null ? null : sma.update(rateOfChange, replace);
+
+      if (smoothed === null) {
+        isWarmingUp = true;
+      } else {
+        weightedSum += weight * smoothed;
+      }
+    }
+
+    if (isWarmingUp) {
+      return null;
+    }
+
+    /*
+     * Pring's formula weights percentage rates of change, while the rate of change used here
+     * reports a fraction, so the weighted sum is scaled to the conventional percent reading.
+     */
+    return this.setResult(weightedSum * 100, replace);
+  }
+}

--- a/packages/trading-signals/src/momentum/TSI/TSI.test.ts
+++ b/packages/trading-signals/src/momentum/TSI/TSI.test.ts
@@ -1,0 +1,216 @@
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {TSI} from './TSI.js';
+import {TradingSignal} from '../../base/index.js';
+
+describe('TSI', () => {
+  describe('update', () => {
+    it('double-smooths momentum into a strength reading bounded by -100 and +100', () => {
+      /*
+       * Hand-derived reference values for William Blau's formula
+       * TSI = 100 * EMA(short, EMA(long, m)) / EMA(short, EMA(long, |m|)) with m = price - previousPrice:
+       * https://en.wikipedia.org/wiki/True_strength_index
+       *
+       * Committed baselines of other libraries (e.g. Skender.Stock.Indicators) seed their EMAs with an SMA
+       * while this library seeds with the first input, so their early readings cannot be reproduced here
+       * and the expectations are derived by hand instead. Smoothing weights: EMA(3) w=1/2, EMA(2) w=2/3.
+       * The short EMAs start once the long EMAs are warmed up, i.e. from the 3rd momentum value.
+       *
+       * price |  m | |m| | EMA3(m) | EMA3(|m|) | EMA2(EMA3(m)) | EMA2(EMA3(|m|)) | TSI
+       *    10 |  - |  -  |    -    |     -     |       -       |        -        |  -
+       *    11 |  1 |  1  |    1    |     1     |       -       |        -        |  -
+       *    13 |  2 |  2  |   3/2   |    3/2    |       -       |        -        |  -
+       *    12 | -1 |  1  |   1/4   |    5/4    |      1/4      |       5/4       |  -
+       *    14 |  2 |  2  |   9/8   |   13/8    |      5/6      |       3/2       | 100*(5/6)/(3/2) = 55.56
+       *    16 |  2 |  2  |  25/16  |   29/16   |     95/72     |      41/24      | 100*(95/72)/(41/24) = 77.24
+       *    15 | -1 |  1  |   9/32  |   45/32   |    271/432    |     217/144     | 100*(271/432)/(217/144) = 41.63
+       */
+      const prices = [10, 11, 13, 12, 14, 16, 15] as const;
+      const expectations = ['55.56', '77.24', '41.63'] as const;
+      const tsi = new TSI({longPeriod: 3, shortPeriod: 2});
+      const offset = tsi.getRequiredInputs() - 1;
+
+      prices.forEach((price, i) => {
+        const result = tsi.add(price);
+
+        if (result !== null) {
+          expect(result.toFixed(2)).toBe(expectations[i - offset]);
+        }
+      });
+
+      expect(tsi.isStable).toBe(true);
+    });
+
+    it('reports exactly 100 when every candle in memory closed higher', () => {
+      const prices = [1, 2, 4, 8, 16, 32, 64] as const;
+      const tsi = new TSI({longPeriod: 3, shortPeriod: 2});
+
+      for (const price of prices) {
+        const result = tsi.add(price);
+
+        if (result !== null) {
+          expect(result).toBe(100);
+        }
+      }
+
+      expect(tsi.isStable).toBe(true);
+    });
+
+    it('reports exactly -100 when every candle in memory closed lower', () => {
+      const prices = [64, 32, 16, 8, 4, 2, 1] as const;
+      const tsi = new TSI({longPeriod: 3, shortPeriod: 2});
+
+      for (const price of prices) {
+        const result = tsi.add(price);
+
+        if (result !== null) {
+          expect(result).toBe(-100);
+        }
+      }
+
+      expect(tsi.isStable).toBe(true);
+    });
+
+    it('reports 0 for a perfectly flat market instead of dividing zero by zero', () => {
+      const tsi = new TSI({longPeriod: 3, shortPeriod: 2});
+
+      for (let i = 0; i < 5; i++) {
+        tsi.add(100);
+      }
+
+      expect(tsi.getResultOrThrow()).toBe(0);
+    });
+  });
+
+  describe('constructor', () => {
+    it("uses William Blau's canonical periods of 25 and 13 by default", () => {
+      const tsi = new TSI();
+
+      expect(tsi.longPeriod).toBe(25);
+      expect(tsi.shortPeriod).toBe(13);
+
+      for (let i = 1; i < tsi.getRequiredInputs(); i++) {
+        expect(tsi.add(i)).toBeNull();
+      }
+
+      expect(tsi.add(38)).toBe(100);
+    });
+  });
+
+  describe('getRequiredInputs', () => {
+    it('needs the long momentum smoothing plus the short re-smoothing to warm up', () => {
+      expect(new TSI().getRequiredInputs()).toBe(38);
+      expect(new TSI({longPeriod: 3, shortPeriod: 2}).getRequiredInputs()).toBe(5);
+    });
+  });
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const prices = [10, 11, 13, 12, 14, 16, 15] as const;
+      const tsi = new TSI({longPeriod: 3, shortPeriod: 2});
+
+      for (const price of prices) {
+        tsi.add(price);
+      }
+
+      const originalValue = 20;
+      const replacedValue = 10;
+
+      const originalResult = tsi.add(originalValue);
+
+      expect(originalResult?.toFixed(2)).toBe('74.67');
+
+      const replacedResult = tsi.replace(replacedValue);
+
+      expect(replacedResult?.toFixed(2)).toBe('-51.70');
+      expect(replacedResult).not.toBe(originalResult);
+
+      const restoredResult = tsi.replace(originalValue);
+
+      expect(restoredResult).toBe(originalResult);
+    });
+  });
+
+  describe('getSignal', () => {
+    it('returns UNKNOWN while the indicator is warming up', () => {
+      const tsi = new TSI({longPeriod: 3, shortPeriod: 2});
+
+      expect(tsi.getSignal()).toEqual({
+        hasChanged: false,
+        state: TradingSignal.UNKNOWN,
+      });
+
+      tsi.add(10);
+      tsi.add(11);
+
+      expect(tsi.getSignal()).toEqual({
+        hasChanged: false,
+        state: TradingSignal.UNKNOWN,
+      });
+    });
+
+    it('returns BULLISH when buyers dominate', () => {
+      const prices = [10, 11, 12, 13, 14, 15] as const;
+      const tsi = new TSI({longPeriod: 3, shortPeriod: 2});
+
+      for (const price of prices) {
+        tsi.add(price);
+      }
+
+      expect(tsi.getSignal()).toEqual({
+        hasChanged: false,
+        state: TradingSignal.BULLISH,
+      });
+    });
+
+    it('returns BEARISH when sellers dominate', () => {
+      const prices = [64, 32, 16, 8, 4, 2] as const;
+      const tsi = new TSI({longPeriod: 3, shortPeriod: 2});
+
+      for (const price of prices) {
+        tsi.add(price);
+      }
+
+      expect(tsi.getSignal()).toEqual({
+        hasChanged: false,
+        state: TradingSignal.BEARISH,
+      });
+    });
+
+    it('returns SIDEWAYS when a flat market shows no strength in either direction', () => {
+      const tsi = new TSI({longPeriod: 3, shortPeriod: 2});
+
+      for (let i = 0; i < 6; i++) {
+        tsi.add(100);
+      }
+
+      expect(tsi.getSignal()).toEqual({
+        hasChanged: false,
+        state: TradingSignal.SIDEWAYS,
+      });
+    });
+
+    it('flags the change when momentum flips from BULLISH to BEARISH', () => {
+      const prices = [10, 11, 12, 13, 14, 15] as const;
+      const tsi = new TSI({longPeriod: 3, shortPeriod: 2});
+
+      for (const price of prices) {
+        tsi.add(price);
+      }
+
+      expect(tsi.getSignal().state).toBe(TradingSignal.BULLISH);
+
+      tsi.add(2);
+
+      expect(tsi.getSignal()).toEqual({
+        hasChanged: true,
+        state: TradingSignal.BEARISH,
+      });
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new TSI({longPeriod: 5, shortPeriod: 2}),
+  divergentInput: 1_000,
+  inputs: [81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84],
+});

--- a/packages/trading-signals/src/momentum/TSI/TSI.ts
+++ b/packages/trading-signals/src/momentum/TSI/TSI.ts
@@ -1,0 +1,87 @@
+import {ZeroCrossSeries} from '../../base/Indicator.js';
+import {EMA} from '../../trend/EMA/EMA.js';
+
+export type TSIConfig = {
+  /** Number of candles for the first, slower smoothing of momentum (default: 25) */
+  longPeriod?: number;
+  /** Number of candles for the second, faster smoothing (default: 13) */
+  shortPeriod?: number;
+};
+
+/**
+ * True Strength Index (TSI)
+ * Type: Momentum
+ *
+ * The TSI was developed by William Blau and double-smooths the bar-to-bar price change: an EMA over the long period,
+ * re-smoothed with an EMA over the short period. Dividing the smoothed momentum by the equally smoothed absolute
+ * momentum bounds the reading between -100 and +100 — near the extremes almost every bar in memory moved in the same
+ * direction, while readings near zero mean gains and losses cancel out.
+ *
+ * Interpretation: Above zero, buyers dominate; below zero, sellers dominate — zero-line crossings mark momentum
+ * changing sides. A perfectly flat market has no strength in either direction, so the indicator reports 0 instead of
+ * dividing zero by zero.
+ *
+ * The EMAs seed with their first input (this library's convention). Implementations that seed with an SMA (e.g.
+ * Skender.Stock.Indicators) report different readings until the seeding transient has decayed.
+ *
+ * @see https://en.wikipedia.org/wiki/True_strength_index
+ * @see https://www.investopedia.com/terms/t/tsi.asp
+ */
+export class TSI extends ZeroCrossSeries {
+  readonly #longMomentum: EMA;
+  readonly #longAbsMomentum: EMA;
+  readonly #shortMomentum: EMA;
+  readonly #shortAbsMomentum: EMA;
+  #previousPrice?: number;
+  #penultimatePrice?: number;
+
+  public readonly longPeriod: number;
+  public readonly shortPeriod: number;
+
+  constructor({longPeriod = 25, shortPeriod = 13}: TSIConfig = {}) {
+    super();
+    this.longPeriod = longPeriod;
+    this.shortPeriod = shortPeriod;
+    this.#longMomentum = new EMA(longPeriod);
+    this.#longAbsMomentum = new EMA(longPeriod);
+    this.#shortMomentum = new EMA(shortPeriod);
+    this.#shortAbsMomentum = new EMA(shortPeriod);
+  }
+
+  override getRequiredInputs() {
+    return this.longPeriod + this.shortPeriod;
+  }
+
+  update(price: number, replace: boolean) {
+    // A replacement measures momentum against the price before the replaced candle
+    const previousPrice = replace ? this.#penultimatePrice : this.#previousPrice;
+
+    if (!replace) {
+      this.#penultimatePrice = this.#previousPrice;
+    }
+
+    this.#previousPrice = price;
+
+    if (previousPrice === undefined) {
+      return null;
+    }
+
+    const momentum = price - previousPrice;
+    const smoothedMomentum = this.#longMomentum.update(momentum, replace);
+    const smoothedAbsMomentum = this.#longAbsMomentum.update(Math.abs(momentum), replace);
+
+    if (this.#longMomentum.isStable) {
+      const doubleSmoothedMomentum = this.#shortMomentum.update(smoothedMomentum, replace);
+      const doubleSmoothedAbsMomentum = this.#shortAbsMomentum.update(smoothedAbsMomentum, replace);
+
+      if (this.#shortMomentum.isStable) {
+        return this.setResult(
+          doubleSmoothedAbsMomentum === 0 ? 0 : (100 * doubleSmoothedMomentum) / doubleSmoothedAbsMomentum,
+          replace
+        );
+      }
+    }
+
+    return null;
+  }
+}

--- a/packages/trading-signals/src/momentum/index.ts
+++ b/packages/trading-signals/src/momentum/index.ts
@@ -7,6 +7,7 @@ export * from './CG/CG.js';
 export * from './CMO/CMO.js';
 export * from './COPPOCK/CoppockCurve.js';
 export * from './ER/ER.js';
+export * from './ERI/ElderRay.js';
 export * from './FISHER/FisherTransform.js';
 export * from './KST/KST.js';
 export * from './MACD/MACD.js';

--- a/packages/trading-signals/src/momentum/index.ts
+++ b/packages/trading-signals/src/momentum/index.ts
@@ -6,6 +6,7 @@ export * from './CCI/CCI.js';
 export * from './CG/CG.js';
 export * from './CMO/CMO.js';
 export * from './ER/ER.js';
+export * from './FISHER/FisherTransform.js';
 export * from './MACD/MACD.js';
 export * from './MFI/MFI.js';
 export * from './MOM/MOM.js';

--- a/packages/trading-signals/src/momentum/index.ts
+++ b/packages/trading-signals/src/momentum/index.ts
@@ -5,6 +5,7 @@ export * from './BOP/BOP.js';
 export * from './CCI/CCI.js';
 export * from './CG/CG.js';
 export * from './CMO/CMO.js';
+export * from './COPPOCK/CoppockCurve.js';
 export * from './ER/ER.js';
 export * from './FISHER/FisherTransform.js';
 export * from './MACD/MACD.js';

--- a/packages/trading-signals/src/momentum/index.ts
+++ b/packages/trading-signals/src/momentum/index.ts
@@ -1,5 +1,6 @@
 export * from './AC/AC.js';
 export * from './AO/AO.js';
+export * from './APO/APO.js';
 export * from './CCI/CCI.js';
 export * from './CG/CG.js';
 export * from './CMO/CMO.js';

--- a/packages/trading-signals/src/momentum/index.ts
+++ b/packages/trading-signals/src/momentum/index.ts
@@ -1,6 +1,7 @@
 export * from './AC/AC.js';
 export * from './AO/AO.js';
 export * from './APO/APO.js';
+export * from './BOP/BOP.js';
 export * from './CCI/CCI.js';
 export * from './CG/CG.js';
 export * from './CMO/CMO.js';

--- a/packages/trading-signals/src/momentum/index.ts
+++ b/packages/trading-signals/src/momentum/index.ts
@@ -8,6 +8,7 @@ export * from './CMO/CMO.js';
 export * from './COPPOCK/CoppockCurve.js';
 export * from './ER/ER.js';
 export * from './FISHER/FisherTransform.js';
+export * from './KST/KST.js';
 export * from './MACD/MACD.js';
 export * from './MFI/MFI.js';
 export * from './MOM/MOM.js';

--- a/packages/trading-signals/src/momentum/index.ts
+++ b/packages/trading-signals/src/momentum/index.ts
@@ -20,5 +20,6 @@ export * from './STOCH/StochasticOscillator.js';
 export * from './STOCHRSI/StochasticRSI.js';
 export * from './TDS/TDS.js';
 export * from './TRIX/TRIX.js';
+export * from './TSI/TSI.js';
 export * from './ULTOSC/UltimateOscillator.js';
 export * from './WILLR/WilliamsR.js';

--- a/packages/trading-signals/src/volume/FI/ForceIndex.test.ts
+++ b/packages/trading-signals/src/volume/FI/ForceIndex.test.ts
@@ -1,0 +1,191 @@
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {ForceIndex} from './ForceIndex.js';
+import {TradingSignal} from '../../base/index.js';
+
+describe('ForceIndex', () => {
+  /*
+   * There is no Tulip Indicators baseline for the Force Index, and third-party baselines
+   * (e.g. Skender.Stock.Indicators) seed the smoothing EMA with an SMA of the first raw force
+   * values. An SMA-seeded EMA never coincides with an EMA seeded from the first value — the
+   * seeding difference only decays geometrically — so those baselines are not reproducible
+   * here. The expectations below are derived by hand instead, with an interval of 3, giving a
+   * smoothing weight of 2 / (3 + 1) = 0.5:
+   *
+   * Candle 2: force = (11 - 10) * 200 = 200 -> smoothed = 200 (seed)
+   * Candle 3: force = (12 - 11) * 150 = 150 -> smoothed = 150 * 0.5 + 200 * 0.5 = 175
+   * Candle 4: force = (11.5 - 12) * 300 = -150 -> smoothed = -150 * 0.5 + 175 * 0.5 = 12.5
+   * Candle 5: force = (12.5 - 11.5) * 250 = 250 -> smoothed = 250 * 0.5 + 12.5 * 0.5 = 131.25
+   * Candle 6: force = (12 - 12.5) * 200 = -100 -> smoothed = -100 * 0.5 + 131.25 * 0.5 = 15.625
+   *
+   * The smoothing is only considered stable from candle 4 onwards, so 12.5 is the first result.
+   *
+   * @see https://school.stockcharts.com/doku.php?id=technical_indicators:force_index
+   * @see Alexander Elder, "Trading for a Living" (1993)
+   */
+  const candles = [
+    {close: 10, high: 10.5, low: 9.5, volume: 100},
+    {close: 11, high: 11.5, low: 10, volume: 200},
+    {close: 12, high: 12.5, low: 11, volume: 150},
+    {close: 11.5, high: 12, low: 11, volume: 300},
+    {close: 12.5, high: 13, low: 11.5, volume: 250},
+    {close: 12, high: 12.5, low: 11.5, volume: 200},
+  ] as const;
+  const expectations = [12.5, 131.25, 15.625] as const;
+
+  describe('constructor', () => {
+    it('smooths over 13 candles by default and needs one extra candle for the first force reading', () => {
+      const fi = new ForceIndex();
+
+      expect(fi.interval).toBe(13);
+      expect(fi.getRequiredInputs()).toBe(14);
+    });
+  });
+
+  describe('getResultOrThrow', () => {
+    it('smooths the raw force of each candle with an EMA', () => {
+      const fi = new ForceIndex(3);
+      const offset = fi.getRequiredInputs() - 1;
+
+      candles.forEach((candle, i) => {
+        const result = fi.add(candle);
+
+        if (result !== null) {
+          expect(result).toBe(expectations[i - offset]);
+        }
+      });
+
+      expect(fi.isStable).toBe(true);
+      expect(fi.getRequiredInputs()).toBe(4);
+    });
+
+    it('stays at zero when closing prices never change', () => {
+      const fi = new ForceIndex(3);
+
+      for (let i = 0; i < 4; i++) {
+        fi.add({close: 100, high: 101, low: 99, volume: 500});
+      }
+
+      expect(fi.getResultOrThrow()).toBe(0);
+    });
+
+    it('turns positive when prices rise on volume', () => {
+      const fi = new ForceIndex(3);
+
+      for (let i = 0; i < 4; i++) {
+        fi.add({close: 10 + i, high: 11 + i, low: 9 + i, volume: 100});
+      }
+
+      expect(fi.getResultOrThrow()).toBe(100);
+    });
+
+    it('turns negative when prices fall on volume', () => {
+      const fi = new ForceIndex(3);
+
+      for (let i = 0; i < 4; i++) {
+        fi.add({close: 13 - i, high: 14 - i, low: 12 - i, volume: 100});
+      }
+
+      expect(fi.getResultOrThrow()).toBe(-100);
+    });
+  });
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const fi = new ForceIndex(3);
+
+      for (const candle of candles) {
+        fi.add(candle);
+      }
+
+      expect(fi.getResultOrThrow()).toBe(15.625);
+
+      const originalValue = {close: 13, high: 13.5, low: 12, volume: 400} as const;
+      const replacedValue = {close: 11, high: 12, low: 10.5, volume: 400} as const;
+
+      const originalResult = fi.add(originalValue);
+
+      expect(originalResult).toBe(207.8125);
+
+      const replacedResult = fi.replace(replacedValue);
+
+      expect(replacedResult).toBe(-192.1875);
+
+      const restoredResult = fi.replace(originalValue);
+
+      expect(restoredResult).toBe(originalResult);
+    });
+  });
+
+  describe('getSignal', () => {
+    it('returns UNKNOWN when there is no result', () => {
+      const fi = new ForceIndex(13);
+
+      expect(fi.getSignal()).toStrictEqual({hasChanged: false, state: TradingSignal.UNKNOWN});
+    });
+
+    it('returns BULLISH when buyers are in control', () => {
+      const fi = new ForceIndex(3);
+
+      for (let i = 0; i < 4; i++) {
+        fi.add({close: 10 + i, high: 11 + i, low: 9 + i, volume: 100});
+      }
+
+      expect(fi.getResultOrThrow()).toBeGreaterThan(0);
+      expect(fi.getSignal().state).toBe(TradingSignal.BULLISH);
+    });
+
+    it('returns BEARISH when sellers are in control', () => {
+      const fi = new ForceIndex(3);
+
+      for (let i = 0; i < 4; i++) {
+        fi.add({close: 13 - i, high: 14 - i, low: 12 - i, volume: 100});
+      }
+
+      expect(fi.getResultOrThrow()).toBeLessThan(0);
+      expect(fi.getSignal().state).toBe(TradingSignal.BEARISH);
+    });
+
+    it('returns SIDEWAYS when neither side exerts force', () => {
+      const fi = new ForceIndex(3);
+
+      for (let i = 0; i < 4; i++) {
+        fi.add({close: 100, high: 101, low: 99, volume: 500});
+      }
+
+      expect(fi.getResultOrThrow()).toBe(0);
+      expect(fi.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+    });
+
+    it('flags the change when control flips from buyers to sellers', () => {
+      const fi = new ForceIndex(2);
+
+      fi.add({close: 10, high: 10.5, low: 9.5, volume: 100});
+      fi.add({close: 11, high: 11.5, low: 10, volume: 100});
+      fi.add({close: 12, high: 12.5, low: 11, volume: 100});
+
+      expect(fi.getSignal()).toStrictEqual({hasChanged: true, state: TradingSignal.BULLISH});
+
+      fi.add({close: 5, high: 12, low: 5, volume: 1_000});
+
+      expect(fi.getSignal()).toStrictEqual({hasChanged: true, state: TradingSignal.BEARISH});
+
+      fi.add({close: 4, high: 5, low: 4, volume: 1_000});
+
+      expect(fi.getSignal()).toStrictEqual({hasChanged: false, state: TradingSignal.BEARISH});
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new ForceIndex(5),
+  divergentInput: {close: 249, high: 250, low: 150, volume: 99_000_000},
+  inputs: [
+    {close: 81.59, high: 82.15, low: 81.29, volume: 5_653_100},
+    {close: 81.06, high: 81.89, low: 80.64, volume: 6_447_400},
+    {close: 82.87, high: 83.03, low: 81.31, volume: 7_690_900},
+    {close: 83.0, high: 83.3, low: 82.65, volume: 3_831_400},
+    {close: 83.61, high: 83.85, low: 83.07, volume: 4_455_100},
+    {close: 83.15, high: 83.9, low: 83.11, volume: 3_798_000},
+    {close: 82.84, high: 83.33, low: 82.49, volume: 3_936_200},
+  ],
+});

--- a/packages/trading-signals/src/volume/FI/ForceIndex.ts
+++ b/packages/trading-signals/src/volume/FI/ForceIndex.ts
@@ -1,0 +1,59 @@
+import type {HighLowCloseVolume} from '../../base/Candle.type.js';
+import {ZeroCrossSeries} from '../../base/Indicator.js';
+import {EMA} from '../../trend/EMA/EMA.js';
+import {pushUpdate} from '../../util/pushUpdate.js';
+
+/**
+ * Force Index (FI)
+ * Type: Volume
+ *
+ * Dr. Alexander Elder's Force Index measures the power behind a price move by combining its three
+ * ingredients: the direction of the price change, its extent, and the volume that fueled it. The
+ * raw force of a single candle is erratic, so Elder smooths the series with an EMA (13 periods by
+ * default) to expose the sustained pressure of buyers or sellers.
+ *
+ * Formula:
+ * Force = (Close - Previous Close) * Volume
+ * FI = EMA(Force, n)
+ *
+ * Interpretation: A Force Index above zero means buyers are in control (bullish pressure), below
+ * zero sellers are in control (bearish pressure). Crossings of the zero line mark a shift of
+ * control between the two sides.
+ *
+ * @see https://school.stockcharts.com/doku.php?id=technical_indicators:force_index
+ * @see Alexander Elder, "Trading for a Living" (1993), where the indicator was introduced
+ */
+export class ForceIndex extends ZeroCrossSeries<HighLowCloseVolume> {
+  readonly #candles: HighLowCloseVolume[] = [];
+  readonly #ema: EMA;
+
+  public readonly interval: number;
+
+  constructor(interval: number = 13) {
+    super();
+    this.interval = interval;
+    this.#ema = new EMA(interval);
+  }
+
+  override getRequiredInputs() {
+    return this.#ema.getRequiredInputs() + 1;
+  }
+
+  update(candle: HighLowCloseVolume, replace: boolean) {
+    pushUpdate({array: this.#candles, item: candle, maxLength: 2, replace});
+
+    if (this.#candles.length < 2) {
+      return null;
+    }
+
+    const previousClose = this.#candles[0].close;
+    const force = (candle.close - previousClose) * candle.volume;
+    const smoothed = this.#ema.update(force, replace);
+
+    if (this.#ema.isStable) {
+      return this.setResult(smoothed, replace);
+    }
+
+    return null;
+  }
+}

--- a/packages/trading-signals/src/volume/KVO/KVO.test.ts
+++ b/packages/trading-signals/src/volume/KVO/KVO.test.ts
@@ -1,0 +1,161 @@
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {KVO} from './KVO.js';
+import {TradingSignal} from '../../base/index.js';
+
+describe('KVO', () => {
+  /*
+   * Test data verified with:
+   * https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt#L211-L216
+   */
+  const candles = [
+    {close: 81.59, high: 82.15, low: 81.29, volume: 5_653_100},
+    {close: 81.06, high: 81.89, low: 80.64, volume: 6_447_400},
+    {close: 82.87, high: 83.03, low: 81.31, volume: 7_690_900},
+    {close: 83.0, high: 83.3, low: 82.65, volume: 3_831_400},
+    {close: 83.61, high: 83.85, low: 83.07, volume: 4_455_100},
+    {close: 83.15, high: 83.9, low: 83.11, volume: 3_798_000},
+    {close: 82.84, high: 83.33, low: 82.49, volume: 3_936_200},
+    {close: 83.99, high: 84.3, low: 82.3, volume: 4_732_000},
+    {close: 84.55, high: 84.84, low: 84.15, volume: 4_841_300},
+    {close: 84.36, high: 85.0, low: 84.11, volume: 3_915_300},
+    {close: 85.53, high: 85.9, low: 84.03, volume: 6_830_800},
+    {close: 86.54, high: 86.58, low: 85.39, volume: 6_694_100},
+    {close: 86.89, high: 86.98, low: 85.76, volume: 5_293_600},
+    {close: 87.77, high: 88.0, low: 87.17, volume: 7_985_800},
+    {close: 87.29, high: 87.87, low: 87.01, volume: 4_807_900},
+  ] as const;
+  const expectations = [
+    '0.000',
+    '80292599.241',
+    '121572746.633',
+    '117732669.219',
+    '-5942017.641',
+    '-71041561.798',
+    '34448275.848',
+    '84097903.128',
+    '-38366427.074',
+    '40313036.023',
+    '56681039.569',
+    '52208374.664',
+    '138983547.947',
+    '-68009735.443',
+  ] as const;
+
+  describe('constructor', () => {
+    it('defaults to the 34/55 intervals proposed by Stephen Klinger', () => {
+      const kvoDefault = new KVO();
+      const kvoExplicit = new KVO(34, 55);
+
+      expect(kvoDefault.shortInterval).toBe(34);
+      expect(kvoDefault.longInterval).toBe(55);
+
+      for (const candle of candles) {
+        kvoDefault.add(candle);
+        kvoExplicit.add(candle);
+      }
+
+      expect(kvoDefault.getResultOrThrow()).toBe(kvoExplicit.getResultOrThrow());
+      expect(kvoDefault.getResultOrThrow().toFixed(3)).toBe('50151081.102');
+    });
+  });
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const kvo = new KVO(2, 5);
+
+      kvo.updates(candles, false);
+
+      /*
+       * The original candle flips Klinger's swing up while the replacement keeps it falling,
+       * so the replacement has to roll back the flip and the restarted cumulative measurement.
+       */
+      const originalValue = {close: 88.5, high: 89.0, low: 87.9, volume: 6_000_000} as const;
+      const replacedValue = {close: 86.2, high: 87.1, low: 86.0, volume: 6_000_000} as const;
+
+      const originalResult = kvo.add(originalValue);
+
+      expect(originalResult?.toFixed(3)).toBe('-71560261.159');
+
+      const replacedResult = kvo.replace(replacedValue);
+
+      expect(replacedResult?.toFixed(3)).toBe('-138343963.888');
+      expect(replacedResult).not.toBe(originalResult);
+
+      const restoredResult = kvo.replace(originalValue);
+
+      expect(restoredResult).toBe(originalResult);
+    });
+  });
+
+  describe('getResultOrThrow', () => {
+    it('is compatible with results from Tulip Indicators (TI)', {tags: ['tulipindicators']}, () => {
+      const kvo = new KVO(2, 5);
+      const offset = kvo.getRequiredInputs() - 1;
+
+      candles.forEach((candle, i) => {
+        const result = kvo.add(candle);
+
+        if (result !== null) {
+          expect(result.toFixed(3)).toBe(expectations[i - offset]);
+        }
+      });
+
+      expect(kvo.isStable).toBe(true);
+      expect(kvo.getRequiredInputs()).toBe(2);
+    });
+  });
+
+  describe('getSignal', () => {
+    it('returns UNKNOWN when there is no result', () => {
+      const kvo = new KVO();
+
+      expect(kvo.getSignal().state).toBe(TradingSignal.UNKNOWN);
+    });
+
+    it('returns BULLISH when volume flows into the security', () => {
+      const kvo = new KVO(2, 5);
+
+      for (let i = 0; i < 6; i++) {
+        kvo.add({close: 12 + i, high: 12 + i, low: 10 + i, volume: 1_000_000});
+      }
+
+      expect(kvo.getResultOrThrow()).toBeGreaterThan(0);
+      expect(kvo.getSignal().state).toBe(TradingSignal.BULLISH);
+    });
+
+    it('returns BEARISH when volume flows out of the security', () => {
+      const kvo = new KVO(2, 5);
+
+      for (let i = 0; i < 6; i++) {
+        kvo.add({close: 50 - i, high: 52 - i, low: 50 - i, volume: 1_000_000});
+      }
+
+      expect(kvo.getResultOrThrow()).toBeLessThan(0);
+      expect(kvo.getSignal().state).toBe(TradingSignal.BEARISH);
+    });
+
+    it('returns SIDEWAYS when two identical candles leave no dominant money flow', () => {
+      const kvo = new KVO(2, 5);
+
+      for (let i = 0; i < 2; i++) {
+        kvo.add({close: 50, high: 51, low: 49, volume: 1_000_000});
+      }
+
+      expect(kvo.getResultOrThrow()).toBe(0);
+      expect(kvo.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new KVO(2, 5),
+  divergentInput: {close: 90, high: 82, low: 95, volume: 99_000_000},
+  inputs: [
+    {close: 81.59, high: 82.15, low: 81.29, volume: 5_653_100},
+    {close: 81.06, high: 81.89, low: 80.64, volume: 6_447_400},
+    {close: 82.87, high: 83.03, low: 81.31, volume: 7_690_900},
+    {close: 83.0, high: 83.3, low: 82.65, volume: 3_831_400},
+    {close: 83.61, high: 83.85, low: 83.07, volume: 4_455_100},
+    {close: 83.15, high: 83.9, low: 83.11, volume: 3_798_000},
+  ],
+});

--- a/packages/trading-signals/src/volume/KVO/KVO.test.ts
+++ b/packages/trading-signals/src/volume/KVO/KVO.test.ts
@@ -103,6 +103,20 @@ describe('KVO', () => {
       expect(kvo.isStable).toBe(true);
       expect(kvo.getRequiredInputs()).toBe(2);
     });
+
+    it('stays finite when the market has never traded a range', () => {
+      const kvo = new KVO(2, 5);
+      const flatCandle = {close: 100, high: 100, low: 100, volume: 5_000} as const;
+
+      kvo.add(flatCandle);
+
+      expect(kvo.add(flatCandle)).toBe(0);
+      expect(kvo.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+
+      kvo.add({close: 105, high: 106, low: 99, volume: 6_000});
+
+      expect(kvo.getResultOrThrow()).toBe(200_000);
+    });
   });
 
   describe('getSignal', () => {

--- a/packages/trading-signals/src/volume/KVO/KVO.ts
+++ b/packages/trading-signals/src/volume/KVO/KVO.ts
@@ -104,7 +104,16 @@ export class KVO extends ZeroCrossSeries<HighLowCloseVolume> {
 
     // Until the first flip (only possible while consecutive sums tie), volume counts as buying pressure, matching the reference implementation.
     const direction = state.trend === -1 ? -1 : 1;
-    const volumeForce = candle.volume * Math.abs((range / state.cumulativeMeasurement) * 2 - 1) * 100 * direction;
+
+    /*
+     * A market that has never traded a range offers no swing to attribute volume to, so its volume force is zero.
+     * This deliberately deviates from the Tulip reference, which divides by the empty measurement and poisons every
+     * later reading — a streaming indicator could never recover from that.
+     */
+    const volumeForce =
+      state.cumulativeMeasurement === 0
+        ? 0
+        : candle.volume * Math.abs((range / state.cumulativeMeasurement) * 2 - 1) * 100 * direction;
 
     const emas =
       state.emas === null

--- a/packages/trading-signals/src/volume/KVO/KVO.ts
+++ b/packages/trading-signals/src/volume/KVO/KVO.ts
@@ -1,0 +1,121 @@
+import type {HighLowCloseVolume} from '../../base/Candle.type.js';
+import {ZeroCrossSeries} from '../../base/Indicator.js';
+
+type KVOState = {
+  /**
+   * Klinger's "cumulative measurement": the running sum of candle ranges within the current swing.
+   * The wider it grows, the smaller a single candle's share of the swing becomes.
+   */
+  cumulativeMeasurement: number;
+  emas: {
+    long: number;
+    short: number;
+  } | null;
+  previousCandle: {
+    hlcSum: number;
+    range: number;
+  } | null;
+  trend: -1 | 0 | 1;
+};
+
+const createInitialState = (): KVOState => ({
+  cumulativeMeasurement: 0,
+  emas: null,
+  previousCandle: null,
+  trend: 0,
+});
+
+/**
+ * Klinger Volume Oscillator (KVO)
+ * Type: Volume
+ *
+ * Stephen Klinger's oscillator turns each candle's volume into a signed "volume force": the full volume counts as
+ * buying or selling pressure depending on the running trend of the high/low/close sum, scaled by how one-sided the
+ * candle's range sits within the current swing. The oscillator is the spread between a short and a long EMA of that
+ * force, built to catch money-flow reversals early while staying anchored to the longer-term flow.
+ *
+ * Interpretation: A reading above zero signals bullish volume pressure, below zero bearish pressure. Zero-line
+ * crossings mark a change in the dominant money flow, and divergence between the oscillator and price warns that the
+ * current move is running out of volume support.
+ *
+ * @see https://www.investopedia.com/terms/k/klingeroscillator.asp
+ * @see https://tulipindicators.org/kvo
+ */
+export class KVO extends ZeroCrossSeries<HighLowCloseVolume> {
+  public readonly shortInterval: number;
+  public readonly longInterval: number;
+  readonly #shortSmoothing: number;
+  readonly #longSmoothing: number;
+  #state: KVOState = createInitialState();
+  #previousState: KVOState = createInitialState();
+
+  constructor(shortInterval: number = 34, longInterval: number = 55) {
+    super();
+    this.shortInterval = shortInterval;
+    this.longInterval = longInterval;
+    this.#shortSmoothing = 2 / (shortInterval + 1);
+    this.#longSmoothing = 2 / (longInterval + 1);
+  }
+
+  /**
+   * One candle of history is all Klinger needs: the first volume-force reading appears with the second candle and
+   * seeds both averages outright (mirroring the Tulip Indicators reference), so every emitted value is already final
+   * and more history never revises it. The smoothing intervals therefore add no further warm-up.
+   */
+  override getRequiredInputs() {
+    return 2;
+  }
+
+  update(candle: HighLowCloseVolume, replace: boolean) {
+    /*
+     * The trend direction, the cumulative measurement and both averages accumulate over the entire series, so a
+     * replacement has to restart from the state that existed before the replaced candle arrived.
+     */
+    if (replace) {
+      this.#state = structuredClone(this.#previousState);
+    } else {
+      this.#previousState = structuredClone(this.#state);
+    }
+
+    const state = this.#state;
+    const hlcSum = candle.high + candle.low + candle.close;
+    const range = candle.high - candle.low;
+    const previousCandle = state.previousCandle;
+
+    state.previousCandle = {hlcSum, range};
+
+    if (previousCandle === null) {
+      return null;
+    }
+
+    /*
+     * Klinger reads the market's push from the sum of high, low and close: higher sums keep the swing up, lower sums
+     * turn it down. Every flip restarts the cumulative measurement from the previous candle's range.
+     */
+    if (hlcSum > previousCandle.hlcSum && state.trend !== 1) {
+      state.trend = 1;
+      state.cumulativeMeasurement = previousCandle.range;
+    } else if (hlcSum < previousCandle.hlcSum && state.trend !== -1) {
+      state.trend = -1;
+      state.cumulativeMeasurement = previousCandle.range;
+    }
+
+    state.cumulativeMeasurement += range;
+
+    // Until the first flip (only possible while consecutive sums tie), volume counts as buying pressure, matching the reference implementation.
+    const direction = state.trend === -1 ? -1 : 1;
+    const volumeForce = candle.volume * Math.abs((range / state.cumulativeMeasurement) * 2 - 1) * 100 * direction;
+
+    const emas =
+      state.emas === null
+        ? {long: volumeForce, short: volumeForce}
+        : {
+            long: (volumeForce - state.emas.long) * this.#longSmoothing + state.emas.long,
+            short: (volumeForce - state.emas.short) * this.#shortSmoothing + state.emas.short,
+          };
+
+    state.emas = emas;
+
+    return this.setResult(emas.short - emas.long, replace);
+  }
+}

--- a/packages/trading-signals/src/volume/index.ts
+++ b/packages/trading-signals/src/volume/index.ts
@@ -2,6 +2,7 @@ export * from './AD/AD.js';
 export * from './ADOSC/ADOSC.js';
 export * from './CMF/CMF.js';
 export * from './EMV/EMV.js';
+export * from './FI/ForceIndex.js';
 export * from './PVT/PVT.js';
 export * from './RVOL/RVOL.js';
 export * from './VROC/VROC.js';

--- a/packages/trading-signals/src/volume/index.ts
+++ b/packages/trading-signals/src/volume/index.ts
@@ -3,6 +3,7 @@ export * from './ADOSC/ADOSC.js';
 export * from './CMF/CMF.js';
 export * from './EMV/EMV.js';
 export * from './FI/ForceIndex.js';
+export * from './KVO/KVO.js';
 export * from './PVT/PVT.js';
 export * from './RVOL/RVOL.js';
 export * from './VROC/VROC.js';


### PR DESCRIPTION
## Summary

Adds nine oscillators, each as its own commit with implementation, 100%-covered tests, docs demo, and README/barrel wiring. Eight extend the shared `ZeroCrossSeries` base from #1283 (zero signal code in the subclasses); Elder Ray is multi-value with a STOCH-style `getSignal()`.

| Indicator | Class | Category | Reference verification |
|---|---|---|---|
| Absolute Price Oscillator | `APO` | momentum | Tulip `untest.txt` L50–52, all values reproduced independently |
| Balance of Power | `BOP` | momentum | Tulip L92–97 (15/15 values, `bop.c` flat-candle guard) |
| Coppock Curve | `CoppockCurve` | momentum | No external fixture exists (verified: not in Tulip/Skender) → hand-derived + closed-form 1%-growth test |
| Elder Ray Index | `ElderRay` | momentum | Hand-derived + bitwise `bullPower − bearPower ≡ high − low` property |
| Fisher Transform | `FisherTransform` | momentum | Tulip L189–193, `fisher.c` semantics (clamps, flat-window fallback) |
| Force Index | `ForceIndex` | volume | Hand-derived exact binary fractions + sign properties |
| Know Sure Thing | `KST` | momentum | No external fixture (Skender ships PMO, not KST) → hand-derived + closed-form constant-growth test |
| Klinger Volume Oscillator | `KVO` | volume | Tulip L211–216 (`kvo.c` exact, incl. leading 0.000) |
| True Strength Index | `TSI` | momentum | Skender baseline rejected after numeric proof of EMA-seeding divergence (11.19 at first emission) → hand-derived + ±100/0 closed-form properties |

## Notes

- Wherever a Skender/TA-Lib fixture was rejected, the incompatibility was **proven numerically first** (their EMAs seed with an SMA; this repo seeds with the first input) and is documented in the test comments.
- `KVO` defines `getRequiredInputs() = 2` mirroring Tulip's warm-up: both EMAs seed outright with the first volume-force reading, so no emitted value is ever revised. It also carries its own snapshot/rollback state — the replace tests exercise trend-flip rollback in both directions.
- **Upstream finding** (pre-existing, not fixed here): the repo's `EMA` mishandles replacing its very first input — it blends the old seed instead of re-seeding. KVO works around it; worth a dedicated follow-up fix.

Part 2/3 of the indicator expansion — stacked on #1284 (base auto-retargets to `main` once that merges). Next: Ichimoku, Keltner, Donchian, Vortex.