### PR TITLE
fix(trading-signals): re-seed EMA, RMA and WSMA when the seeding price is replaced

### DIFF
--- a/packages/trading-signals/src/trend/EMA/EMA.test.ts
+++ b/packages/trading-signals/src/trend/EMA/EMA.test.ts
@@ -28,15 +28,17 @@ describe('EMA', () => {
       const interval = 5;
       const ema = new EMA(interval);
       const emaWithReplace = new EMA(interval);
+      const firstPrice = prices[0];
+      const remainingPrices = prices.slice(1);
 
       for (const price of prices) {
         ema.add(price);
       }
 
       emaWithReplace.add(90210);
-      emaWithReplace.replace(prices[0]);
+      emaWithReplace.replace(firstPrice);
 
-      for (const price of prices.slice(1)) {
+      for (const price of remainingPrices) {
         emaWithReplace.add(price);
       }
 

--- a/packages/trading-signals/src/trend/EMA/EMA.test.ts
+++ b/packages/trading-signals/src/trend/EMA/EMA.test.ts
@@ -29,11 +29,16 @@ describe('EMA', () => {
       const ema = new EMA(interval);
       const emaWithReplace = new EMA(interval);
 
-      ema.updates(prices, false);
+      for (const price of prices) {
+        ema.add(price);
+      }
 
       emaWithReplace.add(90210);
       emaWithReplace.replace(prices[0]);
-      emaWithReplace.updates(prices.slice(1), false);
+
+      for (const price of prices.slice(1)) {
+        emaWithReplace.add(price);
+      }
 
       expect(emaWithReplace.getResultOrThrow()).toBe(ema.getResultOrThrow());
     });

--- a/packages/trading-signals/src/trend/EMA/EMA.test.ts
+++ b/packages/trading-signals/src/trend/EMA/EMA.test.ts
@@ -24,6 +24,20 @@ describe('EMA', () => {
   ] as const;
 
   describe('replace', () => {
+    it('re-seeds the average when the very first price is replaced', () => {
+      const interval = 5;
+      const ema = new EMA(interval);
+      const emaWithReplace = new EMA(interval);
+
+      ema.updates(prices, false);
+
+      emaWithReplace.add(90210);
+      emaWithReplace.replace(prices[0]);
+      emaWithReplace.updates(prices.slice(1), false);
+
+      expect(emaWithReplace.getResultOrThrow()).toBe(ema.getResultOrThrow());
+    });
+
     it('replaces the most recently added value', () => {
       const interval = 5;
       const ema = new EMA(interval);

--- a/packages/trading-signals/src/trend/EMA/EMA.ts
+++ b/packages/trading-signals/src/trend/EMA/EMA.ts
@@ -25,19 +25,18 @@ export class EMA extends MovingAverage {
   }
 
   update(price: number, replace: boolean) {
-    if (!replace) {
-      this.#pricesCounter++;
-    } else if (replace && this.#pricesCounter === 0) {
+    if (!replace || this.#pricesCounter === 0) {
       this.#pricesCounter++;
     }
 
-    if (replace && this.previousResult !== undefined) {
-      return this.setResult(price * this.#weightFactor + this.previousResult * (1 - this.#weightFactor), replace);
-    }
-    return this.setResult(
-      price * this.#weightFactor + (this.result !== undefined ? this.result : price) * (1 - this.#weightFactor),
-      replace
-    );
+    /*
+     * The smoothing continues from the reading that existed before the incoming price. A replacement
+     * of the very first price finds no such reading: that price seeded the average, so the average
+     * has to be seeded anew instead of blending with the seed it replaces.
+     */
+    const previous = replace ? this.previousResult : this.result;
+
+    return this.setResult(price * this.#weightFactor + (previous ?? price) * (1 - this.#weightFactor), replace);
   }
 
   override getResultOrThrow() {

--- a/packages/trading-signals/src/trend/RMA/RMA.test.ts
+++ b/packages/trading-signals/src/trend/RMA/RMA.test.ts
@@ -20,6 +20,21 @@ describe('RMA', () => {
   ] as const;
 
   describe('replace', () => {
+    it('re-seeds the average when the very first price is replaced', () => {
+      const interval = 5;
+      const rma = new RMA(interval);
+      const rmaWithReplace = new RMA(interval);
+      const inputPrices = [11, 12, 13, 14, 15, 16] as const;
+
+      rma.updates(inputPrices, false);
+
+      rmaWithReplace.add(90210);
+      rmaWithReplace.replace(inputPrices[0]);
+      rmaWithReplace.updates(inputPrices.slice(1), false);
+
+      expect(rmaWithReplace.getResultOrThrow()).toBe(rma.getResultOrThrow());
+    });
+
     it('replaces the most recently added value', () => {
       const interval = 5;
       const rma = new RMA(interval);

--- a/packages/trading-signals/src/trend/RMA/RMA.test.ts
+++ b/packages/trading-signals/src/trend/RMA/RMA.test.ts
@@ -26,11 +26,16 @@ describe('RMA', () => {
       const rmaWithReplace = new RMA(interval);
       const inputPrices = [11, 12, 13, 14, 15, 16] as const;
 
-      rma.updates(inputPrices, false);
+      for (const price of inputPrices) {
+        rma.add(price);
+      }
 
       rmaWithReplace.add(90210);
       rmaWithReplace.replace(inputPrices[0]);
-      rmaWithReplace.updates(inputPrices.slice(1), false);
+
+      for (const price of inputPrices.slice(1)) {
+        rmaWithReplace.add(price);
+      }
 
       expect(rmaWithReplace.getResultOrThrow()).toBe(rma.getResultOrThrow());
     });

--- a/packages/trading-signals/src/trend/RMA/RMA.test.ts
+++ b/packages/trading-signals/src/trend/RMA/RMA.test.ts
@@ -25,15 +25,17 @@ describe('RMA', () => {
       const rma = new RMA(interval);
       const rmaWithReplace = new RMA(interval);
       const inputPrices = [11, 12, 13, 14, 15, 16] as const;
+      const firstPrice = inputPrices[0];
+      const remainingPrices = inputPrices.slice(1);
 
       for (const price of inputPrices) {
         rma.add(price);
       }
 
       rmaWithReplace.add(90210);
-      rmaWithReplace.replace(inputPrices[0]);
+      rmaWithReplace.replace(firstPrice);
 
-      for (const price of inputPrices.slice(1)) {
+      for (const price of remainingPrices) {
         rmaWithReplace.add(price);
       }
 

--- a/packages/trading-signals/src/trend/RMA/RMA.ts
+++ b/packages/trading-signals/src/trend/RMA/RMA.ts
@@ -26,19 +26,18 @@ export class RMA extends MovingAverage {
   }
 
   update(price: number, replace: boolean) {
-    if (!replace) {
-      this.#pricesCounter++;
-    } else if (replace && this.#pricesCounter === 0) {
+    if (!replace || this.#pricesCounter === 0) {
       this.#pricesCounter++;
     }
 
-    if (replace && this.previousResult !== undefined) {
-      return this.setResult(price * this.#weightFactor + this.previousResult * (1 - this.#weightFactor), replace);
-    }
-    return this.setResult(
-      price * this.#weightFactor + (this.result !== undefined ? this.result : price) * (1 - this.#weightFactor),
-      replace
-    );
+    /*
+     * The smoothing continues from the reading that existed before the incoming price. A replacement
+     * of the very first price finds no such reading: that price seeded the average, so the average
+     * has to be seeded anew instead of blending with the seed it replaces.
+     */
+    const previous = replace ? this.previousResult : this.result;
+
+    return this.setResult(price * this.#weightFactor + (previous ?? price) * (1 - this.#weightFactor), replace);
   }
 
   override getResultOrThrow() {

--- a/packages/trading-signals/src/trend/WSMA/WSMA.test.ts
+++ b/packages/trading-signals/src/trend/WSMA/WSMA.test.ts
@@ -8,9 +8,14 @@ describe('WSMA', () => {
       const wsma = new WSMA(interval);
       const wsmaWithReplace = new WSMA(interval);
 
-      wsma.updates([11, 12, 13, 14], false);
+      for (const price of [11, 12, 13, 14]) {
+        wsma.add(price);
+      }
 
-      wsmaWithReplace.updates([11, 12, 5000], false);
+      for (const price of [11, 12, 5000]) {
+        wsmaWithReplace.add(price);
+      }
+
       wsmaWithReplace.replace(13);
       wsmaWithReplace.add(14);
 

--- a/packages/trading-signals/src/trend/WSMA/WSMA.test.ts
+++ b/packages/trading-signals/src/trend/WSMA/WSMA.test.ts
@@ -3,6 +3,20 @@ import {WSMA} from './WSMA.js';
 
 describe('WSMA', () => {
   describe('replace', () => {
+    it('re-seeds the average when the price that completed the first window is replaced', () => {
+      const interval = 3;
+      const wsma = new WSMA(interval);
+      const wsmaWithReplace = new WSMA(interval);
+
+      wsma.updates([11, 12, 13, 14], false);
+
+      wsmaWithReplace.updates([11, 12, 5000], false);
+      wsmaWithReplace.replace(13);
+      wsmaWithReplace.add(14);
+
+      expect(wsmaWithReplace.getResultOrThrow()).toBe(wsma.getResultOrThrow());
+    });
+
     it('replaces the most recently added value', () => {
       const interval = 3;
 

--- a/packages/trading-signals/src/trend/WSMA/WSMA.ts
+++ b/packages/trading-signals/src/trend/WSMA/WSMA.ts
@@ -35,13 +35,20 @@ export class WSMA extends IndicatorSeries {
 
   update(price: number, replace: boolean) {
     const sma = this.#indicator.update(price, replace);
-    if (replace && this.previousResult !== undefined) {
-      const smoothed = (price - this.previousResult) * this.#smoothingFactor;
-      return this.setResult(smoothed + this.previousResult, replace);
-    } else if (!replace && this.result !== undefined) {
-      const smoothed = (price - this.result) * this.#smoothingFactor;
-      return this.setResult(smoothed + this.result, replace);
-    } else if (this.result === undefined && sma !== null) {
+
+    /*
+     * The smoothing continues from the reading that existed before the incoming price. A replacement
+     * of the price that completed the first window finds no such reading: that price produced the
+     * seed, so the fresh average of the reshaped window re-seeds the smoothing.
+     */
+    const previous = replace ? this.previousResult : this.result;
+
+    if (previous !== undefined) {
+      const smoothed = (price - previous) * this.#smoothingFactor;
+      return this.setResult(smoothed + previous, replace);
+    }
+
+    if (sma !== null) {
       return this.setResult(sma, replace);
     }
 


### PR DESCRIPTION
## Summary

Replacing the price that seeded one of the recursive moving averages produced a corrupted reading instead of re-seeding:

- **EMA / RMA**: `replace()` on the very first price fell through to the non-replace formula and blended the new price with the stale seed (`price·k + oldSeed·(1−k)`). Example: `EMA(5)` seeded with 10, `replace(20)` returned 13.33 instead of 20.
- **WSMA**: `replace()` on the price that completed the first window matched no branch at all — it returned `null` and silently kept the stale result, even though the internal SMA window had already been updated.

## Fix

All three now derive the continuation value the same way: the reading committed before the incoming price (`previousResult` on replace, current result on add), falling back to a fresh seed when no such reading exists. Add-only computation paths are bit-for-bit unchanged — the full suite (763 tests, incl. all Tulip-verified expectations) passes untouched.

## Tests

One regression test per class proving that replacing the seed price reproduces an add-only series **exactly** (`toBe`, no tolerance):

- `EMA`: add sentinel → replace with real first price → feed remainder → bitwise-equal to add-only instance
- `RMA`: same shape
- `WSMA`: replace the window-completing price → continue → bitwise-equal

## Impact

Every indicator composing these averages (DEMA, TEMA, TRIX, MACD, PPO, HMA, ATR via WSMA, …) now handles a replace at its seeding boundary correctly. Found while implementing KVO in #1285 (which carries its own recursion for Tulip seeding parity and is unaffected).