### PR TITLE
feat(trading-signals): close the indicatorts feature gap (8 indicators + KDJ %J line)

### DIFF
--- a/packages/trading-signals-docs/indicator-demos/momentum/CFO.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/CFO.demo.tsx
@@ -1,0 +1,20 @@
+import {CFO as CFOClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const CFO: IndicatorConfig = {
+  chartTitle: 'CFO (14)',
+  color: '#0ea5e9',
+  createIndicator: () => new CFOClass(14),
+  description: 'Chande Forecast Oscillator',
+  details:
+    'Measures the percentage gap between the close and the close projected by a linear regression over the preceding closes. Positive readings show price running ahead of its own trend (bullish pressure), negative readings show it falling short (bearish pressure).',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
+  id: 'cfo',
+  name: 'CFO',
+  processData: makeProcessData({rowInputs: ['close']}),
+  requiredInputs: 15,
+  type: 'single',
+  yAxisLabel: 'CFO',
+};

--- a/packages/trading-signals-docs/indicator-demos/momentum/Qstick.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/Qstick.demo.tsx
@@ -1,0 +1,20 @@
+import {Qstick as QstickClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const Qstick: IndicatorConfig = {
+  chartTitle: 'Qstick (8)',
+  color: '#0d9488',
+  createIndicator: () => new QstickClass(),
+  description: 'Qstick',
+  details:
+    'Averages the candle bodies (close minus open) over an interval to show whether buyers or sellers control the closes. Above zero buyers close candles above their opens, below zero sellers pin closes below the opens.',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['open', 'high', 'low', 'close']}),
+  id: 'qstick',
+  name: 'Qstick',
+  processData: makeProcessData({rowInputs: ['open', 'high', 'low', 'close']}),
+  requiredInputs: 8,
+  type: 'single',
+  yAxisLabel: 'Qstick',
+};

--- a/packages/trading-signals-docs/indicator-demos/momentum/StochasticOscillator.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/StochasticOscillator.demo.tsx
@@ -14,8 +14,17 @@ const renderStochastic = (config: IndicatorConfig, selectedCandles: Candle[]) =>
   const stoch = new StochasticOscillatorClass({dPeriod: 3, kPeriod: 14, kSlowingPeriod: 3});
   const chartDataK: ChartDataPoint[] = [];
   const chartDataD: ChartDataPoint[] = [];
+  const chartDataJ: ChartDataPoint[] = [];
   const priceData: PriceData[] = [];
-  const sampleValues: {period: number; date: string; close: number; k: ReactNode; d: ReactNode; signal: string}[] = [];
+  const sampleValues: {
+    period: number;
+    date: string;
+    close: number;
+    k: ReactNode;
+    d: ReactNode;
+    j: ReactNode;
+    signal: string;
+  }[] = [];
 
   selectedCandles.forEach((candle, idx) => {
     stoch.add({close: Number(candle.close), high: Number(candle.high), low: Number(candle.low)});
@@ -23,6 +32,7 @@ const renderStochastic = (config: IndicatorConfig, selectedCandles: Candle[]) =>
     const signal = stoch.getSignal();
     chartDataK.push({x: idx + 1, y: result?.stochK ?? null});
     chartDataD.push({x: idx + 1, y: result?.stochD ?? null});
+    chartDataJ.push({x: idx + 1, y: result?.stochJ ?? null});
 
     priceData.push(collectPriceData(candle, idx));
 
@@ -30,6 +40,7 @@ const renderStochastic = (config: IndicatorConfig, selectedCandles: Candle[]) =>
       close: Number(candle.close),
       d: result ? result.stochD.toFixed(2) : <NotAvailable />,
       date: formatDate(candle.openTimeInISO),
+      j: result ? result.stochJ.toFixed(2) : <NotAvailable />,
       k: result ? result.stochK.toFixed(2) : <NotAvailable />,
       period: idx + 1,
       signal: signal.state,
@@ -71,6 +82,13 @@ const renderStochastic = (config: IndicatorConfig, selectedCandles: Candle[]) =>
                 name: '%D',
                 type: 'line',
               },
+              {
+                color: '#38bdf8',
+                data: chartDataJ.map(point => [point.x, point.y]),
+                marker: {fillColor: '#38bdf8'},
+                name: '%J',
+                type: 'line',
+              },
             ],
             title: {
               style: {color: '#e2e8f0', fontSize: '16px', fontWeight: '600'},
@@ -110,6 +128,7 @@ const renderStochastic = (config: IndicatorConfig, selectedCandles: Candle[]) =>
                 <th className="text-left text-slate-300 py-2 px-3">Close</th>
                 <th className="text-left text-slate-300 py-2 px-3">%K</th>
                 <th className="text-left text-slate-300 py-2 px-3">%D</th>
+                <th className="text-left text-slate-300 py-2 px-3">%J</th>
                 <th className="text-left text-slate-300 py-2 px-3">Signal</th>
               </tr>
             </thead>
@@ -121,6 +140,7 @@ const renderStochastic = (config: IndicatorConfig, selectedCandles: Candle[]) =>
                   <td className="text-slate-300 py-2 px-3">${row.close.toFixed(2)}</td>
                   <td className="text-white font-mono py-2 px-3">{row.k}</td>
                   <td className="text-white font-mono py-2 px-3">{row.d}</td>
+                  <td className="text-white font-mono py-2 px-3">{row.j}</td>
                   <td className="py-2 px-3">
                     <SignalBadge signal={row.signal} />
                   </td>

--- a/packages/trading-signals-docs/indicator-demos/momentum/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/index.tsx
@@ -3,6 +3,7 @@ import {AO} from './AO.demo';
 import {APO} from './APO.demo';
 import {BOP} from './BOP.demo';
 import {CCI} from './CCI.demo';
+import {CFO} from './CFO.demo';
 import {CG} from './CG.demo';
 import {CMO} from './CMO.demo';
 import {CoppockCurve} from './CoppockCurve.demo';
@@ -55,6 +56,7 @@ export const indicators: IndicatorConfig[] = [
   KST,
   ElderRay,
   Qstick,
+  CFO,
   TRIX,
   TSI,
 ];

--- a/packages/trading-signals-docs/indicator-demos/momentum/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/index.tsx
@@ -15,6 +15,7 @@ import {MFI} from './MFI.demo';
 import {MOM} from './MOM.demo';
 import {OBV} from './OBV.demo';
 import {PPO} from './PPO.demo';
+import {Qstick} from './Qstick.demo';
 import {REI} from './REI.demo';
 import {ROC} from './ROC.demo';
 import {RSI} from './RSI.demo';
@@ -53,6 +54,7 @@ export const indicators: IndicatorConfig[] = [
   CoppockCurve,
   KST,
   ElderRay,
+  Qstick,
   TRIX,
   TSI,
 ];

--- a/packages/trading-signals-docs/indicator-demos/volatility/MassIndex.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volatility/MassIndex.demo.tsx
@@ -1,0 +1,20 @@
+import {MassIndex as MassIndexClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const MassIndex: IndicatorConfig = {
+  chartTitle: 'Mass Index (25)',
+  color: '#f43f5e',
+  createIndicator: () => new MassIndexClass(25),
+  description: 'Mass Index',
+  details:
+    'Sums the ratio of a single- to a double-smoothed high-low range over 25 bars, so widening ranges inflate the reading regardless of direction. Donald Dorsey’s "reversal bulge" — a rise above 27 followed by a drop below 26.5 — flags a likely trend change, while the direction of the new trend must be read from a companion indicator.',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['high', 'low']}),
+  id: 'mass-index',
+  name: 'Mass Index',
+  processData: makeProcessData({rowInputs: ['high', 'low']}),
+  requiredInputs: 41,
+  type: 'single',
+  yAxisLabel: 'Mass Index',
+};

--- a/packages/trading-signals-docs/indicator-demos/volatility/ProjectionOscillator.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volatility/ProjectionOscillator.demo.tsx
@@ -1,0 +1,20 @@
+import {ProjectionOscillator as ProjectionOscillatorClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const ProjectionOscillator: IndicatorConfig = {
+  chartTitle: 'PO (14)',
+  color: '#f97316',
+  createIndicator: () => new ProjectionOscillatorClass({interval: 14}),
+  description: 'Projection Oscillator',
+  details:
+    'Locates the close within projection bands that ride the linear regression trend of the window: 100 means the close sits on the upper band, 0 on the lower band. Because the bands follow the trend, readings of 80/20 flag overbought/oversold conditions relative to the trend channel instead of a horizontal range.',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
+  id: 'projection-oscillator',
+  name: 'PO',
+  processData: makeProcessData({addInputs: ['high', 'low', 'close'], rowInputs: ['close']}),
+  requiredInputs: 14,
+  type: 'single',
+  yAxisLabel: 'PO',
+};

--- a/packages/trading-signals-docs/indicator-demos/volatility/UlcerIndex.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volatility/UlcerIndex.demo.tsx
@@ -1,0 +1,20 @@
+import {UlcerIndex as UlcerIndexClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const UlcerIndex: IndicatorConfig = {
+  chartTitle: 'Ulcer Index (14)',
+  color: '#a855f7',
+  createIndicator: () => new UlcerIndexClass(14),
+  description: 'Ulcer Index',
+  details:
+    'Downside volatility measure by Peter Martin. Root mean square of percentage drawdowns from the highest close in the window, penalizing both the depth and the duration of declines — upside moves never increase it.',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
+  id: 'ulcer-index',
+  name: 'Ulcer Index',
+  processData: makeProcessData({rowInputs: ['close']}),
+  requiredInputs: 14,
+  type: 'single',
+  yAxisLabel: 'UI',
+};

--- a/packages/trading-signals-docs/indicator-demos/volatility/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volatility/index.tsx
@@ -6,6 +6,7 @@ import {DonchianChannels} from './DonchianChannels.demo';
 import {IQR} from './IQR.demo';
 import {KeltnerChannels} from './KeltnerChannels.demo';
 import {MAD} from './MAD.demo';
+import {MassIndex} from './MassIndex.demo';
 import {NATR} from './NATR.demo';
 import {ProjectionOscillator} from './ProjectionOscillator.demo';
 import {TR} from './TR.demo';
@@ -25,4 +26,5 @@ export const indicators: IndicatorConfig[] = [
   MAD,
   UlcerIndex,
   ProjectionOscillator,
+  MassIndex,
 ];

--- a/packages/trading-signals-docs/indicator-demos/volatility/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volatility/index.tsx
@@ -8,6 +8,7 @@ import {KeltnerChannels} from './KeltnerChannels.demo';
 import {MAD} from './MAD.demo';
 import {NATR} from './NATR.demo';
 import {TR} from './TR.demo';
+import {UlcerIndex} from './UlcerIndex.demo';
 import type {IndicatorConfig} from '../../utils/types';
 
 export const indicators: IndicatorConfig[] = [
@@ -21,4 +22,5 @@ export const indicators: IndicatorConfig[] = [
   BollingerBandsWidth,
   IQR,
   MAD,
+  UlcerIndex,
 ];

--- a/packages/trading-signals-docs/indicator-demos/volatility/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volatility/index.tsx
@@ -7,6 +7,7 @@ import {IQR} from './IQR.demo';
 import {KeltnerChannels} from './KeltnerChannels.demo';
 import {MAD} from './MAD.demo';
 import {NATR} from './NATR.demo';
+import {ProjectionOscillator} from './ProjectionOscillator.demo';
 import {TR} from './TR.demo';
 import {UlcerIndex} from './UlcerIndex.demo';
 import type {IndicatorConfig} from '../../utils/types';
@@ -23,4 +24,5 @@ export const indicators: IndicatorConfig[] = [
   IQR,
   MAD,
   UlcerIndex,
+  ProjectionOscillator,
 ];

--- a/packages/trading-signals-docs/indicator-demos/volume/NVI.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volume/NVI.demo.tsx
@@ -1,0 +1,23 @@
+import {NVI as NVIClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const NVI: IndicatorConfig = {
+  chartTitle: 'Negative Volume Index',
+  color: '#ef4444',
+  createIndicator: () => new NVIClass(),
+  description: 'Negative Volume Index',
+  details:
+    'Cumulative index that starts at 1000 and follows price changes only on falling-volume days, on the premise that "smart money" positions itself quietly while crowded high-volume days are noise. Traditionally read against its own one-year moving average rather than a fixed threshold.',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close', 'volume']}),
+  id: 'nvi',
+  name: 'NVI',
+  processData: makeProcessData({
+    addInputs: ['close', 'high', 'low', 'volume'],
+    rowInputs: ['close', 'volume'],
+  }),
+  requiredInputs: 1,
+  type: 'single',
+  yAxisLabel: 'NVI',
+};

--- a/packages/trading-signals-docs/indicator-demos/volume/PVI.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volume/PVI.demo.tsx
@@ -1,0 +1,23 @@
+import {PVI as PVIClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const PVI: IndicatorConfig = {
+  chartTitle: 'Positive Volume Index',
+  color: '#84cc16',
+  createIndicator: () => new PVIClass(),
+  description: 'Positive Volume Index',
+  details:
+    'Cumulative index starting at 1000 that compounds the percentage price change only on bars with rising volume — tracking what the crowd does on busy days. Read against its own long moving average: above suggests bull-market odds, below warns of a bear market.',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close', 'volume']}),
+  id: 'pvi',
+  name: 'PVI',
+  processData: makeProcessData({
+    addInputs: ['close', 'high', 'low', 'volume'],
+    rowInputs: ['close', 'volume'],
+  }),
+  requiredInputs: 1,
+  type: 'single',
+  yAxisLabel: 'PVI',
+};

--- a/packages/trading-signals-docs/indicator-demos/volume/PVO.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volume/PVO.demo.tsx
@@ -1,0 +1,20 @@
+import {PVO as PVOClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const PVO: IndicatorConfig = {
+  chartTitle: 'PVO (12, 26)',
+  color: '#14b8a6',
+  createIndicator: () => new PVOClass(),
+  description: 'Percentage Volume Oscillator',
+  details:
+    'The PPO applied to volume: divides the spread between the fast and slow volume EMA by the slow EMA. Readings above zero mean volume is expanding and lends conviction to the current move; crossings of the zero line mark a volume regime change.',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['volume']}),
+  id: 'pvo',
+  name: 'PVO',
+  processData: makeProcessData({rowInputs: ['volume']}),
+  requiredInputs: 26,
+  type: 'single',
+  yAxisLabel: 'PVO (%)',
+};

--- a/packages/trading-signals-docs/indicator-demos/volume/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volume/index.tsx
@@ -5,9 +5,10 @@ import {EMV} from './EMV.demo';
 import {ForceIndex} from './ForceIndex.demo';
 import {KVO} from './KVO.demo';
 import {NVI} from './NVI.demo';
+import {PVI} from './PVI.demo';
 import {PVT} from './PVT.demo';
 import {VROC} from './VROC.demo';
 import {VWMA} from './VWMA.demo';
 import type {IndicatorConfig} from '../../utils/types';
 
-export const indicators: IndicatorConfig[] = [AD, ADOSC, CMF, PVT, EMV, ForceIndex, KVO, NVI, VROC, VWMA];
+export const indicators: IndicatorConfig[] = [AD, ADOSC, CMF, PVT, EMV, ForceIndex, KVO, NVI, PVI, VROC, VWMA];

--- a/packages/trading-signals-docs/indicator-demos/volume/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volume/index.tsx
@@ -6,9 +6,10 @@ import {ForceIndex} from './ForceIndex.demo';
 import {KVO} from './KVO.demo';
 import {NVI} from './NVI.demo';
 import {PVI} from './PVI.demo';
+import {PVO} from './PVO.demo';
 import {PVT} from './PVT.demo';
 import {VROC} from './VROC.demo';
 import {VWMA} from './VWMA.demo';
 import type {IndicatorConfig} from '../../utils/types';
 
-export const indicators: IndicatorConfig[] = [AD, ADOSC, CMF, PVT, EMV, ForceIndex, KVO, NVI, PVI, VROC, VWMA];
+export const indicators: IndicatorConfig[] = [AD, ADOSC, CMF, PVT, EMV, ForceIndex, KVO, NVI, PVI, PVO, VROC, VWMA];

--- a/packages/trading-signals-docs/indicator-demos/volume/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volume/index.tsx
@@ -4,9 +4,10 @@ import {CMF} from './CMF.demo';
 import {EMV} from './EMV.demo';
 import {ForceIndex} from './ForceIndex.demo';
 import {KVO} from './KVO.demo';
+import {NVI} from './NVI.demo';
 import {PVT} from './PVT.demo';
 import {VROC} from './VROC.demo';
 import {VWMA} from './VWMA.demo';
 import type {IndicatorConfig} from '../../utils/types';
 
-export const indicators: IndicatorConfig[] = [AD, ADOSC, CMF, PVT, EMV, ForceIndex, KVO, VROC, VWMA];
+export const indicators: IndicatorConfig[] = [AD, ADOSC, CMF, PVT, EMV, ForceIndex, KVO, NVI, VROC, VWMA];

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -71,6 +71,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. On-Balance Volume (OBV)
 1. Parabolic SAR (PSAR)
 1. Percentage Price Oscillator (PPO)
+1. Percentage Volume Oscillator (PVO)
 1. Positive Volume Index (PVI)
 1. Price Volume Trend (PVT)
 1. Qstick (QSTICK)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -63,6 +63,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Klinger Volume Oscillator (KVO)
 1. Know Sure Thing (KST)
 1. Linear Regression (LINREG)
+1. Mass Index (MI)
 1. Mean Absolute Deviation (MAD)
 1. Momentum (MOM / MTM)
 1. Money Flow Index (MFI)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -92,6 +92,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Triple Smoothed EMA Rate of Change (TRIX)
 1. True Range (TR)
 1. True Strength Index (TSI)
+1. Ulcer Index (UI)
 1. Ultimate Oscillator (ULTOSC)
 1. Variable Index Dynamic Average (VIDYA)
 1. Volatility Stop (VSTOP)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -66,6 +66,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Momentum (MOM / MTM)
 1. Money Flow Index (MFI)
 1. Moving Average Convergence Divergence (MACD)
+1. Negative Volume Index (NVI)
 1. Normalized Average True Range (NATR)
 1. On-Balance Volume (OBV)
 1. Parabolic SAR (PSAR)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -71,6 +71,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Parabolic SAR (PSAR)
 1. Percentage Price Oscillator (PPO)
 1. Price Volume Trend (PVT)
+1. Qstick (QSTICK)
 1. Range Expansion Index (REI)
 1. Rate-of-Change (ROC)
 1. Relative Moving Average (RMA)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -71,6 +71,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. On-Balance Volume (OBV)
 1. Parabolic SAR (PSAR)
 1. Percentage Price Oscillator (PPO)
+1. Positive Volume Index (PVI)
 1. Price Volume Trend (PVT)
 1. Qstick (QSTICK)
 1. Range Expansion Index (REI)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -208,7 +208,6 @@ console.log(sma.highest?.toFixed(2)); // "53.33"
 - [Cloud9Trader Indicators (JavaScript)](https://github.com/Cloud9Trader/TechnicalIndicators)
 - [Crypto Trading Hub Indicators (TypeScript)](https://github.com/anandanand84/technicalindicators)
 - [Highcharts Indicators (TypeScript)](https://github.com/highcharts/highcharts/tree/v12.3.0/ts/Stock/Indicators)
-- [Indicator TS (TypeScript)](https://github.com/cinar/indicatorts)
 - [Jesse Trading Bot Indicators (Python)](https://docs.jesse.trade/docs/indicators/reference.html)
 - [LEAN Indicators (C#)](https://github.com/QuantConnect/Lean/tree/master/Indicators)
 - [libindicators (C#)](https://github.com/mgfx/libindicators)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -39,6 +39,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Center of Gravity (CG)
 1. Chaikin Money Flow (CMF)
 1. Chaikin Oscillator (ADOSC)
+1. Chande Forecast Oscillator (CFO)
 1. Chande Momentum Oscillator (CMO)
 1. Chandelier Exit (CE)
 1. Commodity Channel Index (CCI)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -75,6 +75,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Percentage Volume Oscillator (PVO)
 1. Positive Volume Index (PVI)
 1. Price Volume Trend (PVT)
+1. Projection Oscillator (PO)
 1. Qstick (QSTICK)
 1. Range Expansion Index (REI)
 1. Rate-of-Change (ROC)

--- a/packages/trading-signals/src/momentum/CFO/CFO.test.ts
+++ b/packages/trading-signals/src/momentum/CFO/CFO.test.ts
@@ -1,0 +1,213 @@
+import {TradingSignal} from '../../base/Indicator.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {CFO} from './CFO.js';
+
+describe('CFO', () => {
+  describe('update', () => {
+    it('replaces the most recently added value', () => {
+      const cfo = new CFO(5);
+      const closes = [81.59, 81.06, 82.87, 83.0, 83.61] as const;
+
+      for (const close of closes) {
+        cfo.add(close);
+      }
+
+      const originalResult = cfo.add(83.15);
+
+      expect(originalResult?.toFixed(3)).toBe('-1.287');
+
+      const replacedResult = cfo.replace(90);
+
+      expect(replacedResult?.toFixed(3)).toBe('6.422');
+
+      const restoredResult = cfo.replace(83.15);
+
+      expect(restoredResult?.toFixed(3)).toBe('-1.287');
+    });
+
+    it('reports the neutral zero line when the close is zero', () => {
+      const closes = [10, 11, 12, 13, 14, 0] as const;
+      const cfo = new CFO(5);
+
+      for (const close of closes) {
+        cfo.add(close);
+      }
+
+      expect(cfo.getResultOrThrow()).toBe(0);
+      expect(cfo.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+    });
+
+    it('stays on the zero line while price follows a perfectly linear trend', () => {
+      const trends = [
+        {start: 10, step: 1},
+        {start: 100, step: -2.5},
+        {start: 42, step: 0},
+        {start: 7, step: 3},
+      ] as const;
+
+      for (const {start, step} of trends) {
+        const cfo = new CFO(5);
+
+        for (let i = 0; i < 10; i++) {
+          const result = cfo.add(start + i * step);
+
+          if (result !== null) {
+            expect(result).toBe(0);
+          }
+        }
+
+        expect(cfo.getResultOrThrow()).toBe(0);
+        expect(cfo.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+      }
+    });
+  });
+
+  describe('getResultOrThrow', () => {
+    it('matches values derived from Tulip Indicators forecasts', {tags: ['tulipindicators']}, () => {
+      /*
+       * The internal forecast is Tulip's "tsf" (time series forecast, period 5), verified with:
+       * https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt#L430-L432
+       *
+       * Every close pairs with the forecast fitted over the 5 closes preceding it, so each
+       * expectation derives from a Tulip tsf value as CFO = 100 × (close − tsf) / close:
+       *
+       * 100 × (83.15 − 84.220) / 83.15 = -1.287
+       * 100 × (82.84 − 84.214) / 82.84 = -1.659
+       * 100 × (83.99 − 83.121) / 83.99 =  1.035
+       * 100 × (84.55 − 83.681) / 84.55 =  1.028
+       * 100 × (84.36 − 84.444) / 84.36 = -0.100
+       * 100 × (85.53 − 85.017) / 85.53 =  0.600
+       * 100 × (86.54 − 85.979) / 86.54 =  0.648
+       * 100 × (86.89 − 86.818) / 86.89 =  0.083
+       * 100 × (87.77 − 87.632) / 87.77 =  0.157
+       * 100 × (87.29 − 88.672) / 87.29 = -1.583
+       *
+       * Tulip ships the identical pairing as its Forecast Oscillator ("fosc"), so the derived
+       * values equal the reference outputs at:
+       * https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt#L199-L201
+       */
+      const inputs = [
+        81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84, 83.99, 84.55, 84.36, 85.53, 86.54, 86.89, 87.77, 87.29,
+      ] as const;
+      const expectations = [
+        '-1.287',
+        '-1.659',
+        '1.035',
+        '1.028',
+        '-0.100',
+        '0.600',
+        '0.648',
+        '0.083',
+        '0.157',
+        '-1.583',
+      ] as const;
+      const cfo = new CFO(5);
+      const offset = cfo.getRequiredInputs() - 1;
+
+      inputs.forEach((input, i) => {
+        const result = cfo.add(input);
+
+        if (result !== null) {
+          expect(result.toFixed(3)).toBe(expectations[i - offset]);
+        }
+      });
+
+      expect(cfo.isStable).toBe(true);
+    });
+  });
+
+  describe('getRequiredInputs', () => {
+    it('needs one close beyond the regression window', () => {
+      expect(new CFO(5).getRequiredInputs()).toBe(6);
+    });
+
+    it('defaults to an interval of 14', () => {
+      expect(new CFO().getRequiredInputs()).toBe(15);
+    });
+  });
+
+  describe('getSignal', () => {
+    it('returns UNKNOWN before the warm-up is complete', () => {
+      const closes = [10, 11, 12] as const;
+      const cfo = new CFO(5);
+
+      for (const close of closes) {
+        cfo.add(close);
+      }
+
+      const signal = cfo.getSignal();
+
+      expect(signal.state).toBe(TradingSignal.UNKNOWN);
+      expect(signal.hasChanged).toBe(false);
+    });
+
+    it('returns BULLISH when the close runs ahead of its projection', () => {
+      const closes = [10, 11, 12, 13, 14, 20] as const;
+      const cfo = new CFO(5);
+
+      for (const close of closes) {
+        cfo.add(close);
+      }
+
+      const signal = cfo.getSignal();
+
+      expect(signal.state).toBe(TradingSignal.BULLISH);
+      expect(signal.hasChanged).toBe(true);
+    });
+
+    it('returns BEARISH when the close falls short of its projection', () => {
+      const closes = [10, 11, 12, 13, 14, 5] as const;
+      const cfo = new CFO(5);
+
+      for (const close of closes) {
+        cfo.add(close);
+      }
+
+      const signal = cfo.getSignal();
+
+      expect(signal.state).toBe(TradingSignal.BEARISH);
+    });
+
+    it('returns SIDEWAYS when the close matches its projection', () => {
+      const closes = [10, 11, 12, 13, 14, 15] as const;
+      const cfo = new CFO(5);
+
+      for (const close of closes) {
+        cfo.add(close);
+      }
+
+      expect(cfo.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+    });
+
+    it('flags the zero-line cross and keeps the state while the pressure persists', () => {
+      const closes = [10, 11, 12, 13, 14, 20] as const;
+      const cfo = new CFO(5);
+
+      for (const close of closes) {
+        cfo.add(close);
+      }
+
+      expect(cfo.getSignal().state).toBe(TradingSignal.BULLISH);
+
+      cfo.add(5);
+
+      const crossed = cfo.getSignal();
+
+      expect(crossed.state).toBe(TradingSignal.BEARISH);
+      expect(crossed.hasChanged).toBe(true);
+
+      cfo.add(5);
+
+      const persisted = cfo.getSignal();
+
+      expect(persisted.state).toBe(TradingSignal.BEARISH);
+      expect(persisted.hasChanged).toBe(false);
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new CFO(5),
+  divergentInput: 1_000,
+  inputs: [81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84],
+});

--- a/packages/trading-signals/src/momentum/CFO/CFO.ts
+++ b/packages/trading-signals/src/momentum/CFO/CFO.ts
@@ -1,0 +1,79 @@
+import {ZeroCrossSeries} from '../../base/Indicator.js';
+import {pushUpdate} from '../../util/pushUpdate.js';
+
+/**
+ * Chande Forecast Oscillator (CFO)
+ * Type: Momentum
+ *
+ * Developed by Tushar Chande, the oscillator measures how far the close deviates from the close its
+ * own trend had projected for that bar, expressed as a percentage of the close. The projection is a
+ * least-squares regression line fitted through the preceding closes of the interval and extended one
+ * bar ahead — the "time series forecast" (TSF). Tulip Indicators ships the same close-to-forecast
+ * comparison as its Forecast Oscillator.
+ *
+ * Interpretation:
+ * Positive readings mean price runs ahead of its own trend's projection (bullish pressure), negative
+ * readings mean price falls short of it (bearish pressure). A zero-line cross marks the moment price
+ * switches from lagging its trend to leading it, or vice versa. A close of zero makes the percentage
+ * deviation undefined, so the oscillator reports the neutral zero line instead — a worthless
+ * instrument exerts no directional pressure.
+ *
+ * @see https://tulipindicators.org/fosc
+ * @see https://www.fmlabs.com/reference/default.htm?url=ForecastOscillator.htm
+ */
+export class CFO extends ZeroCrossSeries {
+  readonly #closes: number[] = [];
+
+  public readonly interval: number;
+
+  constructor(interval: number = 14) {
+    super();
+    this.interval = interval;
+  }
+
+  override getRequiredInputs() {
+    return this.interval + 1;
+  }
+
+  /**
+   * Projects the straight line through the given closes one bar ahead (the "time series forecast").
+   * Computed locally instead of reusing the linear-regression indicator, because that one
+   * short-circuits windows climbing in unit steps with a projection that lands one bar short —
+   * which would fake pressure here on a perfectly trending price.
+   */
+  #forecast(window: readonly number[]) {
+    const n = window.length;
+    let sumY = 0;
+    let sumXY = 0;
+
+    for (let x = 0; x < n; x++) {
+      sumY += window[x];
+      sumXY += x * window[x];
+    }
+
+    const sumX = ((n - 1) * n) / 2;
+    const sumXX = ((n - 1) * n * (2 * n - 1)) / 6;
+    const slope = (n * sumXY - sumX * sumY) / (n * sumXX - sumX * sumX);
+    const intercept = (sumY - slope * sumX) / n;
+
+    return slope * n + intercept;
+  }
+
+  update(close: number, replace: boolean) {
+    pushUpdate({array: this.#closes, item: close, maxLength: this.getRequiredInputs(), replace: replace});
+
+    if (this.#closes.length < this.getRequiredInputs()) {
+      return null;
+    }
+
+    // A dead market never fabricates a directional signal
+    if (close === 0) {
+      return this.setResult(0, replace);
+    }
+
+    // The forecast for the newest bar is fitted over the closes that precede it
+    const forecast = this.#forecast(this.#closes.slice(0, this.interval));
+
+    return this.setResult((100 * (close - forecast)) / close, replace);
+  }
+}

--- a/packages/trading-signals/src/momentum/QSTICK/Qstick.test.ts
+++ b/packages/trading-signals/src/momentum/QSTICK/Qstick.test.ts
@@ -1,0 +1,192 @@
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {TradingSignal} from '../../base/Indicator.js';
+import {Qstick} from './Qstick.js';
+
+describe('Qstick', () => {
+  /*
+   * Test data verified with:
+   * https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt#L327-L330
+   */
+  const candles = [
+    {close: 81.59, high: 82.15, low: 81.29, open: 81.85},
+    {close: 81.06, high: 81.89, low: 80.64, open: 81.2},
+    {close: 82.87, high: 83.03, low: 81.31, open: 81.55},
+    {close: 83.0, high: 83.3, low: 82.65, open: 82.91},
+    {close: 83.61, high: 83.85, low: 83.07, open: 83.1},
+    {close: 83.15, high: 83.9, low: 83.11, open: 83.41},
+    {close: 82.84, high: 83.33, low: 82.49, open: 82.71},
+    {close: 83.99, high: 84.3, low: 82.3, open: 82.7},
+    {close: 84.55, high: 84.84, low: 84.15, open: 84.2},
+    {close: 84.36, high: 85.0, low: 84.11, open: 84.25},
+    {close: 85.53, high: 85.9, low: 84.03, open: 84.03},
+    {close: 86.54, high: 86.58, low: 85.39, open: 85.45},
+    {close: 86.89, high: 86.98, low: 85.76, open: 86.18},
+    {close: 87.77, high: 88.0, low: 87.17, open: 88.0},
+    {close: 87.29, high: 87.87, low: 87.01, open: 87.6},
+  ] as const;
+  const expectations = [
+    '0.304',
+    '0.304',
+    '0.358',
+    '0.352',
+    '0.404',
+    '0.324',
+    '0.676',
+    '0.868',
+    '0.752',
+    '0.636',
+    '0.552',
+  ] as const;
+
+  describe('constructor', () => {
+    it('defaults to the interval of 8 suggested by Tushar Chande', () => {
+      const qstick = new Qstick();
+
+      expect(qstick.getRequiredInputs()).toBe(8);
+    });
+  });
+
+  describe('getResultOrThrow', () => {
+    it('averages the candle bodies over the interval', {tags: ['tulipindicators']}, () => {
+      const qstick = new Qstick(5);
+      const offset = qstick.getRequiredInputs() - 1;
+
+      candles.forEach((candle, i) => {
+        const result = qstick.add(candle);
+
+        if (i < offset) {
+          expect(result).toBeNull();
+        } else {
+          expect(result?.toFixed(3)).toBe(expectations[i - offset]);
+        }
+      });
+
+      expect(qstick.isStable).toBe(true);
+    });
+  });
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const qstick = new Qstick(3);
+
+      qstick.add({close: 11, high: 12, low: 9, open: 10});
+      qstick.add({close: 12, high: 13, low: 9, open: 10});
+
+      const originalValue = {close: 13, high: 14, low: 9, open: 10} as const;
+      const replacedValue = {close: 10, high: 17, low: 9, open: 16} as const;
+
+      const originalResult = qstick.add(originalValue);
+
+      expect(originalResult).toBe(2);
+
+      const replacedResult = qstick.replace(replacedValue);
+
+      expect(replacedResult).toBe(-1);
+
+      const restoredResult = qstick.replace(originalValue);
+
+      expect(restoredResult).toBe(2);
+    });
+  });
+
+  describe('getSignal', () => {
+    it('returns UNKNOWN before any candle was added', () => {
+      const qstick = new Qstick(2);
+
+      expect(qstick.getSignal()).toEqual({
+        hasChanged: false,
+        state: TradingSignal.UNKNOWN,
+      });
+    });
+
+    it('returns UNKNOWN as long as the window is not filled', () => {
+      const qstick = new Qstick(2);
+
+      qstick.add({close: 15, high: 16, low: 9, open: 10});
+
+      expect(qstick.getSignal()).toEqual({
+        hasChanged: false,
+        state: TradingSignal.UNKNOWN,
+      });
+    });
+
+    it('returns BULLISH when buyers close candles above their opens', () => {
+      const qstick = new Qstick(2);
+
+      qstick.add({close: 15, high: 16, low: 9, open: 10});
+      qstick.add({close: 14, high: 16, low: 9, open: 11});
+
+      expect(qstick.getResultOrThrow()).toBeGreaterThan(0);
+      expect(qstick.getSignal()).toEqual({
+        hasChanged: true,
+        state: TradingSignal.BULLISH,
+      });
+    });
+
+    it('returns BEARISH when sellers pin closes below the opens', () => {
+      const qstick = new Qstick(2);
+
+      qstick.add({close: 10, high: 16, low: 9, open: 15});
+      qstick.add({close: 11, high: 16, low: 9, open: 14});
+
+      expect(qstick.getResultOrThrow()).toBeLessThan(0);
+      expect(qstick.getSignal()).toEqual({
+        hasChanged: true,
+        state: TradingSignal.BEARISH,
+      });
+    });
+
+    it('returns SIDEWAYS for a window of dojis closing exactly where they opened', () => {
+      const qstick = new Qstick(2);
+
+      qstick.add({close: 10, high: 12, low: 9, open: 10});
+      qstick.add({close: 11, high: 13, low: 10, open: 11});
+
+      expect(qstick.getResultOrThrow()).toBe(0);
+      expect(qstick.getSignal()).toEqual({
+        hasChanged: true,
+        state: TradingSignal.SIDEWAYS,
+      });
+    });
+
+    it('keeps the signal unchanged while buyers stay in control', () => {
+      const qstick = new Qstick(2);
+
+      qstick.add({close: 15, high: 16, low: 9, open: 10});
+      qstick.add({close: 14, high: 16, low: 9, open: 11});
+      qstick.add({close: 16, high: 17, low: 10, open: 12});
+
+      expect(qstick.getSignal()).toEqual({
+        hasChanged: false,
+        state: TradingSignal.BULLISH,
+      });
+    });
+
+    it('flags the change when control flips from buyers to sellers', () => {
+      const qstick = new Qstick(2);
+
+      qstick.add({close: 15, high: 16, low: 9, open: 10});
+      qstick.add({close: 14, high: 16, low: 9, open: 11});
+      qstick.add({close: 9, high: 17, low: 8, open: 16});
+
+      expect(qstick.getResultOrThrow()).toBeLessThan(0);
+      expect(qstick.getSignal()).toEqual({
+        hasChanged: true,
+        state: TradingSignal.BEARISH,
+      });
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new Qstick(5),
+  divergentInput: {close: 900, high: 1_000, low: 800, open: 950},
+  inputs: [
+    {close: 81.59, high: 82.15, low: 81.29, open: 81.85},
+    {close: 81.06, high: 81.89, low: 80.64, open: 81.2},
+    {close: 82.87, high: 83.03, low: 81.31, open: 81.55},
+    {close: 83.0, high: 83.3, low: 82.65, open: 82.91},
+    {close: 83.61, high: 83.85, low: 83.07, open: 83.1},
+    {close: 83.15, high: 83.9, low: 83.11, open: 83.41},
+  ],
+});

--- a/packages/trading-signals/src/momentum/QSTICK/Qstick.ts
+++ b/packages/trading-signals/src/momentum/QSTICK/Qstick.ts
@@ -1,0 +1,47 @@
+import type {OpenHighLowClose} from '../../base/Candle.type.js';
+import {ZeroCrossSeries} from '../../base/Indicator.js';
+import {SMA} from '../../trend/SMA/SMA.js';
+
+/**
+ * Qstick
+ * Type: Momentum
+ *
+ * Developed by Tushar Chande, Qstick averages the candle bodies (close minus open) of the last
+ * candles to expose buying or selling pressure that a price chart hides: a market can drift
+ * higher through opening gaps while sellers dominate every session. A positive reading means
+ * buyers close candles above their opens, a negative reading means sellers pin closes below
+ * the opens. Chande suggests an interval of 8 periods.
+ *
+ * Interpretation:
+ * A Qstick above zero signals bullish pressure, below zero bearish pressure. A crossing of the
+ * zero line marks the moment control shifts from one side to the other. A window of dojis
+ * closing exactly where they opened is perfectly balanced (zero).
+ *
+ * @see https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/indicators/qstick.c
+ * @see https://www.investopedia.com/terms/q/qstick.asp
+ */
+export class Qstick extends ZeroCrossSeries<OpenHighLowClose> {
+  readonly #sma: SMA;
+
+  public readonly interval: number;
+
+  constructor(interval: number = 8) {
+    super();
+    this.interval = interval;
+    this.#sma = new SMA(interval);
+  }
+
+  override getRequiredInputs() {
+    return this.interval;
+  }
+
+  update({close, open}: OpenHighLowClose, replace: boolean) {
+    const smaResult = this.#sma.update(close - open, replace);
+
+    if (smaResult === null) {
+      return null;
+    }
+
+    return this.setResult(smaResult, replace);
+  }
+}

--- a/packages/trading-signals/src/momentum/STOCH/StochasticOscillator.test.ts
+++ b/packages/trading-signals/src/momentum/STOCH/StochasticOscillator.test.ts
@@ -30,6 +30,24 @@ describe('StochasticOscillator', () => {
       expect(stoch.getRequiredInputs()).toBe(9);
       expect(stoch.getResultOrThrow().stochK.toFixed(2)).toBe('91.09');
     });
+
+    /*
+     * Hand-derived: with a slowing period of 1, %k equals the raw close position in the 2-candle range.
+     * Candle 2 closes at the very top (%k = 100), candle 3 at the very bottom (%k = 0), so
+     * %d = (100 + 0) / 2 = 50 and %j = 3 × 0 - 2 × 50 = -100, escaping the 0-100 range.
+     */
+    it('projects the divergence between %k and %d as the %j line', () => {
+      const stoch = new StochasticOscillator({dPeriod: 2, kPeriod: 2, kSlowingPeriod: 1});
+
+      stoch.add({close: 5, high: 10, low: 0});
+      stoch.add({close: 10, high: 10, low: 0});
+
+      const result = stoch.add({close: 0, high: 10, low: 0});
+
+      expect(result?.stochK).toBe(0);
+      expect(result?.stochD).toBe(50);
+      expect(result?.stochJ).toBe(-100);
+    });
   });
 
   describe('replace', () => {

--- a/packages/trading-signals/src/momentum/STOCH/StochasticOscillator.ts
+++ b/packages/trading-signals/src/momentum/STOCH/StochasticOscillator.ts
@@ -7,6 +7,8 @@ import {pushUpdate} from '../../util/pushUpdate.js';
 export type StochasticResult = {
   /** Slow stochastic indicator (%D) */
   stochD: number;
+  /** Divergence indicator (%J): amplifies the spread between %K and %D and is not bound to the 0-100 range */
+  stochJ: number;
   /** Fast stochastic indicator (%K) */
   stochK: number;
 };
@@ -33,6 +35,9 @@ export type StochasticOscillatorConfig = {
  * The stochastic k (%k) values represent the relation between current close to the period's price range (high/low). It
  * is sometimes referred as the "fast" stochastic period (fastk). The stochastic d (%d) values represent a Moving
  * Average of the %k values. It is sometimes referred as the "slow" period.
+ *
+ * The stochastic j (%j) line completes the KDJ reading popular on Asian markets: it projects the divergence between
+ * %k and %d ahead (3 × %k - 2 × %d), so it turns before either line and overshoots the 0-100 range at price extremes.
  *
  * @see https://en.wikipedia.org/wiki/Stochastic_oscillator
  * @see https://www.investopedia.com/terms/s/stochasticoscillator.asp
@@ -79,7 +84,8 @@ export class StochasticOscillator extends TechnicalIndicator<StochasticResult, H
       // Prevent division by zero
       fastK = fastK / (divisor === 0 ? 1 : divisor);
       const stochK = this.#smoothK.update(fastK, replace); // (stoch_k, %k)
-      const stochD = stochK && this.#smoothD.update(stochK, replace); // (stoch_d, %d)
+      // A %k of exactly 0 is a legitimate reading (close pinned to the window low) and must still feed the %d smoothing
+      const stochD = stochK !== null ? this.#smoothD.update(stochK, replace) : null; // (stoch_d, %d)
 
       if (stochK !== null && stochD !== null) {
         if (replace) {
@@ -90,6 +96,7 @@ export class StochasticOscillator extends TechnicalIndicator<StochasticResult, H
 
         return (this.result = {
           stochD,
+          stochJ: 3 * stochK - 2 * stochD,
           stochK,
         });
       }

--- a/packages/trading-signals/src/momentum/index.ts
+++ b/packages/trading-signals/src/momentum/index.ts
@@ -3,6 +3,7 @@ export * from './AO/AO.js';
 export * from './APO/APO.js';
 export * from './BOP/BOP.js';
 export * from './CCI/CCI.js';
+export * from './CFO/CFO.js';
 export * from './CG/CG.js';
 export * from './CMO/CMO.js';
 export * from './COPPOCK/CoppockCurve.js';

--- a/packages/trading-signals/src/momentum/index.ts
+++ b/packages/trading-signals/src/momentum/index.ts
@@ -15,6 +15,7 @@ export * from './MFI/MFI.js';
 export * from './MOM/MOM.js';
 export * from './OBV/OBV.js';
 export * from './PPO/PPO.js';
+export * from './QSTICK/Qstick.js';
 export * from './REI/REI.js';
 export * from './ROC/ROC.js';
 export * from './RSI/RSI.js';

--- a/packages/trading-signals/src/volatility/MI/MassIndex.test.ts
+++ b/packages/trading-signals/src/volatility/MI/MassIndex.test.ts
@@ -49,6 +49,17 @@ describe('MassIndex', () => {
   });
 
   describe('getResultOrThrow', () => {
+    it('reads a market that never trades a range as no expansion', () => {
+      const interval = 3;
+      const mi = new MassIndex(interval);
+
+      for (let i = 0; i < 30; i++) {
+        mi.add({high: 100, low: 100});
+      }
+
+      expect(mi.getResultOrThrow()).toBe(interval);
+    });
+
     it('sums the smoothed range ratios over the interval', {tags: ['tulipindicators']}, () => {
       const mi = new MassIndex(3);
       const offset = mi.getRequiredInputs() - 1;

--- a/packages/trading-signals/src/volatility/MI/MassIndex.test.ts
+++ b/packages/trading-signals/src/volatility/MI/MassIndex.test.ts
@@ -1,0 +1,169 @@
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {MassIndex} from './MassIndex.js';
+
+describe('MassIndex', () => {
+  /*
+   * Test data verified with:
+   * https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/atoz.txt#L141-L145
+   * (from "Technical Analysis from A to Z" by Steven B. Achelis, page 182)
+   */
+  const candles = [
+    {high: 38.125, low: 37.75},
+    {high: 38, low: 37.75},
+    {high: 37.9375, low: 37.8125},
+    {high: 37.875, low: 37.625},
+    {high: 38.125, low: 37.5},
+    {high: 38.125, low: 37.5},
+    {high: 37.75, low: 37.5},
+    {high: 37.625, low: 37.4375},
+    {high: 37.6875, low: 37.375},
+    {high: 37.5, low: 37.375},
+    {high: 37.5625, low: 37.375},
+    {high: 37.625, low: 36.8125},
+    {high: 36.6875, low: 36.3125},
+    {high: 36.875, low: 36.25},
+    {high: 36.9375, low: 36.5},
+    {high: 36.5, low: 36.25},
+    {high: 36.9375, low: 36.3125},
+    {high: 37, low: 36.625},
+    {high: 36.875, low: 36.5625},
+    {high: 36.8125, low: 36.375},
+  ] as const;
+  const expectations = ['3.2240', '3.1175'] as const;
+
+  describe('constructor', () => {
+    it('defaults to the 25-bar summation proposed by Donald Dorsey', () => {
+      const mi = new MassIndex();
+
+      expect(mi.interval).toBe(25);
+      expect(mi.getRequiredInputs()).toBe(41);
+    });
+  });
+
+  describe('getRequiredInputs', () => {
+    it('needs both nine-bar smoothing passes plus the summation window to fill', () => {
+      const mi = new MassIndex(3);
+
+      expect(mi.getRequiredInputs()).toBe(19);
+    });
+  });
+
+  describe('getResultOrThrow', () => {
+    it('sums the smoothed range ratios over the interval', {tags: ['tulipindicators']}, () => {
+      const mi = new MassIndex(3);
+      const offset = mi.getRequiredInputs() - 1;
+
+      candles.forEach((candle, i) => {
+        const result = mi.add(candle);
+
+        if (i < offset) {
+          expect(result).toBeNull();
+        } else {
+          expect(result?.toFixed(4)).toBe(expectations[i - offset]);
+        }
+      });
+
+      expect(mi.isStable).toBe(true);
+    });
+
+    it('yields nothing when the candles run out during the warm-up', {tags: ['tulipindicators']}, () => {
+      /*
+       * Test data verified with:
+       * https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt#L254-L257
+       * (Tulip Indicators expects an empty output series for these candles)
+       */
+      const shortCandles = [
+        {high: 82.15, low: 81.29},
+        {high: 81.89, low: 80.64},
+        {high: 83.03, low: 81.31},
+        {high: 83.3, low: 82.65},
+        {high: 83.85, low: 83.07},
+        {high: 83.9, low: 83.11},
+        {high: 83.33, low: 82.49},
+        {high: 84.3, low: 82.3},
+        {high: 84.84, low: 84.15},
+        {high: 85.0, low: 84.11},
+        {high: 85.9, low: 84.03},
+        {high: 86.58, low: 85.39},
+        {high: 86.98, low: 85.76},
+        {high: 88.0, low: 87.17},
+        {high: 87.87, low: 87.01},
+      ] as const;
+      const mi = new MassIndex(5);
+
+      for (const candle of shortCandles) {
+        expect(mi.add(candle)).toBeNull();
+      }
+
+      expect(mi.isStable).toBe(false);
+    });
+  });
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const mi = new MassIndex(3);
+
+      for (const candle of candles.slice(0, -1)) {
+        mi.add(candle);
+      }
+
+      const originalValue = {high: 36.8125, low: 36.375} as const;
+      const replacedValue = {high: 40, low: 35} as const;
+
+      const originalResult = mi.add(originalValue);
+
+      expect(originalResult?.toFixed(4)).toBe('3.1175');
+
+      const replacedResult = mi.replace(replacedValue);
+
+      expect(replacedResult?.toFixed(4)).toBe('4.3610');
+
+      const restoredResult = mi.replace(originalValue);
+
+      expect(restoredResult?.toFixed(4)).toBe('3.1175');
+      expect(restoredResult).toBe(originalResult);
+    });
+
+    it('rebuilds the same reading when a candle is corrected during the second smoothing warm-up', () => {
+      const mi = new MassIndex(3);
+
+      candles.forEach((candle, i) => {
+        if (i === 10) {
+          mi.add({high: 40, low: 35});
+          mi.replace(candle);
+        } else {
+          mi.add(candle);
+        }
+      });
+
+      expect(mi.getResultOrThrow().toFixed(4)).toBe('3.1175');
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new MassIndex(3),
+  divergentInput: {high: 40, low: 35},
+  inputs: [
+    {high: 38.125, low: 37.75},
+    {high: 38, low: 37.75},
+    {high: 37.9375, low: 37.8125},
+    {high: 37.875, low: 37.625},
+    {high: 38.125, low: 37.5},
+    {high: 38.125, low: 37.5},
+    {high: 37.75, low: 37.5},
+    {high: 37.625, low: 37.4375},
+    {high: 37.6875, low: 37.375},
+    {high: 37.5, low: 37.375},
+    {high: 37.5625, low: 37.375},
+    {high: 37.625, low: 36.8125},
+    {high: 36.6875, low: 36.3125},
+    {high: 36.875, low: 36.25},
+    {high: 36.9375, low: 36.5},
+    {high: 36.5, low: 36.25},
+    {high: 36.9375, low: 36.3125},
+    {high: 37, low: 36.625},
+    {high: 36.875, low: 36.5625},
+    {high: 36.8125, low: 36.375},
+  ],
+});

--- a/packages/trading-signals/src/volatility/MI/MassIndex.ts
+++ b/packages/trading-signals/src/volatility/MI/MassIndex.ts
@@ -58,7 +58,14 @@ export class MassIndex extends IndicatorSeries<HighLow> {
       return null;
     }
 
-    pushUpdate({array: this.#ratios, item: single / double, maxLength: this.interval, replace});
+    /*
+     * A market whose candles never trade a range keeps both smoothing passes at zero. A constant
+     * range of any size reads exactly 1, so the dead-market limit is 1 (no expansion) instead of
+     * a division by zero poisoning the sum.
+     */
+    const ratio = double === 0 ? 1 : single / double;
+
+    pushUpdate({array: this.#ratios, item: ratio, maxLength: this.interval, replace});
 
     if (this.#ratios.length === this.interval) {
       return this.setResult(

--- a/packages/trading-signals/src/volatility/MI/MassIndex.ts
+++ b/packages/trading-signals/src/volatility/MI/MassIndex.ts
@@ -1,0 +1,72 @@
+import type {HighLow} from '../../base/Candle.type.js';
+import {IndicatorSeries} from '../../base/Indicator.js';
+import {EMA} from '../../trend/EMA/EMA.js';
+import {pushUpdate} from '../../util/pushUpdate.js';
+
+/**
+ * Mass Index (MI)
+ * Type: Volatility
+ *
+ * The Mass Index was developed by Donald Dorsey (1992) to anticipate trend reversals by watching the high-low range
+ * widen: a swelling range suggests the conviction behind the current trend is eroding. The range is smoothed twice
+ * with a 9-bar EMA (both spans fixed by Dorsey), and the ratio of the single-smoothed to the double-smoothed range
+ * is summed over the interval. Range expansion inflates the reading no matter which way the market moves.
+ *
+ * Interpretation:
+ * Dorsey's "reversal bulge" forms when the 25-bar Mass Index rises above 27 and then falls back below 26.5, marking
+ * a likely trend change. The bulge carries no directional information — the same pattern precedes tops and bottoms
+ * alike — which is why this indicator emits no trading signal; direction has to come from a trend-following
+ * companion such as a moving average.
+ *
+ * @see https://www.investopedia.com/terms/m/mass-index.asp
+ * @see https://tulipindicators.org/mass
+ */
+export class MassIndex extends IndicatorSeries<HighLow> {
+  readonly #single: EMA;
+  readonly #double: EMA;
+  readonly #ratios: number[] = [];
+
+  public readonly interval: number;
+
+  constructor(interval: number = 25) {
+    super();
+    this.interval = interval;
+    this.#single = new EMA(9);
+    this.#double = new EMA(9);
+  }
+
+  override getRequiredInputs() {
+    const firstRatio = this.#single.getRequiredInputs() + this.#double.getRequiredInputs() - 1;
+    return firstRatio + this.interval - 1;
+  }
+
+  update(candle: HighLow, replace: boolean) {
+    const single = this.#single.update(candle.high - candle.low, replace);
+
+    /*
+     * The second smoothing pass starts only once the first pass reflects a full period (mirroring
+     * Tulip Indicators). Feeding it earlier would seed it with a half-formed average and shift
+     * every subsequent reading.
+     */
+    if (!this.#single.isStable) {
+      return null;
+    }
+
+    const double = this.#double.update(single, replace);
+
+    if (!this.#double.isStable) {
+      return null;
+    }
+
+    pushUpdate({array: this.#ratios, item: single / double, maxLength: this.interval, replace});
+
+    if (this.#ratios.length === this.interval) {
+      return this.setResult(
+        this.#ratios.reduce((sum, ratio) => sum + ratio, 0),
+        replace
+      );
+    }
+
+    return null;
+  }
+}

--- a/packages/trading-signals/src/volatility/PO/ProjectionOscillator.test.ts
+++ b/packages/trading-signals/src/volatility/PO/ProjectionOscillator.test.ts
@@ -1,0 +1,245 @@
+import {TradingSignal} from '../../base/index.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {ProjectionOscillator} from './ProjectionOscillator.js';
+
+describe('ProjectionOscillator', () => {
+  /*
+   * There is no Tulip Indicators entry and no reliable public fixture for the Projection Oscillator, so the
+   * expectations below are derived by hand from the original formula by Mel Widner, published in "Technical
+   * Analysis of Stocks & Commodities" (July 1995). The candles are chosen so that every intermediate value is
+   * an exact binary fraction, which allows exact assertions.
+   *
+   * @see https://www.fmlabs.com/reference/default.htm?url=ProjectionOscillator.htm
+   *
+   * Interval 4, x = 0..3: Σx = 6, Σx² = 14, so the least-squares slope over the closes is
+   * m = (4·Σxy − 6·Σy) / (4·14 − 6²) = (4·Σxy − 6·Σy) / 20.
+   *
+   * Window 1 (candles 1-4), closes 10, 11, 12, 13: Σy = 46, Σxy = 74 → m = (296 − 276) / 20 = 1.
+   * Every bar is projected forward to the current bar by m × (remaining bars):
+   *
+   * | Bar | High | Low | Projection | Projected high | Projected low |
+   * | --- | ---- | --- | ---------- | -------------- | ------------- |
+   * | 1   | 11   | 9   | +3         | 14             | 12            |
+   * | 2   | 12   | 10  | +2         | 14             | 12            |
+   * | 3   | 13   | 8   | +1         | 14             | 9             |
+   * | 4   | 14   | 11  | ±0         | 14             | 11            |
+   *
+   * Upper band = 14, lower band = 9 → PO = 100 × (13 − 9) / (14 − 9) = 80.
+   *
+   * Window 2 (candles 2-5), closes 11, 12, 13, 4: Σy = 40, Σxy = 50 → m = (200 − 240) / 20 = −2.
+   *
+   * | Bar | High | Low | Projection | Projected high | Projected low |
+   * | --- | ---- | --- | ---------- | -------------- | ------------- |
+   * | 2   | 12   | 10  | −6         | 6              | 4             |
+   * | 3   | 13   | 8   | −4         | 9              | 4             |
+   * | 4   | 14   | 11  | −2         | 12             | 9             |
+   * | 5   | 13   | 3   | ±0         | 13             | 3             |
+   *
+   * Upper band = 13, lower band = 3 → PO = 100 × (4 − 3) / (13 − 3) = 10.
+   */
+  const uptrendCandles = [
+    {close: 10, high: 11, low: 9},
+    {close: 11, high: 12, low: 10},
+    {close: 12, high: 13, low: 8},
+    {close: 13, high: 14, low: 11},
+  ] as const;
+  const crashCandle = {close: 4, high: 13, low: 3} as const;
+  const candles = [...uptrendCandles, crashCandle] as const;
+
+  describe('getResultOrThrow', () => {
+    it('locates the close within the projection bands', () => {
+      const expectations = [80, 10] as const;
+      const po = new ProjectionOscillator({interval: 4});
+      const offset = po.getRequiredInputs() - 1;
+
+      candles.forEach((candle, i) => {
+        const result = po.add(candle);
+
+        if (result !== null) {
+          expect(result).toBe(expectations[i - offset]);
+        }
+      });
+
+      expect(po.isStable).toBe(true);
+    });
+
+    it('reads 100 when the close is pinned to the upper projection band', () => {
+      /*
+       * When every candle of a steady uptrend closes at its high, all projected highs land exactly on the
+       * latest close, so the close sits on the upper band itself.
+       */
+      const po = new ProjectionOscillator({interval: 4});
+      const closes = [10, 12, 14, 16] as const;
+
+      for (const close of closes) {
+        po.add({close, high: close, low: close - 2});
+      }
+
+      expect(po.getResultOrThrow()).toBe(100);
+    });
+
+    it('reads 0 when the close is pinned to the lower projection band', () => {
+      // Mirror case: closing at the low of every bar puts the close on the lower band itself
+      const po = new ProjectionOscillator({interval: 4});
+      const closes = [10, 12, 14, 16] as const;
+
+      for (const close of closes) {
+        po.add({close, high: close + 2, low: close});
+      }
+
+      expect(po.getResultOrThrow()).toBe(0);
+    });
+
+    it('reads neutral in a completely flat market', () => {
+      const po = new ProjectionOscillator({interval: 4});
+      const flatCandle = {close: 10, high: 10, low: 10} as const;
+
+      for (let i = 0; i < 4; i++) {
+        po.add(flatCandle);
+      }
+
+      expect(po.getResultOrThrow()).toBe(50);
+      expect(po.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+    });
+  });
+
+  describe('getRequiredInputs', () => {
+    it('measures 14 candles by default', () => {
+      const po = new ProjectionOscillator();
+
+      expect(po.getRequiredInputs()).toBe(14);
+    });
+
+    it('matches the configured interval', () => {
+      const po = new ProjectionOscillator({interval: 4});
+
+      expect(po.getRequiredInputs()).toBe(4);
+    });
+  });
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const po = new ProjectionOscillator({interval: 4});
+
+      for (const candle of uptrendCandles) {
+        po.add(candle);
+      }
+
+      /*
+       * Replacement window closes 11, 12, 13, 14: m = (4·80 − 6·50) / 20 = 1; projected highs all 15,
+       * projected lows 13, 10, 12, 12 → PO = 100 × (14 − 10) / (15 − 10) = 80.
+       */
+      const originalValue = crashCandle;
+      const replacedValue = {close: 14, high: 15, low: 12} as const;
+
+      const originalResult = po.add(originalValue);
+
+      expect(originalResult).toBe(10);
+
+      const replacedResult = po.replace(replacedValue);
+
+      expect(replacedResult).toBe(80);
+
+      const restoredResult = po.replace(originalValue);
+
+      expect(restoredResult).toBe(10);
+    });
+  });
+
+  describe('getSignal', () => {
+    it('returns UNKNOWN when there is no result', () => {
+      const po = new ProjectionOscillator({interval: 4});
+      const signal = po.getSignal();
+
+      expect(signal.state).toBe(TradingSignal.UNKNOWN);
+      expect(signal.hasChanged).toBe(false);
+    });
+
+    it('returns BULLISH when the close presses against the upper projection band', () => {
+      const po = new ProjectionOscillator({interval: 4});
+
+      for (const candle of uptrendCandles) {
+        po.add(candle);
+      }
+
+      expect(po.getResultOrThrow()).toBe(80);
+
+      const signal = po.getSignal();
+
+      expect(signal.state).toBe(TradingSignal.BULLISH);
+      expect(signal.hasChanged).toBe(true);
+    });
+
+    it('returns BEARISH when the close falls to the lower projection band', () => {
+      const po = new ProjectionOscillator({interval: 4});
+
+      for (const candle of candles) {
+        po.add(candle);
+      }
+
+      expect(po.getResultOrThrow()).toBe(10);
+
+      const signal = po.getSignal();
+
+      expect(signal.state).toBe(TradingSignal.BEARISH);
+      expect(signal.hasChanged).toBe(true);
+    });
+
+    it('returns SIDEWAYS while a steady trend keeps the close mid-channel', () => {
+      /*
+       * The bands ride the regression trend, so a steady climb with mid-bar closes stays neutral instead of
+       * registering as overbought.
+       */
+      const trendCandles = [
+        {close: 10, high: 11, low: 9},
+        {close: 12, high: 13, low: 11},
+        {close: 14, high: 15, low: 13},
+        {close: 16, high: 17, low: 15},
+        {close: 18, high: 19, low: 17},
+      ] as const;
+      const po = new ProjectionOscillator({interval: 4});
+
+      for (const candle of trendCandles) {
+        po.add(candle);
+      }
+
+      expect(po.getResultOrThrow()).toBe(50);
+
+      const signal = po.getSignal();
+
+      expect(signal.state).toBe(TradingSignal.SIDEWAYS);
+      expect(signal.hasChanged).toBe(false);
+    });
+
+    it('respects custom overbought and oversold thresholds', () => {
+      const strict = new ProjectionOscillator({interval: 4, signalThresholds: {overbought: 90, oversold: 10}});
+      const loose = new ProjectionOscillator({interval: 4, signalThresholds: {oversold: 5}});
+
+      for (const candle of uptrendCandles) {
+        strict.add(candle);
+      }
+
+      expect(strict.getResultOrThrow()).toBe(80);
+      expect(strict.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+
+      for (const candle of candles) {
+        loose.add(candle);
+      }
+
+      expect(loose.getResultOrThrow()).toBe(10);
+      expect(loose.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new ProjectionOscillator({interval: 4}),
+  divergentInput: {close: 1_000, high: 1_000, low: 1_000},
+  inputs: [
+    {close: 10, high: 11, low: 9},
+    {close: 11, high: 12, low: 10},
+    {close: 12, high: 13, low: 8},
+    {close: 13, high: 14, low: 11},
+    {close: 4, high: 13, low: 3},
+  ],
+});

--- a/packages/trading-signals/src/volatility/PO/ProjectionOscillator.test.ts
+++ b/packages/trading-signals/src/volatility/PO/ProjectionOscillator.test.ts
@@ -46,6 +46,14 @@ describe('ProjectionOscillator', () => {
   const crashCandle = {close: 4, high: 13, low: 3} as const;
   const candles = [...uptrendCandles, crashCandle] as const;
 
+  describe('constructor', () => {
+    it('rejects an interval that cannot form a regression slope', () => {
+      expect(() => new ProjectionOscillator({interval: 1})).toThrowError(
+        'The interval has to be at least 2, but "1" was given.'
+      );
+    });
+  });
+
   describe('getResultOrThrow', () => {
     it('locates the close within the projection bands', () => {
       const expectations = [80, 10] as const;

--- a/packages/trading-signals/src/volatility/PO/ProjectionOscillator.ts
+++ b/packages/trading-signals/src/volatility/PO/ProjectionOscillator.ts
@@ -40,6 +40,12 @@ export class ProjectionOscillator extends TrendIndicatorSeries<HighLowClose<numb
     signalThresholds: {overbought = 80, oversold = 20} = {},
   }: ProjectionOscillatorConfig = {}) {
     super();
+
+    // A regression slope needs at least two points; a single bar has no slope to project along
+    if (interval < 2) {
+      throw new Error(`The interval has to be at least 2, but "${interval}" was given.`);
+    }
+
     this.interval = interval;
     this.#overbought = overbought;
     this.#oversold = oversold;

--- a/packages/trading-signals/src/volatility/PO/ProjectionOscillator.ts
+++ b/packages/trading-signals/src/volatility/PO/ProjectionOscillator.ts
@@ -1,0 +1,106 @@
+import type {HighLowClose} from '../../base/Candle.type.js';
+import {TradingSignal, TrendIndicatorSeries} from '../../base/Indicator.js';
+import type {SignalThresholds} from '../../base/SignalThresholds.type.js';
+import {pushUpdate} from '../../util/pushUpdate.js';
+
+export type ProjectionOscillatorConfig = {
+  /** Number of candles in the regression window that forms the projection bands */
+  interval?: number;
+  signalThresholds?: SignalThresholds;
+};
+
+/**
+ * Projection Oscillator (PO)
+ * Type: Volatility
+ *
+ * Developed by Mel Widner and published in "Technical Analysis of Stocks & Commodities" (July 1995), the
+ * Projection Oscillator locates the latest close within its projection bands. A linear regression over the
+ * closes of the window yields the current trend slope, every high and low in the window is projected forward
+ * to the latest candle along that slope, and the band edges are the highest projected high and the lowest
+ * projected low. Because the bands ride the trend, the oscillator reports strength relative to the trend
+ * channel rather than a horizontal trading range: a steady climb reads as neutral, while only a close that
+ * outruns its own regression channel reads as an extreme. It oscillates between 0 (close on the lower band)
+ * and 100 (close on the upper band).
+ *
+ * Interpretation:
+ * A value of 80 or above indicates an overbought condition and 20 or below an oversold condition (both
+ * thresholds can be customized via the constructor). A completely flat window offers no trading range to
+ * locate the close in, so the oscillator reads neutral (50).
+ *
+ * @see https://www.fmlabs.com/reference/default.htm?url=ProjectionOscillator.htm
+ */
+export class ProjectionOscillator extends TrendIndicatorSeries<HighLowClose<number>> {
+  readonly #candles: HighLowClose<number>[] = [];
+  readonly #overbought: number;
+  readonly #oversold: number;
+  public readonly interval: number;
+
+  constructor({
+    interval = 14,
+    signalThresholds: {overbought = 80, oversold = 20} = {},
+  }: ProjectionOscillatorConfig = {}) {
+    super();
+    this.interval = interval;
+    this.#overbought = overbought;
+    this.#oversold = oversold;
+  }
+
+  override getRequiredInputs() {
+    return this.interval;
+  }
+
+  update(candle: HighLowClose<number>, replace: boolean) {
+    pushUpdate({array: this.#candles, item: candle, maxLength: this.interval, replace});
+
+    if (this.#candles.length < this.interval) {
+      return null;
+    }
+
+    const barCount = this.interval;
+    const sumX = (barCount * (barCount - 1)) / 2;
+    const sumXX = (barCount * (barCount - 1) * (2 * barCount - 1)) / 6;
+
+    let sumY = 0;
+    let sumXY = 0;
+
+    this.#candles.forEach(({close}, x) => {
+      sumY += close;
+      sumXY += x * close;
+    });
+
+    const slope = (barCount * sumXY - sumX * sumY) / (barCount * sumXX - sumX * sumX);
+
+    let upper = Number.NEGATIVE_INFINITY;
+    let lower = Number.POSITIVE_INFINITY;
+
+    this.#candles.forEach(({high, low}, x) => {
+      const projection = slope * (barCount - 1 - x);
+      upper = Math.max(upper, high + projection);
+      lower = Math.min(lower, low + projection);
+    });
+
+    // A completely flat window offers no trading range to locate the close in, so the reading is neutral
+    if (upper === lower) {
+      return this.setResult(50, replace);
+    }
+
+    return this.setResult((100 * (candle.close - lower)) / (upper - lower), replace);
+  }
+
+  protected calculateSignalState(result: number | null | undefined) {
+    const hasResult = result !== null && result !== undefined;
+    const isOversold = hasResult && result <= this.#oversold;
+    const isOverbought = hasResult && result >= this.#overbought;
+
+    switch (true) {
+      case !hasResult:
+        return TradingSignal.UNKNOWN;
+      case isOversold:
+        return TradingSignal.BEARISH;
+      case isOverbought:
+        return TradingSignal.BULLISH;
+      default:
+        return TradingSignal.SIDEWAYS;
+    }
+  }
+}

--- a/packages/trading-signals/src/volatility/UI/UlcerIndex.test.ts
+++ b/packages/trading-signals/src/volatility/UI/UlcerIndex.test.ts
@@ -1,0 +1,156 @@
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {UlcerIndex} from './UlcerIndex.js';
+
+describe('UlcerIndex', () => {
+  describe('constructor', () => {
+    it("uses Peter Martin's 14-period window by default", () => {
+      const ui = new UlcerIndex();
+
+      expect(ui.interval).toBe(14);
+      expect(ui.getRequiredInputs()).toBe(14);
+    });
+  });
+
+  describe('getResultOrThrow', () => {
+    it('matches the Skender.Stock.Indicators reference results', () => {
+      /*
+       * The expectations are the Skender.Stock.Indicators v3.0.0 baseline for the Ulcer Index (14)
+       * over the first 30 closes of its default test quotes. The Ulcer Index only ever looks back
+       * one interval, so a leading slice of the series yields the same results as a full run.
+       *
+       * Quotes: https://raw.githubusercontent.com/facioquo/stock-indicators-dotnet/3.0.0/tests/indicators/_testdata/quotes/default.csv
+       * Results: https://raw.githubusercontent.com/facioquo/stock-indicators-dotnet/3.0.0/tests/indicators/_testdata/results/ulcer.standard.json
+       */
+      const closes = [
+        212.8, 214.06, 213.89, 214.66, 213.95, 213.95, 214.55, 214.02, 214.51, 213.75, 214.22, 213.43, 214.21, 213.66,
+        215.03, 216.89, 216.66, 216.32, 214.98, 214.96, 215.05, 215.19, 216.67, 216.28, 216.29, 216.58, 217.86, 218.72,
+        219.91, 220.79,
+      ] as const;
+      const expectations = [
+        '0.2844201',
+        '0.2844201',
+        '0.2836270',
+        '0.2850395',
+        '0.2351403',
+        '0.3326929',
+        '0.4089552',
+        '0.4583534',
+        '0.5039547',
+        '0.4778201',
+        '0.4836963',
+        '0.4791037',
+        '0.4806241',
+        '0.4757002',
+        '0.4757002',
+        '0.4757002',
+        '0.4069892',
+      ] as const;
+      const ui = new UlcerIndex(14);
+      const offset = ui.getRequiredInputs() - 1;
+      let verifiedBars = 0;
+
+      closes.forEach((close, i) => {
+        const result = ui.add(close);
+
+        if (result !== null) {
+          verifiedBars++;
+          expect(result.toFixed(7)).toBe(expectations[i - offset]);
+        }
+      });
+
+      expect(verifiedBars).toBe(expectations.length);
+    });
+
+    it('root-mean-squares the percentage drawdowns from the highest close in the window', () => {
+      /*
+       * Hand-derived reference for Peter Martin's formula with a 3-bar window,
+       * where each bar's drawdown is measured against the highest close seen so far in the window:
+       *
+       * Window [100, 90, 80] — a straight 20% slide:
+       * close | highest close | drawdown %               | drawdown²
+       *   100 |           100 | 0                        | 0
+       *    90 |           100 | 100 × (90−100)/100 = −10 | 100
+       *    80 |           100 | 100 × (80−100)/100 = −20 | 400
+       * UI = sqrt((0 + 100 + 400) / 3) = sqrt(500/3) ≈ 12.9099
+       *
+       * Window [90, 80, 120] — the slide is followed by a recovery to a new high. The recovery
+       * bar itself carries no drawdown, but the underwater bar before it still weighs in:
+       * close | highest close | drawdown %                  | drawdown²
+       *    90 |            90 | 0                           | 0
+       *    80 |            90 | 100 × (80−90)/90 ≈ −11.1111 | 10000/81
+       *   120 |           120 | 0                           | 0
+       * UI = sqrt((10000/81) / 3) = sqrt(10000/243) ≈ 6.4150
+       */
+      const ui = new UlcerIndex(3);
+      const closes = [100, 90, 80] as const;
+
+      for (const close of closes) {
+        ui.add(close);
+      }
+
+      expect(ui.getResultOrThrow()).toBe(12.909944487358056);
+
+      ui.add(120);
+
+      expect(ui.getResultOrThrow()).toBe(6.415002990995841);
+    });
+
+    it('reports exactly 0 when every close is a new high', () => {
+      const closes = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] as const;
+      const ui = new UlcerIndex(5);
+
+      for (const close of closes) {
+        const result = ui.add(close);
+
+        if (result !== null) {
+          expect(result).toBe(0);
+        }
+      }
+
+      expect(ui.isStable).toBe(true);
+    });
+
+    it('reports exactly 0 for a flat market', () => {
+      const ui = new UlcerIndex(3);
+
+      for (let i = 0; i < 4; i++) {
+        ui.add(100);
+      }
+
+      expect(ui.getResultOrThrow()).toBe(0);
+    });
+  });
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const ui = new UlcerIndex(3);
+      const closes = [100, 90, 80] as const;
+
+      for (const close of closes) {
+        ui.add(close);
+      }
+
+      expect(ui.getResultOrThrow()).toBe(12.909944487358056);
+
+      // Window [90, 80, 120]: recovery to a new high — see the hand-derived table above
+      const originalResult = ui.add(120);
+
+      expect(originalResult).toBe(6.415002990995841);
+
+      // Window [90, 80, 70]: drawdowns of −100/9% and −200/9% → UI = sqrt((50000/81) / 3)
+      const replacedResult = ui.replace(70);
+
+      expect(replacedResult).toBe(14.344382763731174);
+
+      const restoredResult = ui.replace(120);
+
+      expect(restoredResult).toBe(originalResult);
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new UlcerIndex(5),
+  divergentInput: 1_000,
+  inputs: [212.8, 214.06, 213.89, 214.66, 213.95, 213.95],
+});

--- a/packages/trading-signals/src/volatility/UI/UlcerIndex.test.ts
+++ b/packages/trading-signals/src/volatility/UI/UlcerIndex.test.ts
@@ -12,6 +12,16 @@ describe('UlcerIndex', () => {
   });
 
   describe('getResultOrThrow', () => {
+    it('reads a market pinned at zero as having no drawdown', () => {
+      const ui = new UlcerIndex(3);
+
+      for (let i = 0; i < 3; i++) {
+        ui.add(0);
+      }
+
+      expect(ui.getResultOrThrow()).toBe(0);
+    });
+
     it('matches the Skender.Stock.Indicators reference results', () => {
       /*
        * The expectations are the Skender.Stock.Indicators v3.0.0 baseline for the Ulcer Index (14)

--- a/packages/trading-signals/src/volatility/UI/UlcerIndex.ts
+++ b/packages/trading-signals/src/volatility/UI/UlcerIndex.ts
@@ -1,0 +1,53 @@
+import {IndicatorSeries} from '../../base/Indicator.js';
+import {pushUpdate} from '../../util/index.js';
+
+/**
+ * Ulcer Index (UI)
+ * Type: Volatility
+ *
+ * Developed by Peter Martin in 1987, the Ulcer Index measures downside volatility: the root mean
+ * square of percentage drawdowns from the highest close within its window. Unlike the standard
+ * deviation, which punishes upside moves just as much as losses, it only registers stress while the
+ * price sits below a recent high — and because every bar spent underwater keeps contributing, it
+ * penalizes the duration of a drawdown as well as its depth. A reading of 0 means the price never
+ * dropped below a running high; higher readings mean deeper and/or longer drawdowns.
+ *
+ * @see http://www.tangotools.com/ui/ui.htm
+ * @see https://school.stockcharts.com/doku.php?id=technical_indicators:ulcer_index
+ */
+export class UlcerIndex extends IndicatorSeries {
+  readonly #closes: number[] = [];
+
+  public readonly interval: number;
+
+  constructor(interval: number = 14) {
+    super();
+    this.interval = interval;
+  }
+
+  override getRequiredInputs() {
+    return this.interval;
+  }
+
+  update(close: number, replace: boolean) {
+    pushUpdate({array: this.#closes, item: close, maxLength: this.interval, replace});
+
+    if (this.#closes.length < this.interval) {
+      return null;
+    }
+
+    let highestClose = -Infinity;
+    let squaredDrawdownSum = 0;
+
+    for (const currentClose of this.#closes) {
+      if (currentClose > highestClose) {
+        highestClose = currentClose;
+      }
+
+      const percentageDrawdown = (100 * (currentClose - highestClose)) / highestClose;
+      squaredDrawdownSum += percentageDrawdown ** 2;
+    }
+
+    return this.setResult(Math.sqrt(squaredDrawdownSum / this.interval), replace);
+  }
+}

--- a/packages/trading-signals/src/volatility/UI/UlcerIndex.ts
+++ b/packages/trading-signals/src/volatility/UI/UlcerIndex.ts
@@ -44,7 +44,8 @@ export class UlcerIndex extends IndicatorSeries {
         highestClose = currentClose;
       }
 
-      const percentageDrawdown = (100 * (currentClose - highestClose)) / highestClose;
+      // A highest close of zero leaves no value to draw down from, so such a bar reads as no drawdown
+      const percentageDrawdown = highestClose === 0 ? 0 : (100 * (currentClose - highestClose)) / highestClose;
       squaredDrawdownSum += percentageDrawdown ** 2;
     }
 

--- a/packages/trading-signals/src/volatility/index.ts
+++ b/packages/trading-signals/src/volatility/index.ts
@@ -6,6 +6,7 @@ export * from './DC/DonchianChannels.js';
 export * from './IQR/IQR.js';
 export * from './KC/KeltnerChannels.js';
 export * from './MAD/MAD.js';
+export * from './MI/MassIndex.js';
 export * from './NATR/NATR.js';
 export * from './PO/ProjectionOscillator.js';
 export * from './TR/TR.js';

--- a/packages/trading-signals/src/volatility/index.ts
+++ b/packages/trading-signals/src/volatility/index.ts
@@ -8,3 +8,4 @@ export * from './KC/KeltnerChannels.js';
 export * from './MAD/MAD.js';
 export * from './NATR/NATR.js';
 export * from './TR/TR.js';
+export * from './UI/UlcerIndex.js';

--- a/packages/trading-signals/src/volatility/index.ts
+++ b/packages/trading-signals/src/volatility/index.ts
@@ -7,5 +7,6 @@ export * from './IQR/IQR.js';
 export * from './KC/KeltnerChannels.js';
 export * from './MAD/MAD.js';
 export * from './NATR/NATR.js';
+export * from './PO/ProjectionOscillator.js';
 export * from './TR/TR.js';
 export * from './UI/UlcerIndex.js';

--- a/packages/trading-signals/src/volume/NVI/NVI.test.ts
+++ b/packages/trading-signals/src/volume/NVI/NVI.test.ts
@@ -3,6 +3,14 @@ import {NVI} from './NVI.js';
 
 describe('NVI', () => {
   describe('getResultOrThrow', () => {
+    it('keeps the index untouched when the previous close is zero', () => {
+      const nvi = new NVI();
+
+      nvi.add({close: 0, high: 0, low: 0, volume: 200});
+
+      expect(nvi.add({close: 10, high: 10, low: 10, volume: 100})).toBe(1_000);
+    });
+
     it('is compatible with results from Tulip Indicators (TI)', {tags: ['tulipindicators']}, () => {
       /*
        * Test data verified with:

--- a/packages/trading-signals/src/volume/NVI/NVI.test.ts
+++ b/packages/trading-signals/src/volume/NVI/NVI.test.ts
@@ -1,0 +1,132 @@
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {NVI} from './NVI.js';
+
+describe('NVI', () => {
+  describe('getResultOrThrow', () => {
+    it('is compatible with results from Tulip Indicators (TI)', {tags: ['tulipindicators']}, () => {
+      /*
+       * Test data verified with:
+       * https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt#L303-L306
+       */
+      const candles = [
+        {close: 81.59, high: 82.15, low: 81.29, volume: 5_653_100},
+        {close: 81.06, high: 81.89, low: 80.64, volume: 6_447_400},
+        {close: 82.87, high: 83.03, low: 81.31, volume: 7_690_900},
+        {close: 83.0, high: 83.3, low: 82.65, volume: 3_831_400},
+        {close: 83.61, high: 83.85, low: 83.07, volume: 4_455_100},
+        {close: 83.15, high: 83.9, low: 83.11, volume: 3_798_000},
+        {close: 82.84, high: 83.33, low: 82.49, volume: 3_936_200},
+        {close: 83.99, high: 84.3, low: 82.3, volume: 4_732_000},
+        {close: 84.55, high: 84.84, low: 84.15, volume: 4_841_300},
+        {close: 84.36, high: 85.0, low: 84.11, volume: 3_915_300},
+        {close: 85.53, high: 85.9, low: 84.03, volume: 6_830_800},
+        {close: 86.54, high: 86.58, low: 85.39, volume: 6_694_100},
+        {close: 86.89, high: 86.98, low: 85.76, volume: 5_293_600},
+        {close: 87.77, high: 88.0, low: 87.17, volume: 7_985_800},
+        {close: 87.29, high: 87.87, low: 87.01, volume: 4_807_900},
+      ] as const;
+      const expectations = [
+        '1000.000',
+        '1000.000',
+        '1000.000',
+        '1001.569',
+        '1001.569',
+        '996.058',
+        '996.058',
+        '996.058',
+        '996.058',
+        '993.820',
+        '993.820',
+        '1005.556',
+        '1009.623',
+        '1009.623',
+        '1004.101',
+      ] as const;
+      const nvi = new NVI();
+
+      candles.forEach((candle, i) => {
+        const result = nvi.add(candle);
+
+        expect(result?.toFixed(3)).toBe(expectations[i]);
+      });
+
+      expect(nvi.isStable).toBe(true);
+      expect(nvi.getRequiredInputs()).toBe(1);
+    });
+
+    it('starts the index at 1000 on the very first candle', () => {
+      const nvi = new NVI();
+
+      expect(nvi.add({close: 81.59, high: 82.15, low: 81.29, volume: 5_653_100})).toBe(1_000);
+    });
+
+    it('keeps the index flat when volume is unchanged', () => {
+      const nvi = new NVI();
+
+      nvi.add({close: 100, high: 100, low: 100, volume: 5_000});
+      nvi.add({close: 200, high: 200, low: 200, volume: 5_000});
+
+      expect(nvi.getResultOrThrow()).toBe(1_000);
+    });
+  });
+
+  describe('replace', () => {
+    /** Keeps the tests focused on close and volume by faking a candle that has no intra-bar movement. */
+    const fakeFlatCandle = (close: number, volume: number) => ({close, high: close, low: close, volume}) as const;
+
+    it('rolls back the accumulation when the replacement no longer shows falling volume', () => {
+      const nvi = new NVI();
+
+      nvi.add(fakeFlatCandle(100, 10_000));
+      nvi.add(fakeFlatCandle(112.5, 8_000));
+
+      const originalValue = fakeFlatCandle(126.5625, 6_000);
+      const replacedValue = fakeFlatCandle(126.5625, 9_000);
+
+      const originalResult = nvi.add(originalValue);
+
+      expect(originalResult).toBe(1_265.625);
+
+      const replacedResult = nvi.replace(replacedValue);
+
+      expect(replacedResult).toBe(1_125);
+
+      const restoredResult = nvi.replace(originalValue);
+
+      expect(restoredResult).toBe(1_265.625);
+    });
+
+    it('applies the accumulation when only the replacement shows falling volume', () => {
+      const nvi = new NVI();
+
+      nvi.add(fakeFlatCandle(100, 10_000));
+      nvi.add(fakeFlatCandle(112.5, 8_000));
+
+      const originalValue = fakeFlatCandle(126.5625, 9_000);
+      const replacedValue = fakeFlatCandle(126.5625, 6_000);
+
+      const originalResult = nvi.add(originalValue);
+
+      expect(originalResult).toBe(1_125);
+
+      const replacedResult = nvi.replace(replacedValue);
+
+      expect(replacedResult).toBe(1_265.625);
+
+      const restoredResult = nvi.replace(originalValue);
+
+      expect(restoredResult).toBe(1_125);
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new NVI(),
+  divergentInput: {close: 500, high: 500, low: 500, volume: 1_000},
+  inputs: [
+    {close: 81.59, high: 82.15, low: 81.29, volume: 5_653_100},
+    {close: 81.06, high: 81.89, low: 80.64, volume: 6_447_400},
+    {close: 82.87, high: 83.03, low: 81.31, volume: 7_690_900},
+    {close: 83.0, high: 83.3, low: 82.65, volume: 3_831_400},
+  ],
+});

--- a/packages/trading-signals/src/volume/NVI/NVI.ts
+++ b/packages/trading-signals/src/volume/NVI/NVI.ts
@@ -43,7 +43,8 @@ export class NVI extends IndicatorSeries<HighLowCloseVolume, NVIState> {
 
     const previousCandle = this.state.previousCandle;
 
-    if (previousCandle !== null && candle.volume < previousCandle.volume) {
+    // A previous close of zero offers no base to measure a price change against, so the index stays put
+    if (previousCandle !== null && previousCandle.close !== 0 && candle.volume < previousCandle.volume) {
       const priceChangeRatio = (candle.close - previousCandle.close) / previousCandle.close;
       this.state.nvi += priceChangeRatio * this.state.nvi;
     }

--- a/packages/trading-signals/src/volume/NVI/NVI.ts
+++ b/packages/trading-signals/src/volume/NVI/NVI.ts
@@ -1,0 +1,55 @@
+import type {HighLowCloseVolume} from '../../base/Candle.type.js';
+import {IndicatorSeries} from '../../base/Indicator.js';
+
+type NVIState = {
+  nvi: number;
+  previousCandle: HighLowCloseVolume | null;
+};
+
+/**
+ * Negative Volume Index (NVI)
+ * Type: Volume
+ *
+ * Developed by Paul Dysart in the 1930s and popularized by Norman Fosback in "Stock Market Logic" (1976), the
+ * Negative Volume Index follows price changes only on days when trading volume declines. The premise is that the
+ * uninformed crowd dominates the busy days while "smart money" positions itself quietly on falling-volume days, so a
+ * rising NVI reflects informed accumulation.
+ *
+ * Formula:
+ * The index starts at 1000. When a bar's volume falls below the previous bar's volume, the index changes by the
+ * closing price's percentage change. On rising or unchanged volume, the index stays flat.
+ *
+ * Interpretation:
+ * The NVI carries no fixed threshold. Fosback read it against its own one-year moving average: an NVI above that
+ * average historically indicated high odds of a bull market. Compare the index to a long moving average of itself —
+ * this class does not emit a standalone signal.
+ *
+ * @see https://www.investopedia.com/terms/n/nvi.asp
+ * @see https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/indicators/nvi.c
+ */
+export class NVI extends IndicatorSeries<HighLowCloseVolume, NVIState> {
+  protected override state: NVIState = {nvi: 1_000, previousCandle: null};
+
+  override getRequiredInputs() {
+    return 1;
+  }
+
+  update(candle: HighLowCloseVolume, replace: boolean) {
+    /*
+     * NVI accumulates onto a running index, so a replacement has to build on the index from
+     * before the replaced candle.
+     */
+    this.trackState(replace);
+
+    const previousCandle = this.state.previousCandle;
+
+    if (previousCandle !== null && candle.volume < previousCandle.volume) {
+      const priceChangeRatio = (candle.close - previousCandle.close) / previousCandle.close;
+      this.state.nvi += priceChangeRatio * this.state.nvi;
+    }
+
+    this.state.previousCandle = candle;
+
+    return this.setResult(this.state.nvi, replace);
+  }
+}

--- a/packages/trading-signals/src/volume/PVI/PVI.test.ts
+++ b/packages/trading-signals/src/volume/PVI/PVI.test.ts
@@ -3,6 +3,14 @@ import {PVI} from './PVI.js';
 
 describe('PVI', () => {
   describe('getResultOrThrow', () => {
+    it('keeps the index untouched when the previous close is zero', () => {
+      const pvi = new PVI();
+
+      pvi.add({close: 0, high: 0, low: 0, volume: 100});
+
+      expect(pvi.add({close: 10, high: 10, low: 10, volume: 200})).toBe(1_000);
+    });
+
     it('is compatible with results from Tulip Indicators (TI)', {tags: ['tulipindicators']}, () => {
       /*
        * Test data verified with:

--- a/packages/trading-signals/src/volume/PVI/PVI.test.ts
+++ b/packages/trading-signals/src/volume/PVI/PVI.test.ts
@@ -1,0 +1,136 @@
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {PVI} from './PVI.js';
+
+describe('PVI', () => {
+  describe('getResultOrThrow', () => {
+    it('is compatible with results from Tulip Indicators (TI)', {tags: ['tulipindicators']}, () => {
+      /*
+       * Test data verified with:
+       * @see https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt#L322-L325
+       */
+      const candles = [
+        {close: 81.59, high: 82.15, low: 81.29, volume: 5_653_100},
+        {close: 81.06, high: 81.89, low: 80.64, volume: 6_447_400},
+        {close: 82.87, high: 83.03, low: 81.31, volume: 7_690_900},
+        {close: 83.0, high: 83.3, low: 82.65, volume: 3_831_400},
+        {close: 83.61, high: 83.85, low: 83.07, volume: 4_455_100},
+        {close: 83.15, high: 83.9, low: 83.11, volume: 3_798_000},
+        {close: 82.84, high: 83.33, low: 82.49, volume: 3_936_200},
+        {close: 83.99, high: 84.3, low: 82.3, volume: 4_732_000},
+        {close: 84.55, high: 84.84, low: 84.15, volume: 4_841_300},
+        {close: 84.36, high: 85.0, low: 84.11, volume: 3_915_300},
+        {close: 85.53, high: 85.9, low: 84.03, volume: 6_830_800},
+        {close: 86.54, high: 86.58, low: 85.39, volume: 6_694_100},
+        {close: 86.89, high: 86.98, low: 85.76, volume: 5_293_600},
+        {close: 87.77, high: 88.0, low: 87.17, volume: 7_985_800},
+        {close: 87.29, high: 87.87, low: 87.01, volume: 4_807_900},
+      ] as const;
+      const expectations = [
+        '1000.000',
+        '993.504',
+        '1015.688',
+        '1015.688',
+        '1023.153',
+        '1023.153',
+        '1019.338',
+        '1033.489',
+        '1040.380',
+        '1040.380',
+        '1054.809',
+        '1054.809',
+        '1054.809',
+        '1065.492',
+        '1065.492',
+      ] as const;
+      const pvi = new PVI();
+      const offset = pvi.getRequiredInputs() - 1;
+
+      candles.forEach((candle, i) => {
+        const result = pvi.add(candle);
+
+        if (result) {
+          expect(result.toFixed(3)).toBe(expectations[i - offset]);
+        }
+      });
+
+      expect(pvi.isStable).toBe(true);
+      expect(pvi.getRequiredInputs()).toBe(1);
+    });
+
+    it('starts the index at its conventional base of 1000 on the first bar', () => {
+      const pvi = new PVI();
+
+      expect(pvi.add({close: 81.59, high: 82.15, low: 81.29, volume: 5_653_100})).toBe(1_000);
+      expect(pvi.isStable).toBe(true);
+    });
+
+    it('keeps the index flat when volume is unchanged', () => {
+      const pvi = new PVI();
+
+      pvi.add({close: 100, high: 100, low: 100, volume: 1_000});
+      pvi.add({close: 150, high: 150, low: 150, volume: 1_000});
+
+      expect(pvi.getResultOrThrow()).toBe(1_000);
+    });
+  });
+
+  describe('replace', () => {
+    /** Keeps the tests focused on close and volume by faking a candle that has no intra-bar movement. */
+    const fakeFlatCandle = (close: number, volume: number) => ({close, high: close, low: close, volume}) as const;
+
+    it('replaces a crowd day with a quiet day and back', () => {
+      const pvi = new PVI();
+
+      pvi.add(fakeFlatCandle(100, 1_000));
+
+      const risingVolume = fakeFlatCandle(110, 2_000);
+      const fallingVolume = fakeFlatCandle(110, 500);
+
+      const originalResult = pvi.add(risingVolume);
+
+      expect(originalResult, 'a 10% close gain on expanding volume compounds the index').toBe(1_100);
+
+      const replacedResult = pvi.replace(fallingVolume);
+
+      expect(replacedResult, 'the same close gain on shrinking volume leaves the index flat').toBe(1_000);
+
+      const restoredResult = pvi.replace(risingVolume);
+
+      expect(restoredResult).toBe(originalResult);
+    });
+
+    it('replaces a quiet day with a crowd day and compounds onto the index from before the replaced bar', () => {
+      const replaced = new PVI();
+
+      replaced.add(fakeFlatCandle(100, 1_000));
+      replaced.add(fakeFlatCandle(110, 2_000));
+      replaced.add(fakeFlatCandle(121, 1_500));
+
+      expect(replaced.getResultOrThrow(), 'shrinking volume leaves the index flat').toBe(1_100);
+
+      replaced.replace(fakeFlatCandle(121, 3_000));
+
+      expect(replaced.getResultOrThrow(), 'a replacement must not count the replaced bar twice').toBe(1_210);
+
+      const reference = new PVI();
+
+      reference.add(fakeFlatCandle(100, 1_000));
+      reference.add(fakeFlatCandle(110, 2_000));
+      reference.add(fakeFlatCandle(121, 3_000));
+
+      expect(replaced.getResultOrThrow()).toBe(reference.getResultOrThrow());
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new PVI(),
+  divergentInput: {close: 500, high: 500, low: 500, volume: 99_000_000},
+  inputs: [
+    {close: 81.59, high: 82.15, low: 81.29, volume: 5_653_100},
+    {close: 81.06, high: 81.89, low: 80.64, volume: 6_447_400},
+    {close: 82.87, high: 83.03, low: 81.31, volume: 7_690_900},
+    {close: 83.0, high: 83.3, low: 82.65, volume: 3_831_400},
+    {close: 83.61, high: 83.85, low: 83.07, volume: 4_455_100},
+  ],
+});

--- a/packages/trading-signals/src/volume/PVI/PVI.ts
+++ b/packages/trading-signals/src/volume/PVI/PVI.ts
@@ -1,0 +1,51 @@
+import type {HighLowCloseVolume} from '../../base/Candle.type.js';
+import {IndicatorSeries} from '../../base/Indicator.js';
+import {pushUpdate} from '../../util/pushUpdate.js';
+
+type PVIState = {
+  candles: HighLowCloseVolume[];
+  pvi: number;
+};
+
+/**
+ * Positive Volume Index (PVI)
+ * Type: Volume
+ *
+ * Devised by Paul Dysart and popularized by Norman Fosback, the Positive Volume Index isolates
+ * what price does on days when volume expands — the days the excitable crowd is most active.
+ * The index starts at 1000 and compounds the closing price change only on bars whose volume
+ * exceeds the previous bar's volume; on shrinking or unchanged volume it stays flat. Its
+ * counterpart NVI does the opposite and follows the quiet days attributed to smart money.
+ *
+ * Interpretation: PVI is read against its own long moving average (Fosback used roughly one
+ * year of daily bars). An index above that average suggests bull-market odds, while an index
+ * below it warns that a bear market is more likely — crowd buying has dried up.
+ *
+ * @see https://www.investopedia.com/terms/p/pvi.asp
+ * @see https://tulipindicators.org/pvi
+ */
+export class PVI extends IndicatorSeries<HighLowCloseVolume, PVIState> {
+  protected override state: PVIState = {candles: [], pvi: 1_000};
+
+  override getRequiredInputs() {
+    return 1;
+  }
+
+  update(candle: HighLowCloseVolume, replace: boolean) {
+    this.trackState(replace);
+
+    // A replacement has already rewound to the state from before the replaced candle, so the incoming candle is always appended
+    pushUpdate({array: this.state.candles, item: candle, maxLength: 2, replace: false});
+
+    if (this.state.candles.length === 2) {
+      const previous = this.state.candles[0];
+
+      // Only a crowd day (expanding volume) moves the index; quiet days leave it untouched
+      if (candle.volume > previous.volume) {
+        this.state.pvi += ((candle.close - previous.close) / previous.close) * this.state.pvi;
+      }
+    }
+
+    return this.setResult(this.state.pvi, replace);
+  }
+}

--- a/packages/trading-signals/src/volume/PVI/PVI.ts
+++ b/packages/trading-signals/src/volume/PVI/PVI.ts
@@ -40,8 +40,11 @@ export class PVI extends IndicatorSeries<HighLowCloseVolume, PVIState> {
     if (this.state.candles.length === 2) {
       const previous = this.state.candles[0];
 
-      // Only a crowd day (expanding volume) moves the index; quiet days leave it untouched
-      if (candle.volume > previous.volume) {
+      /*
+       * Only a crowd day (expanding volume) moves the index; quiet days leave it untouched.
+       * A previous close of zero offers no base to measure a price change against, so the index stays put.
+       */
+      if (previous.close !== 0 && candle.volume > previous.volume) {
         this.state.pvi += ((candle.close - previous.close) / previous.close) * this.state.pvi;
       }
     }

--- a/packages/trading-signals/src/volume/PVO/PVO.test.ts
+++ b/packages/trading-signals/src/volume/PVO/PVO.test.ts
@@ -1,0 +1,160 @@
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {PVO} from './PVO.js';
+import {TradingSignal} from '../../base/index.js';
+
+describe('PVO', () => {
+  /*
+   * There is no Tulip Indicators baseline for the PVO, and third-party baselines
+   * (e.g. Skender.Stock.Indicators v3.0.0) seed their EMAs with an SMA of the first raw
+   * volumes. An SMA-seeded EMA never coincides with an EMA seeded from the first value — the
+   * seeding difference only decays geometrically — so those baselines are not reproducible
+   * here. The expectations below are derived by hand instead, with a fast period of 2
+   * (smoothing weight 2/3) and a slow period of 5 (smoothing weight 1/3). The volumes are
+   * multiples of 3^5 = 243, which keeps every EMA reading an integer:
+   *
+   * volume | fast EMA(2) | slow EMA(5) | PVO
+   *    243 |         243 |         243 |  -
+   *    486 |         405 |         324 |  -
+   *    729 |         621 |         459 |  -
+   *    972 |         855 |         630 |  -
+   *   1215 |        1095 |         825 | 100 * (1095 - 825) / 825 = 32.7272...
+   *   1458 |        1337 |        1036 | 100 * (1337 - 1036) / 1036 = 29.0540...
+   *
+   * The slow EMA is only considered stable from the 5th volume onwards, so 32.73 is the
+   * first result.
+   *
+   * @see https://school.stockcharts.com/doku.php?id=technical_indicators:percentage_volume_oscillator_pvo
+   */
+  const volumes = [243, 486, 729, 972, 1215, 1458] as const;
+  const expectations = ['32.73', '29.05'] as const;
+
+  describe('constructor', () => {
+    it('mirrors the PPO defaults of a 12-candle fast and a 26-candle slow EMA', () => {
+      const pvo = new PVO();
+
+      expect(pvo.fastPeriod).toBe(12);
+      expect(pvo.slowPeriod).toBe(26);
+      expect(pvo.getRequiredInputs()).toBe(26);
+    });
+  });
+
+  describe('getResultOrThrow', () => {
+    it('reports the spread between the fast and slow volume EMA as a percentage of the slow EMA', () => {
+      const pvo = new PVO({fastPeriod: 2, slowPeriod: 5});
+      const offset = pvo.getRequiredInputs() - 1;
+
+      volumes.forEach((volume, i) => {
+        const result = pvo.add(volume);
+
+        if (result !== null) {
+          expect(result.toFixed(2)).toBe(expectations[i - offset]);
+        }
+      });
+
+      expect(pvo.isStable).toBe(true);
+      expect(pvo.getRequiredInputs()).toBe(5);
+    });
+
+    it('reports zero for a halted market instead of dividing by zero', () => {
+      const pvo = new PVO({fastPeriod: 2, slowPeriod: 5});
+
+      for (let i = 0; i < 5; i++) {
+        pvo.add(0);
+      }
+
+      expect(pvo.getResultOrThrow()).toBe(0);
+      expect(pvo.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+    });
+  });
+
+  describe('replace', () => {
+    it('replaces the most recently added volume', () => {
+      const pvo = new PVO({fastPeriod: 2, slowPeriod: 5});
+
+      for (const volume of volumes) {
+        pvo.add(volume);
+      }
+
+      const originalValue = 2_916;
+      const replacedValue = 243;
+
+      const originalResult = pvo.add(originalValue);
+
+      expect(originalResult?.toFixed(2)).toBe('43.72');
+
+      const replacedResult = pvo.replace(replacedValue);
+
+      expect(replacedResult?.toFixed(2)).toBe('-21.25');
+      expect(replacedResult).not.toBe(originalResult);
+
+      const restoredResult = pvo.replace(originalValue);
+
+      expect(restoredResult).toBe(originalResult);
+    });
+  });
+
+  describe('getSignal', () => {
+    it('returns UNKNOWN when there is no result', () => {
+      const pvo = new PVO();
+
+      expect(pvo.getSignal()).toStrictEqual({hasChanged: false, state: TradingSignal.UNKNOWN});
+    });
+
+    it('returns BULLISH while volume is expanding', () => {
+      const pvo = new PVO({fastPeriod: 2, slowPeriod: 5});
+
+      for (let i = 1; i <= 5; i++) {
+        pvo.add(100 * i);
+      }
+
+      expect(pvo.getResultOrThrow()).toBeGreaterThan(0);
+      expect(pvo.getSignal().state).toBe(TradingSignal.BULLISH);
+    });
+
+    it('returns BEARISH while volume is drying up', () => {
+      const pvo = new PVO({fastPeriod: 2, slowPeriod: 5});
+
+      for (let i = 1; i <= 5; i++) {
+        pvo.add(600 - 100 * i);
+      }
+
+      expect(pvo.getResultOrThrow()).toBeLessThan(0);
+      expect(pvo.getSignal().state).toBe(TradingSignal.BEARISH);
+    });
+
+    it('returns SIDEWAYS when volume never changes', () => {
+      const pvo = new PVO({fastPeriod: 2, slowPeriod: 5});
+
+      for (let i = 0; i < 5; i++) {
+        pvo.add(500);
+      }
+
+      expect(pvo.getResultOrThrow()).toBe(0);
+      expect(pvo.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+    });
+
+    it('flags the change when the volume regime flips from expansion to contraction', () => {
+      const pvo = new PVO({fastPeriod: 2, slowPeriod: 5});
+
+      for (let i = 1; i <= 5; i++) {
+        pvo.add(100 * i);
+      }
+
+      expect(pvo.getSignal()).toStrictEqual({hasChanged: true, state: TradingSignal.BULLISH});
+
+      pvo.add(10);
+
+      expect(pvo.getSignal()).toStrictEqual({hasChanged: true, state: TradingSignal.BEARISH});
+
+      pvo.add(10);
+
+      expect(pvo.getSignal()).toStrictEqual({hasChanged: false, state: TradingSignal.BEARISH});
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new PVO({fastPeriod: 2, slowPeriod: 5}),
+  divergentInput: 1_000_000,
+  inputs: [243, 486, 729, 972, 1215, 1458, 1701],
+});

--- a/packages/trading-signals/src/volume/PVO/PVO.ts
+++ b/packages/trading-signals/src/volume/PVO/PVO.ts
@@ -1,0 +1,64 @@
+import {ZeroCrossSeries} from '../../base/Indicator.js';
+import {EMA} from '../../trend/EMA/EMA.js';
+
+export type PVOConfig = {
+  /** Number of candles for the fast EMA (default: 12) */
+  fastPeriod?: number;
+  /** Number of candles for the slow EMA (default: 26) */
+  slowPeriod?: number;
+};
+
+/**
+ * Percentage Volume Oscillator (PVO)
+ * Type: Volume
+ *
+ * The PVO is the PPO applied to volume: it divides the spread between a fast and a slow EMA of volume by the slow
+ * EMA. The percentage form makes volume thrust comparable across instruments — 20 million shares of extra activity
+ * means nothing without knowing what is typical, while "volume runs 10% above its longer-term average" reads the
+ * same everywhere. It consumes the plain volume stream of each candle, exactly as the PPO consumes a price stream.
+ *
+ * Interpretation: A reading above zero means volume is expanding — recent activity outpaces its longer-term
+ * average, lending conviction to the current price move. A reading below zero means volume is drying up. A cross
+ * of the zero line marks a volume regime change from contraction to expansion or back.
+ *
+ * @see https://school.stockcharts.com/doku.php?id=technical_indicators:percentage_volume_oscillator_pvo
+ * @see https://www.investopedia.com/terms/p/ppo.asp
+ */
+export class PVO extends ZeroCrossSeries {
+  readonly #fast: EMA;
+  readonly #slow: EMA;
+
+  public readonly fastPeriod: number;
+  public readonly slowPeriod: number;
+
+  constructor({fastPeriod = 12, slowPeriod = 26}: PVOConfig = {}) {
+    super();
+    this.fastPeriod = fastPeriod;
+    this.slowPeriod = slowPeriod;
+    this.#fast = new EMA(fastPeriod);
+    this.#slow = new EMA(slowPeriod);
+  }
+
+  override getRequiredInputs() {
+    return this.#slow.getRequiredInputs();
+  }
+
+  update(volume: number, replace: boolean) {
+    const fast = this.#fast.update(volume, replace);
+    const slow = this.#slow.update(volume, replace);
+
+    if (!this.#slow.isStable) {
+      return null;
+    }
+
+    /*
+     * A halted market (nothing but zero volume so far) leaves no longer-term average to
+     * compare against, so a neutral zero reading is reported instead of a division error.
+     */
+    if (slow === 0) {
+      return this.setResult(0, replace);
+    }
+
+    return this.setResult((100 * (fast - slow)) / slow, replace);
+  }
+}

--- a/packages/trading-signals/src/volume/index.ts
+++ b/packages/trading-signals/src/volume/index.ts
@@ -6,6 +6,7 @@ export * from './FI/ForceIndex.js';
 export * from './KVO/KVO.js';
 export * from './NVI/NVI.js';
 export * from './PVI/PVI.js';
+export * from './PVO/PVO.js';
 export * from './PVT/PVT.js';
 export * from './RVOL/RVOL.js';
 export * from './VROC/VROC.js';

--- a/packages/trading-signals/src/volume/index.ts
+++ b/packages/trading-signals/src/volume/index.ts
@@ -5,6 +5,7 @@ export * from './EMV/EMV.js';
 export * from './FI/ForceIndex.js';
 export * from './KVO/KVO.js';
 export * from './NVI/NVI.js';
+export * from './PVI/PVI.js';
 export * from './PVT/PVT.js';
 export * from './RVOL/RVOL.js';
 export * from './VROC/VROC.js';

--- a/packages/trading-signals/src/volume/index.ts
+++ b/packages/trading-signals/src/volume/index.ts
@@ -4,6 +4,7 @@ export * from './CMF/CMF.js';
 export * from './EMV/EMV.js';
 export * from './FI/ForceIndex.js';
 export * from './KVO/KVO.js';
+export * from './NVI/NVI.js';
 export * from './PVT/PVT.js';
 export * from './RVOL/RVOL.js';
 export * from './VROC/VROC.js';


### PR DESCRIPTION
## Summary

Closes the remaining indicator gap vs [cinar/indicatorts](https://github.com/cinar/indicatorts) — one commit per item, each with implementation, 100%-covered tests, docs demo, and README/barrel wiring:

| Item | Class | Category | Reference verification |
|---|---|---|---|
| KDJ %J line | `StochasticOscillator` (extended) | momentum | Hand-derived: %K=0, %D=50 → %J=−100 (overshoots 0–100 by design) |
| Qstick | `Qstick` | momentum | Tulip `untest.txt` L327–330 + `qstick.c` |
| Chande Forecast Oscillator | `CFO` | momentum | Tulip `tsf` (L430–432) + cross-checked against Tulip's `fosc` (L199–201) |
| Negative Volume Index | `NVI` | volume | Tulip L303–306, all 15 values |
| Positive Volume Index | `PVI` | volume | Tulip L322–325, all 15 values |
| Percentage Volume Oscillator | `PVO` | volume | Skender rejected after numeric seeding proof → hand-derived integer EMA table |
| Mass Index | `MassIndex` | volatility | `mass.c` port verified bar-by-bar + Tulip `atoz.txt` L141–145 (Achelis fixture) |
| Ulcer Index | `UlcerIndex` | volatility | Skender v3.0.0, 489/489 values at 7 decimals |
| Projection Oscillator | `ProjectionOscillator` | volatility | Widner (TASC 07/1995) hand-derived exact binary fractions — no public fixture exists |

## Bug found & fixed in this PR

**STOCH fabricated %D when %K was exactly 0** (close pinned to the window low): `stochK && smoothD.update(...)` short-circuited on the falsy 0, skipping the %D smoothing and emitting `stochD = 0` instead of the real average. The new hand-derived %J test exposed it; fixed with an explicit null check.

## Bug found, NOT fixed here (follow-up)

`LinearRegression`'s perfect-linear-trend shortcut returns the window's **last** value instead of the one-bar-ahead forecast (window `[10..14]` → returns 14, true forecast 15; only unit-step trends hit the branch). `CFO` carries its own regression buffer to stay correct. Deserves a dedicated fix PR.

## Notes

- `CFO`, `Qstick`, `PVO` extend `ZeroCrossSeries`; `ProjectionOscillator` is threshold-based (`TrendIndicatorSeries`, RSI-style 80/20); `NVI`/`PVI` use the typed `state`/`trackState` rollback for their cumulative indices; `MassIndex`/`UlcerIndex` are plain volatility series with no fabricated signal claims.
- With this, everything in indicatorts that qualifies as a streaming indicator is covered (their strategies/backtest modules are downstream concerns; batch-only architecture not applicable).