### PR TITLE
feat(trading-signals): add Ichimoku Cloud, Keltner/Donchian Channels and Vortex Indicator

### DIFF
--- a/packages/trading-signals-docs/indicator-demos/trend/IchimokuCloud.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/IchimokuCloud.demo.tsx
@@ -1,0 +1,167 @@
+import {Chart as HighchartsChart} from '@highcharts/react';
+import {IchimokuCloud as IchimokuCloudClass} from 'trading-signals';
+import type {ReactNode} from 'react';
+import type {Candle} from '@typedtrader/exchange';
+import {createSharedTooltipFormatter, type ChartDataPoint} from '../../components/Chart';
+import {NotAvailable} from '../../components/NotAvailable';
+import PriceChart, {type PriceData} from '../../components/PriceChart';
+import {formatDate} from '../../utils/formatDate';
+import {collectPriceData} from '../../utils/renderUtils';
+import type {IndicatorConfig} from '../../utils/types';
+
+const renderIchimokuCloud = (config: IndicatorConfig, selectedCandles: Candle[]) => {
+  const ichimoku = new IchimokuCloudClass();
+  const chartDataConversion: ChartDataPoint[] = [];
+  const chartDataBase: ChartDataPoint[] = [];
+  const chartDataSpanA: ChartDataPoint[] = [];
+  const chartDataSpanB: ChartDataPoint[] = [];
+  const priceData: PriceData[] = [];
+  const sampleValues: {
+    period: number;
+    date: string;
+    close: number;
+    conversion: ReactNode;
+    base: ReactNode;
+    spanA: ReactNode;
+    spanB: ReactNode;
+  }[] = [];
+
+  selectedCandles.forEach((candle, idx) => {
+    const result = ichimoku.add({high: Number(candle.high), low: Number(candle.low)});
+
+    chartDataConversion.push({x: idx + 1, y: result?.conversion ?? null});
+    chartDataBase.push({x: idx + 1, y: result?.base ?? null});
+    chartDataSpanA.push({x: idx + 1, y: result?.spanA ?? null});
+    chartDataSpanB.push({x: idx + 1, y: result?.spanB ?? null});
+
+    priceData.push(collectPriceData(candle, idx));
+
+    sampleValues.push({
+      base: result ? result.base.toFixed(2) : <NotAvailable />,
+      close: Number(candle.close),
+      conversion: result ? result.conversion.toFixed(2) : <NotAvailable />,
+      date: formatDate(candle.openTimeInISO),
+      period: idx + 1,
+      spanA: result ? result.spanA.toFixed(2) : <NotAvailable />,
+      spanB: result ? result.spanB.toFixed(2) : <NotAvailable />,
+    });
+  });
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold text-white mb-2 select-text">
+          IchimokuCloud(9, 26, 52) / Required Inputs: {ichimoku.getRequiredInputs()}
+        </h2>
+        <p className="text-slate-300 select-text">{config.description}</p>
+        {config.details && <p className="text-slate-400 text-sm mt-2 select-text">{config.details}</p>}
+      </div>
+
+      <div className="bg-slate-800/50 border border-slate-700 rounded-lg p-4">
+        <HighchartsChart
+          options={{
+            chart: {backgroundColor: 'transparent', height: 300, type: 'line'},
+            credits: {enabled: false},
+            legend: {enabled: true, itemStyle: {color: '#e2e8f0'}},
+            plotOptions: {line: {lineWidth: 2, marker: {enabled: true, radius: 3}}},
+            series: [
+              {
+                color: config.color,
+                data: chartDataConversion.map(point => [point.x, point.y]),
+                marker: {fillColor: config.color},
+                name: 'Conversion (Tenkan-sen)',
+                type: 'line',
+              },
+              {
+                color: '#ef4444',
+                data: chartDataBase.map(point => [point.x, point.y]),
+                marker: {fillColor: '#ef4444'},
+                name: 'Base (Kijun-sen)',
+                type: 'line',
+              },
+              {
+                color: '#10b981',
+                data: chartDataSpanA.map(point => [point.x, point.y]),
+                marker: {fillColor: '#10b981'},
+                name: 'Span A (Senkou A)',
+                type: 'line',
+              },
+              {
+                color: '#f97316',
+                data: chartDataSpanB.map(point => [point.x, point.y]),
+                marker: {fillColor: '#f97316'},
+                name: 'Span B (Senkou B)',
+                type: 'line',
+              },
+            ],
+            title: {style: {color: '#e2e8f0', fontSize: '16px', fontWeight: '600'}, text: 'Ichimoku Cloud (9, 26, 52)'},
+            tooltip: {
+              backgroundColor: '#1e293b',
+              borderColor: '#475569',
+              formatter: createSharedTooltipFormatter(),
+              shared: true,
+              style: {color: '#e2e8f0'},
+            },
+            xAxis: {
+              gridLineColor: '#334155',
+              labels: {style: {color: '#94a3b8'}},
+              title: {style: {color: '#94a3b8'}, text: 'Period'},
+            },
+            yAxis: {
+              gridLineColor: '#334155',
+              labels: {style: {color: '#94a3b8'}},
+              title: {style: {color: '#94a3b8'}, text: 'Price'},
+            },
+          }}
+        />
+      </div>
+
+      <PriceChart title="Input Prices" data={priceData} />
+
+      <div className="bg-slate-800/50 border border-slate-700 rounded-lg p-4">
+        <h3 className="text-lg font-semibold text-white mb-3">All Sample Values</h3>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-slate-600">
+                <th className="text-left py-2 px-3 text-slate-400 font-medium">Period</th>
+                <th className="text-left py-2 px-3 text-slate-400 font-medium">Date</th>
+                <th className="text-left py-2 px-3 text-slate-400 font-medium">Close</th>
+                <th className="text-left py-2 px-3 text-slate-400 font-medium">Conversion</th>
+                <th className="text-left py-2 px-3 text-slate-400 font-medium">Base</th>
+                <th className="text-left py-2 px-3 text-slate-400 font-medium">Span A</th>
+                <th className="text-left py-2 px-3 text-slate-400 font-medium">Span B</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sampleValues.map(row => (
+                <tr key={row.period} className="border-b border-slate-700/50">
+                  <td className="py-2 px-3 text-white font-mono">{row.period}</td>
+                  <td className="py-2 px-3 text-slate-300">{row.date}</td>
+                  <td className="py-2 px-3 text-slate-300">${row.close.toFixed(2)}</td>
+                  <td className="py-2 px-3 text-white font-mono">{row.conversion}</td>
+                  <td className="py-2 px-3 text-white font-mono">{row.base}</td>
+                  <td className="py-2 px-3 text-white font-mono">{row.spanA}</td>
+                  <td className="py-2 px-3 text-white font-mono">{row.spanB}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const IchimokuCloud: IndicatorConfig = {
+  color: '#3b82f6',
+  createIndicator: () => new IchimokuCloudClass(),
+  customRender: renderIchimokuCloud,
+  description: 'Ichimoku Cloud',
+  details:
+    'Maps trend and equilibrium at a glance: each line is the midpoint between the highest high and the lowest low of its window, and the two spans enclose the cloud that traders read as support and resistance. All values are computed at the current bar — the traditional 26-bar forward displacement of the cloud is left to the chart.',
+  id: 'ichimoku',
+  name: 'Ichimoku Cloud',
+  requiredInputs: 52,
+  type: 'custom',
+};

--- a/packages/trading-signals-docs/indicator-demos/trend/VortexIndicator.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/VortexIndicator.demo.tsx
@@ -1,0 +1,148 @@
+import {Chart as HighchartsChart} from '@highcharts/react';
+import {VortexIndicator as VortexIndicatorClass} from 'trading-signals';
+import type {ReactNode} from 'react';
+import type {Candle} from '@typedtrader/exchange';
+import {createSharedTooltipFormatter, type ChartDataPoint} from '../../components/Chart';
+import {NotAvailable} from '../../components/NotAvailable';
+import PriceChart, {type PriceData} from '../../components/PriceChart';
+import {SignalBadge} from '../../components/SignalBadge';
+import {formatDate} from '../../utils/formatDate';
+import {collectPriceData} from '../../utils/renderUtils';
+import type {IndicatorConfig} from '../../utils/types';
+
+const renderVortexIndicator = (config: IndicatorConfig, selectedCandles: Candle[]) => {
+  const vortex = new VortexIndicatorClass(14);
+  const chartDataPlus: ChartDataPoint[] = [];
+  const chartDataMinus: ChartDataPoint[] = [];
+  const priceData: PriceData[] = [];
+  const sampleValues: {
+    period: number;
+    date: string;
+    close: number;
+    plus: ReactNode;
+    minus: ReactNode;
+    signal: string;
+  }[] = [];
+
+  selectedCandles.forEach((candle, idx) => {
+    const result = vortex.add({close: Number(candle.close), high: Number(candle.high), low: Number(candle.low)});
+    const trendSignal = vortex.getSignal();
+    chartDataPlus.push({x: idx + 1, y: result?.plus ?? null});
+    chartDataMinus.push({x: idx + 1, y: result?.minus ?? null});
+
+    priceData.push(collectPriceData(candle, idx));
+
+    sampleValues.push({
+      close: Number(candle.close),
+      date: formatDate(candle.openTimeInISO),
+      minus: result ? result.minus.toFixed(4) : <NotAvailable />,
+      period: idx + 1,
+      plus: result ? result.plus.toFixed(4) : <NotAvailable />,
+      signal: trendSignal.state,
+    });
+  });
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold text-white mb-2 select-text">
+          Vortex Indicator({vortex.interval}) / Required Inputs: {vortex.getRequiredInputs()}
+        </h2>
+        <p className="text-slate-300 select-text">{config.description}</p>
+        {config.details && <p className="text-slate-400 text-sm mt-2 select-text">{config.details}</p>}
+      </div>
+
+      <div className="bg-slate-800/50 border border-slate-700 rounded-lg p-4">
+        <HighchartsChart
+          options={{
+            chart: {backgroundColor: 'transparent', height: 300, type: 'line'},
+            credits: {enabled: false},
+            legend: {enabled: true, itemStyle: {color: '#e2e8f0'}},
+            plotOptions: {line: {lineWidth: 2, marker: {enabled: true, radius: 3}}},
+            series: [
+              {
+                color: '#10b981',
+                data: chartDataPlus.map(point => [point.x, point.y]),
+                marker: {fillColor: '#10b981'},
+                name: 'VI+',
+                type: 'line',
+              },
+              {
+                color: '#ef4444',
+                data: chartDataMinus.map(point => [point.x, point.y]),
+                marker: {fillColor: '#ef4444'},
+                name: 'VI−',
+                type: 'line',
+              },
+            ],
+            title: {style: {color: '#e2e8f0', fontSize: '16px', fontWeight: '600'}, text: 'Vortex Indicator (14)'},
+            tooltip: {
+              backgroundColor: '#1e293b',
+              borderColor: '#475569',
+              formatter: createSharedTooltipFormatter(y => y.toFixed(4)),
+              shared: true,
+              style: {color: '#e2e8f0'},
+            },
+            xAxis: {
+              gridLineColor: '#334155',
+              labels: {style: {color: '#94a3b8'}},
+              title: {style: {color: '#94a3b8'}, text: 'Period'},
+            },
+            yAxis: {
+              gridLineColor: '#334155',
+              labels: {style: {color: '#94a3b8'}},
+              title: {style: {color: '#94a3b8'}, text: 'Vortex'},
+            },
+          }}
+        />
+      </div>
+
+      <PriceChart title="Input Prices" data={priceData} />
+
+      <div className="bg-slate-800/50 border border-slate-700 rounded-lg p-4">
+        <h3 className="text-lg font-semibold text-white mb-3">All Sample Values</h3>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-slate-600">
+                <th className="text-left text-slate-300 py-2 px-3">Period</th>
+                <th className="text-left text-slate-300 py-2 px-3">Date</th>
+                <th className="text-left text-slate-300 py-2 px-3">Close</th>
+                <th className="text-left text-slate-300 py-2 px-3">VI+</th>
+                <th className="text-left text-slate-300 py-2 px-3">VI−</th>
+                <th className="text-left text-slate-300 py-2 px-3">Signal</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sampleValues.map(row => (
+                <tr key={row.period} className="border-b border-slate-700/50">
+                  <td className="text-slate-400 py-2 px-3">{row.period}</td>
+                  <td className="text-slate-300 py-2 px-3">{row.date}</td>
+                  <td className="text-slate-300 py-2 px-3">${row.close.toFixed(2)}</td>
+                  <td className="text-white font-mono py-2 px-3">{row.plus}</td>
+                  <td className="text-white font-mono py-2 px-3">{row.minus}</td>
+                  <td className="py-2 px-3">
+                    <SignalBadge signal={row.signal} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const VortexIndicator: IndicatorConfig = {
+  color: '#10b981',
+  createIndicator: () => new VortexIndicatorClass(14),
+  customRender: renderVortexIndicator,
+  description: 'Vortex Indicator',
+  details:
+    'Tracks upward and downward trend movement as two lines normalized by the true range. The upper line names the side in control; a crossover of VI+ and VI− suggests a trend change.',
+  id: 'vortex',
+  name: 'Vortex Indicator',
+  requiredInputs: 15,
+  type: 'custom',
+};

--- a/packages/trading-signals-docs/indicator-demos/trend/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/index.tsx
@@ -6,6 +6,7 @@ import {ChandelierExit} from './ChandelierExit.demo';
 import {DEMA} from './DEMA.demo';
 import {FRAMA} from './FRAMA.demo';
 import {HMA} from './HMA.demo';
+import {IchimokuCloud} from './IchimokuCloud.demo';
 import {KAMA} from './KAMA.demo';
 import {T3} from './T3.demo';
 import {TEMA} from './TEMA.demo';
@@ -46,6 +47,7 @@ export const indicators: IndicatorConfig[] = [
   VIDYA,
   FRAMA,
   VortexIndicator,
+  IchimokuCloud,
   Aroon,
   ChandelierExit,
   WMA,

--- a/packages/trading-signals-docs/indicator-demos/trend/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/index.tsx
@@ -11,6 +11,7 @@ import {T3} from './T3.demo';
 import {TEMA} from './TEMA.demo';
 import {TRIMA} from './TRIMA.demo';
 import {VIDYA} from './VIDYA.demo';
+import {VortexIndicator} from './VortexIndicator.demo';
 import {DMA} from './DMA.demo';
 import {DX} from './DX.demo';
 import {EMA} from './EMA.demo';
@@ -44,6 +45,7 @@ export const indicators: IndicatorConfig[] = [
   ZLEMA,
   VIDYA,
   FRAMA,
+  VortexIndicator,
   Aroon,
   ChandelierExit,
   WMA,

--- a/packages/trading-signals-docs/indicator-demos/volatility/DonchianChannels.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volatility/DonchianChannels.demo.tsx
@@ -1,0 +1,22 @@
+import {DonchianChannels as DonchianChannelsClass} from 'trading-signals';
+import type {IndicatorConfig} from '../../utils/types';
+import {renderBands} from './renderBands';
+
+export const DonchianChannels: IndicatorConfig = {
+  color: '#14b8a6',
+  createIndicator: () => new DonchianChannelsClass(20),
+  customRender: (cfg, candles) =>
+    renderBands(cfg, candles, {
+      addCandle: (indicator, candle) => indicator.add({high: Number(candle.high), low: Number(candle.low)}),
+      createIndicator: () => new DonchianChannelsClass(20),
+      details:
+        'Frames the recent trading range: the upper band tracks the highest high and the lower band the lowest low of the interval, with the middle band halfway between. A widening channel signals rising volatility, and trend followers read new channel extremes as breakout levels.',
+      label: 'DonchianChannels',
+      paramString: '20',
+    }),
+  description: 'Donchian Channels',
+  id: 'donchian-channels',
+  name: 'Donchian Channels',
+  requiredInputs: 20,
+  type: 'custom',
+};

--- a/packages/trading-signals-docs/indicator-demos/volatility/KeltnerChannels.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volatility/KeltnerChannels.demo.tsx
@@ -1,0 +1,23 @@
+import {KeltnerChannels as KeltnerChannelsClass} from 'trading-signals';
+import type {IndicatorConfig} from '../../utils/types';
+import {renderBands} from './renderBands';
+
+export const KeltnerChannels: IndicatorConfig = {
+  color: '#14b8a6',
+  createIndicator: () => new KeltnerChannelsClass(),
+  customRender: (cfg, candles) =>
+    renderBands(cfg, candles, {
+      addCandle: (indicator, candle) =>
+        indicator.add({close: Number(candle.close), high: Number(candle.high), low: Number(candle.low)}),
+      createIndicator: () => new KeltnerChannelsClass(),
+      details:
+        'Volatility envelope around an EMA whose channel width follows the Average True Range. Because the width tracks trading ranges instead of the standard deviation of closes, the channels also react to gaps and intraday swings.',
+      label: 'KeltnerChannels',
+      paramString: '20, 10, 2',
+    }),
+  description: 'Keltner Channels',
+  id: 'keltner-channels',
+  name: 'Keltner Channels',
+  requiredInputs: 20,
+  type: 'custom',
+};

--- a/packages/trading-signals-docs/indicator-demos/volatility/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volatility/index.tsx
@@ -4,6 +4,7 @@ import {BollingerBands} from './BollingerBands.demo';
 import {BollingerBandsWidth} from './BollingerBandsWidth.demo';
 import {DonchianChannels} from './DonchianChannels.demo';
 import {IQR} from './IQR.demo';
+import {KeltnerChannels} from './KeltnerChannels.demo';
 import {MAD} from './MAD.demo';
 import {NATR} from './NATR.demo';
 import {TR} from './TR.demo';
@@ -13,6 +14,7 @@ export const indicators: IndicatorConfig[] = [
   BollingerBands,
   AccelerationBands,
   DonchianChannels,
+  KeltnerChannels,
   ATR,
   NATR,
   TR,

--- a/packages/trading-signals-docs/indicator-demos/volatility/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volatility/index.tsx
@@ -2,6 +2,7 @@ import {AccelerationBands} from './AccelerationBands.demo';
 import {ATR} from './ATR.demo';
 import {BollingerBands} from './BollingerBands.demo';
 import {BollingerBandsWidth} from './BollingerBandsWidth.demo';
+import {DonchianChannels} from './DonchianChannels.demo';
 import {IQR} from './IQR.demo';
 import {MAD} from './MAD.demo';
 import {NATR} from './NATR.demo';
@@ -11,6 +12,7 @@ import type {IndicatorConfig} from '../../utils/types';
 export const indicators: IndicatorConfig[] = [
   BollingerBands,
   AccelerationBands,
+  DonchianChannels,
   ATR,
   NATR,
   TR,

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -93,6 +93,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Volume Rate of Change (VROC)
 1. Volume-Weighted Average Price (VWAP)
 1. Volume Weighted Moving Average (VWMA)
+1. Vortex Indicator (VI)
 1. Weighted Moving Average (WMA)
 1. Wilder's Smoothed Moving Average (WSMA / WWS / SMMA / MEMA)
 1. Williams %R (WILLR)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -44,6 +44,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Commodity Channel Index (CCI)
 1. Coppock Curve (COPPOCK)
 1. Directional Movement Index (DMI / DX)
+1. Donchian Channels (DC)
 1. Double Exponential Moving Average (DEMA)
 1. Dual Moving Average (DMA)
 1. Ease of Movement (EMV)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -57,6 +57,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Hull Moving Average (HMA)
 1. Interquartile Range (IQR)
 1. Kaufman's Adaptive Moving Average (KAMA)
+1. Keltner Channels (KC)
 1. Klinger Volume Oscillator (KVO)
 1. Know Sure Thing (KST)
 1. Linear Regression (LINREG)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -55,6 +55,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Force Index (FI)
 1. Fractal Adaptive Moving Average (FRAMA)
 1. Hull Moving Average (HMA)
+1. Ichimoku Cloud (ICHIMOKU)
 1. Interquartile Range (IQR)
 1. Kaufman's Adaptive Moving Average (KAMA)
 1. Keltner Channels (KC)

--- a/packages/trading-signals/src/trend/ICHIMOKU/IchimokuCloud.test.ts
+++ b/packages/trading-signals/src/trend/ICHIMOKU/IchimokuCloud.test.ts
@@ -1,0 +1,227 @@
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {IchimokuCloud} from './IchimokuCloud.js';
+
+describe('IchimokuCloud', () => {
+  describe('constructor', () => {
+    it('uses the intervals 9, 26 and 52 published by Goichi Hosoda by default', () => {
+      const ichimoku = new IchimokuCloud();
+
+      expect(ichimoku.conversionInterval).toBe(9);
+      expect(ichimoku.baseInterval).toBe(26);
+      expect(ichimoku.spanBInterval).toBe(52);
+    });
+  });
+
+  describe('getRequiredInputs', () => {
+    it('reports the slowest of the three windows', () => {
+      expect(new IchimokuCloud().getRequiredInputs()).toBe(52);
+      expect(new IchimokuCloud({baseInterval: 3, conversionInterval: 10, spanBInterval: 4}).getRequiredInputs()).toBe(
+        10
+      );
+    });
+  });
+
+  describe('getResultOrThrow', () => {
+    it('calculates each line as the midpoint of its own window', () => {
+      /*
+       * Hand-derived with the tiny windows 2/3/4, chosen so every window carries a different extreme.
+       * Each line is (highest high + lowest low) / 2 of its window, Span A is the middle of the
+       * conversion and base lines:
+       *
+       * | Bar | High | Low | Conversion (2)     | Base (3)          | Span A               | Span B (4)          |
+       * |-----|------|-----|--------------------|-------------------|----------------------|---------------------|
+       * | 1   | 20   | 2   | -                  | -                 | -                    | -                   |
+       * | 2   | 16   | 6   | -                  | -                 | -                    | -                   |
+       * | 3   | 11   | 7   | -                  | -                 | -                    | -                   |
+       * | 4   | 10   | 8   | (11 + 7) / 2 = 9   | (16 + 6) / 2 = 11 | (9 + 11) / 2 = 10    | (20 + 2) / 2 = 11   |
+       * | 5   | 9    | 5   | (10 + 5) / 2 = 7.5 | (11 + 5) / 2 = 8  | (7.5 + 8) / 2 = 7.75 | (16 + 5) / 2 = 10.5 |
+       */
+      const candles = [
+        {high: 20, low: 2},
+        {high: 16, low: 6},
+        {high: 11, low: 7},
+        {high: 10, low: 8},
+        {high: 9, low: 5},
+      ] as const;
+      const expectations = [
+        {base: 11, conversion: 9, spanA: 10, spanB: 11},
+        {base: 8, conversion: 7.5, spanA: 7.75, spanB: 10.5},
+      ] as const;
+      const ichimoku = new IchimokuCloud({baseInterval: 3, conversionInterval: 2, spanBInterval: 4});
+      const offset = ichimoku.getRequiredInputs() - 1;
+
+      candles.forEach((candle, i) => {
+        const result = ichimoku.add(candle);
+
+        if (result) {
+          expect(result).toEqual(expectations[i - offset]);
+        }
+      });
+
+      expect(ichimoku.isStable).toBe(true);
+    });
+
+    it('is compatible with results from Skender.Stock.Indicators', () => {
+      /*
+       * Test data verified with the Ichimoku(9, 26, 52) baseline of "Skender.Stock.Indicators" v3.0.0.
+       * Candles are the first 70 high/low pairs of its reference quote history:
+       * https://github.com/DaveSkender/Stock.Indicators/blob/3.0.0/tests/indicators/_testdata/quotes/default.csv#L2-L71
+       * Conversion (Tenkan-sen) and base (Kijun-sen) expectations are its committed baseline values for the
+       * same bars:
+       * https://github.com/DaveSkender/Stock.Indicators/blob/3.0.0/tests/indicators/_testdata/results/ichimoku.standard.json#L410-L561
+       * Skender stores the senkou spans chart-aligned, displaced 26 rows into the future, so the span
+       * expectations for bar i are taken from its row i + 26 — the values it computed at bar i:
+       * https://github.com/DaveSkender/Stock.Indicators/blob/3.0.0/tests/indicators/_testdata/results/ichimoku.standard.json#L618-L769
+       */
+      const candles = [
+        {high: 213.35, low: 211.52},
+        {high: 214.22, low: 213.15},
+        {high: 214.06, low: 213.02},
+        {high: 215.17, low: 213.42},
+        {high: 214.53, low: 213.91},
+        {high: 214.89, low: 213.52},
+        {high: 214.55, low: 213.13},
+        {high: 214.22, low: 212.53},
+        {high: 214.84, low: 214.17},
+        {high: 214.25, low: 213.33},
+        {high: 214.27, low: 213.42},
+        {high: 214.46, low: 212.96},
+        {high: 214.75, low: 213.49},
+        {high: 214.28, low: 212.83},
+        {high: 215.48, low: 213.77},
+        {high: 216.89, low: 215.89},
+        {high: 217.02, low: 216.36},
+        {high: 216.91, low: 216.12},
+        {high: 215.59, low: 213.9},
+        {high: 215.03, low: 213.82},
+        {high: 215.96, low: 214.4},
+        {high: 215.5, low: 214.29},
+        {high: 216.87, low: 215.84},
+        {high: 216.66, low: 215.92},
+        {high: 216.97, low: 216.09},
+        {high: 216.72, low: 215.7},
+        {high: 218.19, low: 216.84},
+        {high: 218.97, low: 217.88},
+        {high: 220.19, low: 219.23},
+        {high: 220.8, low: 219.33},
+        {high: 222.15, low: 220.5},
+        {high: 222.16, low: 220.93},
+        {high: 222.1, low: 221.01},
+        {high: 223.62, low: 222.5},
+        {high: 223.47, low: 222.8},
+        {high: 223.81, low: 222.55},
+        {high: 223.71, low: 222.41},
+        {high: 224.2, low: 223.29},
+        {high: 223.86, low: 222.98},
+        {high: 227.04, low: 225.2},
+        {high: 226.34, low: 225.05},
+        {high: 225.43, low: 224.6},
+        {high: 224.97, low: 223.92},
+        {high: 224.64, low: 223.68},
+        {high: 224.51, low: 223.34},
+        {high: 224.13, low: 222.72},
+        {high: 224.87, low: 223.52},
+        {high: 224.72, low: 224.13},
+        {high: 224.13, low: 223.14},
+        {high: 226.21, low: 224.18},
+        {high: 225.99, low: 224.95},
+        {high: 225.8, low: 224.91},
+        {high: 225.22, low: 224.24},
+        {high: 225.46, low: 221.64},
+        {high: 222.61, low: 221.13},
+        {high: 223.31, low: 221.66},
+        {high: 223.02, low: 221.05},
+        {high: 221.96, low: 219.77},
+        {high: 223.75, low: 221.22},
+        {high: 223.75, low: 222.72},
+        {high: 224.43, low: 223.24},
+        {high: 224.42, low: 223.63},
+        {high: 223.96, low: 221.95},
+        {high: 223.53, low: 222.56},
+        {high: 225.25, low: 222.55},
+        {high: 223.97, low: 222.44},
+        {high: 223.93, low: 222.64},
+        {high: 224.18, low: 222.73},
+        {high: 223.15, low: 221.41},
+        {high: 222.95, low: 221.82},
+      ] as const;
+      const expectations = [
+        {base: '221.9400', conversion: '224.4650', spanA: '223.2025', spanB: '219.2800'},
+        {base: '222.4600', conversion: '224.4650', spanA: '223.4625', spanB: '219.7850'},
+        {base: '223.1350', conversion: '223.9250', spanA: '223.5300', spanB: '219.7850'},
+        {base: '223.1850', conversion: '223.6700', spanA: '223.4275', spanB: '219.7850'},
+        {base: '223.7700', conversion: '223.6700', spanA: '223.7200', spanB: '219.7850'},
+        {base: '223.9850', conversion: '223.6300', spanA: '223.8075', spanB: '219.7850'},
+        {base: '223.4050', conversion: '222.9900', spanA: '223.1975', spanB: '219.7850'},
+        {base: '223.4050', conversion: '222.8800', spanA: '223.1425', spanB: '219.7850'},
+        {base: '223.4050', conversion: '222.7850', spanA: '223.0950', spanB: '219.9350'},
+        {base: '223.4050', conversion: '222.6150', spanA: '223.0100', spanB: '219.9350'},
+        {base: '223.4050', conversion: '222.6150', spanA: '223.0100', spanB: '219.9350'},
+        {base: '223.4050', conversion: '222.1000', spanA: '222.7525', spanB: '219.9350'},
+        {base: '223.4050', conversion: '222.1000', spanA: '222.7525', spanB: '219.9350'},
+        {base: '223.4050', conversion: '222.5100', spanA: '222.9575', spanB: '219.9350'},
+        {base: '223.0550', conversion: '222.5100', spanA: '222.7825', spanB: '220.4050'},
+        {base: '222.9900', conversion: '223.2350', spanA: '223.1125', spanB: '220.4300'},
+        {base: '222.9900', conversion: '223.6000', spanA: '223.2950', spanB: '220.4300'},
+        {base: '222.9900', conversion: '223.3300', spanA: '223.1600', spanB: '220.4300'},
+        {base: '222.9900', conversion: '223.3300', spanA: '223.1600', spanB: '220.4300'},
+      ] as const;
+      const ichimoku = new IchimokuCloud();
+      const offset = ichimoku.getRequiredInputs() - 1;
+
+      candles.forEach((candle, i) => {
+        const result = ichimoku.add(candle);
+
+        if (result) {
+          expect({
+            base: result.base.toFixed(4),
+            conversion: result.conversion.toFixed(4),
+            spanA: result.spanA.toFixed(4),
+            spanB: result.spanB.toFixed(4),
+          }).toEqual(expectations[i - offset]);
+        }
+      });
+
+      expect(ichimoku.isStable).toBe(true);
+    });
+  });
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const ichimoku = new IchimokuCloud({baseInterval: 3, conversionInterval: 2, spanBInterval: 4});
+
+      ichimoku.add({high: 20, low: 2});
+      ichimoku.add({high: 16, low: 6});
+      ichimoku.add({high: 11, low: 7});
+      ichimoku.add({high: 10, low: 8});
+
+      // A candle spanning 5 to 30 dominates every window, so all lines meet at its midpoint 17.5
+      const originalCandle = {high: 30, low: 5} as const;
+      const replacementCandle = {high: 9, low: 3} as const;
+
+      const originalResult = ichimoku.add(originalCandle);
+
+      expect(originalResult).toEqual({base: 17.5, conversion: 17.5, spanA: 17.5, spanB: 17.5});
+
+      const replacedResult = ichimoku.replace(replacementCandle);
+
+      expect(replacedResult).toEqual({base: 7, conversion: 6.5, spanA: 6.75, spanB: 9.5});
+
+      const restoredResult = ichimoku.replace(originalCandle);
+
+      expect(restoredResult).toEqual(originalResult);
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new IchimokuCloud({baseInterval: 3, conversionInterval: 2, spanBInterval: 4}),
+  divergentInput: {high: 500, low: 1},
+  inputs: [
+    {high: 20, low: 2},
+    {high: 16, low: 6},
+    {high: 11, low: 7},
+    {high: 10, low: 8},
+    {high: 9, low: 5},
+  ],
+});

--- a/packages/trading-signals/src/trend/ICHIMOKU/IchimokuCloud.ts
+++ b/packages/trading-signals/src/trend/ICHIMOKU/IchimokuCloud.ts
@@ -1,7 +1,5 @@
 import type {HighLow} from '../../base/Candle.type.js';
 import {TechnicalIndicator} from '../../base/Indicator.js';
-import {getMaximum} from '../../util/getMaximum.js';
-import {getMinimum} from '../../util/getMinimum.js';
 import {pushUpdate} from '../../util/pushUpdate.js';
 
 export type IchimokuCloudResult = {
@@ -59,11 +57,17 @@ export class IchimokuCloud extends TechnicalIndicator<IchimokuCloudResult, HighL
     return Math.max(this.baseInterval, this.conversionInterval, this.spanBInterval);
   }
 
-  // Hosoda's equilibrium: the middle of the range traded over the window
+  // Hosoda's equilibrium: the middle of the range traded over the window, in a single pass to keep the hot path allocation-free
   #getMidpoint(interval: number) {
-    const window = this.#candles.slice(-interval);
-    const highestHigh = getMaximum(window.map(candle => candle.high));
-    const lowestLow = getMinimum(window.map(candle => candle.low));
+    const start = this.#candles.length - interval;
+    let highestHigh = this.#candles[start].high;
+    let lowestLow = this.#candles[start].low;
+
+    for (let i = start + 1; i < this.#candles.length; i++) {
+      const {high, low} = this.#candles[i];
+      highestHigh = Math.max(highestHigh, high);
+      lowestLow = Math.min(lowestLow, low);
+    }
 
     return (highestHigh + lowestLow) / 2;
   }

--- a/packages/trading-signals/src/trend/ICHIMOKU/IchimokuCloud.ts
+++ b/packages/trading-signals/src/trend/ICHIMOKU/IchimokuCloud.ts
@@ -1,0 +1,88 @@
+import type {HighLow} from '../../base/Candle.type.js';
+import {TechnicalIndicator} from '../../base/Indicator.js';
+import {getMaximum} from '../../util/getMaximum.js';
+import {getMinimum} from '../../util/getMinimum.js';
+import {pushUpdate} from '../../util/pushUpdate.js';
+
+export type IchimokuCloudResult = {
+  /** Kijun-sen: equilibrium of the medium-term trading range */
+  base: number;
+  /** Tenkan-sen: equilibrium of the short-term trading range */
+  conversion: number;
+  /** Senkou Span A: midpoint between conversion and base line, the faster cloud boundary */
+  spanA: number;
+  /** Senkou Span B: equilibrium of the long-term trading range, the slower cloud boundary */
+  spanB: number;
+};
+
+export type IchimokuCloudConfig = {
+  /** Window of the Kijun-sen base line (default: 26) */
+  baseInterval?: number;
+  /** Window of the Tenkan-sen conversion line (default: 9) */
+  conversionInterval?: number;
+  /** Window of the Senkou Span B line (default: 52) */
+  spanBInterval?: number;
+};
+
+/**
+ * Ichimoku Cloud (ICHIMOKU)
+ * Type: Trend
+ *
+ * The Ichimoku Cloud (Ichimoku Kinko Hyo, "one-glance equilibrium chart") was developed by the Japanese journalist
+ * Goichi Hosoda and published in 1969. Every line is the midpoint between the highest high and the lowest low of its
+ * window, so each line marks the equilibrium of a trading range: the fast conversion line (Tenkan-sen) tracks short
+ * swings, the slower base line (Kijun-sen) anchors the medium-term range, and the two leading spans (Senkou Span A/B)
+ * enclose the cloud (Kumo) that traders read as support and resistance.
+ *
+ * On a chart, both spans are plotted 26 bars ahead of the current bar and the lagging span (Chikou) 26 bars behind
+ * it. This implementation returns the values as computed at the current bar and leaves the plotting displacement to
+ * the consumer, which is the convention streaming libraries use. The lagging span is omitted entirely because
+ * undisplaced it is just the current close.
+ *
+ * @see https://www.investopedia.com/terms/i/ichimoku-cloud.asp
+ * @see https://en.wikipedia.org/wiki/Ichimoku_Kink%C5%8D_Hy%C5%8D
+ */
+export class IchimokuCloud extends TechnicalIndicator<IchimokuCloudResult, HighLow<number>> {
+  readonly #candles: HighLow<number>[] = [];
+  public readonly baseInterval: number;
+  public readonly conversionInterval: number;
+  public readonly spanBInterval: number;
+
+  constructor({baseInterval = 26, conversionInterval = 9, spanBInterval = 52}: IchimokuCloudConfig = {}) {
+    super();
+    this.baseInterval = baseInterval;
+    this.conversionInterval = conversionInterval;
+    this.spanBInterval = spanBInterval;
+  }
+
+  override getRequiredInputs() {
+    return Math.max(this.baseInterval, this.conversionInterval, this.spanBInterval);
+  }
+
+  // Hosoda's equilibrium: the middle of the range traded over the window
+  #getMidpoint(interval: number) {
+    const window = this.#candles.slice(-interval);
+    const highestHigh = getMaximum(window.map(candle => candle.high));
+    const lowestLow = getMinimum(window.map(candle => candle.low));
+
+    return (highestHigh + lowestLow) / 2;
+  }
+
+  update(candle: HighLow<number>, replace: boolean) {
+    pushUpdate({array: this.#candles, item: candle, maxLength: this.getRequiredInputs(), replace: replace});
+
+    if (this.#candles.length < this.getRequiredInputs()) {
+      return null;
+    }
+
+    const conversion = this.#getMidpoint(this.conversionInterval);
+    const base = this.#getMidpoint(this.baseInterval);
+
+    return (this.result = {
+      base,
+      conversion,
+      spanA: (conversion + base) / 2,
+      spanB: this.#getMidpoint(this.spanBInterval),
+    });
+  }
+}

--- a/packages/trading-signals/src/trend/VI/VortexIndicator.test.ts
+++ b/packages/trading-signals/src/trend/VI/VortexIndicator.test.ts
@@ -1,0 +1,264 @@
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {VortexIndicator} from './VortexIndicator.js';
+import {TradingSignal} from '../../base/index.js';
+
+describe('VortexIndicator', () => {
+  describe('update', () => {
+    it('relates each candle to the previous one and normalizes both movement sums by the total true range', () => {
+      /*
+       * Formula (Etienne Botes & Douglas Siepman, "The Vortex Indicator",
+       * Technical Analysis of Stocks & Commodities, January 2010):
+       * VM+ = |High - Previous Low|, VM- = |Low - Previous High|
+       * VI+ = Sum(VM+) / Sum(TR), VI- = Sum(VM-) / Sum(TR) over the interval
+       * https://school.stockcharts.com/doku.php?id=technical_indicators:vortex_indicator
+       *
+       * The expectations below are derived by hand with interval 2:
+       *
+       * | Bar | High | Low | Close | VM+ | VM- | TR | VI+         | VI-         |
+       * |-----|------|-----|-------|-----|-----|----|-------------|-------------|
+       * | 1   | 12   | 8   | 10    | -   | -   | -  | -           | -           |
+       * | 2   | 14   | 10  | 12    | 6   | 2   | 4  | -           | -           |
+       * | 3   | 16   | 12  | 14    | 6   | 2   | 4  | 12/8 = 1.5  | 4/8 = 0.5   |
+       * | 4   | 15   | 11  | 12    | 3   | 5   | 4  | 9/8 = 1.125 | 7/8 = 0.875 |
+       */
+      const candles = [
+        {close: 10, high: 12, low: 8},
+        {close: 12, high: 14, low: 10},
+        {close: 14, high: 16, low: 12},
+        {close: 12, high: 15, low: 11},
+      ] as const;
+      const expectations = [
+        {minus: 0.5, plus: 1.5},
+        {minus: 0.875, plus: 1.125},
+      ] as const;
+      const vortex = new VortexIndicator(2);
+      const offset = vortex.getRequiredInputs() - 1;
+
+      candles.forEach((candle, i) => {
+        const result = vortex.add(candle);
+
+        if (result) {
+          expect(result).toEqual(expectations[i - offset]);
+        }
+      });
+
+      expect(vortex.isStable).toBe(true);
+    });
+
+    it('matches the Skender.Stock.Indicators reference results', () => {
+      /*
+       * The expectations are the Skender.Stock.Indicators v3.0.0 baseline for VI(14) over the
+       * first 30 candles of its default test quotes. The Vortex Indicator only ever looks back
+       * one interval, so a leading slice of the series yields the same results as a full run.
+       *
+       * Quotes: https://raw.githubusercontent.com/facioquo/stock-indicators-dotnet/3.0.0/tests/indicators/_testdata/quotes/default.csv
+       * Results: https://raw.githubusercontent.com/facioquo/stock-indicators-dotnet/3.0.0/tests/indicators/_testdata/results/vortex.standard.json
+       */
+      const candles = [
+        {close: 212.8, high: 213.35, low: 211.52},
+        {close: 214.06, high: 214.22, low: 213.15},
+        {close: 213.89, high: 214.06, low: 213.02},
+        {close: 214.66, high: 215.17, low: 213.42},
+        {close: 213.95, high: 214.53, low: 213.91},
+        {close: 213.95, high: 214.89, low: 213.52},
+        {close: 214.55, high: 214.55, low: 213.13},
+        {close: 214.02, high: 214.22, low: 212.53},
+        {close: 214.51, high: 214.84, low: 214.17},
+        {close: 213.75, high: 214.25, low: 213.33},
+        {close: 214.22, high: 214.27, low: 213.42},
+        {close: 213.43, high: 214.46, low: 212.96},
+        {close: 214.21, high: 214.75, low: 213.49},
+        {close: 213.66, high: 214.28, low: 212.83},
+        {close: 215.03, high: 215.48, low: 213.77},
+        {close: 216.89, high: 216.89, low: 215.89},
+        {close: 216.66, high: 217.02, low: 216.36},
+        {close: 216.32, high: 216.91, low: 216.12},
+        {close: 214.98, high: 215.59, low: 213.9},
+        {close: 214.96, high: 215.03, low: 213.82},
+        {close: 215.05, high: 215.96, low: 214.4},
+        {close: 215.19, high: 215.5, low: 214.29},
+        {close: 216.67, high: 216.87, low: 215.84},
+        {close: 216.28, high: 216.66, low: 215.92},
+        {close: 216.29, high: 216.97, low: 216.09},
+        {close: 216.58, high: 216.72, low: 215.7},
+        {close: 217.86, high: 218.19, low: 216.84},
+        {close: 218.72, high: 218.97, low: 217.88},
+        {close: 219.91, high: 220.19, low: 219.23},
+        {close: 220.79, high: 220.8, low: 219.33},
+      ] as const;
+      const expectations = [
+        {minus: '0.8119', plus: '1.0460'},
+        {minus: '0.8042', plus: '1.0439'},
+        {minus: '0.7848', plus: '1.0767'},
+        {minus: '0.8417', plus: '1.0449'},
+        {minus: '0.8593', plus: '0.9256'},
+        {minus: '0.9058', plus: '0.9410'},
+        {minus: '0.8412', plus: '0.9913'},
+        {minus: '0.8590', plus: '1.0349'},
+        {minus: '0.8360', plus: '1.0031'},
+        {minus: '0.8255', plus: '1.0645'},
+        {minus: '0.8106', plus: '1.0686'},
+        {minus: '0.8293', plus: '1.0741'},
+        {minus: '0.7717', plus: '1.0946'},
+        {minus: '0.6991', plus: '1.1868'},
+        {minus: '0.6988', plus: '1.1909'},
+        {minus: '0.7393', plus: '1.1300'},
+      ] as const;
+      const vortex = new VortexIndicator(14);
+      const offset = vortex.getRequiredInputs() - 1;
+      let verifiedBars = 0;
+
+      candles.forEach((candle, i) => {
+        const result = vortex.add(candle);
+
+        if (result) {
+          verifiedBars++;
+          const expected = expectations[i - offset];
+          expect(result.minus.toFixed(4)).toBe(expected.minus);
+          expect(result.plus.toFixed(4)).toBe(expected.plus);
+        }
+      });
+
+      expect(verifiedBars).toBe(expectations.length);
+    });
+
+    it('reports zero on both lines when the whole window shows no true range', () => {
+      const vortex = new VortexIndicator(2);
+
+      vortex.add({close: 10, high: 10, low: 10});
+      vortex.add({close: 10, high: 10, low: 10});
+      vortex.add({close: 10, high: 10, low: 10});
+
+      expect(vortex.getResultOrThrow()).toEqual({minus: 0, plus: 0});
+      expect(vortex.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+    });
+
+    it('stays sideways when the price freezes right after a wide candle', () => {
+      /*
+       * Every candle in the window is flat at the previous close, so the market never moved,
+       * yet the wide candle just before the window skews the raw movement sums to the downside
+       * (VM+ = 5 vs. VM- = 10). A frozen market must not fabricate a direction from that skew.
+       */
+      const vortex = new VortexIndicator(2);
+
+      vortex.add({close: 10, high: 20, low: 5});
+      vortex.add({close: 10, high: 10, low: 10});
+      vortex.add({close: 10, high: 10, low: 10});
+
+      expect(vortex.getResultOrThrow()).toEqual({minus: 0, plus: 0});
+      expect(vortex.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+    });
+  });
+
+  describe('getRequiredInputs', () => {
+    it('needs one candle more than the interval, which defaults to 14 periods', () => {
+      expect(new VortexIndicator().getRequiredInputs()).toBe(15);
+      expect(new VortexIndicator(2).getRequiredInputs()).toBe(3);
+    });
+  });
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const vortex = new VortexIndicator(2);
+
+      vortex.add({close: 10, high: 12, low: 8});
+      vortex.add({close: 12, high: 14, low: 10});
+      vortex.add({close: 14, high: 16, low: 12});
+
+      const originalCandle = {close: 12, high: 15, low: 11} as const;
+      const replacementCandle = {close: 18, high: 20, low: 16} as const;
+
+      const originalResult = vortex.add(originalCandle);
+
+      expect(originalResult).toEqual({minus: 0.875, plus: 1.125});
+
+      const replacedResult = vortex.replace(replacementCandle);
+
+      expect(replacedResult).toEqual({minus: 0.2, plus: 1.4});
+
+      const restoredResult = vortex.replace(originalCandle);
+
+      expect(restoredResult).toEqual({minus: 0.875, plus: 1.125});
+    });
+  });
+
+  describe('getSignal', () => {
+    it('returns UNKNOWN before the warm-up is complete', () => {
+      const vortex = new VortexIndicator(2);
+
+      expect(vortex.getSignal()).toEqual({hasChanged: false, state: TradingSignal.UNKNOWN});
+
+      vortex.add({close: 10, high: 11, low: 9});
+      vortex.add({close: 10, high: 11, low: 9});
+
+      expect(vortex.getSignal()).toEqual({hasChanged: false, state: TradingSignal.UNKNOWN});
+    });
+
+    it('returns BULLISH when the upward movement line trades above the downward one', () => {
+      const vortex = new VortexIndicator(2);
+
+      vortex.add({close: 10, high: 12, low: 8});
+      vortex.add({close: 12, high: 14, low: 10});
+      vortex.add({close: 14, high: 16, low: 12});
+
+      expect(vortex.getResultOrThrow()).toEqual({minus: 0.5, plus: 1.5});
+      expect(vortex.getSignal().state).toBe(TradingSignal.BULLISH);
+    });
+
+    it('returns BEARISH when the downward movement line trades above the upward one', () => {
+      const vortex = new VortexIndicator(2);
+
+      vortex.add({close: 14, high: 16, low: 12});
+      vortex.add({close: 12, high: 14, low: 10});
+      vortex.add({close: 10, high: 12, low: 8});
+
+      expect(vortex.getResultOrThrow()).toEqual({minus: 1.5, plus: 0.5});
+      expect(vortex.getSignal().state).toBe(TradingSignal.BEARISH);
+    });
+
+    it('returns SIDEWAYS when both lines are equal', () => {
+      /*
+       * Identical candles with a real trading range push both lines to exactly 1: every
+       * high-to-previous-low reach equals the low-to-previous-high reach, so neither side
+       * gains an edge even though the market is moving.
+       */
+      const vortex = new VortexIndicator(2);
+
+      vortex.add({close: 10, high: 11, low: 9});
+      vortex.add({close: 10, high: 11, low: 9});
+      vortex.add({close: 10, high: 11, low: 9});
+
+      expect(vortex.getResultOrThrow()).toEqual({minus: 1, plus: 1});
+      expect(vortex.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+    });
+
+    it('flags a change only when the signal switches its state', () => {
+      const vortex = new VortexIndicator(2);
+
+      vortex.add({close: 10, high: 11, low: 9});
+      vortex.add({close: 10, high: 11, low: 9});
+      vortex.add({close: 10, high: 11, low: 9});
+
+      expect(vortex.getSignal()).toEqual({hasChanged: true, state: TradingSignal.SIDEWAYS});
+
+      vortex.add({close: 18, high: 20, low: 14});
+
+      expect(vortex.getSignal()).toEqual({hasChanged: true, state: TradingSignal.BULLISH});
+
+      vortex.add({close: 24, high: 26, low: 20});
+
+      expect(vortex.getSignal()).toEqual({hasChanged: false, state: TradingSignal.BULLISH});
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new VortexIndicator(2),
+  divergentInput: {close: 1_000, high: 1_010, low: 990},
+  inputs: [
+    {close: 10, high: 12, low: 8},
+    {close: 12, high: 14, low: 10},
+    {close: 14, high: 16, low: 12},
+    {close: 12, high: 15, low: 11},
+  ],
+});

--- a/packages/trading-signals/src/trend/VI/VortexIndicator.ts
+++ b/packages/trading-signals/src/trend/VI/VortexIndicator.ts
@@ -1,0 +1,119 @@
+import type {HighLowClose} from '../../base/Candle.type.js';
+import {TechnicalIndicator, TradingSignal} from '../../base/Indicator.js';
+import {pushUpdate} from '../../util/pushUpdate.js';
+
+export type VortexResult = {
+  /** Downward movement line (VI−) */
+  minus: number;
+  /** Upward movement line (VI+) */
+  plus: number;
+};
+
+/**
+ * Vortex Indicator (VI)
+ * Type: Trend
+ *
+ * The Vortex Indicator was developed by Etienne Botes and Douglas Siepman and published in the January 2010 issue of
+ * "Technical Analysis of Stocks & Commodities". It draws two lines from the interplay of consecutive candles: VI+
+ * captures upward trend movement as the reach from each candle's high back to the previous candle's low, while VI−
+ * captures downward movement as the reach from each candle's low back to the previous candle's high. Both movement
+ * sums are normalized by the total True Range of the interval, so the lines oscillate around 1.
+ *
+ * Interpretation: The upper line names the side in control — an uptrend when VI+ trades above VI−, a downtrend when
+ * VI− trades above VI+. A crossover of the two lines suggests a trend change.
+ *
+ * @see https://school.stockcharts.com/doku.php?id=technical_indicators:vortex_indicator
+ * @see https://www.investopedia.com/terms/v/vortex-indicator-vi.asp
+ */
+export class VortexIndicator extends TechnicalIndicator<VortexResult, HighLowClose<number>> {
+  public readonly interval: number;
+  readonly #candles: HighLowClose<number>[] = [];
+  #previousResult?: VortexResult;
+
+  constructor(interval: number = 14) {
+    super();
+    this.interval = interval;
+  }
+
+  override getRequiredInputs() {
+    return this.interval + 1;
+  }
+
+  update(candle: HighLowClose<number>, replace: boolean) {
+    pushUpdate({array: this.#candles, item: candle, maxLength: this.interval + 1, replace: replace});
+
+    if (this.#candles.length <= this.interval) {
+      return null;
+    }
+
+    let upwardMovement = 0;
+    let downwardMovement = 0;
+    let trueRange = 0;
+
+    for (let i = 1; i < this.#candles.length; i++) {
+      const current = this.#candles[i];
+      const previous = this.#candles[i - 1];
+      upwardMovement += Math.abs(current.high - previous.low);
+      downwardMovement += Math.abs(current.low - previous.high);
+      trueRange += Math.max(
+        current.high - current.low,
+        Math.abs(current.high - previous.close),
+        Math.abs(current.low - previous.close)
+      );
+    }
+
+    if (replace) {
+      this.result = this.#previousResult;
+    }
+
+    this.#previousResult = this.result;
+
+    /*
+     * A window without any true range means the price never moved, so there is no movement to
+     * attribute to either line. Reporting zero on both sides keeps a dead market sideways
+     * instead of fabricating a direction from a division by zero.
+     */
+    if (trueRange === 0) {
+      return (this.result = {
+        minus: 0,
+        plus: 0,
+      });
+    }
+
+    return (this.result = {
+      minus: downwardMovement / trueRange,
+      plus: upwardMovement / trueRange,
+    });
+  }
+
+  protected calculateSignal(result?: VortexResult | null | undefined) {
+    const hasResult = result !== null && result !== undefined;
+    const isBullish = hasResult && result.plus > result.minus;
+    const isBearish = hasResult && result.minus > result.plus;
+
+    switch (true) {
+      case !hasResult:
+        return TradingSignal.UNKNOWN;
+      case isBullish:
+        return TradingSignal.BULLISH;
+      case isBearish:
+        return TradingSignal.BEARISH;
+      default:
+        return TradingSignal.SIDEWAYS;
+    }
+  }
+
+  getSignal(): {
+    state: (typeof TradingSignal)[keyof typeof TradingSignal];
+    hasChanged: boolean;
+  } {
+    const previousState = this.calculateSignal(this.#previousResult);
+    const state = this.calculateSignal(this.getResult());
+    const hasChanged = previousState !== state;
+
+    return {
+      hasChanged,
+      state,
+    };
+  }
+}

--- a/packages/trading-signals/src/trend/index.ts
+++ b/packages/trading-signals/src/trend/index.ts
@@ -10,6 +10,7 @@ export * from './EMA/EMA.js';
 export * from './FRAMA/FRAMA.js';
 export * from './HIGHER_LOW_TRAIL/HigherLowTrail.js';
 export * from './HMA/HMA.js';
+export * from './ICHIMOKU/IchimokuCloud.js';
 export * from './KAMA/KAMA.js';
 export * from './LINREG/LinearRegression.js';
 export * from './MA/MovingAverage.js';

--- a/packages/trading-signals/src/trend/index.ts
+++ b/packages/trading-signals/src/trend/index.ts
@@ -24,6 +24,7 @@ export * from './SWING_LOW/SwingLow.js';
 export * from './T3/T3.js';
 export * from './TEMA/TEMA.js';
 export * from './TRIMA/TRIMA.js';
+export * from './VI/VortexIndicator.js';
 export * from './VIDYA/VIDYA.js';
 export * from './VSTOP/VolatilityStop.js';
 export * from './VWAP/VWAP.js';

--- a/packages/trading-signals/src/volatility/DC/DonchianChannels.test.ts
+++ b/packages/trading-signals/src/volatility/DC/DonchianChannels.test.ts
@@ -1,0 +1,180 @@
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {DonchianChannels} from './DonchianChannels.js';
+
+describe('DonchianChannels', () => {
+  describe('constructor', () => {
+    it('uses an interval of 20 by default', () => {
+      const dc = new DonchianChannels();
+
+      expect(dc.interval).toBe(20);
+      expect(dc.getRequiredInputs()).toBe(20);
+    });
+  });
+
+  describe('getResultOrThrow', () => {
+    it('frames a small window with values readable straight from the inputs', () => {
+      const dc = new DonchianChannels(3);
+
+      dc.add({high: 10, low: 8});
+      dc.add({high: 12, low: 9});
+
+      expect(dc.add({high: 11, low: 7})).toEqual({lower: 7, middle: 9.5, upper: 12});
+    });
+
+    it('drops an old extreme once it slides out of the window', () => {
+      const dc = new DonchianChannels(3);
+
+      dc.add({high: 100, low: 1});
+      dc.add({high: 10, low: 8});
+
+      expect(dc.add({high: 11, low: 9}), 'the extreme candle still dominates both bands').toEqual({
+        lower: 1,
+        middle: 50.5,
+        upper: 100,
+      });
+
+      expect(dc.add({high: 12, low: 7}), 'the extreme candle no longer counts').toEqual({
+        lower: 7,
+        middle: 9.5,
+        upper: 12,
+      });
+    });
+
+    it('is compatible with results from Skender.Stock.Indicators', () => {
+      /*
+       * Test data verified with Skender.Stock.Indicators v3.0.0:
+       * https://github.com/DaveSkender/Stock.Indicators/blob/3.0.0/tests/indicators/_testdata/quotes/default.csv (first 40 rows)
+       * https://github.com/DaveSkender/Stock.Indicators/blob/3.0.0/tests/indicators/_testdata/results/donchian.standard.json (array indices 20-40, zero-based)
+       *
+       * Skender builds the channel from the candles preceding the current one
+       * (https://github.com/DaveSkender/Stock.Indicators/blob/3.0.0/src/a-d/Donchian/Donchian.StaticSeries.cs#L39),
+       * while the classic definition includes the current candle. Both cover the same window one candle apart, so
+       * the expectations below are Skender's values shifted back by one candle. All values match exactly.
+       */
+      const candles = [
+        {high: 213.35, low: 211.52},
+        {high: 214.22, low: 213.15},
+        {high: 214.06, low: 213.02},
+        {high: 215.17, low: 213.42},
+        {high: 214.53, low: 213.91},
+        {high: 214.89, low: 213.52},
+        {high: 214.55, low: 213.13},
+        {high: 214.22, low: 212.53},
+        {high: 214.84, low: 214.17},
+        {high: 214.25, low: 213.33},
+        {high: 214.27, low: 213.42},
+        {high: 214.46, low: 212.96},
+        {high: 214.75, low: 213.49},
+        {high: 214.28, low: 212.83},
+        {high: 215.48, low: 213.77},
+        {high: 216.89, low: 215.89},
+        {high: 217.02, low: 216.36},
+        {high: 216.91, low: 216.12},
+        {high: 215.59, low: 213.9},
+        {high: 215.03, low: 213.82},
+        {high: 215.96, low: 214.4},
+        {high: 215.5, low: 214.29},
+        {high: 216.87, low: 215.84},
+        {high: 216.66, low: 215.92},
+        {high: 216.97, low: 216.09},
+        {high: 216.72, low: 215.7},
+        {high: 218.19, low: 216.84},
+        {high: 218.97, low: 217.88},
+        {high: 220.19, low: 219.23},
+        {high: 220.8, low: 219.33},
+        {high: 222.15, low: 220.5},
+        {high: 222.16, low: 220.93},
+        {high: 222.1, low: 221.01},
+        {high: 223.62, low: 222.5},
+        {high: 223.47, low: 222.8},
+        {high: 223.81, low: 222.55},
+        {high: 223.71, low: 222.41},
+        {high: 224.2, low: 223.29},
+        {high: 223.86, low: 222.98},
+        {high: 227.04, low: 225.2},
+      ] as const;
+
+      const expectations = [
+        {lower: 211.52, middle: 214.27, upper: 217.02},
+        {lower: 212.53, middle: 214.775, upper: 217.02},
+        {lower: 212.53, middle: 214.775, upper: 217.02},
+        {lower: 212.53, middle: 214.775, upper: 217.02},
+        {lower: 212.53, middle: 214.775, upper: 217.02},
+        {lower: 212.53, middle: 214.775, upper: 217.02},
+        {lower: 212.53, middle: 214.775, upper: 217.02},
+        {lower: 212.53, middle: 215.36, upper: 218.19},
+        {lower: 212.83, middle: 215.9, upper: 218.97},
+        {lower: 212.83, middle: 216.51, upper: 220.19},
+        {lower: 212.83, middle: 216.815, upper: 220.8},
+        {lower: 212.83, middle: 217.49, upper: 222.15},
+        {lower: 212.83, middle: 217.495, upper: 222.16},
+        {lower: 212.83, middle: 217.495, upper: 222.16},
+        {lower: 213.77, middle: 218.695, upper: 223.62},
+        {lower: 213.82, middle: 218.72, upper: 223.62},
+        {lower: 213.82, middle: 218.815, upper: 223.81},
+        {lower: 213.82, middle: 218.815, upper: 223.81},
+        {lower: 213.82, middle: 219.01, upper: 224.2},
+        {lower: 213.82, middle: 219.01, upper: 224.2},
+        {lower: 214.29, middle: 220.665, upper: 227.04},
+      ] as const;
+
+      const dc = new DonchianChannels(20);
+      const offset = dc.getRequiredInputs() - 1;
+
+      candles.forEach((candle, i) => {
+        const result = dc.add(candle);
+
+        if (result) {
+          expect(result).toEqual(expectations[i - offset]);
+        }
+      });
+
+      expect(dc.isStable).toBe(true);
+    });
+  });
+
+  describe('update', () => {
+    it('replaces the most recently added candle', () => {
+      const dc = new DonchianChannels(3);
+
+      dc.add({high: 10, low: 8});
+      dc.add({high: 12, low: 9});
+
+      const originalCandle = {high: 11, low: 7} as const;
+      const replacedCandle = {high: 20, low: 9} as const;
+
+      const originalResult = dc.add(originalCandle);
+
+      expect(originalResult).toEqual({lower: 7, middle: 9.5, upper: 12});
+
+      const replacedResult = dc.replace(replacedCandle);
+
+      expect(replacedResult, 'the replaced candle sets a new high and retires the old low').toEqual({
+        lower: 8,
+        middle: 14,
+        upper: 20,
+      });
+
+      const restoredResult = dc.replace(originalCandle);
+
+      expect(restoredResult, 'replacing back reproduces the original channel').toEqual({
+        lower: 7,
+        middle: 9.5,
+        upper: 12,
+      });
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new DonchianChannels(5),
+  divergentInput: {high: 1_000, low: 500},
+  inputs: [
+    {high: 213.35, low: 211.52},
+    {high: 214.22, low: 213.15},
+    {high: 214.06, low: 213.02},
+    {high: 215.17, low: 213.42},
+    {high: 214.53, low: 213.91},
+    {high: 214.89, low: 213.52},
+  ],
+});

--- a/packages/trading-signals/src/volatility/DC/DonchianChannels.ts
+++ b/packages/trading-signals/src/volatility/DC/DonchianChannels.ts
@@ -1,6 +1,6 @@
 import type {HighLow} from '../../base/Candle.type.js';
 import {TechnicalIndicator} from '../../base/Indicator.js';
-import {getMaximum, getMinimum, pushUpdate} from '../../util/index.js';
+import {pushUpdate} from '../../util/index.js';
 
 export type DonchianChannelsResult = {
   lower: number;
@@ -44,8 +44,14 @@ export class DonchianChannels extends TechnicalIndicator<DonchianChannelsResult,
       return null;
     }
 
-    const upper = getMaximum(this.#candles.map(({high}) => high));
-    const lower = getMinimum(this.#candles.map(({low}) => low));
+    // A single pass over the window keeps the hot path free of per-candle array allocations
+    let upper = this.#candles[0].high;
+    let lower = this.#candles[0].low;
+
+    for (const {high, low} of this.#candles) {
+      upper = Math.max(upper, high);
+      lower = Math.min(lower, low);
+    }
 
     return (this.result = {
       lower,

--- a/packages/trading-signals/src/volatility/DC/DonchianChannels.ts
+++ b/packages/trading-signals/src/volatility/DC/DonchianChannels.ts
@@ -1,0 +1,56 @@
+import type {HighLow} from '../../base/Candle.type.js';
+import {TechnicalIndicator} from '../../base/Indicator.js';
+import {getMaximum, getMinimum, pushUpdate} from '../../util/index.js';
+
+export type DonchianChannelsResult = {
+  lower: number;
+  middle: number;
+  upper: number;
+};
+
+/**
+ * Donchian Channels (DC)
+ * Type: Volatility
+ *
+ * Donchian Channels were developed by Richard Donchian, a pioneer of trend following. The upper band marks the
+ * highest high and the lower band the lowest low of the last candles, with the middle band halfway between the two.
+ * The channel frames the recent trading range: a widening channel signals rising volatility, a narrowing channel a
+ * quiet market. Trend followers — most famously the Turtle Traders — read a new channel extreme as a breakout level.
+ *
+ * Following the classic definition, the current candle is part of the channel. Some libraries (e.g.
+ * Skender.Stock.Indicators) build the channel from the preceding candles only, which yields the same series shifted
+ * by one candle.
+ *
+ * @see https://www.investopedia.com/terms/d/donchianchannels.asp
+ * @see https://dotnet.stockindicators.dev/indicators/Donchian/
+ */
+export class DonchianChannels extends TechnicalIndicator<DonchianChannelsResult, HighLow<number>> {
+  readonly #candles: HighLow<number>[] = [];
+  public readonly interval: number;
+
+  constructor(interval: number = 20) {
+    super();
+    this.interval = interval;
+  }
+
+  override getRequiredInputs() {
+    return this.interval;
+  }
+
+  update(candle: HighLow<number>, replace: boolean) {
+    pushUpdate({array: this.#candles, item: candle, maxLength: this.interval, replace: replace});
+
+    if (this.#candles.length < this.interval) {
+      return null;
+    }
+
+    const upper = getMaximum(this.#candles.map(({high}) => high));
+    const lower = getMinimum(this.#candles.map(({low}) => low));
+
+    return (this.result = {
+      lower,
+      middle: (upper + lower) / 2,
+      upper,
+    });
+  }
+}

--- a/packages/trading-signals/src/volatility/KC/KeltnerChannels.test.ts
+++ b/packages/trading-signals/src/volatility/KC/KeltnerChannels.test.ts
@@ -1,0 +1,201 @@
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {KeltnerChannels} from './KeltnerChannels.js';
+import {ATR} from '../ATR/ATR.js';
+import {EMA} from '../../trend/EMA/EMA.js';
+
+/*
+ * Hand-derived reference series. No Tulip Indicators data exists for Keltner Channels, and
+ * external baselines (e.g. Skender.Stock.Indicators) seed the EMA with an SMA of the first
+ * closes, while this library seeds the EMA with the first close itself — at the sixth candle
+ * below, an SMA-seeded EMA yields 14.625 instead of 14.6875, so those baselines cannot be
+ * reproduced here and the series is derived by hand instead.
+ *
+ * Config: EMA interval 3 (weight 2 / 4 = 0.5, seeded with the first close), ATR interval 2
+ * (Wilder smoothing 1 / 2, seeded with the average of the first two true ranges), multiplier 2.
+ * TR = max(high - low, |high - previous close|, |low - previous close|); the first TR is
+ * high - low. Channel lines: middle ± 2 × ATR.
+ *
+ * | # | High | Low | Close | EMA(3)  | TR | ATR(2)  | Lower | Middle  | Upper  |
+ * |---|------|-----|-------|---------|----|---------|-------|---------|--------|
+ * | 1 | 12   |  8  | 10    | 10      | 4  | -       | -     | -       | -      |
+ * | 2 | 13   | 10  | 12    | 11      | 3  | 3.5     | -     | -       | -      |
+ * | 3 | 15   | 11  | 14    | 12.5    | 4  | 3.75    | 5     | 12.5    | 20     |
+ * | 4 | 14   | 10  | 11    | 11.75   | 4  | 3.875   | 4     | 11.75   | 19.5   |
+ * | 5 | 16   | 12  | 15    | 13.375  | 5  | 4.4375  | 4.5   | 13.375  | 22.25  |
+ * | 6 | 17   | 13  | 16    | 14.6875 | 4  | 4.21875 | 6.25  | 14.6875 | 23.125 |
+ *
+ * All values are exact binary fractions, so the assertions compare exact numbers.
+ * Formula verified with: https://school.stockcharts.com/doku.php?id=technical_indicators:keltner_channels
+ */
+const referenceConfig = {atrInterval: 2, emaInterval: 3, multiplier: 2} as const;
+
+const referenceCandles = [
+  {close: 10, high: 12, low: 8},
+  {close: 12, high: 13, low: 10},
+  {close: 14, high: 15, low: 11},
+  {close: 11, high: 14, low: 10},
+  {close: 15, high: 16, low: 12},
+  {close: 16, high: 17, low: 13},
+] as const;
+
+describe('KeltnerChannels', () => {
+  describe('constructor', () => {
+    it('defaults to an EMA of 20, an ATR of 10 and a multiplier of 2', () => {
+      const withDefaults = new KeltnerChannels();
+      const explicit = new KeltnerChannels({atrInterval: 10, emaInterval: 20, multiplier: 2});
+
+      expect(withDefaults.atrInterval).toBe(10);
+      expect(withDefaults.emaInterval).toBe(20);
+      expect(withDefaults.multiplier).toBe(2);
+      expect(withDefaults.getRequiredInputs()).toBe(20);
+
+      for (let i = 0; i < 25; i++) {
+        const candle = {close: 100 + i, high: 102 + i, low: 97 + i} as const;
+        withDefaults.add(candle);
+        explicit.add(candle);
+      }
+
+      expect(withDefaults.getResultOrThrow()).toEqual(explicit.getResultOrThrow());
+    });
+  });
+
+  describe('getRequiredInputs', () => {
+    it('is driven by the slower of its two component indicators', () => {
+      const emaBound = new KeltnerChannels({atrInterval: 2, emaInterval: 5, multiplier: 2});
+      const atrBound = new KeltnerChannels({atrInterval: 7, emaInterval: 3, multiplier: 2});
+
+      expect(emaBound.getRequiredInputs()).toBe(5);
+      expect(atrBound.getRequiredInputs()).toBe(7);
+    });
+  });
+
+  describe('update', () => {
+    it('matches the hand-derived reference series', () => {
+      const expectations = [
+        {lower: 5, middle: 12.5, upper: 20},
+        {lower: 4, middle: 11.75, upper: 19.5},
+        {lower: 4.5, middle: 13.375, upper: 22.25},
+        {lower: 6.25, middle: 14.6875, upper: 23.125},
+      ] as const;
+      const kc = new KeltnerChannels(referenceConfig);
+      const offset = kc.getRequiredInputs() - 1;
+
+      referenceCandles.forEach((candle, i) => {
+        const result = kc.add(candle);
+
+        if (result) {
+          expect(result).toEqual(expectations[i - offset]);
+        }
+      });
+
+      expect(kc.isStable).toBe(true);
+      expect(kc.getRequiredInputs()).toBe(3);
+    });
+
+    it('yields no result while the ATR is still warming up even though the EMA is already stable', () => {
+      const kc = new KeltnerChannels({atrInterval: 5, emaInterval: 3, multiplier: 2});
+
+      referenceCandles.forEach((candle, i) => {
+        const result = kc.add(candle);
+
+        if (i < 4) {
+          expect(result).toBeNull();
+        } else {
+          expect(result).not.toBeNull();
+        }
+      });
+    });
+
+    it('separates the channel lines by twice the multiplier times the ATR', () => {
+      const candles = [
+        {close: 91, high: 95, low: 88},
+        {close: 96, high: 98, low: 90},
+        {close: 94, high: 99, low: 92},
+        {close: 89, high: 95, low: 87},
+        {close: 92, high: 93, low: 86},
+        {close: 99, high: 101, low: 91},
+        {close: 104, high: 106, low: 98},
+        {close: 101, high: 107, low: 99},
+        {close: 97, high: 103, low: 94},
+        {close: 103, high: 105, low: 96},
+        {close: 106, high: 110, low: 102},
+        {close: 100, high: 108, low: 99},
+      ] as const;
+      const multiplier = 3;
+      const kc = new KeltnerChannels({atrInterval: 4, emaInterval: 6, multiplier});
+      const atr = new ATR(4);
+      let stableResults = 0;
+
+      for (const candle of candles) {
+        const result = kc.add(candle);
+        const atrResult = atr.add(candle);
+
+        if (result && atrResult !== null) {
+          stableResults++;
+          expect(result.upper - result.lower).toBeCloseTo(2 * multiplier * atrResult, 12);
+        }
+      }
+
+      expect(stableResults).toBe(candles.length - 5);
+    });
+
+    it('pins all three lines to the price when candles never move', () => {
+      const kc = new KeltnerChannels(referenceConfig);
+
+      for (let i = 0; i < 10; i++) {
+        kc.add({close: 100, high: 100, low: 100});
+      }
+
+      expect(kc.getResultOrThrow()).toEqual({lower: 100, middle: 100, upper: 100});
+    });
+
+    it('collapses the channel lines onto the middle EMA line when the multiplier is zero', () => {
+      const kc = new KeltnerChannels({atrInterval: 2, emaInterval: 3, multiplier: 0});
+      const ema = new EMA(3);
+
+      referenceCandles.forEach(candle => {
+        const result = kc.add(candle);
+        const emaResult = ema.add(candle.close);
+
+        if (result) {
+          expect(result.lower).toBe(result.middle);
+          expect(result.upper).toBe(result.middle);
+          expect(result.middle).toBe(emaResult);
+        }
+      });
+
+      expect(kc.isStable).toBe(true);
+    });
+  });
+
+  describe('replace', () => {
+    it('replaces the most recently added candle and can restore it', () => {
+      const kc = new KeltnerChannels(referenceConfig);
+
+      for (const candle of referenceCandles) {
+        kc.add(candle);
+      }
+
+      const originalCandle = {close: 17, high: 18, low: 14} as const;
+      const replacementCandle = {close: 12, high: 20, low: 10} as const;
+
+      const originalResult = kc.add(originalCandle);
+
+      expect(originalResult).toEqual({lower: 7.625, middle: 15.84375, upper: 24.0625});
+
+      const replacedResult = kc.replace(replacementCandle);
+
+      expect(replacedResult).toEqual({lower: -0.875, middle: 13.34375, upper: 27.5625});
+
+      const restoredResult = kc.replace(originalCandle);
+
+      expect(restoredResult).toEqual({lower: 7.625, middle: 15.84375, upper: 24.0625});
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new KeltnerChannels(referenceConfig),
+  divergentInput: {close: 90, high: 100, low: 80},
+  inputs: referenceCandles,
+});

--- a/packages/trading-signals/src/volatility/KC/KeltnerChannels.ts
+++ b/packages/trading-signals/src/volatility/KC/KeltnerChannels.ts
@@ -1,0 +1,76 @@
+import {TechnicalIndicator} from '../../base/Indicator.js';
+import type {HighLowClose} from '../../base/Candle.type.js';
+import {EMA} from '../../trend/EMA/EMA.js';
+import {ATR} from '../ATR/ATR.js';
+
+export type KeltnerChannelsResult = {
+  lower: number;
+  middle: number;
+  upper: number;
+};
+
+export type KeltnerChannelsConfig = {
+  /** Number of candles for the Average True Range that sets the channel width (default: 10) */
+  atrInterval?: number;
+  /** Number of candles for the Exponential Moving Average that forms the middle line (default: 20) */
+  emaInterval?: number;
+  /** How many ATRs the upper and lower channel lines sit away from the middle line (default: 2) */
+  multiplier?: number;
+};
+
+/**
+ * Keltner Channels (KC)
+ * Type: Volatility
+ *
+ * Keltner Channels wrap a volatility-scaled envelope around an Exponential Moving Average: the
+ * channel width follows the Average True Range, so the channels breathe with the market — widening
+ * in turbulent phases and tightening in quiet ones. Unlike Bollinger Bands, whose width comes from
+ * the standard deviation of closing prices, the ATR-based width also picks up gaps and intraday
+ * swings, which makes the channels a smoother, trend-friendlier envelope.
+ *
+ * Chester Keltner's original 1960 version placed a Simple Moving Average of the typical price
+ * inside bands derived from the high-low range. This implementation follows the modern definition
+ * popularized by Linda Bradford Raschke: an EMA middle line with ATR-based channel lines.
+ *
+ * @see https://school.stockcharts.com/doku.php?id=technical_indicators:keltner_channels
+ * @see https://www.investopedia.com/terms/k/keltnerchannel.asp
+ */
+export class KeltnerChannels extends TechnicalIndicator<KeltnerChannelsResult, HighLowClose<number>> {
+  readonly #middle: EMA;
+  readonly #atr: ATR;
+
+  public readonly atrInterval: number;
+  public readonly emaInterval: number;
+  public readonly multiplier: number;
+
+  constructor({atrInterval = 10, emaInterval = 20, multiplier = 2}: KeltnerChannelsConfig = {}) {
+    super();
+    this.atrInterval = atrInterval;
+    this.emaInterval = emaInterval;
+    this.multiplier = multiplier;
+    this.#middle = new EMA(emaInterval);
+    this.#atr = new ATR(atrInterval);
+  }
+
+  override getRequiredInputs() {
+    return Math.max(this.#middle.getRequiredInputs(), this.#atr.getRequiredInputs());
+  }
+
+  update(candle: HighLowClose<number>, replace: boolean) {
+    this.#middle.update(candle.close, replace);
+    this.#atr.update(candle, replace);
+
+    if (this.#middle.isStable && this.#atr.isStable) {
+      const middle = this.#middle.getResultOrThrow();
+      const channelOffset = this.multiplier * this.#atr.getResultOrThrow();
+
+      return (this.result = {
+        lower: middle - channelOffset,
+        middle,
+        upper: middle + channelOffset,
+      });
+    }
+
+    return null;
+  }
+}

--- a/packages/trading-signals/src/volatility/index.ts
+++ b/packages/trading-signals/src/volatility/index.ts
@@ -2,6 +2,7 @@ export * from './ABANDS/AccelerationBands.js';
 export * from './ATR/ATR.js';
 export * from './BBANDS/BollingerBands.js';
 export * from './BBW/BollingerBandsWidth.js';
+export * from './DC/DonchianChannels.js';
 export * from './IQR/IQR.js';
 export * from './MAD/MAD.js';
 export * from './NATR/NATR.js';

--- a/packages/trading-signals/src/volatility/index.ts
+++ b/packages/trading-signals/src/volatility/index.ts
@@ -4,6 +4,7 @@ export * from './BBANDS/BollingerBands.js';
 export * from './BBW/BollingerBandsWidth.js';
 export * from './DC/DonchianChannels.js';
 export * from './IQR/IQR.js';
+export * from './KC/KeltnerChannels.js';
 export * from './MAD/MAD.js';
 export * from './NATR/NATR.js';
 export * from './TR/TR.js';


### PR DESCRIPTION
## Summary

Adds the four multi-value indicators, each as its own commit with implementation, 100%-covered tests, docs demo, and README/barrel wiring. All extend `TechnicalIndicator<Result, Input>` with exported closed result types.

| Indicator | Class | Category | Reference verification |
|---|---|---|---|
| Donchian Channels | `DonchianChannels` | volatility | Skender v3.0.0 baseline, **bit-exact across 482 values** (their exclusive-window convention shifted by one bar — documented in JSDoc + test) |
| Keltner Channels | `KeltnerChannels` | volatility | Skender rejected after numeric seeding proof → hand-derived exact binary fractions + band-width property asserted against a live repo `ATR` |
| Ichimoku Cloud | `IchimokuCloud` | trend | Skender baseline, **0 mismatches across all 502 bars** at 4 decimals (their chart-displaced senkou columns un-shifted by 26 for comparison) |
| Vortex Indicator | `VortexIndicator` | trend | Skender baseline, **max diff 0 across 488 rows** + TASC/StockCharts worksheet hand test |

## Notes

- `IchimokuCloud` returns values computed at the current bar; the 26-bar plotting displacement (and the lagging span, which undisplaced is just the close) is left to the consumer — stated in the JSDoc, and the Skender comparison accounts for it.
- `VortexIndicator` carries a STOCH-style `getSignal()` (VI+/VI− crossover) plus a ΣTR = 0 guard that keeps a dead market SIDEWAYS instead of fabricating direction.
- `KeltnerChannels` implements the modern Raschke EMA/ATR definition (EMA 20 / ATR 10 / ×2); Keltner's 1960 SMA-of-typical-price original is documented as intentionally not implemented.
- `DonchianChannels` uses the classic current-bar-inclusive window; deliberately no breakout signal, since price can never close outside its own inclusive channel.

Part 3/3 of the indicator expansion — stacked on #1285. With this, all 19 indicators from the roadmap are in: 6 MA variants (#1284), 9 oscillators (#1285), 4 channel/multi-value (this PR).