### PR TITLE
feat(trading-signals): close the Cloud9Trader feature gap (PB, DPO, PGO, GAPO, PMO)

### DIFF
--- a/packages/trading-signals-docs/indicator-demos/momentum/DPO.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/DPO.demo.tsx
@@ -1,0 +1,20 @@
+import {DPO as DPOClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const DPO: IndicatorConfig = {
+  chartTitle: 'DPO (20)',
+  color: '#f472b6',
+  createIndicator: () => new DPOClass(20),
+  description: 'Detrended Price Oscillator',
+  details:
+    'Strips the prevailing trend by comparing a displaced close against its surrounding average, exposing the short-term price cycle. Above zero the cycle trades above the average (bullish pressure), below zero beneath it (bearish pressure). Each reading describes the bar half an interval plus one bar back, not the latest candle.',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
+  id: 'dpo',
+  name: 'DPO',
+  processData: makeProcessData({rowInputs: ['close']}),
+  requiredInputs: 20,
+  type: 'single',
+  yAxisLabel: 'DPO',
+};

--- a/packages/trading-signals-docs/indicator-demos/momentum/PGO.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/PGO.demo.tsx
@@ -1,0 +1,20 @@
+import {PGO as PGOClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const PGO: IndicatorConfig = {
+  chartTitle: 'PGO (14)',
+  color: '#0ea5e9',
+  createIndicator: () => new PGOClass(),
+  description: 'Pretty Good Oscillator',
+  details:
+    'Measures how far the close has traveled from its simple moving average, expressed in units of smoothed true range. Mark Johnson used it as a breakout system: readings above +3 flag a long breakout, readings below -3 a short breakout.',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
+  id: 'pgo',
+  name: 'PGO',
+  processData: makeProcessData({addInputs: ['high', 'low', 'close'], rowInputs: ['close']}),
+  requiredInputs: 27,
+  type: 'single',
+  yAxisLabel: 'PGO',
+};

--- a/packages/trading-signals-docs/indicator-demos/momentum/PMO.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/PMO.demo.tsx
@@ -1,0 +1,142 @@
+import {Chart as HighchartsChart} from '@highcharts/react';
+import {PMO as PMOClass} from 'trading-signals';
+import type {ReactNode} from 'react';
+import type {Candle} from '@typedtrader/exchange';
+import {createSharedTooltipFormatter, type ChartDataPoint} from '../../components/Chart';
+import {NotAvailable} from '../../components/NotAvailable';
+import PriceChart, {type PriceData} from '../../components/PriceChart';
+import {SignalBadge} from '../../components/SignalBadge';
+import {formatDate} from '../../utils/formatDate';
+import {collectPriceData} from '../../utils/renderUtils';
+import type {IndicatorConfig} from '../../utils/types';
+
+const renderPMO = (config: IndicatorConfig, selectedCandles: Candle[]) => {
+  const pmo = new PMOClass();
+  const chartDataPMO: ChartDataPoint[] = [];
+  const chartDataSignal: ChartDataPoint[] = [];
+  const priceData: PriceData[] = [];
+  const sampleValues: {period: number; date: string; close: number; result: ReactNode; signal: string}[] = [];
+
+  selectedCandles.forEach((candle, idx) => {
+    pmo.add(Number(candle.close));
+    const result = pmo.isStable ? pmo.getResult() : null;
+    const trendSignal = pmo.getSignal();
+    chartDataPMO.push({x: idx + 1, y: result?.pmo ?? null});
+    chartDataSignal.push({x: idx + 1, y: result?.signal ?? null});
+
+    priceData.push(collectPriceData(candle, idx));
+
+    sampleValues.push({
+      close: Number(candle.close),
+      date: formatDate(candle.openTimeInISO),
+      period: idx + 1,
+      result: result ? `${result.pmo.toFixed(4)}` : <NotAvailable />,
+      signal: trendSignal.state,
+    });
+  });
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold text-white mb-2 select-text">
+          PMO(35, 20, 10) / Required Inputs: {pmo.getRequiredInputs()}
+        </h2>
+        <p className="text-slate-300 select-text">{config.description}</p>
+        <p className="text-slate-400 text-sm mt-2 select-text">
+          Double-smooths the one-bar percentage price change, scaled by 10. Crossing above the signal line = bullish,
+          crossing below = bearish.
+        </p>
+      </div>
+
+      <div className="bg-slate-800/50 border border-slate-700 rounded-lg p-4">
+        <HighchartsChart
+          options={{
+            chart: {backgroundColor: 'transparent', height: 300, type: 'line'},
+            credits: {enabled: false},
+            legend: {enabled: true, itemStyle: {color: '#e2e8f0'}},
+            plotOptions: {
+              line: {lineWidth: 2, marker: {enabled: true, radius: 3}},
+            },
+            series: [
+              {
+                color: config.color,
+                data: chartDataPMO.map(point => [point.x, point.y]),
+                marker: {fillColor: config.color},
+                name: 'PMO',
+                type: 'line',
+              },
+              {
+                color: '#f97316',
+                data: chartDataSignal.map(point => [point.x, point.y]),
+                marker: {fillColor: '#f97316'},
+                name: 'Signal',
+                type: 'line',
+              },
+            ],
+            title: {style: {color: '#e2e8f0', fontSize: '16px', fontWeight: '600'}, text: 'PMO (35,20,10)'},
+            tooltip: {
+              backgroundColor: '#1e293b',
+              borderColor: '#475569',
+              formatter: createSharedTooltipFormatter(y => y.toFixed(4)),
+              shared: true,
+              style: {color: '#e2e8f0'},
+            },
+            xAxis: {
+              gridLineColor: '#334155',
+              labels: {style: {color: '#94a3b8'}},
+              title: {style: {color: '#94a3b8'}, text: 'Period'},
+            },
+            yAxis: {
+              gridLineColor: '#334155',
+              labels: {style: {color: '#94a3b8'}},
+              title: {style: {color: '#94a3b8'}, text: 'Value'},
+            },
+          }}
+        />
+      </div>
+
+      <PriceChart title="Input Prices" data={priceData} />
+
+      <div className="bg-slate-800/50 border border-slate-700 rounded-lg p-4">
+        <h3 className="text-lg font-semibold text-white mb-3">All Sample Values</h3>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-slate-600">
+                <th className="text-left text-slate-300 py-2 px-3">Period</th>
+                <th className="text-left text-slate-300 py-2 px-3">Date</th>
+                <th className="text-left text-slate-300 py-2 px-3">Close</th>
+                <th className="text-left text-slate-300 py-2 px-3">PMO</th>
+                <th className="text-left text-slate-300 py-2 px-3">Signal</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sampleValues.map(row => (
+                <tr key={row.period} className="border-b border-slate-700/50">
+                  <td className="text-slate-400 py-2 px-3">{row.period}</td>
+                  <td className="text-slate-300 py-2 px-3">{row.date}</td>
+                  <td className="text-slate-300 py-2 px-3">${row.close.toFixed(2)}</td>
+                  <td className="text-white font-mono py-2 px-3">{row.result}</td>
+                  <td className="py-2 px-3">
+                    <SignalBadge signal={row.signal} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const PMO: IndicatorConfig = {
+  color: '#0ea5e9',
+  createIndicator: () => new PMOClass(),
+  customRender: renderPMO,
+  description: 'DecisionPoint Price Momentum Oscillator',
+  id: 'pmo',
+  name: 'PMO',
+  requiredInputs: 55,
+  type: 'custom',
+};

--- a/packages/trading-signals-docs/indicator-demos/momentum/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/index.tsx
@@ -7,6 +7,7 @@ import {CFO} from './CFO.demo';
 import {CG} from './CG.demo';
 import {CMO} from './CMO.demo';
 import {CoppockCurve} from './CoppockCurve.demo';
+import {DPO} from './DPO.demo';
 import {ElderRay} from './ElderRay.demo';
 import {ER} from './ER.demo';
 import {FisherTransform} from './FisherTransform.demo';
@@ -57,6 +58,7 @@ export const indicators: IndicatorConfig[] = [
   ElderRay,
   Qstick,
   CFO,
+  DPO,
   TRIX,
   TSI,
 ];

--- a/packages/trading-signals-docs/indicator-demos/momentum/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/index.tsx
@@ -16,6 +16,7 @@ import {MACD} from './MACD.demo';
 import {MFI} from './MFI.demo';
 import {MOM} from './MOM.demo';
 import {OBV} from './OBV.demo';
+import {PGO} from './PGO.demo';
 import {PPO} from './PPO.demo';
 import {Qstick} from './Qstick.demo';
 import {REI} from './REI.demo';
@@ -59,6 +60,7 @@ export const indicators: IndicatorConfig[] = [
   Qstick,
   CFO,
   DPO,
+  PGO,
   TRIX,
   TSI,
 ];

--- a/packages/trading-signals-docs/indicator-demos/momentum/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/index.tsx
@@ -17,6 +17,7 @@ import {MFI} from './MFI.demo';
 import {MOM} from './MOM.demo';
 import {OBV} from './OBV.demo';
 import {PGO} from './PGO.demo';
+import {PMO} from './PMO.demo';
 import {PPO} from './PPO.demo';
 import {Qstick} from './Qstick.demo';
 import {REI} from './REI.demo';
@@ -61,6 +62,7 @@ export const indicators: IndicatorConfig[] = [
   CFO,
   DPO,
   PGO,
+  PMO,
   TRIX,
   TSI,
 ];

--- a/packages/trading-signals-docs/indicator-demos/volatility/GAPO.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volatility/GAPO.demo.tsx
@@ -1,0 +1,20 @@
+import {GAPO as GAPOClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const GAPO: IndicatorConfig = {
+  chartTitle: 'GAPO (14)',
+  color: '#84cc16',
+  createIndicator: () => new GAPOClass(14),
+  description: 'Gopalakrishnan Range Index',
+  details:
+    'Relates the trading range of the window (highest high minus lowest low) to the window length on a logarithmic scale. Rising readings mean the range is widening (growing volatility), falling readings a contracting, quiet market. Range expansion carries no directional information, so the reading must be paired with a trend indicator to trade it.',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['high', 'low']}),
+  id: 'gapo',
+  name: 'Gopalakrishnan Range Index',
+  processData: makeProcessData({rowInputs: ['high', 'low']}),
+  requiredInputs: 14,
+  type: 'single',
+  yAxisLabel: 'GAPO',
+};

--- a/packages/trading-signals-docs/indicator-demos/volatility/PercentB.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volatility/PercentB.demo.tsx
@@ -1,0 +1,20 @@
+import {PercentB as PercentBClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const PercentB: IndicatorConfig = {
+  chartTitle: '%B (20, 2)',
+  color: '#06b6d4',
+  createIndicator: () => new PercentBClass({deviationMultiplier: 2, interval: 20}),
+  description: 'Bollinger Bands %B',
+  details:
+    'Locates the close within the Bollinger Bands: 1 means the close sits on the upper band, 0 on the lower band and 0.5 on the middle band. The reading is not clamped, so values above 1 or below 0 flag closes breaking out of the bands (overbought/oversold pressure).',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
+  id: 'percent-b',
+  name: '%B',
+  processData: makeProcessData({rowInputs: ['close']}),
+  requiredInputs: 20,
+  type: 'single',
+  yAxisLabel: '%B',
+};

--- a/packages/trading-signals-docs/indicator-demos/volatility/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volatility/index.tsx
@@ -3,6 +3,7 @@ import {ATR} from './ATR.demo';
 import {BollingerBands} from './BollingerBands.demo';
 import {BollingerBandsWidth} from './BollingerBandsWidth.demo';
 import {DonchianChannels} from './DonchianChannels.demo';
+import {GAPO} from './GAPO.demo';
 import {IQR} from './IQR.demo';
 import {KeltnerChannels} from './KeltnerChannels.demo';
 import {MAD} from './MAD.demo';
@@ -27,4 +28,5 @@ export const indicators: IndicatorConfig[] = [
   UlcerIndex,
   ProjectionOscillator,
   MassIndex,
+  GAPO,
 ];

--- a/packages/trading-signals-docs/indicator-demos/volatility/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volatility/index.tsx
@@ -9,6 +9,7 @@ import {KeltnerChannels} from './KeltnerChannels.demo';
 import {MAD} from './MAD.demo';
 import {MassIndex} from './MassIndex.demo';
 import {NATR} from './NATR.demo';
+import {PercentB} from './PercentB.demo';
 import {ProjectionOscillator} from './ProjectionOscillator.demo';
 import {TR} from './TR.demo';
 import {UlcerIndex} from './UlcerIndex.demo';
@@ -23,6 +24,7 @@ export const indicators: IndicatorConfig[] = [
   NATR,
   TR,
   BollingerBandsWidth,
+  PercentB,
   IQR,
   MAD,
   UlcerIndex,

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -35,6 +35,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Awesome Oscillator (AO)
 1. Balance of Power (BOP)
 1. Bollinger Bands (BBANDS)
+1. Bollinger Bands %B (PB)
 1. Bollinger Bands Width (BBW)
 1. Center of Gravity (CG)
 1. Chaikin Money Flow (CMF)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -79,6 +79,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Percentage Volume Oscillator (PVO)
 1. Positive Volume Index (PVI)
 1. Pretty Good Oscillator (PGO)
+1. Price Momentum Oscillator (PMO)
 1. Price Volume Trend (PVT)
 1. Projection Oscillator (PO)
 1. Qstick (QSTICK)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -44,6 +44,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Chandelier Exit (CE)
 1. Commodity Channel Index (CCI)
 1. Coppock Curve (COPPOCK)
+1. Detrended Price Oscillator (DPO)
 1. Directional Movement Index (DMI / DX)
 1. Donchian Channels (DC)
 1. Double Exponential Moving Average (DEMA)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -78,6 +78,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Percentage Price Oscillator (PPO)
 1. Percentage Volume Oscillator (PVO)
 1. Positive Volume Index (PVI)
+1. Pretty Good Oscillator (PGO)
 1. Price Volume Trend (PVT)
 1. Projection Oscillator (PO)
 1. Qstick (QSTICK)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -210,7 +210,6 @@ console.log(sma.highest?.toFixed(2)); // "53.33"
 
 ## Alternatives
 
-- [Cloud9Trader Indicators (JavaScript)](https://github.com/Cloud9Trader/TechnicalIndicators)
 - [Crypto Trading Hub Indicators (TypeScript)](https://github.com/anandanand84/technicalindicators)
 - [Highcharts Indicators (TypeScript)](https://github.com/highcharts/highcharts/tree/v12.3.0/ts/Stock/Indicators)
 - [Jesse Trading Bot Indicators (Python)](https://docs.jesse.trade/docs/indicators/reference.html)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -210,7 +210,6 @@ console.log(sma.highest?.toFixed(2)); // "53.33"
 
 ## Alternatives
 
-- [Crypto Trading Hub Indicators (TypeScript)](https://github.com/anandanand84/technicalindicators)
 - [Highcharts Indicators (TypeScript)](https://github.com/highcharts/highcharts/tree/v12.3.0/ts/Stock/Indicators)
 - [Jesse Trading Bot Indicators (Python)](https://docs.jesse.trade/docs/indicators/reference.html)
 - [LEAN Indicators (C#)](https://github.com/QuantConnect/Lean/tree/master/Indicators)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -56,6 +56,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Fisher Transform (FISHER)
 1. Force Index (FI)
 1. Fractal Adaptive Moving Average (FRAMA)
+1. Gopalakrishnan Range Index (GAPO)
 1. Hull Moving Average (HMA)
 1. Ichimoku Cloud (ICHIMOKU)
 1. Interquartile Range (IQR)

--- a/packages/trading-signals/src/momentum/DPO/DPO.test.ts
+++ b/packages/trading-signals/src/momentum/DPO/DPO.test.ts
@@ -1,0 +1,159 @@
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {DPO} from './DPO.js';
+import {TradingSignal} from '../../base/Indicator.js';
+
+describe('DPO', () => {
+  describe('update', () => {
+    it('replaces the most recently added value', () => {
+      const prices = [81.59, 81.06, 82.87, 83.0, 83.61] as const;
+      const dpo = new DPO(5);
+
+      for (const price of prices) {
+        dpo.add(price);
+      }
+
+      const originalValue = 83.15;
+      const replacedValue = 90;
+
+      dpo.add(originalValue);
+
+      expect(dpo.getResultOrThrow().toFixed(3)).toBe('0.132');
+
+      dpo.replace(replacedValue);
+
+      expect(dpo.getResultOrThrow().toFixed(3)).toBe('-1.238');
+
+      dpo.replace(originalValue);
+
+      expect(dpo.getResultOrThrow().toFixed(3)).toBe('0.132');
+    });
+  });
+
+  describe('getResultOrThrow', () => {
+    it('detrends prices to expose the cycle', {tags: ['tulipindicators']}, () => {
+      /*
+       * Test data verified with:
+       * https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt#L162-L164
+       */
+      const prices = [
+        81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84, 83.99, 84.55, 84.36, 85.53, 86.54, 86.89, 87.77, 87.29,
+      ] as const;
+      const expectations = [
+        '-1.366',
+        '0.132',
+        '-0.094',
+        '0.292',
+        '-0.478',
+        '-0.938',
+        '-0.264',
+        '-0.444',
+        '-1.214',
+        '-0.688',
+        '-0.264',
+      ] as const;
+      const dpo = new DPO(5);
+      const offset = dpo.getRequiredInputs() - 1;
+
+      prices.forEach((price, i) => {
+        const result = dpo.add(price);
+
+        if (result !== null) {
+          expect(result.toFixed(3)).toBe(expectations[i - offset]);
+        }
+      });
+
+      expect(dpo.isStable).toBe(true);
+    });
+  });
+
+  describe('getRequiredInputs', () => {
+    it('warms up over one full interval of 20 bars by default', () => {
+      const dpo = new DPO();
+
+      expect(dpo.getRequiredInputs()).toBe(20);
+    });
+
+    it('waits for the displaced close even after the average is ready', () => {
+      const dpo = new DPO(2);
+
+      expect(dpo.getRequiredInputs()).toBe(3);
+      expect(dpo.add(10)).toBeNull();
+      expect(dpo.add(20)).toBeNull();
+      expect(dpo.add(30)).toBe(-15);
+    });
+  });
+
+  describe('getSignal', () => {
+    it('returns UNKNOWN before the warm-up is complete', () => {
+      const dpo = new DPO(5);
+
+      dpo.add(81.59);
+
+      const signal = dpo.getSignal();
+
+      expect(signal.state).toBe(TradingSignal.UNKNOWN);
+      expect(signal.hasChanged).toBe(false);
+    });
+
+    it('returns BULLISH when the cycle trades above the average', () => {
+      const prices = [100, 90, 80, 70, 60] as const;
+      const dpo = new DPO(5);
+
+      for (const price of prices) {
+        dpo.add(price);
+      }
+
+      expect(dpo.getResultOrThrow()).toBe(10);
+      expect(dpo.getSignal().state).toBe(TradingSignal.BULLISH);
+    });
+
+    it('returns BEARISH when the cycle trades below the average', () => {
+      const prices = [60, 70, 80, 90, 100] as const;
+      const dpo = new DPO(5);
+
+      for (const price of prices) {
+        dpo.add(price);
+      }
+
+      expect(dpo.getResultOrThrow()).toBe(-10);
+      expect(dpo.getSignal().state).toBe(TradingSignal.BEARISH);
+    });
+
+    it('returns SIDEWAYS when the cycle sits exactly on the average', () => {
+      const prices = [80, 80, 80, 80, 80] as const;
+      const dpo = new DPO(5);
+
+      for (const price of prices) {
+        dpo.add(price);
+      }
+
+      expect(dpo.getResultOrThrow()).toBe(0);
+      expect(dpo.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+    });
+
+    it('tracks signal changes across zero crossings', () => {
+      const prices = [100, 90, 80, 70, 60] as const;
+      const dpo = new DPO(5);
+
+      for (const price of prices) {
+        dpo.add(price);
+      }
+
+      expect(dpo.getSignal()).toEqual({hasChanged: true, state: TradingSignal.BULLISH});
+
+      dpo.add(60);
+
+      expect(dpo.getSignal()).toEqual({hasChanged: false, state: TradingSignal.BULLISH});
+
+      dpo.add(200);
+
+      expect(dpo.getSignal()).toEqual({hasChanged: true, state: TradingSignal.BEARISH});
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new DPO(5),
+  divergentInput: 1_000,
+  inputs: [81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84],
+});

--- a/packages/trading-signals/src/momentum/DPO/DPO.ts
+++ b/packages/trading-signals/src/momentum/DPO/DPO.ts
@@ -1,0 +1,58 @@
+import {ZeroCrossSeries} from '../../base/Indicator.js';
+import {SMA} from '../../trend/SMA/SMA.js';
+import {pushUpdate} from '../../util/pushUpdate.js';
+
+/**
+ * Detrended Price Oscillator (DPO)
+ * Type: Momentum
+ *
+ * The Detrended Price Oscillator strips the prevailing trend out of price by comparing a past
+ * close against the moving average of the bars surrounding it. What remains is the short-term
+ * price cycle, which makes it easier to gauge the length and magnitude of swings between cycle
+ * highs and lows.
+ *
+ * The compared close sits half an interval plus one bar in the past, so each reading describes
+ * the cycle at that earlier bar — not at the most recent candle. DPO is a tool for measuring
+ * cycles, not for timing entries on the latest bar.
+ *
+ * Interpretation: A reading above zero means price traded above its surrounding average (a cycle
+ * high is forming), while a reading below zero means price traded beneath it (a cycle low is
+ * forming).
+ *
+ * @see https://tulipindicators.org/dpo
+ * @see https://www.investopedia.com/terms/d/detrended-price-oscillator-dpo.asp
+ */
+export class DPO extends ZeroCrossSeries {
+  public readonly interval: number;
+  readonly #average: SMA;
+  readonly #displacement: number;
+  readonly #history: number[];
+  readonly #historyLength: number;
+
+  constructor(interval: number = 20) {
+    super();
+    this.interval = interval;
+    // Half an interval plus one bar centers the average window on the compared close
+    this.#displacement = Math.floor(interval / 2) + 1;
+    this.#history = [];
+    this.#historyLength = this.#displacement + 1;
+    this.#average = new SMA(interval);
+  }
+
+  override getRequiredInputs() {
+    // Very short intervals need more bars for the displaced close than for the average
+    return Math.max(this.interval, this.#historyLength);
+  }
+
+  update(price: number, replace: boolean) {
+    pushUpdate({array: this.#history, item: price, maxLength: this.#historyLength, replace: replace});
+
+    const average = this.#average.update(price, replace);
+
+    if (this.#history.length === this.#historyLength && average !== null) {
+      return this.setResult(this.#history[0] - average, replace);
+    }
+
+    return null;
+  }
+}

--- a/packages/trading-signals/src/momentum/PGO/PGO.test.ts
+++ b/packages/trading-signals/src/momentum/PGO/PGO.test.ts
@@ -1,0 +1,255 @@
+import {TradingSignal} from '../../base/index.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {PGO} from './PGO.js';
+
+describe('PGO', () => {
+  /*
+   * There is no Tulip Indicators entry for the Pretty Good Oscillator, and pandas-ta's exact numbers cannot
+   * be reproduced by a streaming implementation on a short series: pandas-ta computes Wilder's smoothing via
+   * pandas' `ewm(adjust=True)`, which re-weights the entire history on every bar, and seeds its EMA with the
+   * mean of the first `interval` values, while the moving averages in this library seed from their first
+   * input and smooth recursively. Both converge on long series but disagree on any short worksheet. The
+   * expectations below are therefore derived by hand from the published formula — close minus its Simple
+   * Moving Average, divided by an EMA of the Wilder-smoothed Average True Range — with candles shaped so
+   * that every intermediate value is an exact binary fraction, which allows exact assertions.
+   *
+   * Formula sources:
+   * @see https://www.fmlabs.com/reference/default.htm?url=PGO.htm
+   * @see https://github.com/twopirllc/pandas-ta (pandas_ta/momentum/pgo.py)
+   *
+   * Worksheet (interval 3): every candle keeps a true range of exactly 4, so the Wilder-smoothed ATR reads 4
+   * from bar 3 on and its EMA stays 4 once seeded — stable on bar 5 (2 × 3 − 1 candles).
+   *
+   * | Bar | Close | High | Low | TR | ATR | EMA(ATR) | SMA(3)      | PGO                   |
+   * | --- | ----- | ---- | --- | -- | --- | -------- | ----------- | --------------------- |
+   * | 1   | 12    | 14   | 10  | 4  | —   | —        | —           | —                     |
+   * | 2   | 15    | 16   | 12  | 4  | —   | —        | —           | —                     |
+   * | 3   | 18    | 19   | 15  | 4  | 4   | 4        | 45 / 3 = 15 | — (EMA warming up)    |
+   * | 4   | 15    | 18   | 14  | 4  | 4   | 4        | 48 / 3 = 16 | — (EMA warming up)    |
+   * | 5   | 18    | 19   | 15  | 4  | 4   | 4        | 51 / 3 = 17 | (18 − 17) / 4 = 0.25  |
+   * | 6   | 15    | 18   | 14  | 4  | 4   | 4        | 48 / 3 = 16 | (15 − 16) / 4 = −0.25 |
+   */
+  const candles = [
+    {close: 12, high: 14, low: 10},
+    {close: 15, high: 16, low: 12},
+    {close: 18, high: 19, low: 15},
+    {close: 15, high: 18, low: 14},
+    {close: 18, high: 19, low: 15},
+    {close: 15, high: 18, low: 14},
+  ] as const;
+
+  describe('getResultOrThrow', () => {
+    it('expresses the distance between the close and its moving average in units of smoothed true range', () => {
+      const expectations = [0.25, -0.25] as const;
+      const pgo = new PGO({interval: 3});
+      const offset = pgo.getRequiredInputs() - 1;
+
+      candles.forEach((candle, i) => {
+        const result = pgo.add(candle);
+
+        if (result !== null) {
+          expect(result).toBe(expectations[i - offset]);
+        }
+      });
+
+      expect(pgo.isStable).toBe(true);
+    });
+
+    it('yields the same reading for the same pattern at ten times the price', () => {
+      const base = new PGO({interval: 3});
+      const scaled = new PGO({interval: 3});
+
+      candles.forEach(candle => {
+        const baseResult = base.add(candle);
+        const scaledResult = scaled.add({close: candle.close * 10, high: candle.high * 10, low: candle.low * 10});
+
+        expect(scaledResult).toBe(baseResult);
+      });
+
+      expect(scaled.getResultOrThrow()).toBe(-0.25);
+    });
+
+    it('reads neutral when a dead market leaves no volatility to measure against', () => {
+      const pgo = new PGO({interval: 3});
+      const flatCandle = {close: 100, high: 100, low: 100} as const;
+
+      for (let i = 0; i < 5; i++) {
+        pgo.add(flatCandle);
+      }
+
+      expect(pgo.getResultOrThrow()).toBe(0);
+      expect(pgo.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+    });
+  });
+
+  describe('getRequiredInputs', () => {
+    it('needs 27 candles by default because the two smoothing stages fill up in sequence', () => {
+      const pgo = new PGO();
+
+      expect(pgo.getRequiredInputs()).toBe(27);
+    });
+
+    it('needs one candle less than twice the configured interval', () => {
+      const pgo = new PGO({interval: 3});
+
+      expect(pgo.getRequiredInputs()).toBe(5);
+    });
+  });
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const pgo = new PGO({interval: 3});
+
+      for (const candle of candles.slice(0, 5)) {
+        pgo.add(candle);
+      }
+
+      /*
+       * The replacement candle keeps the true range at 4 (high − low = 4, high − previous close = 4) and
+       * shifts the window closes to 15, 18, 21: SMA = 54 / 3 = 18 → PGO = (21 − 18) / 4 = 0.75.
+       */
+      const originalValue = candles[5];
+      const replacedValue = {close: 21, high: 22, low: 18} as const;
+
+      const originalResult = pgo.add(originalValue);
+
+      expect(originalResult).toBe(-0.25);
+
+      const replacedResult = pgo.replace(replacedValue);
+
+      expect(replacedResult).toBe(0.75);
+
+      const restoredResult = pgo.replace(originalValue);
+
+      expect(restoredResult).toBe(-0.25);
+    });
+  });
+
+  describe('getSignal', () => {
+    const quietCandle = {close: 100, high: 102, low: 98} as const;
+
+    it('returns UNKNOWN when there is no result', () => {
+      const pgo = new PGO({interval: 3});
+      const signal = pgo.getSignal();
+
+      expect(signal.state).toBe(TradingSignal.UNKNOWN);
+      expect(signal.hasChanged).toBe(false);
+    });
+
+    it('signals a long breakout when the close runs more than three smoothed true ranges above its average', () => {
+      const pgo = new PGO({interval: 3});
+
+      for (let i = 0; i < 5; i++) {
+        pgo.add(quietCandle);
+      }
+
+      expect(pgo.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+
+      /*
+       * The breakout candle lifts the true range from 4 to 64: ATR = 4 + (64 − 4) / 3 = 24, its EMA =
+       * (24 + 4) / 2 = 14, SMA = (100 + 100 + 164) / 3 = 364/3 → PGO = (164 − 364/3) / 14 = 64/21 ≈ 3.05.
+       */
+      pgo.add({close: 164, high: 164, low: 100});
+
+      expect(pgo.getResultOrThrow().toFixed(2)).toBe('3.05');
+
+      const signal = pgo.getSignal();
+
+      expect(signal.state).toBe(TradingSignal.BULLISH);
+      expect(signal.hasChanged).toBe(true);
+    });
+
+    it('signals a short breakout when the close falls more than three smoothed true ranges below its average', () => {
+      const pgo = new PGO({interval: 3});
+
+      for (let i = 0; i < 5; i++) {
+        pgo.add(quietCandle);
+      }
+
+      expect(pgo.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+
+      /*
+       * Mirror of the long breakout: the true range jumps to 64, the denominator to 14, and the window
+       * closes average 236/3 → PGO = (36 − 236/3) / 14 = −64/21 ≈ −3.05.
+       */
+      pgo.add({close: 36, high: 100, low: 36});
+
+      expect(pgo.getResultOrThrow().toFixed(2)).toBe('-3.05');
+
+      const signal = pgo.getSignal();
+
+      expect(signal.state).toBe(TradingSignal.BEARISH);
+      expect(signal.hasChanged).toBe(true);
+    });
+
+    it('returns SIDEWAYS while the close stays within the breakout territory', () => {
+      const pgo = new PGO({interval: 3});
+
+      for (const candle of candles) {
+        pgo.add(candle);
+      }
+
+      expect(pgo.getResultOrThrow()).toBe(-0.25);
+
+      const signal = pgo.getSignal();
+
+      expect(signal.state).toBe(TradingSignal.SIDEWAYS);
+      expect(signal.hasChanged).toBe(false);
+    });
+
+    it('turns bullish exactly at the overbought threshold', () => {
+      const defaults = new PGO({interval: 3});
+      const custom = new PGO({interval: 3, signalThresholds: {overbought: 0.5, oversold: -0.5}});
+      const calmCandle = {close: 15, high: 17, low: 13} as const;
+      // Keeps the true range at 4 while lifting the close 2 points above the window average: PGO = 2 / 4 = 0.5
+      const pushCandle = {close: 18, high: 19, low: 15} as const;
+
+      for (const pgo of [defaults, custom]) {
+        for (let i = 0; i < 4; i++) {
+          pgo.add(calmCandle);
+        }
+
+        pgo.add(pushCandle);
+
+        expect(pgo.getResultOrThrow()).toBe(0.5);
+      }
+
+      expect(custom.getSignal().state).toBe(TradingSignal.BULLISH);
+      expect(defaults.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+    });
+
+    it('turns bearish exactly at the oversold threshold', () => {
+      const defaults = new PGO({interval: 3});
+      const custom = new PGO({interval: 3, signalThresholds: {overbought: 0.5, oversold: -0.5}});
+      const calmCandle = {close: 15, high: 17, low: 13} as const;
+      // Keeps the true range at 4 while dropping the close 2 points below the window average: PGO = −2 / 4 = −0.5
+      const dropCandle = {close: 12, high: 16, low: 12} as const;
+
+      for (const pgo of [defaults, custom]) {
+        for (let i = 0; i < 4; i++) {
+          pgo.add(calmCandle);
+        }
+
+        pgo.add(dropCandle);
+
+        expect(pgo.getResultOrThrow()).toBe(-0.5);
+      }
+
+      expect(custom.getSignal().state).toBe(TradingSignal.BEARISH);
+      expect(defaults.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new PGO({interval: 3}),
+  divergentInput: {close: 1_000, high: 1_000, low: 1_000},
+  inputs: [
+    {close: 12, high: 14, low: 10},
+    {close: 15, high: 16, low: 12},
+    {close: 18, high: 19, low: 15},
+    {close: 15, high: 18, low: 14},
+    {close: 18, high: 19, low: 15},
+    {close: 15, high: 18, low: 14},
+  ],
+});

--- a/packages/trading-signals/src/momentum/PGO/PGO.ts
+++ b/packages/trading-signals/src/momentum/PGO/PGO.ts
@@ -1,0 +1,101 @@
+import type {HighLowClose} from '../../base/Candle.type.js';
+import {TradingSignal, TrendIndicatorSeries} from '../../base/Indicator.js';
+import type {SignalThresholds} from '../../base/SignalThresholds.type.js';
+import {EMA} from '../../trend/EMA/EMA.js';
+import {SMA} from '../../trend/SMA/SMA.js';
+import {WSMA} from '../../trend/WSMA/WSMA.js';
+import {ATR} from '../../volatility/ATR/ATR.js';
+
+export type PGOConfig = {
+  /** Number of candles used for the moving average of closes and for each smoothing stage of the true range */
+  interval?: number;
+  signalThresholds?: SignalThresholds;
+};
+
+/**
+ * Pretty Good Oscillator (PGO)
+ * Type: Momentum
+ *
+ * Created by Mark Johnson, the Pretty Good Oscillator measures how far the current close has traveled from its
+ * N-day Simple Moving Average, expressed in units of average true range. Rescaling the distance by volatility
+ * makes readings comparable across instruments and market phases: a 5-point rally means little in a market
+ * that swings 10 points a day, but a lot in one that barely moves.
+ *
+ * Following the de-facto reference implementation (pandas-ta), the true range is smoothed twice: Wilder's
+ * smoothing forms the Average True Range, and an EMA of that ATR forms the denominator. FM Labs documents a
+ * variant that applies a single EMA directly to the true range.
+ *
+ * Interpretation:
+ * Johnson used the oscillator as a breakout system for longer-term trades: a reading of +3.0 or more signals
+ * a long breakout (bullish pressure), a reading of -3.0 or less a short breakout (bearish pressure). Both
+ * thresholds can be customized via the constructor. A completely dead market offers no volatility yardstick
+ * to measure distance with, so the oscillator reads neutral (0).
+ *
+ * @see https://www.fmlabs.com/reference/default.htm?url=PGO.htm
+ * @see https://library.tradingtechnologies.com/trade/chrt-ti-pretty-good-oscillator.html
+ * @see https://github.com/twopirllc/pandas-ta
+ */
+export class PGO extends TrendIndicatorSeries<HighLowClose<number>> {
+  readonly #sma: SMA;
+  readonly #atr: ATR;
+  readonly #atrSmoothing: EMA;
+  readonly #overbought: number;
+  readonly #oversold: number;
+  public readonly interval: number;
+
+  constructor({interval = 14, signalThresholds: {overbought = 3, oversold = -3} = {}}: PGOConfig = {}) {
+    super();
+
+    this.interval = interval;
+    this.#sma = new SMA(interval);
+    // Wilder's smoothing forms the ATR before the EMA refines it, matching the pandas-ta reference
+    this.#atr = new ATR(interval, WSMA);
+    this.#atrSmoothing = new EMA(interval);
+    this.#overbought = overbought;
+    this.#oversold = oversold;
+  }
+
+  override getRequiredInputs() {
+    // The two smoothing stages fill up in sequence: the second stage receives its first value on the candle that completes the first stage
+    return this.#atr.getRequiredInputs() + this.#atrSmoothing.getRequiredInputs() - 1;
+  }
+
+  update(candle: HighLowClose<number>, replace: boolean) {
+    const sma = this.#sma.update(candle.close, replace);
+    const atr = this.#atr.update(candle, replace);
+
+    if (atr !== null) {
+      this.#atrSmoothing.update(atr, replace);
+    }
+
+    if (sma === null || !this.#atrSmoothing.isStable) {
+      return null;
+    }
+
+    const smoothedAtr = this.#atrSmoothing.getResultOrThrow();
+
+    // A dead market leaves no distance to measure in units of volatility, so the reading is neutral
+    if (smoothedAtr === 0) {
+      return this.setResult(0, replace);
+    }
+
+    return this.setResult((candle.close - sma) / smoothedAtr, replace);
+  }
+
+  protected calculateSignalState(result: number | null | undefined) {
+    const hasResult = result !== null && result !== undefined;
+    const isOversold = hasResult && result <= this.#oversold;
+    const isOverbought = hasResult && result >= this.#overbought;
+
+    switch (true) {
+      case !hasResult:
+        return TradingSignal.UNKNOWN;
+      case isOversold:
+        return TradingSignal.BEARISH;
+      case isOverbought:
+        return TradingSignal.BULLISH;
+      default:
+        return TradingSignal.SIDEWAYS;
+    }
+  }
+}

--- a/packages/trading-signals/src/momentum/PMO/PMO.test.ts
+++ b/packages/trading-signals/src/momentum/PMO/PMO.test.ts
@@ -67,6 +67,15 @@ describe('PMO', () => {
   });
 
   describe('constructor', () => {
+    it('rejects a smoothing interval that cannot form a finite weight', () => {
+      expect(() => new PMO({smoothing1: 0})).toThrowError(
+        'The interval has to be a positive number, but "0" was given.'
+      );
+      expect(() => new PMO({smoothing2: Number.NaN})).toThrowError(
+        'The interval has to be a positive number, but "NaN" was given.'
+      );
+    });
+
     it("uses Carl Swenlin's canonical periods of 35, 20 and 10 by default", () => {
       const pmo = new PMO();
 

--- a/packages/trading-signals/src/momentum/PMO/PMO.test.ts
+++ b/packages/trading-signals/src/momentum/PMO/PMO.test.ts
@@ -1,0 +1,213 @@
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {PMO} from './PMO.js';
+import {TradingSignal} from '../../base/index.js';
+
+describe('PMO', () => {
+  describe('update', () => {
+    it('double-smooths the one-bar percentage change into the PMO line and pairs it with a signal EMA', () => {
+      /*
+       * Hand-derived reference values for Carl Swenlin's DecisionPoint formula
+       * PMO = smooth2(10 * smooth1(100 * (price / previousPrice - 1))) with signal = EMA(PMO),
+       * where both custom smoothing stages weight the newest bar with 2/interval:
+       * https://chartschool.stockcharts.com/table-of-contents/technical-indicators-and-overlays/technical-indicators/decisionpoint-price-momentum-oscillator-pmo
+       *
+       * Committed baselines of other libraries (e.g. Skender.Stock.Indicators v3.0.0) seed all
+       * three stages with an SMA while this library seeds with the first input, so their early
+       * readings cannot be reproduced here (fed with their 502-quote dataset, both agree to 6
+       * decimals only after ~300 bars of transient decay) and the expectations are derived by
+       * hand instead. Smoothing weights: stage one (4) w=1/2, stage two (3) w=2/3, signal
+       * EMA(3) w=1/2. Stage two starts once stage one is warmed up, the signal EMA once stage
+       * two is warmed up.
+       *
+       * price  | roc  | smooth1 | 10*smooth1 | PMO                | signal
+       * 100    |  -   |    -    |     -      | -                  | -
+       * 150    |  50  |   50    |     -      | -                  | -
+       * 75     | -50  |    0    |     -      | -                  | -
+       * 150    | 100  |   50    |     -      | -                  | -
+       * 225    |  50  |   50    |    500     | 500 (warming)      | -
+       * 112.5  | -50  |    0    |     0      | 500/3 (warming)    | -
+       * 225    | 100  |   50    |    500     | 3500/9 = 388.89    | 3500/9 = 388.89
+       * 337.5  |  50  |   50    |    500     | 12500/27 = 462.96  | 11500/27 = 425.93
+       * 168.75 | -50  |    0    |     0      | 12500/81 = 154.32  | 23500/81 = 290.12
+       */
+      const prices = [100, 150, 75, 150, 225, 112.5, 225, 337.5, 168.75] as const;
+      const expectations = [
+        {pmo: '388.8889', signal: '388.8889'},
+        {pmo: '462.9630', signal: '425.9259'},
+        {pmo: '154.3210', signal: '290.1235'},
+      ] as const;
+      const pmo = new PMO({signalInterval: 3, smoothing1: 4, smoothing2: 3});
+      const offset = pmo.getRequiredInputs() - 1;
+
+      prices.forEach((price, i) => {
+        const result = pmo.add(price);
+
+        if (result !== null) {
+          const expected = expectations[i - offset];
+
+          expect(result.pmo.toFixed(4)).toBe(expected.pmo);
+          expect(result.signal.toFixed(4)).toBe(expected.signal);
+        }
+      });
+
+      expect(pmo.isStable).toBe(true);
+    });
+
+    it('scales the smoothed percentage change by ten, so a market doubling every bar reads 1000', () => {
+      const prices = [1, 2, 4, 8, 16, 32, 64] as const;
+      const pmo = new PMO({signalInterval: 3, smoothing1: 4, smoothing2: 3});
+
+      for (const price of prices) {
+        pmo.add(price);
+      }
+
+      expect(pmo.getResultOrThrow().pmo).toBe(1000);
+      expect(pmo.getResultOrThrow().signal).toBe(1000);
+    });
+  });
+
+  describe('constructor', () => {
+    it("uses Carl Swenlin's canonical periods of 35, 20 and 10 by default", () => {
+      const pmo = new PMO();
+
+      expect(pmo.smoothing1).toBe(35);
+      expect(pmo.smoothing2).toBe(20);
+      expect(pmo.signalInterval).toBe(10);
+      expect(pmo.isStable).toBe(false);
+
+      for (let i = 1; i < pmo.getRequiredInputs(); i++) {
+        expect(pmo.add(2 ** (i - 1))).toBeNull();
+      }
+
+      const result = pmo.add(2 ** 54);
+
+      expect(result?.pmo.toFixed(6)).toBe('1000.000000');
+      expect(result?.signal.toFixed(6)).toBe('1000.000000');
+      expect(pmo.isStable).toBe(true);
+    });
+  });
+
+  describe('getRequiredInputs', () => {
+    it('needs both custom smoothing stages to warm up', () => {
+      expect(new PMO().getRequiredInputs()).toBe(55);
+      expect(new PMO({signalInterval: 3, smoothing1: 4, smoothing2: 3}).getRequiredInputs()).toBe(7);
+    });
+  });
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const prices = [100, 150, 75, 150, 225, 112.5, 225, 337.5] as const;
+      const pmo = new PMO({signalInterval: 3, smoothing1: 4, smoothing2: 3});
+
+      for (const price of prices) {
+        pmo.add(price);
+      }
+
+      // Losing half vs. doubling: 12500/81 & 23500/81 vs. 53000/81 & 43750/81
+      const originalValue = 168.75;
+      const replacedValue = 675;
+
+      const originalResult = pmo.add(originalValue);
+
+      expect(originalResult?.pmo.toFixed(4)).toBe('154.3210');
+      expect(originalResult?.signal.toFixed(4)).toBe('290.1235');
+
+      const replacedResult = pmo.replace(replacedValue);
+
+      expect(replacedResult?.pmo.toFixed(4)).toBe('654.3210');
+      expect(replacedResult?.signal.toFixed(4)).toBe('540.1235');
+
+      const restoredResult = pmo.replace(originalValue);
+
+      expect(restoredResult?.pmo).toBe(originalResult?.pmo);
+      expect(restoredResult?.signal).toBe(originalResult?.signal);
+    });
+  });
+
+  describe('getSignal', () => {
+    it('returns UNKNOWN while the indicator is warming up', () => {
+      const pmo = new PMO({signalInterval: 3, smoothing1: 4, smoothing2: 3});
+
+      expect(pmo.getSignal()).toEqual({
+        hasChanged: false,
+        state: TradingSignal.UNKNOWN,
+      });
+
+      pmo.add(100);
+      pmo.add(150);
+
+      expect(pmo.getSignal()).toEqual({
+        hasChanged: false,
+        state: TradingSignal.UNKNOWN,
+      });
+    });
+
+    it('returns BULLISH when the PMO rises above its signal line', () => {
+      const prices = [100, 150, 75, 150, 225, 112.5, 225, 337.5] as const;
+      const pmo = new PMO({signalInterval: 3, smoothing1: 4, smoothing2: 3});
+
+      for (const price of prices) {
+        pmo.add(price);
+      }
+
+      expect(pmo.getSignal().state).toBe(TradingSignal.BULLISH);
+    });
+
+    it('returns BEARISH when the PMO falls below its signal line', () => {
+      const prices = [100, 150, 75, 150, 225, 112.5, 225, 337.5, 168.75] as const;
+      const pmo = new PMO({signalInterval: 3, smoothing1: 4, smoothing2: 3});
+
+      for (const price of prices) {
+        pmo.add(price);
+      }
+
+      expect(pmo.getSignal().state).toBe(TradingSignal.BEARISH);
+    });
+
+    it('returns SIDEWAYS when a flat market keeps both lines equal at zero', () => {
+      const pmo = new PMO({signalInterval: 3, smoothing1: 4, smoothing2: 3});
+
+      for (let i = 0; i < 8; i++) {
+        pmo.add(100);
+      }
+
+      expect(pmo.getResultOrThrow().pmo).toBe(0);
+
+      expect(pmo.getSignal()).toEqual({
+        hasChanged: false,
+        state: TradingSignal.SIDEWAYS,
+      });
+    });
+
+    it('flags the change when momentum flips from BULLISH to BEARISH', () => {
+      const prices = [100, 150, 75, 150, 225, 112.5, 225, 337.5] as const;
+      const pmo = new PMO({signalInterval: 3, smoothing1: 4, smoothing2: 3});
+
+      for (const price of prices) {
+        pmo.add(price);
+      }
+
+      expect(pmo.getSignal().state).toBe(TradingSignal.BULLISH);
+
+      pmo.add(168.75);
+
+      expect(pmo.getSignal()).toEqual({
+        hasChanged: true,
+        state: TradingSignal.BEARISH,
+      });
+
+      pmo.add(84.375);
+
+      expect(pmo.getSignal()).toEqual({
+        hasChanged: false,
+        state: TradingSignal.BEARISH,
+      });
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new PMO({signalInterval: 2, smoothing1: 3, smoothing2: 2}),
+  divergentInput: 1_000,
+  inputs: [81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84],
+});

--- a/packages/trading-signals/src/momentum/PMO/PMO.ts
+++ b/packages/trading-signals/src/momentum/PMO/PMO.ts
@@ -27,6 +27,11 @@ class DecisionPointSmoothing {
   readonly #weightFactor: number;
 
   constructor(interval: number) {
+    // The smoothing weight divides by the interval, so only a finite positive number keeps every reading finite
+    if (!Number.isFinite(interval) || interval < 1) {
+      throw new Error(`The interval has to be a positive number, but "${interval}" was given.`);
+    }
+
     this.#interval = interval;
     this.#weightFactor = 2 / interval;
   }

--- a/packages/trading-signals/src/momentum/PMO/PMO.ts
+++ b/packages/trading-signals/src/momentum/PMO/PMO.ts
@@ -1,0 +1,171 @@
+import {TechnicalIndicator, TradingSignal} from '../../base/Indicator.js';
+import {EMA} from '../../trend/EMA/EMA.js';
+
+export type PMOConfig = {
+  /** Number of candles for the signal line's EMA over the PMO line (default: 10) */
+  signalInterval?: number;
+  /** Number of candles for the first, slower smoothing of the one-bar percentage change (default: 35) */
+  smoothing1?: number;
+  /** Number of candles for the second, faster smoothing whose output is the PMO line (default: 20) */
+  smoothing2?: number;
+};
+
+export type PMOResult = {
+  pmo: number;
+  signal: number;
+};
+
+/**
+ * DecisionPoint weights the newest bar with 2/interval — slightly heavier than a standard EMA's
+ * 2/(interval + 1) — so the shared EMA building block cannot express the two PMO smoothing stages.
+ */
+class DecisionPointSmoothing {
+  #inputCounter = 0;
+  #current?: number;
+  #previous?: number;
+  readonly #interval: number;
+  readonly #weightFactor: number;
+
+  constructor(interval: number) {
+    this.#interval = interval;
+    this.#weightFactor = 2 / interval;
+  }
+
+  get isStable() {
+    return this.#inputCounter >= this.#interval;
+  }
+
+  update(value: number, replace: boolean) {
+    /*
+     * The smoothing continues from the reading before the incoming value; replacing the value
+     * that seeded it starts the seeding anew.
+     */
+    const previous = replace ? this.#previous : this.#current;
+
+    if (!replace) {
+      this.#inputCounter++;
+      this.#previous = this.#current;
+    }
+
+    if (previous === undefined) {
+      return (this.#current = value);
+    }
+
+    return (this.#current = value * this.#weightFactor + previous * (1 - this.#weightFactor));
+  }
+}
+
+/**
+ * DecisionPoint Price Momentum Oscillator (PMO)
+ * Type: Momentum
+ *
+ * Carl Swenlin's PMO double-smooths the one-bar percentage price change with DecisionPoint's
+ * custom smoothing and scales it by 10, so a market gaining a smoothed one percent per bar reads
+ * as 10. Because it measures percentage change rather than price, readings stay comparable across
+ * instruments and timeframes.
+ *
+ * Interpretation: The PMO crossing above its signal line (an EMA of the PMO) signals strengthening
+ * momentum (bullish); crossing below signals weakening momentum (bearish). When both lines are
+ * equal, momentum favors neither direction (sideways).
+ *
+ * All smoothing stages seed with their first input (this library's convention). Implementations
+ * that seed with an SMA (e.g. Skender.Stock.Indicators) report different readings until the
+ * seeding transient has decayed.
+ *
+ * @see https://chartschool.stockcharts.com/table-of-contents/technical-indicators-and-overlays/technical-indicators/decisionpoint-price-momentum-oscillator-pmo
+ */
+export class PMO extends TechnicalIndicator<PMOResult, number> {
+  #previousPrice?: number;
+  #penultimatePrice?: number;
+  #previousResult?: PMOResult;
+
+  readonly #rateOfChangeSmoothing: DecisionPointSmoothing;
+  readonly #pmoSmoothing: DecisionPointSmoothing;
+  readonly #signal: EMA;
+
+  public readonly signalInterval: number;
+  public readonly smoothing1: number;
+  public readonly smoothing2: number;
+
+  constructor({signalInterval = 10, smoothing1 = 35, smoothing2 = 20}: PMOConfig = {}) {
+    super();
+    this.signalInterval = signalInterval;
+    this.smoothing1 = smoothing1;
+    this.smoothing2 = smoothing2;
+    this.#rateOfChangeSmoothing = new DecisionPointSmoothing(smoothing1);
+    this.#pmoSmoothing = new DecisionPointSmoothing(smoothing2);
+    this.#signal = new EMA(signalInterval);
+  }
+
+  override getRequiredInputs() {
+    return this.smoothing1 + this.smoothing2;
+  }
+
+  update(price: number, replace: boolean) {
+    // A replacement measures the percentage change against the price before the replaced candle
+    const previousPrice = replace ? this.#penultimatePrice : this.#previousPrice;
+
+    if (!replace) {
+      this.#penultimatePrice = this.#previousPrice;
+    }
+
+    this.#previousPrice = price;
+
+    if (previousPrice === undefined) {
+      return null;
+    }
+
+    const rateOfChange = 100 * (price / previousPrice - 1);
+    const smoothedRateOfChange = this.#rateOfChangeSmoothing.update(rateOfChange, replace);
+
+    if (this.#rateOfChangeSmoothing.isStable) {
+      // Scaling by 10 turns a smoothed one-percent-per-bar gain into a reading of 10
+      const pmo = this.#pmoSmoothing.update(10 * smoothedRateOfChange, replace);
+
+      if (this.#pmoSmoothing.isStable) {
+        const signal = this.#signal.update(pmo, replace);
+
+        if (replace) {
+          this.result = this.#previousResult;
+        }
+
+        this.#previousResult = this.result;
+
+        return (this.result = {
+          pmo,
+          signal,
+        });
+      }
+    }
+
+    return null;
+  }
+
+  protected calculateSignal(result?: PMOResult | null) {
+    const hasResult = result !== null && result !== undefined;
+    const isBullish = hasResult && result.pmo > result.signal;
+    const isBearish = hasResult && result.pmo < result.signal;
+
+    switch (true) {
+      case !hasResult:
+        return TradingSignal.UNKNOWN;
+      case isBullish:
+        return TradingSignal.BULLISH;
+      case isBearish:
+        return TradingSignal.BEARISH;
+      default:
+        return TradingSignal.SIDEWAYS;
+    }
+  }
+
+  getSignal() {
+    const previousState = this.calculateSignal(this.#previousResult);
+    const state = this.calculateSignal(this.getResult());
+    const hasChanged = previousState !== state;
+
+    return {
+      hasChanged,
+      state,
+    };
+  }
+}

--- a/packages/trading-signals/src/momentum/index.ts
+++ b/packages/trading-signals/src/momentum/index.ts
@@ -17,6 +17,7 @@ export * from './MFI/MFI.js';
 export * from './MOM/MOM.js';
 export * from './OBV/OBV.js';
 export * from './PGO/PGO.js';
+export * from './PMO/PMO.js';
 export * from './PPO/PPO.js';
 export * from './QSTICK/Qstick.js';
 export * from './REI/REI.js';

--- a/packages/trading-signals/src/momentum/index.ts
+++ b/packages/trading-signals/src/momentum/index.ts
@@ -7,6 +7,7 @@ export * from './CFO/CFO.js';
 export * from './CG/CG.js';
 export * from './CMO/CMO.js';
 export * from './COPPOCK/CoppockCurve.js';
+export * from './DPO/DPO.js';
 export * from './ER/ER.js';
 export * from './ERI/ElderRay.js';
 export * from './FISHER/FisherTransform.js';

--- a/packages/trading-signals/src/momentum/index.ts
+++ b/packages/trading-signals/src/momentum/index.ts
@@ -16,6 +16,7 @@ export * from './MACD/MACD.js';
 export * from './MFI/MFI.js';
 export * from './MOM/MOM.js';
 export * from './OBV/OBV.js';
+export * from './PGO/PGO.js';
 export * from './PPO/PPO.js';
 export * from './QSTICK/Qstick.js';
 export * from './REI/REI.js';

--- a/packages/trading-signals/src/volatility/GAPO/GAPO.test.ts
+++ b/packages/trading-signals/src/volatility/GAPO/GAPO.test.ts
@@ -1,0 +1,141 @@
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {GAPO} from './GAPO.js';
+
+describe('GAPO', () => {
+  describe('constructor', () => {
+    it('uses an interval of 14 by default', () => {
+      const gapo = new GAPO();
+
+      expect(gapo.interval).toBe(14);
+      expect(gapo.getRequiredInputs()).toBe(14);
+    });
+
+    it('rejects a one-bar window, because the logarithm of 1 is zero and would divide the reading by zero', () => {
+      expect(() => new GAPO(1)).toThrow('The interval has to be at least 2, but "1" was given.');
+    });
+  });
+
+  describe('getResultOrThrow', () => {
+    it('relates the trading range of the window to the window length on a log scale', () => {
+      /*
+       * Hand-derived worksheet following the FM Labs definition
+       * (https://www.fmlabs.com/reference/default.htm?url=GAPO.htm), published by
+       * Jayanthi Gopalakrishnan in "Technical Analysis of Stocks & Commodities" (January 2000).
+       *
+       * The ranges are powers of the interval (10), so the expected readings are exact:
+       *
+       * | Candle | High | Low | Window | Highest High | Lowest Low | Range | log(range) / log(10) |
+       * | ------ | ---- | --- | ------ | ------------ | ---------- | ----- | -------------------- |
+       * | 1      | 105  | 101 |        |              |            |       |                      |
+       * | 2      | 106  | 100 |        |              |            |       |                      |
+       * | 3      | 104  | 102 |        |              |            |       |                      |
+       * | 4      | 110  | 103 |        |              |            |       |                      |
+       * | 5      | 107  | 101 |        |              |            |       |                      |
+       * | 6      | 108  | 102 |        |              |            |       |                      |
+       * | 7      | 105  | 100 |        |              |            |       |                      |
+       * | 8      | 109  | 104 |        |              |            |       |                      |
+       * | 9      | 106  | 103 |        |              |            |       |                      |
+       * | 10     | 107  | 102 | 1-10   | 110 (#4)     | 100 (#2)   | 10    | 1                    |
+       * | 11     | 200  | 150 | 2-11   | 200 (#11)    | 100 (#2)   | 100   | 2                    |
+       */
+      const candles = [
+        {high: 105, low: 101},
+        {high: 106, low: 100},
+        {high: 104, low: 102},
+        {high: 110, low: 103},
+        {high: 107, low: 101},
+        {high: 108, low: 102},
+        {high: 105, low: 100},
+        {high: 109, low: 104},
+        {high: 106, low: 103},
+        {high: 107, low: 102},
+        {high: 200, low: 150},
+      ] as const;
+
+      const expectations = [1, 2] as const;
+      const gapo = new GAPO(10);
+      const offset = gapo.getRequiredInputs() - 1;
+
+      candles.forEach((candle, i) => {
+        const result = gapo.add(candle);
+
+        if (result !== null) {
+          expect(result).toBe(expectations[i - offset]);
+        }
+      });
+
+      expect(gapo.isStable).toBe(true);
+    });
+
+    it('lets the reading fall once a dominating extreme leaves the window', () => {
+      const gapo = new GAPO(10);
+
+      gapo.add({high: 200, low: 100});
+
+      for (let i = 0; i < 8; i++) {
+        gapo.add({high: 105, low: 101});
+      }
+
+      expect(gapo.add({high: 106, low: 102}), 'the wide candle still dominates the range').toBe(2);
+      expect(gapo.add({high: 110, low: 100}), 'the wide candle no longer counts').toBe(1);
+    });
+
+    it('reads 0 on a flat window, because a rangeless window carries no range information', () => {
+      const gapo = new GAPO(2);
+
+      gapo.add({high: 5, low: 5});
+
+      expect(gapo.add({high: 5, low: 5})).toBe(0);
+    });
+  });
+
+  describe('update', () => {
+    it('replaces the most recently added candle', () => {
+      const warmupCandles = [
+        {high: 105, low: 101},
+        {high: 106, low: 100},
+        {high: 104, low: 102},
+        {high: 110, low: 103},
+        {high: 107, low: 101},
+        {high: 108, low: 102},
+        {high: 105, low: 100},
+        {high: 109, low: 104},
+        {high: 106, low: 103},
+      ] as const;
+
+      const gapo = new GAPO(10);
+
+      for (const candle of warmupCandles) {
+        gapo.add(candle);
+      }
+
+      const originalCandle = {high: 107, low: 102} as const;
+      const replacedCandle = {high: 200, low: 102} as const;
+
+      const originalResult = gapo.add(originalCandle);
+
+      expect(originalResult).toBe(1);
+
+      const replacedResult = gapo.replace(replacedCandle);
+
+      expect(replacedResult, 'the replaced candle stretches the range tenfold').toBe(2);
+
+      const restoredResult = gapo.replace(originalCandle);
+
+      expect(restoredResult, 'replacing back reproduces the original reading').toBe(1);
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new GAPO(5),
+  divergentInput: {high: 1_000, low: 500},
+  inputs: [
+    {high: 213.35, low: 211.52},
+    {high: 214.22, low: 213.15},
+    {high: 214.06, low: 213.02},
+    {high: 215.17, low: 213.42},
+    {high: 214.53, low: 213.91},
+    {high: 214.89, low: 213.52},
+  ],
+});

--- a/packages/trading-signals/src/volatility/GAPO/GAPO.ts
+++ b/packages/trading-signals/src/volatility/GAPO/GAPO.ts
@@ -1,0 +1,66 @@
+import type {HighLow} from '../../base/Candle.type.js';
+import {IndicatorSeries} from '../../base/Indicator.js';
+import {pushUpdate} from '../../util/pushUpdate.js';
+
+/**
+ * Gopalakrishnan Range Index (GAPO)
+ * Type: Volatility
+ *
+ * Developed by Jayanthi Gopalakrishnan and published in "Technical Analysis of Stocks & Commodities"
+ * (January 2000), the Gopalakrishnan Range Index reads range expansion and contraction on a logarithmic
+ * scale: the trading range of the window (highest high minus lowest low) is related to the window length
+ * by dividing the logarithm of the range by the logarithm of the interval. Because the reading is a ratio
+ * of logarithms, any log base yields the same value.
+ *
+ * Interpretation:
+ * A rising reading means the trading range is widening (growing volatility), a falling reading means it is
+ * contracting (quiet market). Range expansion carries no directional information — a crash widens the range
+ * just as a rally does — which is why this indicator emits no trading signal.
+ *
+ * @see https://www.fmlabs.com/reference/default.htm?url=GAPO.htm
+ */
+export class GAPO extends IndicatorSeries<HighLow> {
+  readonly #candles: HighLow[] = [];
+  public readonly interval: number;
+
+  constructor(interval: number = 14) {
+    super();
+
+    // A one-bar window cannot normalize the range: the logarithm of 1 is zero, which would divide the reading by zero
+    if (interval < 2) {
+      throw new Error(`The interval has to be at least 2, but "${interval}" was given.`);
+    }
+
+    this.interval = interval;
+  }
+
+  override getRequiredInputs() {
+    return this.interval;
+  }
+
+  update(candle: HighLow, replace: boolean) {
+    pushUpdate({array: this.#candles, item: candle, maxLength: this.interval, replace});
+
+    if (this.#candles.length < this.interval) {
+      return null;
+    }
+
+    // A single pass over the window keeps the hot path free of per-candle array allocations
+    let highest = this.#candles[0].high;
+    let lowest = this.#candles[0].low;
+
+    for (const {high, low} of this.#candles) {
+      highest = Math.max(highest, high);
+      lowest = Math.min(lowest, low);
+    }
+
+    const range = highest - lowest;
+
+    // A rangeless window carries no range information to put on the log scale (its logarithm would read minus infinity)
+    if (range === 0) {
+      return this.setResult(0, replace);
+    }
+
+    return this.setResult(Math.log(range) / Math.log(this.interval), replace);
+  }
+}

--- a/packages/trading-signals/src/volatility/PB/PercentB.test.ts
+++ b/packages/trading-signals/src/volatility/PB/PercentB.test.ts
@@ -1,0 +1,293 @@
+import {TradingSignal} from '../../base/index.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {BollingerBands} from '../BBANDS/BollingerBands.js';
+import {PercentB} from './PercentB.js';
+
+describe('PercentB', () => {
+  describe('getResultOrThrow', () => {
+    it('is compatible with results derived from Tulip Indicators (TI)', {tags: ['tulipindicators']}, () => {
+      /*
+       * Tulip Indicators publishes reference bands for "bbands 5 2" but no %B row, so the expectations are
+       * derived arithmetically from the published lower and upper bands: %B = (close − lower) / (upper − lower).
+       * This repository's Bollinger Bands reproduce exactly that Tulip block (see the BollingerBands test),
+       * so the derivation carries over one to one:
+       *
+       * | Close | Lower  | Upper  | (close − lower) / (upper − lower) | %B   |
+       * | ----- | ------ | ------ | --------------------------------- | ---- |
+       * | 83.61 | 80.530 | 84.322 | 3.080 / 3.792                     | 0.81 |
+       * | 83.15 | 80.987 | 84.489 | 2.163 / 3.502                     | 0.62 |
+       * | 82.84 | 82.533 | 83.655 | 0.307 / 1.122                     | 0.27 |
+       * | 83.99 | 82.472 | 84.164 | 1.518 / 1.692                     | 0.90 |
+       * | 84.55 | 82.418 | 84.838 | 2.132 / 2.420                     | 0.88 |
+       * | 84.36 | 82.435 | 85.121 | 1.925 / 2.686                     | 0.72 |
+       * | 85.53 | 82.511 | 85.997 | 3.019 / 3.486                     | 0.87 |
+       * | 86.54 | 83.143 | 86.845 | 3.397 / 3.702                     | 0.92 |
+       * | 86.89 | 83.536 | 87.612 | 3.354 / 4.076                     | 0.82 |
+       * | 87.77 | 83.870 | 88.566 | 3.900 / 4.696                     | 0.83 |
+       * | 87.29 | 85.289 | 88.319 | 2.001 / 3.030                     | 0.66 |
+       *
+       * Tulip rounds its bands to three decimals, which shifts the derived %B in the third decimal, so the
+       * assertions compare two decimals.
+       *
+       * @see https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt#L86-L90
+       */
+      const closes = [
+        81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84, 83.99, 84.55, 84.36, 85.53, 86.54, 86.89, 87.77, 87.29,
+      ] as const;
+      const expectations = [
+        '0.81',
+        '0.62',
+        '0.27',
+        '0.90',
+        '0.88',
+        '0.72',
+        '0.87',
+        '0.92',
+        '0.82',
+        '0.83',
+        '0.66',
+      ] as const;
+      const percentB = new PercentB({deviationMultiplier: 2, interval: 5});
+      const offset = percentB.getRequiredInputs() - 1;
+
+      closes.forEach((close, i) => {
+        const result = percentB.add(close);
+
+        if (result !== null) {
+          expect(result.toFixed(2)).toBe(expectations[i - offset]);
+        }
+      });
+
+      expect(percentB.isStable).toBe(true);
+    });
+
+    it('locates the close within a live set of Bollinger Bands', () => {
+      const closes = [81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84, 83.99, 84.55, 84.36] as const;
+      const percentB = new PercentB({deviationMultiplier: 2, interval: 5});
+      const bollingerBands = new BollingerBands(5, 2);
+
+      for (const close of closes) {
+        const result = percentB.add(close);
+        const bands = bollingerBands.add(close);
+
+        if (result !== null && bands !== null) {
+          expect(result).toBe((close - bands.lower) / (bands.upper - bands.lower));
+        }
+      }
+
+      expect(percentB.isStable).toBe(true);
+    });
+
+    it('reads 1 when the close sits exactly on the upper band', () => {
+      /*
+       * Four identical closes plus one outlier land the outlier exactly on a band: with five values the
+       * window's standard deviation is two fifths of the outlier's distance from the cluster and the average
+       * moves one fifth of it, so two standard deviations on top of the average reach the outlier exactly.
+       */
+      const percentB = new PercentB({interval: 5});
+      const closes = [10, 10, 10, 10] as const;
+
+      for (const close of closes) {
+        percentB.add(close);
+      }
+
+      expect(percentB.add(20)).toBe(1);
+    });
+
+    it('reads 0 when the close sits exactly on the lower band', () => {
+      // Mirror case: the outlier below the cluster lands exactly on the lower band
+      const percentB = new PercentB({interval: 5});
+      const closes = [10, 10, 10, 10] as const;
+
+      for (const close of closes) {
+        percentB.add(close);
+      }
+
+      expect(percentB.add(0)).toBe(0);
+    });
+
+    it('exceeds 1 when the close breaks above the upper band', () => {
+      /*
+       * %B is not clamped. Halving the band distance to one standard deviation leaves the same outlier 50%
+       * beyond the band, so the reading overshoots to exactly 1.5.
+       */
+      const percentB = new PercentB({deviationMultiplier: 1, interval: 5});
+      const closes = [10, 10, 10, 10] as const;
+
+      for (const close of closes) {
+        percentB.add(close);
+      }
+
+      expect(percentB.add(20)).toBe(1.5);
+    });
+
+    it('falls below 0 when the close breaks below the lower band', () => {
+      const percentB = new PercentB({deviationMultiplier: 1, interval: 5});
+      const closes = [10, 10, 10, 10] as const;
+
+      for (const close of closes) {
+        percentB.add(close);
+      }
+
+      expect(percentB.add(0)).toBe(-0.5);
+    });
+
+    it('reads neutral in a completely flat market', () => {
+      const percentB = new PercentB({interval: 5});
+
+      for (let i = 0; i < 5; i++) {
+        percentB.add(10);
+      }
+
+      expect(percentB.getResultOrThrow()).toBe(0.5);
+      expect(percentB.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+    });
+  });
+
+  describe('getRequiredInputs', () => {
+    it('measures 20 closes by default', () => {
+      const percentB = new PercentB();
+
+      expect(percentB.getRequiredInputs()).toBe(20);
+    });
+
+    it('matches the configured interval', () => {
+      const percentB = new PercentB({interval: 5});
+
+      expect(percentB.getRequiredInputs()).toBe(5);
+    });
+  });
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const percentB = new PercentB({interval: 5});
+      const closes = [10, 10, 10, 10] as const;
+
+      for (const close of closes) {
+        percentB.add(close);
+      }
+
+      const originalValue = 20;
+      const replacedValue = 0;
+
+      const originalResult = percentB.add(originalValue);
+
+      expect(originalResult).toBe(1);
+
+      const replacedResult = percentB.replace(replacedValue);
+
+      expect(replacedResult).toBe(0);
+
+      const restoredResult = percentB.replace(originalValue);
+
+      expect(restoredResult).toBe(1);
+    });
+  });
+
+  describe('getSignal', () => {
+    it('returns UNKNOWN when there is no result', () => {
+      const percentB = new PercentB({interval: 5});
+      const signal = percentB.getSignal();
+
+      expect(signal.state).toBe(TradingSignal.UNKNOWN);
+      expect(signal.hasChanged).toBe(false);
+    });
+
+    it('returns BULLISH when the close presses above the upper band', () => {
+      const percentB = new PercentB({interval: 5});
+      const closes = [10, 10, 10, 10, 20] as const;
+
+      for (const close of closes) {
+        percentB.add(close);
+      }
+
+      expect(percentB.getResultOrThrow()).toBe(1);
+
+      const signal = percentB.getSignal();
+
+      expect(signal.state).toBe(TradingSignal.BULLISH);
+      expect(signal.hasChanged).toBe(true);
+    });
+
+    it('returns BEARISH when the close presses below the lower band', () => {
+      const percentB = new PercentB({interval: 5});
+      const closes = [10, 10, 10, 10, 0] as const;
+
+      for (const close of closes) {
+        percentB.add(close);
+      }
+
+      expect(percentB.getResultOrThrow()).toBe(0);
+
+      const signal = percentB.getSignal();
+
+      expect(signal.state).toBe(TradingSignal.BEARISH);
+      expect(signal.hasChanged).toBe(true);
+    });
+
+    it('returns SIDEWAYS while the close stays inside the bands', () => {
+      const percentB = new PercentB({interval: 5});
+      const closes = [10, 11, 12, 13, 14] as const;
+
+      for (const close of closes) {
+        percentB.add(close);
+      }
+
+      expect(percentB.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+    });
+
+    it('flags a signal change when the close breaks out of the bands', () => {
+      const percentB = new PercentB({interval: 5});
+
+      for (let i = 0; i < 6; i++) {
+        percentB.add(10);
+      }
+
+      expect(percentB.getSignal()).toEqual({hasChanged: false, state: TradingSignal.SIDEWAYS});
+
+      percentB.add(20);
+
+      expect(percentB.getSignal()).toEqual({hasChanged: true, state: TradingSignal.BULLISH});
+    });
+
+    it('restores the previous signal state on replace', () => {
+      const percentB = new PercentB({interval: 5});
+
+      for (let i = 0; i < 6; i++) {
+        percentB.add(10);
+      }
+
+      percentB.add(20);
+
+      expect(percentB.getSignal().state).toBe(TradingSignal.BULLISH);
+
+      percentB.replace(10);
+
+      expect(percentB.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+    });
+
+    it('respects custom overbought and oversold thresholds', () => {
+      const signalThresholds = {overbought: 0.8, oversold: 0.2} as const;
+      const rising = new PercentB({interval: 5, signalThresholds});
+      const falling = new PercentB({interval: 5, signalThresholds});
+
+      for (const close of [10, 11, 12, 13, 14] as const) {
+        rising.add(close);
+      }
+
+      expect(rising.getSignal().state).toBe(TradingSignal.BULLISH);
+
+      for (const close of [14, 13, 12, 11, 10] as const) {
+        falling.add(close);
+      }
+
+      expect(falling.getSignal().state).toBe(TradingSignal.BEARISH);
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new PercentB({deviationMultiplier: 2, interval: 5}),
+  divergentInput: 1_000,
+  inputs: [81.59, 81.06, 82.87, 83.0, 83.61, 83.15],
+});

--- a/packages/trading-signals/src/volatility/PB/PercentB.ts
+++ b/packages/trading-signals/src/volatility/PB/PercentB.ts
@@ -1,0 +1,85 @@
+import {TradingSignal, TrendIndicatorSeries} from '../../base/Indicator.js';
+import type {SignalThresholds} from '../../base/SignalThresholds.type.js';
+import {BollingerBands} from '../BBANDS/BollingerBands.js';
+
+export type PercentBConfig = {
+  /** Distance of the bands from the moving average, in standard deviations of the window */
+  deviationMultiplier?: number;
+  /** Number of closes in the moving window that forms the bands */
+  interval?: number;
+  signalThresholds?: SignalThresholds;
+};
+
+/**
+ * Bollinger Bands %B (PB)
+ * Type: Volatility
+ *
+ * Developed by John A. Bollinger, %B condenses his Bollinger Bands into a single number that locates the
+ * close within the bands: 1 means the close sits on the upper band, 0 on the lower band and 0.5 on the
+ * middle band (the moving average). The reading is not clamped, so a close beyond the bands pushes %B
+ * above 1 or below 0 — which is how band breakouts show up in the value.
+ *
+ * Interpretation:
+ * A value of 1 or above indicates an overbought market with the price pressing above the upper band
+ * (bullish pressure), and 0 or below an oversold market with the price pressing below the lower band
+ * (bearish pressure); both thresholds can be customized via the constructor. A completely flat market
+ * collapses the bands onto the average, which offers no trading range to locate the close in, so %B
+ * reads neutral (0.5).
+ *
+ * @see https://school.stockcharts.com/doku.php?id=technical_indicators:bollinger_band_perce_b
+ * @see https://www.tradingview.com/support/solutions/43000501971-bollinger-bands-b-b/
+ */
+export class PercentB extends TrendIndicatorSeries {
+  readonly #bollingerBands: BollingerBands;
+  readonly #overbought: number;
+  readonly #oversold: number;
+
+  constructor({
+    deviationMultiplier = 2,
+    interval = 20,
+    signalThresholds: {overbought = 1, oversold = 0} = {},
+  }: PercentBConfig = {}) {
+    super();
+    this.#bollingerBands = new BollingerBands(interval, deviationMultiplier);
+    this.#overbought = overbought;
+    this.#oversold = oversold;
+  }
+
+  override getRequiredInputs() {
+    return this.#bollingerBands.getRequiredInputs();
+  }
+
+  update(close: number, replace: boolean) {
+    const bands = this.#bollingerBands.update(close, replace);
+
+    if (bands === null) {
+      return null;
+    }
+
+    const range = bands.upper - bands.lower;
+
+    // A completely flat market offers no trading range to locate the close in, so the reading is neutral
+    if (range === 0) {
+      return this.setResult(0.5, replace);
+    }
+
+    return this.setResult((close - bands.lower) / range, replace);
+  }
+
+  protected calculateSignalState(result: number | null | undefined) {
+    const hasResult = result !== null && result !== undefined;
+    const isOversold = hasResult && result <= this.#oversold;
+    const isOverbought = hasResult && result >= this.#overbought;
+
+    switch (true) {
+      case !hasResult:
+        return TradingSignal.UNKNOWN;
+      case isOversold:
+        return TradingSignal.BEARISH;
+      case isOverbought:
+        return TradingSignal.BULLISH;
+      default:
+        return TradingSignal.SIDEWAYS;
+    }
+  }
+}

--- a/packages/trading-signals/src/volatility/index.ts
+++ b/packages/trading-signals/src/volatility/index.ts
@@ -9,6 +9,7 @@ export * from './KC/KeltnerChannels.js';
 export * from './MAD/MAD.js';
 export * from './MI/MassIndex.js';
 export * from './NATR/NATR.js';
+export * from './PB/PercentB.js';
 export * from './PO/ProjectionOscillator.js';
 export * from './TR/TR.js';
 export * from './UI/UlcerIndex.js';

--- a/packages/trading-signals/src/volatility/index.ts
+++ b/packages/trading-signals/src/volatility/index.ts
@@ -3,6 +3,7 @@ export * from './ATR/ATR.js';
 export * from './BBANDS/BollingerBands.js';
 export * from './BBW/BollingerBandsWidth.js';
 export * from './DC/DonchianChannels.js';
+export * from './GAPO/GAPO.js';
 export * from './IQR/IQR.js';
 export * from './KC/KeltnerChannels.js';
 export * from './MAD/MAD.js';


### PR DESCRIPTION
## Summary

Sources [Cloud9Trader/TechnicalIndicators](https://github.com/Cloud9Trader/TechnicalIndicators) — of its 50 indicators, 39 were already covered and 5 fall to the triviality filter (envelopes, raw volume, stddev util, Aroon oscillator arithmetic). The 5 genuinely missing ones land here, one commit each:

| Indicator | Class | Category | Reference verification |
|---|---|---|---|
| Bollinger Bands %B | `PercentB` | volatility | Derived arithmetically from Tulip's `bbands` block (L86–90) + engineered exact band-boundary tests (%B exactly 1/0) |
| Detrended Price Oscillator | `DPO` | momentum | Tulip `untest.txt` L162–164 + `dpo.c` (price displacement, not SMA displacement); honest warm-up for intervals ≤ 2 where Tulip reads out-of-bounds |
| Pretty Good Oscillator | `PGO` | momentum | pandas-ta semantics (double-smoothed denominator: Wilder ATR → EMA), hand-derived exact fractions; FM Labs divergence documented |
| Gopalakrishnan Range Index | `GAPO` | volatility | TASC Jan 2000 / FM Labs formula, hand-derived exact log values |
| Price Momentum Oscillator | `PMO` | momentum | StockCharts DPMO methodology (2/n custom smoothing ×2 + EMA(10) signal); Skender rejected after 1.1e-16 port proof of SMA seeding |

## Notes

- `PercentB` and `PGO` are threshold-based (`TrendIndicatorSeries`); `DPO` is zero-cross; `GAPO` is a plain volatility series; `PMO` is two-line (pmo + signal) with a MACD-style `getSignal()` that deliberately maps pmo === signal to SIDEWAYS (neutral-state rule) instead of MACD's default-to-BEARISH.
- **Skipped by design**: Cloud9Trader's Daily Pivot Points — a session-aware level generator, not a streaming indicator; shout if you want it anyway.
- Final commit removes Cloud9Trader from the README Alternatives list (fully sourced).

Stacked on #1290 (base auto-retargets when it merges). Library sourcing progress: indicatorts ✓ (#1290), Cloud9Trader ✓ (this PR); next up: technicalindicators.