### PR TITLE
feat(trading-signals): close the Jesse feature gap (9 indicators)

### DIFF
--- a/packages/trading-signals-docs/indicator-demos/momentum/STC.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/STC.demo.tsx
@@ -1,0 +1,20 @@
+import {STC as STCClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const STC: IndicatorConfig = {
+  chartTitle: 'STC (23, 50, 10)',
+  color: '#2dd4bf',
+  createIndicator: () => new STCClass(),
+  description: 'Schaff Trend Cycle',
+  details:
+    'STC runs the MACD line through two rounds of stochastic scaling and halfway smoothing, so it completes its 0-100 swings well before the MACD turns. Values of 75 or above indicate overbought, 25 or below indicate oversold.',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
+  id: 'stc',
+  name: 'STC',
+  processData: makeProcessData({rowInputs: ['close']}),
+  requiredInputs: 68,
+  type: 'single',
+  yAxisLabel: 'STC',
+};

--- a/packages/trading-signals-docs/indicator-demos/momentum/WaddahAttarExplosion.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/WaddahAttarExplosion.demo.tsx
@@ -1,0 +1,182 @@
+import {Chart as HighchartsChart} from '@highcharts/react';
+import {WaddahAttarExplosion as WaddahAttarExplosionClass} from 'trading-signals';
+import type {ReactNode} from 'react';
+import type {Candle} from '@typedtrader/exchange';
+import {createSharedTooltipFormatter} from '../../components/Chart';
+import {NotAvailable} from '../../components/NotAvailable';
+import PriceChart, {type PriceData} from '../../components/PriceChart';
+import {SignalBadge} from '../../components/SignalBadge';
+import {formatDate} from '../../utils/formatDate';
+import {collectPriceData} from '../../utils/renderUtils';
+import type {IndicatorConfig} from '../../utils/types';
+
+/*
+ * The demo shrinks the SHK lookbacks (EMA 20/40, BB 20, ATR 100) to EMA 10/20, BB 10, ATR 20 so the
+ * indicator warms up within the 40-candle sample datasets; sensitivity, band width and dead zone
+ * multiplier stay at their published defaults.
+ */
+const createWaddahAttarExplosion = () =>
+  new WaddahAttarExplosionClass({atrInterval: 20, bandsInterval: 10, longInterval: 20, shortInterval: 10});
+
+const renderWaddahAttarExplosion = (config: IndicatorConfig, selectedCandles: Candle[]) => {
+  const wae = createWaddahAttarExplosion();
+  const chartDataTrend: {color: string; x: number; y: number | null}[] = [];
+  const chartDataExplosion: [number, number | null][] = [];
+  const chartDataDeadZone: [number, number | null][] = [];
+  const priceData: PriceData[] = [];
+  const sampleValues: {
+    period: number;
+    date: string;
+    close: number;
+    trend: ReactNode;
+    explosion: ReactNode;
+    deadZone: ReactNode;
+    signal: string;
+  }[] = [];
+
+  selectedCandles.forEach((candle, idx) => {
+    wae.add({close: Number(candle.close), high: Number(candle.high), low: Number(candle.low)});
+    const result = wae.isStable ? wae.getResult() : null;
+    const signal = wae.getSignal();
+    const trend = result?.trend ?? 0;
+    chartDataTrend.push({
+      color: trend > 0 ? '#22c55e' : trend < 0 ? '#ef4444' : '#64748b',
+      x: idx + 1,
+      y: result?.trend ?? null,
+    });
+    chartDataExplosion.push([idx + 1, result?.explosion ?? null]);
+    chartDataDeadZone.push([idx + 1, result?.deadZone ?? null]);
+
+    priceData.push(collectPriceData(candle, idx));
+
+    sampleValues.push({
+      close: Number(candle.close),
+      date: formatDate(candle.openTimeInISO),
+      deadZone: result ? result.deadZone.toFixed(4) : <NotAvailable />,
+      explosion: result ? result.explosion.toFixed(4) : <NotAvailable />,
+      period: idx + 1,
+      signal: signal.state,
+      trend: result ? result.trend.toFixed(4) : <NotAvailable />,
+    });
+  });
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold text-white mb-2 select-text">
+          WAE(10, 20, BB 10, ATR 20) / Required Inputs: {wae.getRequiredInputs()}
+        </h2>
+        <p className="text-slate-300 select-text">{config.description}</p>
+        <p className="text-slate-400 text-sm mt-2 select-text">
+          Trade only on explosion: when the explosion line rises above the dead zone, the trend histogram names the
+          direction — green pushes up, red pushes down. Everything below the dead zone is noise.
+        </p>
+      </div>
+
+      <div className="bg-slate-800/50 border border-slate-700 rounded-lg p-4">
+        <HighchartsChart
+          options={{
+            chart: {backgroundColor: 'transparent', height: 300, type: 'line'},
+            credits: {enabled: false},
+            legend: {enabled: true, itemStyle: {color: '#e2e8f0'}},
+            plotOptions: {
+              column: {borderWidth: 0},
+              line: {lineWidth: 2, marker: {enabled: true, radius: 3}},
+            },
+            series: [
+              {
+                data: chartDataTrend,
+                name: 'Trend',
+                opacity: 0.7,
+                type: 'column',
+              },
+              {
+                color: config.color,
+                data: chartDataExplosion,
+                marker: {fillColor: config.color},
+                name: 'Explosion',
+                type: 'line',
+              },
+              {
+                color: '#3b82f6',
+                dashStyle: 'Dash',
+                data: chartDataDeadZone,
+                marker: {enabled: false},
+                name: 'Dead Zone',
+                type: 'line',
+              },
+            ],
+            title: {
+              style: {color: '#e2e8f0', fontSize: '16px', fontWeight: '600'},
+              text: 'Waddah Attar Explosion (10, 20, BB 10, ATR 20)',
+            },
+            tooltip: {
+              backgroundColor: '#1e293b',
+              borderColor: '#475569',
+              formatter: createSharedTooltipFormatter(y => y.toFixed(4)),
+              shared: true,
+              style: {color: '#e2e8f0'},
+            },
+            xAxis: {
+              gridLineColor: '#334155',
+              labels: {style: {color: '#94a3b8'}},
+              title: {style: {color: '#94a3b8'}, text: 'Period'},
+            },
+            yAxis: {
+              gridLineColor: '#334155',
+              labels: {style: {color: '#94a3b8'}},
+              title: {style: {color: '#94a3b8'}, text: 'Value'},
+            },
+          }}
+        />
+      </div>
+
+      <PriceChart title="Input Prices" data={priceData} />
+
+      <div className="bg-slate-800/50 border border-slate-700 rounded-lg p-4">
+        <h3 className="text-lg font-semibold text-white mb-3">All Sample Values</h3>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-slate-600">
+                <th className="text-left text-slate-300 py-2 px-3">Period</th>
+                <th className="text-left text-slate-300 py-2 px-3">Date</th>
+                <th className="text-left text-slate-300 py-2 px-3">Close</th>
+                <th className="text-left text-slate-300 py-2 px-3">Trend</th>
+                <th className="text-left text-slate-300 py-2 px-3">Explosion</th>
+                <th className="text-left text-slate-300 py-2 px-3">Dead Zone</th>
+                <th className="text-left text-slate-300 py-2 px-3">Signal</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sampleValues.map(row => (
+                <tr key={row.period} className="border-b border-slate-700/50">
+                  <td className="text-slate-400 py-2 px-3">{row.period}</td>
+                  <td className="text-slate-300 py-2 px-3">{row.date}</td>
+                  <td className="text-slate-300 py-2 px-3">${row.close.toFixed(2)}</td>
+                  <td className="text-white font-mono py-2 px-3">{row.trend}</td>
+                  <td className="text-white font-mono py-2 px-3">{row.explosion}</td>
+                  <td className="text-white font-mono py-2 px-3">{row.deadZone}</td>
+                  <td className="py-2 px-3">
+                    <SignalBadge signal={row.signal} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const WaddahAttarExplosion: IndicatorConfig = {
+  color: '#a0522d',
+  createIndicator: createWaddahAttarExplosion,
+  customRender: renderWaddahAttarExplosion,
+  description: 'Waddah Attar Explosion',
+  id: 'waddah-attar',
+  name: 'WAE',
+  requiredInputs: 21,
+  type: 'custom',
+};

--- a/packages/trading-signals-docs/indicator-demos/momentum/WaveTrend.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/WaveTrend.demo.tsx
@@ -1,0 +1,153 @@
+import {Chart as HighchartsChart} from '@highcharts/react';
+import {WaveTrend as WaveTrendClass} from 'trading-signals';
+import type {ReactNode} from 'react';
+import type {Candle} from '@typedtrader/exchange';
+import {createSharedTooltipFormatter, type ChartDataPoint} from '../../components/Chart';
+import {NotAvailable} from '../../components/NotAvailable';
+import PriceChart, {type PriceData} from '../../components/PriceChart';
+import {SignalBadge} from '../../components/SignalBadge';
+import {formatDate} from '../../utils/formatDate';
+import {collectPriceData} from '../../utils/renderUtils';
+import type {IndicatorConfig} from '../../utils/types';
+
+const renderWaveTrend = (config: IndicatorConfig, selectedCandles: Candle[]) => {
+  const wt = new WaveTrendClass();
+  const chartDataWt1: ChartDataPoint[] = [];
+  const chartDataWt2: ChartDataPoint[] = [];
+  const priceData: PriceData[] = [];
+  const sampleValues: {period: number; date: string; close: number; wt1: ReactNode; wt2: ReactNode; signal: string}[] =
+    [];
+
+  selectedCandles.forEach((candle, idx) => {
+    wt.add({close: Number(candle.close), high: Number(candle.high), low: Number(candle.low)});
+    const result = wt.isStable ? wt.getResult() : null;
+    const signal = wt.getSignal();
+    chartDataWt1.push({x: idx + 1, y: result?.wt1 ?? null});
+    chartDataWt2.push({x: idx + 1, y: result?.wt2 ?? null});
+
+    priceData.push(collectPriceData(candle, idx));
+
+    sampleValues.push({
+      close: Number(candle.close),
+      date: formatDate(candle.openTimeInISO),
+      period: idx + 1,
+      signal: signal.state,
+      wt1: result ? result.wt1.toFixed(2) : <NotAvailable />,
+      wt2: result ? result.wt2.toFixed(2) : <NotAvailable />,
+    });
+  });
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold text-white mb-2 select-text">
+          WaveTrend({wt.channelInterval}, {wt.averageInterval}, {wt.smoothingInterval}) / Required Inputs:{' '}
+          {wt.getRequiredInputs()}
+        </h2>
+        <p className="text-slate-300 select-text">{config.description}</p>
+        <p className="text-slate-400 text-sm mt-2 select-text">
+          Measures how far the average price stretches from its smoothed channel. WT1 crossing above WT2 = bullish,
+          crossing below = bearish. Readings beyond ±53 mark the overbought/oversold bands, beyond ±60 extreme levels.
+        </p>
+      </div>
+
+      <div className="bg-slate-800/50 border border-slate-700 rounded-lg p-4">
+        <HighchartsChart
+          options={{
+            chart: {backgroundColor: 'transparent', height: 300, type: 'line'},
+            credits: {enabled: false},
+            legend: {enabled: true, itemStyle: {color: '#e2e8f0'}},
+            plotOptions: {
+              line: {lineWidth: 2, marker: {enabled: true, radius: 3}},
+            },
+            series: [
+              {
+                color: config.color,
+                data: chartDataWt1.map(point => [point.x, point.y]),
+                marker: {fillColor: config.color},
+                name: 'WT1',
+                type: 'line',
+              },
+              {
+                color: '#f97316',
+                data: chartDataWt2.map(point => [point.x, point.y]),
+                marker: {fillColor: '#f97316'},
+                name: 'WT2',
+                type: 'line',
+              },
+            ],
+            title: {style: {color: '#e2e8f0', fontSize: '16px', fontWeight: '600'}, text: 'WaveTrend (10,21,4)'},
+            tooltip: {
+              backgroundColor: '#1e293b',
+              borderColor: '#475569',
+              formatter: createSharedTooltipFormatter(y => y.toFixed(4)),
+              shared: true,
+              style: {color: '#e2e8f0'},
+            },
+            xAxis: {
+              gridLineColor: '#334155',
+              labels: {style: {color: '#94a3b8'}},
+              title: {style: {color: '#94a3b8'}, text: 'Period'},
+            },
+            yAxis: {
+              gridLineColor: '#334155',
+              labels: {style: {color: '#94a3b8'}},
+              plotLines: [
+                {color: '#ef4444', dashStyle: 'Dash', value: 60, width: 1},
+                {color: '#ef4444', dashStyle: 'Dot', value: 53, width: 1},
+                {color: '#22c55e', dashStyle: 'Dot', value: -53, width: 1},
+                {color: '#22c55e', dashStyle: 'Dash', value: -60, width: 1},
+              ],
+              title: {style: {color: '#94a3b8'}, text: 'Value'},
+            },
+          }}
+        />
+      </div>
+
+      <PriceChart title="Input Prices" data={priceData} />
+
+      <div className="bg-slate-800/50 border border-slate-700 rounded-lg p-4">
+        <h3 className="text-lg font-semibold text-white mb-3">All Sample Values</h3>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-slate-600">
+                <th className="text-left text-slate-300 py-2 px-3">Period</th>
+                <th className="text-left text-slate-300 py-2 px-3">Date</th>
+                <th className="text-left text-slate-300 py-2 px-3">Close</th>
+                <th className="text-left text-slate-300 py-2 px-3">WT1</th>
+                <th className="text-left text-slate-300 py-2 px-3">WT2</th>
+                <th className="text-left text-slate-300 py-2 px-3">Signal</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sampleValues.map(row => (
+                <tr key={row.period} className="border-b border-slate-700/50">
+                  <td className="text-slate-400 py-2 px-3">{row.period}</td>
+                  <td className="text-slate-300 py-2 px-3">{row.date}</td>
+                  <td className="text-slate-300 py-2 px-3">${row.close.toFixed(2)}</td>
+                  <td className="text-white font-mono py-2 px-3">{row.wt1}</td>
+                  <td className="text-white font-mono py-2 px-3">{row.wt2}</td>
+                  <td className="py-2 px-3">
+                    <SignalBadge signal={row.signal} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const WaveTrend: IndicatorConfig = {
+  color: '#14b8a6',
+  createIndicator: () => new WaveTrendClass(),
+  customRender: renderWaveTrend,
+  description: 'WaveTrend Oscillator',
+  id: 'wavetrend',
+  name: 'WaveTrend',
+  requiredInputs: 21,
+  type: 'custom',
+};

--- a/packages/trading-signals-docs/indicator-demos/momentum/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/index.tsx
@@ -24,6 +24,7 @@ import {Qstick} from './Qstick.demo';
 import {REI} from './REI.demo';
 import {ROC} from './ROC.demo';
 import {RSI} from './RSI.demo';
+import {STC} from './STC.demo';
 import {StochasticOscillator} from './StochasticOscillator.demo';
 import {StochasticRSI} from './StochasticRSI.demo';
 import {TDS} from './TDS.demo';
@@ -66,6 +67,7 @@ export const indicators: IndicatorConfig[] = [
   DPO,
   PGO,
   PMO,
+  STC,
   TRIX,
   TSI,
   WaveTrend,

--- a/packages/trading-signals-docs/indicator-demos/momentum/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/index.tsx
@@ -31,6 +31,7 @@ import {TDS} from './TDS.demo';
 import {TRIX} from './TRIX.demo';
 import {TSI} from './TSI.demo';
 import {UltimateOscillator} from './UltimateOscillator.demo';
+import {WaddahAttarExplosion} from './WaddahAttarExplosion.demo';
 import {WaveTrend} from './WaveTrend.demo';
 import {WilliamsR} from './WilliamsR.demo';
 import type {IndicatorConfig} from '../../utils/types';
@@ -71,4 +72,5 @@ export const indicators: IndicatorConfig[] = [
   TRIX,
   TSI,
   WaveTrend,
+  WaddahAttarExplosion,
 ];

--- a/packages/trading-signals-docs/indicator-demos/momentum/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/index.tsx
@@ -30,6 +30,7 @@ import {TDS} from './TDS.demo';
 import {TRIX} from './TRIX.demo';
 import {TSI} from './TSI.demo';
 import {UltimateOscillator} from './UltimateOscillator.demo';
+import {WaveTrend} from './WaveTrend.demo';
 import {WilliamsR} from './WilliamsR.demo';
 import type {IndicatorConfig} from '../../utils/types';
 
@@ -67,4 +68,5 @@ export const indicators: IndicatorConfig[] = [
   PMO,
   TRIX,
   TSI,
+  WaveTrend,
 ];

--- a/packages/trading-signals-docs/indicator-demos/trend/MAMA.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/MAMA.demo.tsx
@@ -1,0 +1,148 @@
+import {Chart as HighchartsChart} from '@highcharts/react';
+import {MAMA as MAMAClass} from 'trading-signals';
+import type {ReactNode} from 'react';
+import type {Candle} from '@typedtrader/exchange';
+import {createSharedTooltipFormatter, type ChartDataPoint} from '../../components/Chart';
+import {NotAvailable} from '../../components/NotAvailable';
+import PriceChart, {type PriceData} from '../../components/PriceChart';
+import {SignalBadge} from '../../components/SignalBadge';
+import {formatDate} from '../../utils/formatDate';
+import {collectPriceData} from '../../utils/renderUtils';
+import type {IndicatorConfig} from '../../utils/types';
+
+const renderMAMA = (config: IndicatorConfig, selectedCandles: Candle[]) => {
+  const mama = new MAMAClass();
+  const chartDataMAMA: ChartDataPoint[] = [];
+  const chartDataFAMA: ChartDataPoint[] = [];
+  const priceData: PriceData[] = [];
+  const sampleValues: {
+    period: number;
+    date: string;
+    close: number;
+    mama: ReactNode;
+    fama: ReactNode;
+    signal: string;
+  }[] = [];
+
+  selectedCandles.forEach((candle, idx) => {
+    const result = mama.add(Number(candle.close));
+    const trendSignal = mama.getSignal();
+    chartDataMAMA.push({x: idx + 1, y: result?.mama ?? null});
+    chartDataFAMA.push({x: idx + 1, y: result?.fama ?? null});
+
+    priceData.push(collectPriceData(candle, idx));
+
+    sampleValues.push({
+      close: Number(candle.close),
+      date: formatDate(candle.openTimeInISO),
+      fama: result ? result.fama.toFixed(4) : <NotAvailable />,
+      mama: result ? result.mama.toFixed(4) : <NotAvailable />,
+      period: idx + 1,
+      signal: trendSignal.state,
+    });
+  });
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold text-white mb-2 select-text">
+          MAMA({mama.fastLimit}, {mama.slowLimit}) / Required Inputs: {mama.getRequiredInputs()}
+        </h2>
+        <p className="text-slate-300 select-text">{config.description}</p>
+        {config.details && <p className="text-slate-400 text-sm mt-2 select-text">{config.details}</p>}
+      </div>
+
+      <div className="bg-slate-800/50 border border-slate-700 rounded-lg p-4">
+        <HighchartsChart
+          options={{
+            chart: {backgroundColor: 'transparent', height: 300, type: 'line'},
+            credits: {enabled: false},
+            legend: {enabled: true, itemStyle: {color: '#e2e8f0'}},
+            plotOptions: {line: {lineWidth: 2, marker: {enabled: true, radius: 3}}},
+            series: [
+              {
+                color: config.color,
+                data: chartDataMAMA.map(point => [point.x, point.y]),
+                marker: {fillColor: config.color},
+                name: 'MAMA',
+                type: 'line',
+              },
+              {
+                color: '#f97316',
+                data: chartDataFAMA.map(point => [point.x, point.y]),
+                marker: {fillColor: '#f97316'},
+                name: 'FAMA',
+                type: 'line',
+              },
+            ],
+            title: {style: {color: '#e2e8f0', fontSize: '16px', fontWeight: '600'}, text: 'MAMA (0.5, 0.05)'},
+            tooltip: {
+              backgroundColor: '#1e293b',
+              borderColor: '#475569',
+              formatter: createSharedTooltipFormatter(y => y.toFixed(4)),
+              shared: true,
+              style: {color: '#e2e8f0'},
+            },
+            xAxis: {
+              gridLineColor: '#334155',
+              labels: {style: {color: '#94a3b8'}},
+              title: {style: {color: '#94a3b8'}, text: 'Period'},
+            },
+            yAxis: {
+              gridLineColor: '#334155',
+              labels: {style: {color: '#94a3b8'}},
+              title: {style: {color: '#94a3b8'}, text: 'Price'},
+            },
+          }}
+        />
+      </div>
+
+      <PriceChart title="Input Prices" data={priceData} />
+
+      <div className="bg-slate-800/50 border border-slate-700 rounded-lg p-4">
+        <h3 className="text-lg font-semibold text-white mb-3">All Sample Values</h3>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-slate-600">
+                <th className="text-left text-slate-300 py-2 px-3">Period</th>
+                <th className="text-left text-slate-300 py-2 px-3">Date</th>
+                <th className="text-left text-slate-300 py-2 px-3">Close</th>
+                <th className="text-left text-slate-300 py-2 px-3">MAMA</th>
+                <th className="text-left text-slate-300 py-2 px-3">FAMA</th>
+                <th className="text-left text-slate-300 py-2 px-3">Signal</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sampleValues.map(row => (
+                <tr key={row.period} className="border-b border-slate-700/50">
+                  <td className="text-slate-400 py-2 px-3">{row.period}</td>
+                  <td className="text-slate-300 py-2 px-3">{row.date}</td>
+                  <td className="text-slate-300 py-2 px-3">${row.close.toFixed(2)}</td>
+                  <td className="text-white font-mono py-2 px-3">{row.mama}</td>
+                  <td className="text-white font-mono py-2 px-3">{row.fama}</td>
+                  <td className="py-2 px-3">
+                    <SignalBadge signal={row.signal} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const MAMA: IndicatorConfig = {
+  color: '#3b82f6',
+  createIndicator: () => new MAMAClass(),
+  customRender: renderMAMA,
+  description: 'MESA Adaptive Moving Average',
+  details:
+    'Adapts its smoothing to the dominant market cycle measured by a Hilbert transform: it hugs price during trends and freezes in congestion. MAMA crossing above its following average (FAMA) signals bullish pressure, crossing below signals bearish pressure.',
+  id: 'mama',
+  name: 'MAMA',
+  requiredInputs: 33,
+  type: 'custom',
+};

--- a/packages/trading-signals-docs/indicator-demos/trend/McGinleyDynamic.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/McGinleyDynamic.demo.tsx
@@ -1,0 +1,20 @@
+import {McGinleyDynamic as McGinleyDynamicClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const McGinleyDynamic: IndicatorConfig = {
+  chartTitle: 'McGinley Dynamic (14)',
+  color: '#f59e0b',
+  createIndicator: () => new McGinleyDynamicClass(14),
+  description: 'McGinley Dynamic',
+  details:
+    'A self-adjusting moving average that speeds up in falling markets and slows down in rising ones, hugging price more closely than an EMA without the whipsaws of a fixed-period average.',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
+  id: 'mcginley-dynamic',
+  name: 'MD',
+  processData: makeProcessData({rowInputs: ['close']}),
+  requiredInputs: 14,
+  type: 'single',
+  yAxisLabel: 'Price',
+};

--- a/packages/trading-signals-docs/indicator-demos/trend/SuperSmoother.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/SuperSmoother.demo.tsx
@@ -1,0 +1,20 @@
+import {SuperSmoother as SuperSmootherClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const SuperSmoother: IndicatorConfig = {
+  chartTitle: 'SuperSmoother (10)',
+  color: '#38bdf8',
+  createIndicator: () => new SuperSmootherClass(10),
+  description: 'SuperSmoother Filter',
+  details:
+    "John Ehlers' 2-pole Butterworth low-pass filter fed with a two-bar price average. It rejects wave components shorter than the interval as aliasing noise while following price with considerably less lag than an SMA or EMA of comparable smoothness.",
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
+  id: 'supersmoother',
+  name: 'SuperSmoother',
+  processData: makeProcessData({rowInputs: ['close']}),
+  requiredInputs: 10,
+  type: 'single',
+  yAxisLabel: 'Price',
+};

--- a/packages/trading-signals-docs/indicator-demos/trend/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/index.tsx
@@ -23,6 +23,7 @@ import {PSAR} from './PSAR.demo';
 import {RMA} from './RMA.demo';
 import {SMA} from './SMA.demo';
 import {SMA15} from './SMA15.demo';
+import {SuperSmoother} from './SuperSmoother.demo';
 import {SuperTrend} from './SuperTrend.demo';
 import {SwingHigh} from './SwingHigh.demo';
 import {SwingLow} from './SwingLow.demo';
@@ -48,6 +49,7 @@ export const indicators: IndicatorConfig[] = [
   VIDYA,
   FRAMA,
   McGinleyDynamic,
+  SuperSmoother,
   VortexIndicator,
   IchimokuCloud,
   Aroon,

--- a/packages/trading-signals-docs/indicator-demos/trend/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/index.tsx
@@ -8,6 +8,7 @@ import {FRAMA} from './FRAMA.demo';
 import {HMA} from './HMA.demo';
 import {IchimokuCloud} from './IchimokuCloud.demo';
 import {KAMA} from './KAMA.demo';
+import {MAMA} from './MAMA.demo';
 import {McGinleyDynamic} from './McGinleyDynamic.demo';
 import {T3} from './T3.demo';
 import {TEMA} from './TEMA.demo';
@@ -49,6 +50,7 @@ export const indicators: IndicatorConfig[] = [
   VIDYA,
   FRAMA,
   McGinleyDynamic,
+  MAMA,
   SuperSmoother,
   VortexIndicator,
   IchimokuCloud,

--- a/packages/trading-signals-docs/indicator-demos/trend/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/index.tsx
@@ -8,6 +8,7 @@ import {FRAMA} from './FRAMA.demo';
 import {HMA} from './HMA.demo';
 import {IchimokuCloud} from './IchimokuCloud.demo';
 import {KAMA} from './KAMA.demo';
+import {McGinleyDynamic} from './McGinleyDynamic.demo';
 import {T3} from './T3.demo';
 import {TEMA} from './TEMA.demo';
 import {TRIMA} from './TRIMA.demo';
@@ -46,6 +47,7 @@ export const indicators: IndicatorConfig[] = [
   ZLEMA,
   VIDYA,
   FRAMA,
+  McGinleyDynamic,
   VortexIndicator,
   IchimokuCloud,
   Aroon,

--- a/packages/trading-signals-docs/indicator-demos/volatility/CHOP.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volatility/CHOP.demo.tsx
@@ -1,0 +1,20 @@
+import {CHOP as CHOPClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const CHOP: IndicatorConfig = {
+  chartTitle: 'CHOP (14)',
+  color: '#0ea5e9',
+  createIndicator: () => new CHOPClass(14),
+  description: 'Choppiness Index',
+  details:
+    'Compares the ground price actually covered (the sum of true ranges) with the span of the window on a logarithmic scale, bounded between 0 and 100. Readings above 61.8 mark a consolidating, choppy market where trend-following entries are prone to whipsaws; readings below 38.2 mark a strong trend. The reading is direction-agnostic — a crash and a rally both read as trending — so the direction must come from a companion trend indicator.',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
+  id: 'chop',
+  name: 'Choppiness Index',
+  processData: makeProcessData({addInputs: ['high', 'low', 'close'], rowInputs: ['close']}),
+  requiredInputs: 15,
+  type: 'single',
+  yAxisLabel: 'CHOP',
+};

--- a/packages/trading-signals-docs/indicator-demos/volatility/CVI.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volatility/CVI.demo.tsx
@@ -1,0 +1,20 @@
+import {CVI as CVIClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const CVI: IndicatorConfig = {
+  chartTitle: 'Chaikin Volatility (10)',
+  color: '#0ea5e9',
+  createIndicator: () => new CVIClass(10),
+  description: 'Chaikin Volatility',
+  details:
+    'Smooths the candle range (high minus low) and reports how much that smoothed range has grown or shrunk over the lookback, in percent. Positive readings mean volatility is expanding, negative readings a calming market, so a zero-cross flags a volatility regime change. Marc Chaikin reads it together with price direction: a volatility spike while prices fall often marks panic selling near a bottom, while fading volatility during rising prices points to a maturing uptrend.',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['high', 'low']}),
+  id: 'cvi',
+  name: 'Chaikin Volatility',
+  processData: makeProcessData({rowInputs: ['high', 'low']}),
+  requiredInputs: 20,
+  type: 'single',
+  yAxisLabel: 'CVI',
+};

--- a/packages/trading-signals-docs/indicator-demos/volatility/TTMSqueeze.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volatility/TTMSqueeze.demo.tsx
@@ -1,0 +1,175 @@
+import {Chart as HighchartsChart} from '@highcharts/react';
+import {TTMSqueeze as TTMSqueezeClass} from 'trading-signals';
+import type {ReactNode} from 'react';
+import type {Candle} from '@typedtrader/exchange';
+import {createSharedTooltipFormatter} from '../../components/Chart';
+import {NotAvailable} from '../../components/NotAvailable';
+import PriceChart, {type PriceData} from '../../components/PriceChart';
+import {SignalBadge} from '../../components/SignalBadge';
+import {formatDate} from '../../utils/formatDate';
+import {collectPriceData} from '../../utils/renderUtils';
+import type {IndicatorConfig} from '../../utils/types';
+
+type HistogramPoint = {x: number; y: number | null; color?: string};
+
+/** LazyBear's histogram look: bright while momentum builds, dark while it fades. */
+const momentumColor = (momentum: number, previous: number | null) => {
+  const isBuilding = previous === null || Math.abs(momentum) > Math.abs(previous);
+
+  if (momentum >= 0) {
+    return isBuilding ? '#84cc16' : '#15803d';
+  }
+
+  return isBuilding ? '#ef4444' : '#7f1d1d';
+};
+
+const renderTTMSqueeze = (config: IndicatorConfig, selectedCandles: Candle[]) => {
+  const squeeze = new TTMSqueezeClass();
+  const chartDataMomentum: HistogramPoint[] = [];
+  const chartDataSqueeze: HistogramPoint[] = [];
+  const priceData: PriceData[] = [];
+  const sampleValues: {
+    period: number;
+    date: string;
+    close: number;
+    momentum: ReactNode;
+    squeezed: string;
+    signal: string;
+  }[] = [];
+  let previousMomentum: number | null = null;
+
+  selectedCandles.forEach((candle, idx) => {
+    squeeze.add({close: Number(candle.close), high: Number(candle.high), low: Number(candle.low)});
+    const result = squeeze.getResult();
+    const trendSignal = squeeze.getSignal();
+
+    chartDataMomentum.push({
+      color: result ? momentumColor(result.momentum, previousMomentum) : undefined,
+      x: idx + 1,
+      y: result?.momentum ?? null,
+    });
+    chartDataSqueeze.push({
+      color: result?.isSqueezed ? '#f59e0b' : '#64748b',
+      x: idx + 1,
+      y: result ? 0 : null,
+    });
+    previousMomentum = result?.momentum ?? previousMomentum;
+
+    priceData.push(collectPriceData(candle, idx));
+
+    sampleValues.push({
+      close: Number(candle.close),
+      date: formatDate(candle.openTimeInISO),
+      momentum: result ? result.momentum.toFixed(4) : <NotAvailable />,
+      period: idx + 1,
+      signal: trendSignal.state,
+      squeezed: result ? (result.isSqueezed ? 'Yes' : 'No') : '-',
+    });
+  });
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold text-white mb-2 select-text">
+          TTM Squeeze(20, ×2 / 20, ×1.5) / Required Inputs: {squeeze.getRequiredInputs()}
+        </h2>
+        <p className="text-slate-300 select-text">{config.description}</p>
+        <p className="text-slate-400 text-sm mt-2 select-text">
+          Amber dots on the zero line mark a squeeze: Bollinger Bands trading inside the Keltner Channel, a coiled
+          market before an explosive move. The histogram names the side positioned to receive that move.
+        </p>
+      </div>
+
+      <div className="bg-slate-800/50 border border-slate-700 rounded-lg p-4">
+        <HighchartsChart
+          options={{
+            chart: {backgroundColor: 'transparent', height: 300, type: 'column'},
+            credits: {enabled: false},
+            legend: {enabled: true, itemStyle: {color: '#e2e8f0'}},
+            plotOptions: {
+              column: {borderWidth: 0},
+              line: {lineWidth: 0, marker: {enabled: true, radius: 3}},
+            },
+            series: [
+              {
+                color: config.color,
+                data: chartDataMomentum.map(point => ({color: point.color, x: point.x, y: point.y})),
+                name: 'Momentum',
+                type: 'column',
+              },
+              {
+                color: '#f59e0b',
+                data: chartDataSqueeze.map(point => ({color: point.color, x: point.x, y: point.y})),
+                name: 'Squeeze',
+                type: 'line',
+              },
+            ],
+            title: {style: {color: '#e2e8f0', fontSize: '16px', fontWeight: '600'}, text: 'TTM Squeeze (20, 2, 1.5)'},
+            tooltip: {
+              backgroundColor: '#1e293b',
+              borderColor: '#475569',
+              formatter: createSharedTooltipFormatter(y => y.toFixed(4)),
+              shared: true,
+              style: {color: '#e2e8f0'},
+            },
+            xAxis: {
+              gridLineColor: '#334155',
+              labels: {style: {color: '#94a3b8'}},
+              title: {style: {color: '#94a3b8'}, text: 'Period'},
+            },
+            yAxis: {
+              gridLineColor: '#334155',
+              labels: {style: {color: '#94a3b8'}},
+              title: {style: {color: '#94a3b8'}, text: 'Momentum'},
+            },
+          }}
+        />
+      </div>
+
+      <PriceChart title="Input Prices" data={priceData} />
+
+      <div className="bg-slate-800/50 border border-slate-700 rounded-lg p-4">
+        <h3 className="text-lg font-semibold text-white mb-3">All Sample Values</h3>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-slate-600">
+                <th className="text-left text-slate-300 py-2 px-3">Period</th>
+                <th className="text-left text-slate-300 py-2 px-3">Date</th>
+                <th className="text-left text-slate-300 py-2 px-3">Close</th>
+                <th className="text-left text-slate-300 py-2 px-3">Momentum</th>
+                <th className="text-left text-slate-300 py-2 px-3">Squeeze</th>
+                <th className="text-left text-slate-300 py-2 px-3">Signal</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sampleValues.map(row => (
+                <tr key={row.period} className="border-b border-slate-700/50">
+                  <td className="text-slate-400 py-2 px-3">{row.period}</td>
+                  <td className="text-slate-300 py-2 px-3">{row.date}</td>
+                  <td className="text-slate-300 py-2 px-3">${row.close.toFixed(2)}</td>
+                  <td className="text-white font-mono py-2 px-3">{row.momentum}</td>
+                  <td className="text-slate-300 py-2 px-3">{row.squeezed}</td>
+                  <td className="py-2 px-3">
+                    <SignalBadge signal={row.signal} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const TTMSqueeze: IndicatorConfig = {
+  color: '#84cc16',
+  createIndicator: () => new TTMSqueezeClass(),
+  customRender: renderTTMSqueeze,
+  description: 'TTM Squeeze (Squeeze Momentum)',
+  id: 'ttm-squeeze',
+  name: 'TTM Squeeze',
+  requiredInputs: 39,
+  type: 'custom',
+};

--- a/packages/trading-signals-docs/indicator-demos/volatility/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volatility/index.tsx
@@ -2,6 +2,7 @@ import {AccelerationBands} from './AccelerationBands.demo';
 import {ATR} from './ATR.demo';
 import {BollingerBands} from './BollingerBands.demo';
 import {BollingerBandsWidth} from './BollingerBandsWidth.demo';
+import {CHOP} from './CHOP.demo';
 import {CVI} from './CVI.demo';
 import {DonchianChannels} from './DonchianChannels.demo';
 import {GAPO} from './GAPO.demo';
@@ -33,4 +34,5 @@ export const indicators: IndicatorConfig[] = [
   MassIndex,
   GAPO,
   CVI,
+  CHOP,
 ];

--- a/packages/trading-signals-docs/indicator-demos/volatility/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volatility/index.tsx
@@ -2,6 +2,7 @@ import {AccelerationBands} from './AccelerationBands.demo';
 import {ATR} from './ATR.demo';
 import {BollingerBands} from './BollingerBands.demo';
 import {BollingerBandsWidth} from './BollingerBandsWidth.demo';
+import {CVI} from './CVI.demo';
 import {DonchianChannels} from './DonchianChannels.demo';
 import {GAPO} from './GAPO.demo';
 import {IQR} from './IQR.demo';
@@ -31,4 +32,5 @@ export const indicators: IndicatorConfig[] = [
   ProjectionOscillator,
   MassIndex,
   GAPO,
+  CVI,
 ];

--- a/packages/trading-signals-docs/indicator-demos/volatility/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volatility/index.tsx
@@ -14,6 +14,7 @@ import {NATR} from './NATR.demo';
 import {PercentB} from './PercentB.demo';
 import {ProjectionOscillator} from './ProjectionOscillator.demo';
 import {TR} from './TR.demo';
+import {TTMSqueeze} from './TTMSqueeze.demo';
 import {UlcerIndex} from './UlcerIndex.demo';
 import type {IndicatorConfig} from '../../utils/types';
 
@@ -35,4 +36,5 @@ export const indicators: IndicatorConfig[] = [
   GAPO,
   CVI,
   CHOP,
+  TTMSqueeze,
 ];

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -115,6 +115,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Volume-Weighted Average Price (VWAP)
 1. Volume Weighted Moving Average (VWMA)
 1. Vortex Indicator (VI)
+1. Waddah Attar Explosion (WAE)
 1. WaveTrend (WT)
 1. Weighted Moving Average (WMA)
 1. Wilder's Smoothed Moving Average (WSMA / WWS / SMMA / MEMA)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -113,6 +113,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Volume-Weighted Average Price (VWAP)
 1. Volume Weighted Moving Average (VWMA)
 1. Vortex Indicator (VI)
+1. WaveTrend (WT)
 1. Weighted Moving Average (WMA)
 1. Wilder's Smoothed Moving Average (WSMA / WWS / SMMA / MEMA)
 1. Williams %R (WILLR)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -96,6 +96,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Spencer's 15-Point Moving Average (SMA15)
 1. Stochastic Oscillator (STOCH)
 1. Stochastic RSI (STOCHRSI)
+1. SuperSmoother Filter (SUPERSMOOTHER)
 1. SuperTrend (SUPERTREND)
 1. Tillson T3 Moving Average (T3)
 1. Tom Demark's Sequential Indicator (TDS)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -40,6 +40,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Center of Gravity (CG)
 1. Chaikin Money Flow (CMF)
 1. Chaikin Oscillator (ADOSC)
+1. Chaikin Volatility (CVI)
 1. Chande Forecast Oscillator (CFO)
 1. Chande Momentum Oscillator (CMO)
 1. Chandelier Exit (CE)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -70,6 +70,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Know Sure Thing (KST)
 1. Linear Regression (LINREG)
 1. Mass Index (MI)
+1. McGinley Dynamic (MD)
 1. Mean Absolute Deviation (MAD)
 1. Momentum (MOM / MTM)
 1. Money Flow Index (MFI)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -220,7 +220,6 @@ console.log(sma.highest?.toFixed(2)); // "53.33"
 
 ## Alternatives
 
-- [Jesse Trading Bot Indicators (Python)](https://docs.jesse.trade/docs/indicators/reference.html)
 - [LEAN Indicators (C#)](https://github.com/QuantConnect/Lean/tree/master/Indicators)
 - [libindicators (C#)](https://github.com/mgfx/libindicators)
 - [Pandas TA (Python)](https://github.com/twopirllc/pandas-ta)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -106,6 +106,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Triple Smoothed EMA Rate of Change (TRIX)
 1. True Range (TR)
 1. True Strength Index (TSI)
+1. TTM Squeeze (SQUEEZE)
 1. Ulcer Index (UI)
 1. Ultimate Oscillator (ULTOSC)
 1. Variable Index Dynamic Average (VIDYA)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -72,6 +72,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Mass Index (MI)
 1. McGinley Dynamic (MD)
 1. Mean Absolute Deviation (MAD)
+1. MESA Adaptive Moving Average (MAMA)
 1. Momentum (MOM / MTM)
 1. Money Flow Index (MFI)
 1. Moving Average Convergence Divergence (MACD)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -44,6 +44,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Chande Forecast Oscillator (CFO)
 1. Chande Momentum Oscillator (CMO)
 1. Chandelier Exit (CE)
+1. Choppiness Index (CHOP)
 1. Commodity Channel Index (CCI)
 1. Coppock Curve (COPPOCK)
 1. Detrended Price Oscillator (DPO)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -92,6 +92,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Relative Moving Average (RMA)
 1. Relative Strength Index (RSI)
 1. Relative Volume (RVOL)
+1. Schaff Trend Cycle (STC)
 1. Simple Moving Average (SMA)
 1. Spencer's 15-Point Moving Average (SMA15)
 1. Stochastic Oscillator (STOCH)

--- a/packages/trading-signals/src/momentum/STC/STC.test.ts
+++ b/packages/trading-signals/src/momentum/STC/STC.test.ts
@@ -1,0 +1,238 @@
+import {TradingSignal} from '../../base/index.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {STC} from './STC.js';
+
+describe('STC', () => {
+  /*
+   * Reference data note: Skender.Stock.Indicators v3.0.0 ships `stc.standard.json`, but it does
+   * not implement Doug Schaff's formula — their STC is a single stochastic pass over the MACD
+   * line whose %K is smoothed with a 3-bar SMA, instead of Schaff's cascade of two stochastic
+   * scalings that each carry half of every change. Feeding their `default.csv` quotes through
+   * this implementation confirms the structural difference: the 435 comparable bars diverge by
+   * up to 86.68 (mean 15.64), and long stretches of their series pin at exactly 0 where the
+   * cascade reads a neutral 50. No seeding tweak can reconcile the two, so the expectations
+   * below are hand-derived from Schaff's formula instead.
+   *
+   * Worksheet for a cycle interval of 3 with EMAs over 1 and 3 prices: the fast EMA echoes the
+   * price itself and the slow EMA carries exactly half of every change, so every stage below
+   * stays an exact binary fraction. MACD readings are collected once both EMAs are warm
+   * (t >= 3). %K locates the latest MACD in its 3-reading window (equal extremes read 50), %D
+   * carries half of every %K change, %KK locates %D in its own 3-reading window and the STC
+   * carries half of every %KK change.
+   *
+   * | t  | price | slow EMA | MACD | %K    | %D        | %KK | STC  |
+   * |----|-------|----------|------|-------|-----------|-----|------|
+   * | 1  | 10    | 10       |      |       |           |     |      |
+   * | 2  | 12    | 11       |      |       |           |     |      |
+   * | 3  | 15    | 13       | 2    |       |           |     |      |
+   * | 4  | 21    | 17       | 4    |       |           |     |      |
+   * | 5  | 23    | 20       | 3    | 50    | 50        |     |      |
+   * | 6  | 18    | 19       | -1   | 0     | 25        |     |      |
+   * | 7  | 35    | 27       | 8    | 100   | 62.5      | 100 | 100  |
+   * | 8  | 43    | 35       | 8    | 100   | 81.25     | 100 | 100  |
+   * | 9  | 35    | 35       | 0    | 0     | 40.625    | 0   | 50   |
+   * | 10 | 48    | 41.5     | 6.5  | 81.25 | 60.9375   | 50  | 50   |
+   * | 11 | 37.5  | 39.5     | -2   | 0     | 30.46875  | 0   | 25   |
+   * | 12 | 33.5  | 36.5     | -3   | 0     | 15.234375 | 0   | 12.5 |
+   */
+  const worksheetConfig = {cycleInterval: 3, fastInterval: 1, slowInterval: 3} as const;
+  const worksheetPrices = [10, 12, 15, 21, 23, 18, 35, 43, 35, 48, 37.5, 33.5] as const;
+
+  describe('constructor', () => {
+    it('rejects a cycle interval that cannot span a range', () => {
+      expect(() => new STC({cycleInterval: 1})).toThrowError(
+        'The cycle interval has to be at least 2, but "1" was given.'
+      );
+    });
+  });
+
+  describe('getResultOrThrow', () => {
+    it('runs the MACD line through two stochastic scalings with halfway smoothing', () => {
+      const expectations = [100, 100, 50, 50, 25, 12.5] as const;
+      const stc = new STC(worksheetConfig);
+      const offset = stc.getRequiredInputs() - 1;
+      let resultCount = 0;
+
+      worksheetPrices.forEach((price, i) => {
+        const result = stc.add(price);
+
+        if (result !== null) {
+          resultCount += 1;
+          expect(result).toBe(expectations[i - offset]);
+        }
+      });
+
+      expect(resultCount).toBe(expectations.length);
+      expect(stc.isStable).toBe(true);
+    });
+
+    it('reads a dead-flat market as neutral', () => {
+      const stc = new STC(worksheetConfig);
+
+      for (let i = 0; i < 7; i++) {
+        stc.add(100);
+      }
+
+      expect(stc.getResultOrThrow()).toBe(50);
+      expect(stc.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+    });
+
+    it('completes the declared warm-up exactly using its default intervals', () => {
+      /*
+       * A dead-flat warm-up parks the MACD at zero, so the first cycle reading is neutral; the
+       * rally that follows tops every window from then on, which lifts the first STC reading to
+       * exactly 100 once both scaling windows are filled.
+       */
+      const stc = new STC();
+      const requiredInputs = stc.getRequiredInputs();
+      const priceAt = (bar: number) => (bar < 60 ? 100 : 100 + (bar - 59) * 10);
+
+      for (let bar = 1; bar < requiredInputs; bar++) {
+        expect(stc.add(priceAt(bar)), `no result after ${bar} of ${requiredInputs} prices`).toBeNull();
+      }
+
+      expect(stc.add(priceAt(requiredInputs))).toBe(100);
+    });
+  });
+
+  describe('getRequiredInputs', () => {
+    it('spans the slower EMA warm-up plus both scaling windows', () => {
+      expect(new STC().getRequiredInputs()).toBe(68);
+      expect(new STC(worksheetConfig).getRequiredInputs()).toBe(7);
+    });
+  });
+
+  describe('replace', () => {
+    it('replaces the most recently added value across both smoothing stages', () => {
+      const stc = new STC(worksheetConfig);
+
+      for (const price of worksheetPrices.slice(0, 10)) {
+        stc.add(price);
+      }
+
+      /*
+       * Replacing the 11th price with 100: the slow EMA reads 0.5 × 100 + 0.5 × 41.5 = 70.75, so
+       * the MACD jumps to 29.25 — the top of its window (%K = 100). %D resumes from 60.9375 and
+       * reaches 80.46875, again the top of its window (%KK = 100), and the STC resumes from 50
+       * and reaches 75. Restoring the original price has to rewind both smoothing stages back to
+       * the worksheet values.
+       */
+      const originalValue = 37.5;
+      const replacedValue = 100;
+
+      const originalResult = stc.add(originalValue);
+
+      expect(originalResult).toBe(25);
+
+      const replacedResult = stc.replace(replacedValue);
+
+      expect(replacedResult).toBe(75);
+
+      const restoredResult = stc.replace(originalValue);
+
+      expect(restoredResult).toBe(25);
+    });
+  });
+
+  describe('getSignal', () => {
+    it('returns UNKNOWN while the indicator warms up', () => {
+      const stc = new STC(worksheetConfig);
+
+      for (const price of worksheetPrices.slice(0, 6)) {
+        stc.add(price);
+      }
+
+      const signal = stc.getSignal();
+
+      expect(signal.state).toBe(TradingSignal.UNKNOWN);
+      expect(signal.hasChanged).toBe(false);
+    });
+
+    it('returns BULLISH when the cycle is overbought', () => {
+      const stc = new STC(worksheetConfig);
+
+      for (const price of worksheetPrices.slice(0, 7)) {
+        stc.add(price);
+      }
+
+      expect(stc.getResultOrThrow()).toBe(100);
+
+      const signal = stc.getSignal();
+
+      expect(signal.state).toBe(TradingSignal.BULLISH);
+      expect(signal.hasChanged).toBe(true);
+    });
+
+    it('returns SIDEWAYS when the cycle rests mid-range', () => {
+      const stc = new STC(worksheetConfig);
+
+      for (const price of worksheetPrices.slice(0, 9)) {
+        stc.add(price);
+      }
+
+      expect(stc.getResultOrThrow()).toBe(50);
+
+      const signal = stc.getSignal();
+
+      expect(signal.state).toBe(TradingSignal.SIDEWAYS);
+      expect(signal.hasChanged).toBe(true);
+    });
+
+    it('returns BEARISH when the cycle is oversold', () => {
+      const stc = new STC(worksheetConfig);
+
+      for (const price of worksheetPrices.slice(0, 11)) {
+        stc.add(price);
+      }
+
+      // A reading exactly on the oversold threshold already counts as oversold
+      expect(stc.getResultOrThrow()).toBe(25);
+
+      const signal = stc.getSignal();
+
+      expect(signal.state).toBe(TradingSignal.BEARISH);
+      expect(signal.hasChanged).toBe(true);
+    });
+
+    it('keeps the signal state while the cycle stays put', () => {
+      const stc = new STC(worksheetConfig);
+
+      for (const price of worksheetPrices) {
+        stc.add(price);
+      }
+
+      expect(stc.getResultOrThrow()).toBe(12.5);
+
+      const signal = stc.getSignal();
+
+      expect(signal.state).toBe(TradingSignal.BEARISH);
+      expect(signal.hasChanged).toBe(false);
+    });
+
+    it('respects custom overbought and oversold thresholds', () => {
+      const stc = new STC({...worksheetConfig, signalThresholds: {overbought: 100, oversold: 10}});
+
+      for (const price of worksheetPrices.slice(0, 7)) {
+        stc.add(price);
+      }
+
+      // A reading exactly on the overbought threshold already counts as overbought
+      expect(stc.getResultOrThrow()).toBe(100);
+      expect(stc.getSignal().state).toBe(TradingSignal.BULLISH);
+
+      for (const price of worksheetPrices.slice(7, 11)) {
+        stc.add(price);
+      }
+
+      // The default thresholds would read 25 as oversold, but the widened band keeps it neutral
+      expect(stc.getResultOrThrow()).toBe(25);
+      expect(stc.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new STC({cycleInterval: 3, fastInterval: 1, slowInterval: 3}),
+  divergentInput: 1_000,
+  inputs: [10, 12, 15, 21, 23, 18, 35, 43, 35, 48, 37.5, 33.5],
+});

--- a/packages/trading-signals/src/momentum/STC/STC.ts
+++ b/packages/trading-signals/src/momentum/STC/STC.ts
@@ -1,0 +1,145 @@
+import {TradingSignal, TrendIndicatorSeries} from '../../base/Indicator.js';
+import type {SignalThresholds} from '../../base/SignalThresholds.type.js';
+import {EMA} from '../../trend/EMA/EMA.js';
+import {pushUpdate} from '../../util/pushUpdate.js';
+
+export type STCConfig = {
+  /** Number of readings in the window of both stochastic scalings (default: 10) */
+  cycleInterval?: number;
+  /** Number of candles for the fast EMA of the underlying MACD line (default: 23) */
+  fastInterval?: number;
+  signalThresholds?: SignalThresholds;
+  /** Number of candles for the slow EMA of the underlying MACD line (default: 50) */
+  slowInterval?: number;
+};
+
+/**
+ * Locates the latest reading within the range of its window on a 0-100 scale. A window whose
+ * readings are all equal offers no range to locate the latest reading in, so it reads neutral.
+ */
+function stochasticPosition(window: readonly number[]) {
+  const latest = window[window.length - 1];
+  const highest = Math.max(...window);
+  const lowest = Math.min(...window);
+
+  if (highest === lowest) {
+    return 50;
+  }
+
+  return (100 * (latest - lowest)) / (highest - lowest);
+}
+
+/**
+ * Schaff Trend Cycle (STC)
+ * Type: Momentum
+ *
+ * Developed by the currency trader Doug Schaff, the Schaff Trend Cycle treats the MACD line as
+ * a cycling series and runs it through two rounds of stochastic scaling: the MACD is located
+ * within its recent range on a 0-100 scale, that reading is smoothed by carrying half of every
+ * change, and the outcome is located and smoothed once more. The double pass completes its
+ * swings between 0 and 100 well before the MACD it is built on turns, which is why the STC is
+ * popular for timing entries in fast-moving markets such as FX.
+ *
+ * Interpretation:
+ * A value of 75 or above indicates an overbought market and 25 or below an oversold market
+ * (both thresholds can be customized via the constructor). A scaling window whose readings are
+ * all equal reads neutral (50), so a dead market never fabricates a directional reading.
+ *
+ * All smoothing stages seed with their first input (this library's convention). Note that
+ * Skender.Stock.Indicators ships a simplified STC (a single SMA-smoothed stochastic pass over
+ * the MACD), so its readings are not comparable.
+ *
+ * @see https://www.investopedia.com/articles/forex/10/schaff-trend-cycle-indicator.asp
+ */
+export class STC extends TrendIndicatorSeries {
+  readonly #fastEma: EMA;
+  readonly #slowEma: EMA;
+  readonly #dSmoothing: EMA;
+  readonly #stcSmoothing: EMA;
+  readonly #macdWindow: number[] = [];
+  readonly #dWindow: number[] = [];
+  readonly #overbought: number;
+  readonly #oversold: number;
+
+  public readonly cycleInterval: number;
+  public readonly fastInterval: number;
+  public readonly slowInterval: number;
+
+  constructor({
+    cycleInterval = 10,
+    fastInterval = 23,
+    signalThresholds: {overbought = 75, oversold = 25} = {},
+    slowInterval = 50,
+  }: STCConfig = {}) {
+    super();
+
+    // A window of a single reading offers no range to locate that reading in
+    if (cycleInterval < 2) {
+      throw new Error(`The cycle interval has to be at least 2, but "${cycleInterval}" was given.`);
+    }
+
+    this.cycleInterval = cycleInterval;
+    this.fastInterval = fastInterval;
+    this.slowInterval = slowInterval;
+    this.#fastEma = new EMA(fastInterval);
+    this.#slowEma = new EMA(slowInterval);
+    /*
+     * Schaff smooths both cycle stages by carrying half of every change into the running value.
+     * An EMA spanning three readings weighs incoming values at exactly one half, so it provides
+     * that smoothing along with the bookkeeping to replace the latest reading.
+     */
+    this.#dSmoothing = new EMA(3);
+    this.#stcSmoothing = new EMA(3);
+    this.#overbought = overbought;
+    this.#oversold = oversold;
+  }
+
+  override getRequiredInputs() {
+    // Both EMAs have to be warm before the first MACD reading, then each scaling window fills up
+    return Math.max(this.fastInterval, this.slowInterval) + 2 * (this.cycleInterval - 1);
+  }
+
+  update(price: number, replace: boolean) {
+    const fastEma = this.#fastEma.update(price, replace);
+    const slowEma = this.#slowEma.update(price, replace);
+
+    if (!this.#fastEma.isStable || !this.#slowEma.isStable) {
+      return null;
+    }
+
+    const macd = fastEma - slowEma;
+
+    pushUpdate({array: this.#macdWindow, item: macd, maxLength: this.cycleInterval, replace});
+
+    if (this.#macdWindow.length < this.cycleInterval) {
+      return null;
+    }
+
+    const stochD = this.#dSmoothing.update(stochasticPosition(this.#macdWindow), replace);
+
+    pushUpdate({array: this.#dWindow, item: stochD, maxLength: this.cycleInterval, replace});
+
+    if (this.#dWindow.length < this.cycleInterval) {
+      return null;
+    }
+
+    return this.setResult(this.#stcSmoothing.update(stochasticPosition(this.#dWindow), replace), replace);
+  }
+
+  protected calculateSignalState(result: number | null | undefined) {
+    const hasResult = result !== null && result !== undefined;
+    const isOversold = hasResult && result <= this.#oversold;
+    const isOverbought = hasResult && result >= this.#overbought;
+
+    switch (true) {
+      case !hasResult:
+        return TradingSignal.UNKNOWN;
+      case isOversold:
+        return TradingSignal.BEARISH;
+      case isOverbought:
+        return TradingSignal.BULLISH;
+      default:
+        return TradingSignal.SIDEWAYS;
+    }
+  }
+}

--- a/packages/trading-signals/src/momentum/WAE/WaddahAttarExplosion.test.ts
+++ b/packages/trading-signals/src/momentum/WAE/WaddahAttarExplosion.test.ts
@@ -1,0 +1,227 @@
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {WaddahAttarExplosion} from './WaddahAttarExplosion.js';
+import {TradingSignal} from '../../base/index.js';
+
+/*
+ * Formulation pinned to "Waddah Attar Explosion V2 [SHK]" by shayankm on TradingView
+ * (https://www.tradingview.com/script/d9IjcYyS-Waddah-Attar-Explosion-V2-SHK/), a port of LazyBear's
+ * WAE_LB with an ATR-based dead zone:
+ *
+ *   trend     = (macd - macd[1 bar ago]) * sensitivity, with macd = EMA(short, close) - EMA(long, close)
+ *   explosion = upper - lower Bollinger Band (SMA basis, population standard deviation)
+ *   deadZone  = RMA(TrueRange, atrInterval) * deadZoneMultiplier
+ *
+ * The worksheet below shrinks the SHK lookbacks so that every step stays an exact binary fraction:
+ * the EMA weights become 1/2 (interval 3) and 1/4 (interval 7), and every candle spans
+ * high = close + 2 / low = close - 2 while consecutive closes never move more than 2, which locks
+ * every True Range at 4, the ATR at 4 and the dead zone at 4 * 0.5 = 2.
+ *
+ * | Bar | Close | EMA(3) | EMA(7)                     | MACD     | Trend = ΔMACD * 10 | Explosion = BB(2, 2) width |
+ * | --- | ----- | ------ | -------------------------- | -------- | ------------------ | -------------------------- |
+ * | 1-7 | 100   | 100    | 100                        | 0        | -                  | 0                          |
+ * | 8   | 102   | 101    | 100.5 = 201/2              | 1/2      | 5                  | 4                          |
+ * | 9   | 101   | 101    | 100.625 = 805/8            | 3/8      | -5/4 = -1.25       | 2                          |
+ * | 10  | 99    | 100    | 100.21875 = 3207/32        | -7/32    | -95/16 = -5.9375   | 4                          |
+ * | 11  | 99    | 99.5   | 99.9140625 = 12789/128     | -53/128  | -125/64 = -1.953125| 0                          |
+ * | 12  | 99    | 99.25  | 99.685546875 = 51039/512   | -223/512 | -55/256 = -0.21484375 | 0                       |
+ *
+ * MACD and BB emit earlier than the full indicator, but the first complete reading needs the slow
+ * EMA plus one candle (8), so bar 8 is the first result. Bar 9 is the guard case: its explosion (2)
+ * lands exactly on the dead zone (2), and matching the noise floor is not enough — only exceeding it
+ * counts as an explosion.
+ */
+const worksheetConfig = {
+  atrInterval: 3,
+  bandsInterval: 2,
+  bandsMultiplier: 2,
+  deadZoneMultiplier: 0.5,
+  longInterval: 7,
+  sensitivity: 10,
+  shortInterval: 3,
+} as const;
+
+const worksheetCandles = [
+  {close: 100, high: 102, low: 98},
+  {close: 100, high: 102, low: 98},
+  {close: 100, high: 102, low: 98},
+  {close: 100, high: 102, low: 98},
+  {close: 100, high: 102, low: 98},
+  {close: 100, high: 102, low: 98},
+  {close: 100, high: 102, low: 98},
+  {close: 102, high: 104, low: 100},
+  {close: 101, high: 103, low: 99},
+  {close: 99, high: 101, low: 97},
+  {close: 99, high: 101, low: 97},
+  {close: 99, high: 101, low: 97},
+] as const;
+
+/*
+ * Two averages with the same lookback stay identical forever, so their spread and with it the trend
+ * is exactly zero on every bar — while the closes jump far enough for the volatility channel to open
+ * way above the noise floor.
+ */
+const flatTrendConfig = {
+  atrInterval: 2,
+  bandsInterval: 4,
+  bandsMultiplier: 2,
+  deadZoneMultiplier: 0.5,
+  longInterval: 2,
+  sensitivity: 10,
+  shortInterval: 2,
+} as const;
+
+function createWorksheetIndicator(bars: number) {
+  const wae = new WaddahAttarExplosion(worksheetConfig);
+
+  for (const candle of worksheetCandles.slice(0, bars)) {
+    wae.add(candle);
+  }
+
+  return wae;
+}
+
+describe('WaddahAttarExplosion', () => {
+  describe('update', () => {
+    it('matches the hand-derived worksheet of the pinned SHK formulation', () => {
+      const expectations = [
+        {deadZone: 2, explosion: 4, trend: 5},
+        {deadZone: 2, explosion: 2, trend: -1.25},
+        {deadZone: 2, explosion: 4, trend: -5.9375},
+        {deadZone: 2, explosion: 0, trend: -1.953125},
+        {deadZone: 2, explosion: 0, trend: -0.21484375},
+      ] as const;
+      const wae = new WaddahAttarExplosion(worksheetConfig);
+      const offset = wae.getRequiredInputs() - 1;
+      let verifiedBars = 0;
+
+      worksheetCandles.forEach((candle, i) => {
+        const result = wae.add(candle);
+
+        if (result) {
+          verifiedBars++;
+          expect(result).toEqual(expectations[i - offset]);
+        }
+      });
+
+      expect(verifiedBars).toBe(expectations.length);
+      expect(wae.isStable).toBe(true);
+    });
+
+    it('produces no result while the dead zone average is still warming up', () => {
+      const wae = new WaddahAttarExplosion();
+
+      for (let i = 1; i < 100; i++) {
+        const result = wae.add({close: 100 + (i % 5), high: 101 + (i % 5), low: 99 + (i % 5)});
+
+        expect(result).toBeNull();
+      }
+
+      expect(wae.isStable).toBe(false);
+      expect(wae.add({close: 100, high: 101, low: 99})).not.toBeNull();
+      expect(wae.isStable).toBe(true);
+    });
+  });
+
+  describe('getRequiredInputs', () => {
+    it('defaults to the 100-candle dead zone lookback of the pinned SHK formulation', () => {
+      expect(new WaddahAttarExplosion().getRequiredInputs()).toBe(100);
+    });
+
+    it('is driven by the slowest component', () => {
+      // The trend needs one candle more than its slow average (7 + 1)
+      expect(new WaddahAttarExplosion(worksheetConfig).getRequiredInputs()).toBe(8);
+      // The volatility channel (4) outlasts both the trend (2 + 1) and the dead zone (2)
+      expect(new WaddahAttarExplosion(flatTrendConfig).getRequiredInputs()).toBe(4);
+    });
+  });
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      /*
+       * Replacing the last worksheet candle with a close of 101 rewinds the trend base to bar 11
+       * (MACD -53/128): the fast EMA becomes (101 + 99.5) / 2 = 100.25, the slow EMA becomes
+       * 101/4 + 99.9140625 * 3/4 = 51295/512, so the MACD is 33/512 and the trend is
+       * (33/512 + 53/128) * 10 = 1225/256 = 4.78515625. The Bollinger window {99, 101} opens the
+       * explosion to 4, and the True Range stays locked at 4, keeping the dead zone at 2.
+       */
+      const wae = createWorksheetIndicator(11);
+      const originalCandle = {close: 99, high: 101, low: 97} as const;
+      const replacementCandle = {close: 101, high: 103, low: 99} as const;
+
+      const originalResult = wae.add(originalCandle);
+
+      expect(originalResult).toEqual({deadZone: 2, explosion: 0, trend: -0.21484375});
+
+      const replacedResult = wae.replace(replacementCandle);
+
+      expect(replacedResult).toEqual({deadZone: 2, explosion: 4, trend: 4.78515625});
+
+      const restoredResult = wae.replace(originalCandle);
+
+      expect(restoredResult).toEqual({deadZone: 2, explosion: 0, trend: -0.21484375});
+    });
+  });
+
+  describe('getSignal', () => {
+    it('returns UNKNOWN before the warm-up is complete', () => {
+      const wae = createWorksheetIndicator(7);
+
+      expect(wae.getSignal()).toEqual({hasChanged: false, state: TradingSignal.UNKNOWN});
+    });
+
+    it('returns BULLISH when the explosion exceeds the dead zone and the trend pushes up', () => {
+      const wae = createWorksheetIndicator(8);
+
+      expect(wae.getResultOrThrow()).toEqual({deadZone: 2, explosion: 4, trend: 5});
+      expect(wae.getSignal()).toEqual({hasChanged: true, state: TradingSignal.BULLISH});
+    });
+
+    it('returns BEARISH when the explosion exceeds the dead zone and the trend pushes down', () => {
+      const wae = createWorksheetIndicator(10);
+
+      expect(wae.getResultOrThrow()).toEqual({deadZone: 2, explosion: 4, trend: -5.9375});
+      expect(wae.getSignal()).toEqual({hasChanged: true, state: TradingSignal.BEARISH});
+    });
+
+    it('returns SIDEWAYS when the explosion only matches the dead zone instead of exceeding it', () => {
+      const wae = createWorksheetIndicator(9);
+
+      expect(wae.getResultOrThrow()).toEqual({deadZone: 2, explosion: 2, trend: -1.25});
+      expect(wae.getSignal()).toEqual({hasChanged: true, state: TradingSignal.SIDEWAYS});
+    });
+
+    it('keeps a flat trend sideways even when volatility explodes', () => {
+      const wae = new WaddahAttarExplosion(flatTrendConfig);
+
+      for (const close of [100, 200, 300, 400]) {
+        wae.add({close, high: close + 1, low: close - 1});
+      }
+
+      const result = wae.getResultOrThrow();
+
+      expect(result.trend).toBe(0);
+      expect(result.explosion).toBeGreaterThan(result.deadZone);
+      expect(wae.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+    });
+
+    it('flags a change only when the signal switches its state', () => {
+      const wae = createWorksheetIndicator(10);
+
+      expect(wae.getSignal()).toEqual({hasChanged: true, state: TradingSignal.BEARISH});
+
+      wae.add(worksheetCandles[10]);
+
+      expect(wae.getSignal()).toEqual({hasChanged: true, state: TradingSignal.SIDEWAYS});
+
+      wae.add(worksheetCandles[11]);
+
+      expect(wae.getSignal()).toEqual({hasChanged: false, state: TradingSignal.SIDEWAYS});
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new WaddahAttarExplosion(worksheetConfig),
+  divergentInput: {close: 1_000, high: 1_002, low: 998},
+  inputs: worksheetCandles,
+});

--- a/packages/trading-signals/src/momentum/WAE/WaddahAttarExplosion.ts
+++ b/packages/trading-signals/src/momentum/WAE/WaddahAttarExplosion.ts
@@ -1,0 +1,163 @@
+import type {HighLowClose} from '../../base/Candle.type.js';
+import {TechnicalIndicator, TradingSignal} from '../../base/Indicator.js';
+import {EMA} from '../../trend/EMA/EMA.js';
+import {ATR} from '../../volatility/ATR/ATR.js';
+import {BollingerBands} from '../../volatility/BBANDS/BollingerBands.js';
+import {MACD} from '../MACD/MACD.js';
+
+export type WaddahAttarExplosionResult = {
+  /** Noise floor: as long as the explosion stays at or below this level, the move counts as noise, not as tradable */
+  deadZone: number;
+  /** Energy of the current move, measured as the full width of the volatility channel */
+  explosion: number;
+  /** Signed thrust of the move: positive pushes up, negative pushes down */
+  trend: number;
+};
+
+export type WaddahAttarExplosionConfig = {
+  /** Lookback of the volatility average behind the dead zone. SHK default: 100 */
+  atrInterval?: number;
+  /** Lookback of the volatility channel behind the explosion. SHK default: 20 */
+  bandsInterval?: number;
+  /** Width factor of the volatility channel. SHK default: 2 */
+  bandsMultiplier?: number;
+  /** Scales the volatility average up to the noise floor. SHK default: 3.7 */
+  deadZoneMultiplier?: number;
+  /** Lookback of the slow average behind the trend thrust. SHK default: 40 */
+  longInterval?: number;
+  /** Scales the bar-over-bar thrust into a plottable magnitude. SHK default: 150 */
+  sensitivity?: number;
+  /** Lookback of the fast average behind the trend thrust. SHK default: 20 */
+  shortInterval?: number;
+};
+
+/**
+ * Waddah Attar Explosion (WAE)
+ * Type: Momentum
+ *
+ * Created by Waddah Attar for MetaTrader and popularized through LazyBear's TradingView port, the indicator answers
+ * one question: is there enough energy in the market to make a move worth trading, and in which direction? It combines
+ * three readings per candle: the trend (the bar-over-bar change of the MACD line, scaled by a sensitivity factor), the
+ * explosion (the width of the Bollinger Bands, i.e. how much volatility the move carries) and the dead zone (an
+ * ATR-based noise floor below which volatility is considered meaningless).
+ *
+ * This implementation pins the "Waddah Attar Explosion V2 [SHK]" formulation, whose ATR-based dead zone adapts to the
+ * instrument's price scale instead of relying on a fixed pip threshold: the trend is the one-bar change of a 20/40 EMA
+ * spread scaled by 150, the explosion is the width of Bollinger Bands over 20 candles with 2 standard deviations, and
+ * the dead zone is the Wilder-smoothed True Range over 100 candles multiplied by 3.7. One deviation from the Pine
+ * original: instead of zero-filling the dead zone while its volatility average is still warming up, no result is
+ * produced until every component is warmed up, so an unfinished noise floor never fabricates an "explosion".
+ *
+ * Interpretation: Trade only on explosion. When the explosion rises above the dead zone, the market offers enough
+ * energy for a move, and the sign of the trend names its direction (bullish above zero, bearish below). While the
+ * explosion stays at or below the dead zone, any trend reading counts as noise and the market is treated as sideways.
+ *
+ * @see https://www.tradingview.com/script/d9IjcYyS-Waddah-Attar-Explosion-V2-SHK/
+ * @see https://www.tradingview.com/script/iu3kKWDI-Waddah-Attar-Explosion-LazyBear/
+ */
+export class WaddahAttarExplosion extends TechnicalIndicator<WaddahAttarExplosionResult, HighLowClose<number>> {
+  public readonly deadZoneMultiplier: number;
+  public readonly sensitivity: number;
+
+  readonly #atr: ATR;
+  readonly #bands: BollingerBands;
+  readonly #macd: MACD;
+
+  #currentMacd?: number;
+  #previousMacd?: number;
+  #previousResult?: WaddahAttarExplosionResult;
+
+  constructor({
+    atrInterval = 100,
+    bandsInterval = 20,
+    bandsMultiplier = 2,
+    deadZoneMultiplier = 3.7,
+    longInterval = 40,
+    sensitivity = 150,
+    shortInterval = 20,
+  }: WaddahAttarExplosionConfig = {}) {
+    super();
+    this.deadZoneMultiplier = deadZoneMultiplier;
+    this.sensitivity = sensitivity;
+    this.#atr = new ATR(atrInterval);
+    this.#bands = new BollingerBands(bandsInterval, bandsMultiplier);
+    /*
+     * Waddah Attar reads only the spread between the fast and the slow average. The crossover line a
+     * classic MACD carries plays no role here, so it is kept at a one-bar length where it merely
+     * mirrors the spread.
+     */
+    this.#macd = new MACD(new EMA(shortInterval), new EMA(longInterval), new EMA(1));
+  }
+
+  override getRequiredInputs() {
+    return Math.max(this.#macd.getRequiredInputs() + 1, this.#bands.getRequiredInputs(), this.#atr.getRequiredInputs());
+  }
+
+  update(candle: HighLowClose<number>, replace: boolean) {
+    const macd = this.#macd.update(candle.close, replace);
+    const bands = this.#bands.update(candle.close, replace);
+    const atr = this.#atr.update(candle, replace);
+
+    /*
+     * The thrust compares the current average spread with the spread one bar earlier. A replacement
+     * discards the reading of the bar being replaced, so the comparison base has to be the spread
+     * from before that bar.
+     */
+    if (replace) {
+      this.#currentMacd = this.#previousMacd;
+    }
+
+    this.#previousMacd = this.#currentMacd;
+    this.#currentMacd = macd?.macd;
+
+    const previousMacd = this.#previousMacd;
+
+    if (macd === null || bands === null || atr === null || previousMacd === undefined) {
+      return null;
+    }
+
+    if (replace) {
+      this.result = this.#previousResult;
+    }
+
+    this.#previousResult = this.result;
+
+    return (this.result = {
+      deadZone: atr * this.deadZoneMultiplier,
+      explosion: bands.upper - bands.lower,
+      trend: (macd.macd - previousMacd) * this.sensitivity,
+    });
+  }
+
+  protected calculateSignal(result?: WaddahAttarExplosionResult | null | undefined) {
+    const hasResult = result !== null && result !== undefined;
+    const isExploding = hasResult && result.explosion > result.deadZone;
+    const isBullish = isExploding && result.trend > 0;
+    const isBearish = isExploding && result.trend < 0;
+
+    switch (true) {
+      case !hasResult:
+        return TradingSignal.UNKNOWN;
+      case isBullish:
+        return TradingSignal.BULLISH;
+      case isBearish:
+        return TradingSignal.BEARISH;
+      default:
+        return TradingSignal.SIDEWAYS;
+    }
+  }
+
+  getSignal(): {
+    state: (typeof TradingSignal)[keyof typeof TradingSignal];
+    hasChanged: boolean;
+  } {
+    const previousState = this.calculateSignal(this.#previousResult);
+    const state = this.calculateSignal(this.getResult());
+    const hasChanged = previousState !== state;
+
+    return {
+      hasChanged,
+      state,
+    };
+  }
+}

--- a/packages/trading-signals/src/momentum/WT/WaveTrend.test.ts
+++ b/packages/trading-signals/src/momentum/WT/WaveTrend.test.ts
@@ -1,0 +1,199 @@
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {WaveTrend} from './WaveTrend.js';
+import {TradingSignal} from '../../base/index.js';
+
+describe('WaveTrend', () => {
+  describe('update', () => {
+    it('normalizes the stretch of the average price from its channel and smooths it into wave and trigger lines', () => {
+      /*
+       * Formula (LazyBear, "WaveTrend Oscillator [WT]", TradingView, 2014):
+       * ap  = hlc3
+       * esa = ema(ap, channelInterval)
+       * d   = ema(|ap - esa|, channelInterval)
+       * ci  = (ap - esa) / (0.015 * d)
+       * wt1 = ema(ci, averageInterval)
+       * wt2 = sma(wt1, smoothingInterval)
+       * https://www.tradingview.com/script/2KE8wTuF-Indicator-WaveTrend-Oscillator-WT/
+       *
+       * The expectations below are derived by hand with every interval set to 2, so each EMA
+       * weights the incoming value with 2/3 and the previous reading with 1/3. On the first
+       * candle the channel sits exactly on the average price, so the deviation is zero and the
+       * flat-market guard pins ci to 0. Exact fractions:
+       *
+       * | Bar | High | Low | Close | ap | esa  | |ap-esa| | d     | ci     | wt1       | wt2      |
+       * |-----|------|-----|-------|----|------|----------|-------|--------|-----------|----------|
+       * | 1   | 12   | 8   | 10    | 10 | 10   | 0        | 0     | 0      | 0         | -        |
+       * | 2   | 15   | 11  | 13    | 13 | 12   | 1        | 2/3   | 100    | 200/3     | 100/3    |
+       * | 3   | 18   | 14  | 16    | 16 | 44/3 | 4/3      | 10/9  | 80     | 680/9     | 640/9    |
+       * | 4   | 9    | 5   | 7     | 7  | 86/9 | 23/9     | 56/27 | -575/7 | -5590/189 | 4345/189 |
+       */
+      const candles = [
+        {close: 10, high: 12, low: 8},
+        {close: 13, high: 15, low: 11},
+        {close: 16, high: 18, low: 14},
+        {close: 7, high: 9, low: 5},
+      ] as const;
+      const expectations = [
+        {wt1: '66.6667', wt2: '33.3333'},
+        {wt1: '75.5556', wt2: '71.1111'},
+        {wt1: '-29.5767', wt2: '22.9894'},
+      ] as const;
+      const wt = new WaveTrend({averageInterval: 2, channelInterval: 2, smoothingInterval: 2});
+      const offset = wt.getRequiredInputs() - 1;
+
+      candles.forEach((candle, i) => {
+        const result = wt.add(candle);
+
+        if (result) {
+          const expected = expectations[i - offset];
+          expect(result.wt1.toFixed(4)).toBe(expected.wt1);
+          expect(result.wt2.toFixed(4)).toBe(expected.wt2);
+        }
+      });
+
+      expect(wt.isStable).toBe(true);
+    });
+
+    it('reports zero on both lines when the market never leaves its channel', () => {
+      /*
+       * Identical candles keep the average price glued to its own channel, so there is no
+       * deviation to normalize by. Both lines must stay at zero instead of turning NaN.
+       */
+      const wt = new WaveTrend({averageInterval: 2, channelInterval: 2, smoothingInterval: 2});
+
+      wt.add({close: 8, high: 8, low: 8});
+      wt.add({close: 8, high: 8, low: 8});
+      wt.add({close: 8, high: 8, low: 8});
+
+      expect(wt.getResultOrThrow()).toEqual({wt1: 0, wt2: 0});
+      expect(wt.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+    });
+
+    it('withholds results until the fast wave line completes its warm-up', () => {
+      const wt = new WaveTrend({averageInterval: 3, channelInterval: 2, smoothingInterval: 2});
+
+      expect(wt.add({close: 10, high: 12, low: 8})).toBeNull();
+      expect(wt.add({close: 13, high: 15, low: 11})).toBeNull();
+      expect(wt.add({close: 16, high: 18, low: 14})).not.toBeNull();
+    });
+
+    it('withholds results until the price channel completes its warm-up', () => {
+      const wt = new WaveTrend({averageInterval: 2, channelInterval: 3, smoothingInterval: 2});
+
+      expect(wt.add({close: 10, high: 12, low: 8})).toBeNull();
+      expect(wt.add({close: 13, high: 15, low: 11})).toBeNull();
+      expect(wt.add({close: 16, high: 18, low: 14})).not.toBeNull();
+    });
+  });
+
+  describe('getRequiredInputs', () => {
+    it("is driven by the slowest smoothing stage and defaults to LazyBear's 10/21/4 setup", () => {
+      expect(new WaveTrend().getRequiredInputs()).toBe(21);
+      expect(new WaveTrend({averageInterval: 2, channelInterval: 2, smoothingInterval: 2}).getRequiredInputs()).toBe(2);
+      expect(new WaveTrend({averageInterval: 2, channelInterval: 2, smoothingInterval: 5}).getRequiredInputs()).toBe(5);
+    });
+  });
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      /*
+       * The first three candles match the hand-derived worksheet of the update test. Replacing
+       * its fourth candle (ap = 7) with a rally candle (ap = 20) yields, in exact fractions:
+       * esa = 164/9, |ap-esa| = 16/9, d = 14/9, ci = 1600/21, wt1 = 14360/189, wt2 = 14320/189.
+       * Restoring the original candle must reproduce the worksheet values exactly, which
+       * requires every smoothing stage to roll back to its reading from before the replacement.
+       */
+      const wt = new WaveTrend({averageInterval: 2, channelInterval: 2, smoothingInterval: 2});
+
+      wt.add({close: 10, high: 12, low: 8});
+      wt.add({close: 13, high: 15, low: 11});
+      wt.add({close: 16, high: 18, low: 14});
+
+      const originalCandle = {close: 7, high: 9, low: 5} as const;
+      const replacementCandle = {close: 20, high: 22, low: 18} as const;
+
+      const originalResult = wt.add(originalCandle);
+
+      expect(originalResult?.wt1.toFixed(4)).toBe('-29.5767');
+      expect(originalResult?.wt2.toFixed(4)).toBe('22.9894');
+
+      const replacedResult = wt.replace(replacementCandle);
+
+      expect(replacedResult?.wt1.toFixed(4)).toBe('75.9788');
+      expect(replacedResult?.wt2.toFixed(4)).toBe('75.7672');
+
+      const restoredResult = wt.replace(originalCandle);
+
+      expect(restoredResult?.wt1.toFixed(4)).toBe('-29.5767');
+      expect(restoredResult?.wt2.toFixed(4)).toBe('22.9894');
+    });
+  });
+
+  describe('getSignal', () => {
+    it('returns UNKNOWN before the warm-up is complete', () => {
+      const wt = new WaveTrend({averageInterval: 2, channelInterval: 2, smoothingInterval: 2});
+
+      expect(wt.getSignal()).toEqual({hasChanged: false, state: TradingSignal.UNKNOWN});
+
+      wt.add({close: 10, high: 12, low: 8});
+
+      expect(wt.getSignal()).toEqual({hasChanged: false, state: TradingSignal.UNKNOWN});
+    });
+
+    it('returns BULLISH when the fast wave line trades above its trigger line', () => {
+      const wt = new WaveTrend({averageInterval: 2, channelInterval: 2, smoothingInterval: 2});
+
+      wt.add({close: 10, high: 12, low: 8});
+      wt.add({close: 13, high: 15, low: 11});
+
+      expect(wt.getSignal().state).toBe(TradingSignal.BULLISH);
+    });
+
+    it('returns BEARISH when the fast wave line trades below its trigger line', () => {
+      const wt = new WaveTrend({averageInterval: 2, channelInterval: 2, smoothingInterval: 2});
+
+      wt.add({close: 16, high: 18, low: 14});
+      wt.add({close: 13, high: 15, low: 11});
+
+      expect(wt.getSignal().state).toBe(TradingSignal.BEARISH);
+    });
+
+    it('returns SIDEWAYS when both lines are equal', () => {
+      const wt = new WaveTrend({averageInterval: 2, channelInterval: 2, smoothingInterval: 2});
+
+      wt.add({close: 8, high: 8, low: 8});
+      wt.add({close: 8, high: 8, low: 8});
+
+      expect(wt.getResultOrThrow()).toEqual({wt1: 0, wt2: 0});
+      expect(wt.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+    });
+
+    it('flags a change only when the signal switches its state', () => {
+      const wt = new WaveTrend({averageInterval: 2, channelInterval: 2, smoothingInterval: 2});
+
+      wt.add({close: 8, high: 8, low: 8});
+      wt.add({close: 8, high: 8, low: 8});
+
+      expect(wt.getSignal()).toEqual({hasChanged: true, state: TradingSignal.SIDEWAYS});
+
+      wt.add({close: 14, high: 16, low: 12});
+
+      expect(wt.getSignal()).toEqual({hasChanged: true, state: TradingSignal.BULLISH});
+
+      wt.add({close: 20, high: 22, low: 18});
+
+      expect(wt.getSignal()).toEqual({hasChanged: false, state: TradingSignal.BULLISH});
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new WaveTrend({averageInterval: 2, channelInterval: 2, smoothingInterval: 2}),
+  divergentInput: {close: 1_000, high: 1_010, low: 990},
+  inputs: [
+    {close: 10, high: 12, low: 8},
+    {close: 13, high: 15, low: 11},
+    {close: 16, high: 18, low: 14},
+    {close: 7, high: 9, low: 5},
+  ],
+});

--- a/packages/trading-signals/src/momentum/WT/WaveTrend.ts
+++ b/packages/trading-signals/src/momentum/WT/WaveTrend.ts
@@ -1,0 +1,120 @@
+import {EMA} from '../../trend/EMA/EMA.js';
+import {SMA} from '../../trend/SMA/SMA.js';
+import type {HighLowClose} from '../../base/Candle.type.js';
+import {TechnicalIndicator, TradingSignal} from '../../base/Indicator.js';
+
+export type WaveTrendResult = {
+  /** Fast wave line (WT1) */
+  wt1: number;
+  /** Trigger line (WT2) trailing the fast wave line */
+  wt2: number;
+};
+
+export type WaveTrendConfig = {
+  /** Number of readings smoothing the normalized channel stretch into the fast wave line ("Average Length") */
+  averageInterval?: number;
+  /** Number of candles forming the smoothed price channel the average price is measured against ("Channel Length") */
+  channelInterval?: number;
+  /** Number of fast wave line readings averaged into the trigger line */
+  smoothingInterval?: number;
+};
+
+/**
+ * WaveTrend (WT)
+ * Type: Momentum
+ *
+ * The WaveTrend Oscillator was published by the TradingView author LazyBear in 2014 and has become a popular momentum
+ * gauge on crypto dashboards. It measures how far the average price (HLC3) has stretched away from an exponentially
+ * smoothed channel of itself, normalizes that stretch by the average absolute deviation (scaled by the CCI constant
+ * 0.015 so that regular trading lands roughly inside ±100), and smooths the readings into a fast wave line (WT1) and
+ * a trailing trigger line (WT2).
+ *
+ * Interpretation: WT1 trading above the trigger line signals bullish momentum, below it bearish momentum. Readings
+ * beyond ±53 mark the overbought/oversold bands and beyond ±60 extreme levels; a cross of the two lines inside those
+ * bands is the classic WaveTrend entry.
+ *
+ * @see https://www.tradingview.com/script/2KE8wTuF-Indicator-WaveTrend-Oscillator-WT/
+ * @see https://medium.com/@samuel.mcculloch/lets-take-a-look-at-wavetrend-with-crosses-lazybear-s-indicator-2ece1737f72f
+ */
+export class WaveTrend extends TechnicalIndicator<WaveTrendResult, HighLowClose<number>> {
+  public readonly averageInterval: number;
+  public readonly channelInterval: number;
+  public readonly smoothingInterval: number;
+  readonly #channel: EMA;
+  readonly #deviation: EMA;
+  readonly #wave: EMA;
+  readonly #trigger: SMA;
+  #previousResult?: WaveTrendResult;
+
+  constructor({averageInterval = 21, channelInterval = 10, smoothingInterval = 4}: WaveTrendConfig = {}) {
+    super();
+    this.averageInterval = averageInterval;
+    this.channelInterval = channelInterval;
+    this.smoothingInterval = smoothingInterval;
+    this.#channel = new EMA(channelInterval);
+    this.#deviation = new EMA(channelInterval);
+    this.#wave = new EMA(averageInterval);
+    this.#trigger = new SMA(smoothingInterval);
+  }
+
+  override getRequiredInputs() {
+    return Math.max(this.averageInterval, this.channelInterval, this.smoothingInterval);
+  }
+
+  update(candle: HighLowClose<number>, replace: boolean) {
+    const averagePrice = (candle.high + candle.low + candle.close) / 3;
+    const channel = this.#channel.update(averagePrice, replace);
+    const deviation = this.#deviation.update(Math.abs(averagePrice - channel), replace);
+
+    /*
+     * A market glued to its channel has no deviation to normalize by. Reporting zero stretch keeps
+     * a dead market neutral instead of fabricating momentum from a division by zero.
+     */
+    const channelIndex = deviation === 0 ? 0 : (averagePrice - channel) / (0.015 * deviation);
+    const wt1 = this.#wave.update(channelIndex, replace);
+    const wt2 = this.#trigger.update(wt1, replace);
+
+    if (wt2 === null || !this.#wave.isStable || !this.#channel.isStable) {
+      return null;
+    }
+
+    if (replace) {
+      this.result = this.#previousResult;
+    }
+
+    this.#previousResult = this.result;
+
+    return (this.result = {wt1, wt2});
+  }
+
+  protected calculateSignal(result?: WaveTrendResult | null | undefined) {
+    const hasResult = result !== null && result !== undefined;
+    const isBullish = hasResult && result.wt1 > result.wt2;
+    const isBearish = hasResult && result.wt1 < result.wt2;
+
+    switch (true) {
+      case !hasResult:
+        return TradingSignal.UNKNOWN;
+      case isBullish:
+        return TradingSignal.BULLISH;
+      case isBearish:
+        return TradingSignal.BEARISH;
+      default:
+        return TradingSignal.SIDEWAYS;
+    }
+  }
+
+  getSignal(): {
+    state: (typeof TradingSignal)[keyof typeof TradingSignal];
+    hasChanged: boolean;
+  } {
+    const previousState = this.calculateSignal(this.#previousResult);
+    const state = this.calculateSignal(this.getResult());
+    const hasChanged = previousState !== state;
+
+    return {
+      hasChanged,
+      state,
+    };
+  }
+}

--- a/packages/trading-signals/src/momentum/index.ts
+++ b/packages/trading-signals/src/momentum/index.ts
@@ -24,6 +24,7 @@ export * from './QSTICK/Qstick.js';
 export * from './REI/REI.js';
 export * from './ROC/ROC.js';
 export * from './RSI/RSI.js';
+export * from './STC/STC.js';
 export * from './STOCH/StochasticOscillator.js';
 export * from './STOCHRSI/StochasticRSI.js';
 export * from './TDS/TDS.js';

--- a/packages/trading-signals/src/momentum/index.ts
+++ b/packages/trading-signals/src/momentum/index.ts
@@ -31,3 +31,4 @@ export * from './TRIX/TRIX.js';
 export * from './TSI/TSI.js';
 export * from './ULTOSC/UltimateOscillator.js';
 export * from './WILLR/WilliamsR.js';
+export * from './WT/WaveTrend.js';

--- a/packages/trading-signals/src/momentum/index.ts
+++ b/packages/trading-signals/src/momentum/index.ts
@@ -31,5 +31,6 @@ export * from './TDS/TDS.js';
 export * from './TRIX/TRIX.js';
 export * from './TSI/TSI.js';
 export * from './ULTOSC/UltimateOscillator.js';
+export * from './WAE/WaddahAttarExplosion.js';
 export * from './WILLR/WilliamsR.js';
 export * from './WT/WaveTrend.js';

--- a/packages/trading-signals/src/trend/MA/MovingAverageTypes.ts
+++ b/packages/trading-signals/src/trend/MA/MovingAverageTypes.ts
@@ -5,6 +5,7 @@ import type {HMA} from '../HMA/HMA.js';
 import type {McGinleyDynamic} from '../MD/McGinleyDynamic.js';
 import type {RMA} from '../RMA/RMA.js';
 import type {SMA} from '../SMA/SMA.js';
+import type {SuperSmoother} from '../SUPERSMOOTHER/SuperSmoother.js';
 import type {T3} from '../T3/T3.js';
 import type {TRIMA} from '../TRIMA/TRIMA.js';
 import type {VIDYA} from '../VIDYA/VIDYA.js';
@@ -20,6 +21,7 @@ export type MovingAverageTypes =
   | typeof McGinleyDynamic
   | typeof RMA
   | typeof SMA
+  | typeof SuperSmoother
   | typeof T3
   | typeof TRIMA
   | typeof VIDYA

--- a/packages/trading-signals/src/trend/MA/MovingAverageTypes.ts
+++ b/packages/trading-signals/src/trend/MA/MovingAverageTypes.ts
@@ -2,6 +2,7 @@ import type {ALMA} from '../ALMA/ALMA.js';
 import type {EMA} from '../EMA/EMA.js';
 import type {FRAMA} from '../FRAMA/FRAMA.js';
 import type {HMA} from '../HMA/HMA.js';
+import type {McGinleyDynamic} from '../MD/McGinleyDynamic.js';
 import type {RMA} from '../RMA/RMA.js';
 import type {SMA} from '../SMA/SMA.js';
 import type {T3} from '../T3/T3.js';
@@ -16,6 +17,7 @@ export type MovingAverageTypes =
   | typeof EMA
   | typeof FRAMA
   | typeof HMA
+  | typeof McGinleyDynamic
   | typeof RMA
   | typeof SMA
   | typeof T3

--- a/packages/trading-signals/src/trend/MAMA/MAMA.test.ts
+++ b/packages/trading-signals/src/trend/MAMA/MAMA.test.ts
@@ -1,0 +1,354 @@
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {MAMA, type MAMAResult} from './MAMA.js';
+import {TradingSignal} from '../../base/index.js';
+
+/*
+ * Median prices ((high + low) / 2) of the official 252-bar daily series that TA-Lib ships with its
+ * regression suite. TA-Lib's own MAMA regression run transforms the candles into exactly this
+ * median price series before feeding them ("it is an AVGPRICE in John Ehlers book").
+ *
+ * Data: https://github.com/TA-Lib/ta-lib/blob/main/src/tools/ta_regtest/test_data.c
+ * Setup: https://github.com/TA-Lib/ta-lib/blob/main/src/tools/ta_regtest/ta_test_func/test_ma.c
+ */
+const TALIB_MEDIAN_PRICES = [
+  92, 93.1725, 95.3125, 94.845, 94.4075, 94.11, 93.5, 91.735, 90.955, 91.6875, 94.5, 97.97, 97.5775, 90.7825, 89.0325,
+  92.095, 91.155, 89.7175, 90.61, 91, 88.9225, 87.515, 86.4375, 83.89, 83.0025, 82.8125, 82.845, 86.735, 86.86, 87.5475,
+  85.78, 86.1725, 86.4375, 87.25, 88.9375, 88.205, 85.8125, 84.595, 83.6575, 84.455, 83.5, 86.7825, 88.1725, 89.265,
+  90.86, 90.7825, 91.86, 90.36, 89.86, 90.9225, 89.5, 87.6725, 86.5, 84.2825, 82.9075, 84.25, 85.6875, 86.61, 88.2825,
+  89.5325, 89.5, 88.095, 90.625, 92.235, 91.6725, 92.5925, 93.015, 91.1725, 90.985, 90.3775, 88.25, 86.9075, 84.0925,
+  83.1875, 84.2525, 97.86, 99.875, 103.265, 105.9375, 103.5, 103.11, 103.61, 104.64, 106.815, 104.9525, 105.5, 107.14,
+  109.735, 109.845, 110.985, 120, 119.875, 117.9075, 119.4075, 117.9525, 117.22, 115.6425, 113.11, 111.75, 114.5175,
+  114.745, 115.47, 112.53, 112.03, 113.435, 114.22, 119.595, 117.965, 118.715, 115.03, 114.53, 115, 116.53, 120.185,
+  120.5, 120.595, 124.185, 125.375, 122.97, 123, 124.435, 123.44, 124.03, 128.185, 129.655, 130.875, 132.345, 132.065,
+  133.815, 135.66, 137.035, 137.47, 137.345, 136.315, 136.44, 136.285, 129.095, 128.31, 126, 124.03, 123.935, 125.03,
+  127.25, 125.62, 125.53, 123.905, 120.655, 119.965, 120.78, 124, 122.78, 120.72, 121.78, 122.405, 123.25, 126.185,
+  127.56, 126.565, 123.06, 122.715, 123.59, 122.31, 122.465, 123.965, 123.97, 124.155, 124.435, 127, 125.5, 128.875,
+  130.535, 132.315, 134.065, 136.035, 133.78, 132.75, 133.47, 130.97, 127.595, 128.44, 127.94, 125.81, 124.625, 122.72,
+  124.09, 123.22, 121.405, 120.935, 118.28, 118.375, 121.155, 120.905, 117.125, 113.06, 114.905, 112.435, 107.935,
+  105.97, 106.37, 106.845, 106.97, 110.03, 91, 93.56, 93.62, 95.31, 94.185, 94.78, 97.625, 97.59, 95.25, 94.72, 92.22,
+  91.565, 92.22, 93.81, 95.59, 96.185, 94.625, 95.12, 94, 93.745, 95.905, 101.745, 106.44, 107.935, 103.405, 105.06,
+  104.155, 103.31, 103.345, 104.84, 110.405, 114.5, 117.315, 118.25, 117.185, 109.75, 109.655, 108.53, 106.22, 107.72,
+  109.84, 109.095, 109.09, 109.155, 109.315, 109.06, 109.905, 109.625, 109.53, 108.06,
+] as const;
+
+describe('MAMA', () => {
+  describe('update', () => {
+    it('reproduces the published TA-Lib regression values over its official test data', () => {
+      /*
+       * TA-Lib publishes the expected first and last values of a MAMA(0.5, 0.05) run over its
+       * 252-bar regression data, along with the output placement (first value on bar 33,
+       * 220 values in total):
+       *
+       * MAMA first: 85.3643, MAMA last: 110.1116
+       * FAMA first: 81.88, FAMA last: 108.82
+       *
+       * https://github.com/TA-Lib/ta-lib/blob/main/src/tools/ta_regtest/ta_test_func/test_ma.c
+       * (lines 145-151)
+       */
+      const mama = new MAMA();
+      const results = [];
+
+      for (const price of TALIB_MEDIAN_PRICES) {
+        const result = mama.add(price);
+
+        if (result) {
+          results.push(result);
+        }
+      }
+
+      expect(results.length).toBe(220);
+
+      const first = results[0];
+      const last = results[results.length - 1];
+
+      expect(first.mama.toFixed(4)).toBe('85.3643');
+      expect(first.fama.toFixed(2)).toBe('81.88');
+      expect(last.mama.toFixed(4)).toBe('110.1116');
+      expect(last.fama.toFixed(2)).toBe('108.82');
+    });
+
+    it('matches a line-by-line port of the TA-Lib reference implementation bar for bar', () => {
+      /*
+       * TA-Lib publishes only the first and last value of its MAMA regression run, so no full
+       * reference sequence exists to copy. The expectations below come from a line-by-line
+       * JavaScript port of TA-Lib's `ta_MAMA.c` — a port that reproduces all four published
+       * regression values over the full 252-bar series (see the test above) — executed over the
+       * first 60 median prices. The port keeps TA-Lib's even/odd circular Hilbert buffers while
+       * this implementation uses the direct lag windows of Ehlers' original article (John Ehlers,
+       * "MESA Adaptive Moving Averages", Technical Analysis of Stocks & Commodities, September
+       * 2001): two independently structured implementations agreeing bar for bar is the
+       * verification.
+       */
+      const prices = TALIB_MEDIAN_PRICES.slice(0, 60);
+      const expectations = [
+        {fama: '81.88465805', mama: '85.36425577'},
+        {fama: '81.97400517', mama: '85.45854298'},
+        {fama: '82.06546731', mama: '85.63249083'},
+        {fama: '82.15785854', mama: '85.76111629'},
+        {fama: '82.24800421', mama: '85.76368548'},
+        {fama: '82.98083884', mama: '85.17934274'},
+        {fama: '83.03389914', mama: '85.10325060'},
+        {fama: '83.08482261', mama: '85.07083807'},
+        {fama: '83.13250945', mama: '84.99229617'},
+        {fama: '83.82123161', mama: '85.88739808'},
+        {fama: '83.87574215', mama: '86.00165318'},
+        {fama: '83.93296911', mama: '86.16482052'},
+        {fama: '83.99463437', mama: '86.39957949'},
+        {fama: '84.06023665', mama: '86.61872552'},
+        {fama: '85.35501817', mama: '89.23936276'},
+        {fama: '85.45352759', mama: '89.29539462'},
+        {fama: '85.55028002', mama: '89.32362489'},
+        {fama: '85.64661223', mama: '89.40356865'},
+        {fama: '85.74065668', mama: '89.40839021'},
+        {fama: '85.83018016', mama: '89.32159570'},
+        {fama: '85.91393855', mama: '89.18051592'},
+        {fama: '86.11833090', mama: '86.73150796'},
+        {fama: '86.12888032', mama: '86.54030756'},
+        {fama: '85.94544869', mama: '85.39515378'},
+        {fama: '85.93205675', mama: '85.40977109'},
+        {fama: '85.92049989', mama: '85.46978254'},
+        {fama: '85.91274785', mama: '85.61041841'},
+        {fama: '85.91009222', mama: '85.80652249'},
+      ] as const;
+      const mama = new MAMA();
+      const offset = mama.getRequiredInputs() - 1;
+      let verifiedBars = 0;
+
+      prices.forEach((price, i) => {
+        const result = mama.add(price);
+
+        if (result) {
+          verifiedBars++;
+          const expected = expectations[i - offset];
+          expect(result.mama.toFixed(8)).toBe(expected.mama);
+          expect(result.fama.toFixed(8)).toBe(expected.fama);
+        }
+      });
+
+      expect(verifiedBars).toBe(expectations.length);
+    });
+
+    it('moves faster and stalls slower within custom smoothing limits', () => {
+      /*
+       * Expectations derived from the same TA-Lib port with fastLimit 0.9 and slowLimit 0.02,
+       * proving the limits are wired into the adaptive smoothing instead of the defaults.
+       */
+      const mama = new MAMA({fastLimit: 0.9, slowLimit: 0.02});
+      const results = [];
+
+      for (const price of TALIB_MEDIAN_PRICES.slice(0, 60)) {
+        const result = mama.add(price);
+
+        if (result) {
+          results.push(result);
+        }
+      }
+
+      const first = results[0];
+      const last = results[results.length - 1];
+
+      expect(first.mama.toFixed(8)).toBe('86.16493452');
+      expect(first.fama.toFixed(8)).toBe('84.88020055');
+      expect(last.mama.toFixed(8)).toBe('84.77229582');
+      expect(last.fama.toFixed(8)).toBe('85.61075332');
+    });
+
+    it('follows a slow swing whose cycle is longer than the measurable 50-bar band', () => {
+      /*
+       * A 60-bar sine cycle drives the raw period reading beyond the 50-bar cap of the homodyne
+       * discriminator. Expectations derived from the TA-Lib port (see above).
+       */
+      const prices = Array.from({length: 60}, (_, i) => 100 + 30 * Math.sin((2 * Math.PI * i) / 60));
+      const mama = new MAMA();
+      const results = [];
+
+      for (const price of prices) {
+        const result = mama.add(price);
+
+        if (result) {
+          results.push(result);
+        }
+      }
+
+      expect(results.length).toBe(28);
+
+      const last = results[results.length - 1];
+
+      expect(last.mama.toFixed(8)).toBe('81.12254429');
+      expect(last.fama.toFixed(8)).toBe('80.37168933');
+    });
+
+    it('pins both averages inside the corridor their smoothing limits allow', () => {
+      /*
+       * The adaptive smoothing factor always stays within (0, 1], so each new MAMA value is a
+       * weighted middle between its previous value and the latest price — it may never overshoot
+       * either side. FAMA moves at half that speed towards MAMA, so it is pinned between its
+       * previous value and the current MAMA the same way.
+       */
+      const mama = new MAMA();
+      let previous: MAMAResult | null = null;
+
+      for (const price of TALIB_MEDIAN_PRICES) {
+        const result = mama.add(price);
+
+        if (result && previous) {
+          expect(result.mama).toBeGreaterThanOrEqual(Math.min(previous.mama, price));
+          expect(result.mama).toBeLessThanOrEqual(Math.max(previous.mama, price));
+          expect(result.fama).toBeGreaterThanOrEqual(Math.min(previous.fama, result.mama));
+          expect(result.fama).toBeLessThanOrEqual(Math.max(previous.fama, result.mama));
+        }
+
+        previous = result;
+      }
+
+      expect(mama.isStable).toBe(true);
+    });
+
+    it('lets the following average trail the adaptive average through a sustained rise', () => {
+      const prices = Array.from({length: 40}, (_, i) => 10 + i);
+      const mama = new MAMA();
+      let verifiedBars = 0;
+
+      for (const price of prices) {
+        const result = mama.add(price);
+
+        if (result) {
+          verifiedBars++;
+          expect(result.fama).toBeLessThan(result.mama);
+        }
+      }
+
+      expect(verifiedBars).toBe(8);
+    });
+
+    it('converges both averages to the price of a flat series', () => {
+      const mama = new MAMA();
+      let result: MAMAResult | null = null;
+
+      for (let i = 0; i < 100; i++) {
+        result = mama.add(250);
+      }
+
+      expect(result?.mama).toBeCloseTo(250, 7);
+      expect(result?.fama).toBeCloseTo(250, 7);
+    });
+  });
+
+  describe('getRequiredInputs', () => {
+    it('needs 33 bars, matching the TA-Lib lookback of 32 plus the emitting bar', () => {
+      expect(new MAMA().getRequiredInputs()).toBe(33);
+    });
+  });
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const mama = new MAMA();
+
+      for (const price of TALIB_MEDIAN_PRICES.slice(0, 33)) {
+        mama.add(price);
+      }
+
+      const originalPrice = TALIB_MEDIAN_PRICES[33];
+      const originalResult = mama.add(originalPrice);
+
+      expect(originalResult?.mama.toFixed(8)).toBe('85.45854298');
+      expect(originalResult?.fama.toFixed(8)).toBe('81.97400517');
+
+      const replacedResult = mama.replace(1_000);
+
+      expect(replacedResult?.mama.toFixed(8)).toBe('542.68212788');
+      expect(replacedResult?.fama.toFixed(8)).toBe('197.08402551');
+
+      const restoredResult = mama.replace(originalPrice);
+
+      expect(restoredResult).toStrictEqual(originalResult);
+    });
+  });
+
+  describe('getSignal', () => {
+    it('returns UNKNOWN before the warm-up is complete', () => {
+      const mama = new MAMA();
+
+      expect(mama.getSignal()).toEqual({hasChanged: false, state: TradingSignal.UNKNOWN});
+
+      for (const price of TALIB_MEDIAN_PRICES.slice(0, 32)) {
+        mama.add(price);
+      }
+
+      expect(mama.getSignal()).toEqual({hasChanged: false, state: TradingSignal.UNKNOWN});
+    });
+
+    it('returns BULLISH when the adaptive average trades above its following average', () => {
+      const mama = new MAMA();
+
+      for (let i = 0; i < 40; i++) {
+        mama.add(10 + i);
+      }
+
+      expect(mama.getSignal().state).toBe(TradingSignal.BULLISH);
+    });
+
+    it('returns BEARISH when the adaptive average trades below its following average', () => {
+      const mama = new MAMA();
+
+      for (let i = 0; i < 40; i++) {
+        mama.add(10 + i);
+      }
+
+      for (const price of [46, 43, 40, 37, 34] as const) {
+        mama.add(price);
+      }
+
+      expect(mama.getSignal().state).toBe(TradingSignal.BEARISH);
+    });
+
+    it('returns SIDEWAYS when both averages coincide', () => {
+      /*
+       * A series pinned at zero keeps both recursive averages exactly at their zero seed, so
+       * neither line ever gains an edge over the other.
+       */
+      const mama = new MAMA();
+
+      for (let i = 0; i < 33; i++) {
+        mama.add(0);
+      }
+
+      expect(mama.getResultOrThrow()).toEqual({fama: 0, mama: 0});
+      expect(mama.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+    });
+
+    it('flags a change only when the signal switches its state', () => {
+      const mama = new MAMA();
+
+      for (let i = 0; i < 33; i++) {
+        mama.add(10 + i);
+      }
+
+      expect(mama.getSignal()).toEqual({hasChanged: true, state: TradingSignal.BULLISH});
+
+      mama.add(43);
+
+      expect(mama.getSignal()).toEqual({hasChanged: false, state: TradingSignal.BULLISH});
+
+      for (let i = 34; i < 40; i++) {
+        mama.add(10 + i);
+      }
+
+      for (const price of [46, 43, 40, 37] as const) {
+        mama.add(price);
+      }
+
+      expect(mama.getSignal()).toEqual({hasChanged: false, state: TradingSignal.BULLISH});
+
+      mama.add(34);
+
+      expect(mama.getSignal()).toEqual({hasChanged: true, state: TradingSignal.BEARISH});
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new MAMA(),
+  divergentInput: 1_000,
+  inputs: TALIB_MEDIAN_PRICES.slice(0, 40),
+});

--- a/packages/trading-signals/src/trend/MAMA/MAMA.ts
+++ b/packages/trading-signals/src/trend/MAMA/MAMA.ts
@@ -1,0 +1,256 @@
+import {TechnicalIndicator, TradingSignal} from '../../base/Indicator.js';
+
+export type MAMAConfig = {
+  /** Upper bound of the adaptive smoothing factor, in effect while price is trending (default: 0.5) */
+  fastLimit?: number;
+  /** Lower bound of the adaptive smoothing factor, in effect while price is cycling sideways (default: 0.05) */
+  slowLimit?: number;
+};
+
+export type MAMAResult = {
+  /** Following Adaptive Moving Average: trails the MAMA line at half its speed and acts as its signal line */
+  fama: number;
+  /** MESA Adaptive Moving Average: hugs price during trends and flattens out in congestion */
+  mama: number;
+};
+
+type MAMAState = {
+  barsTotal: number;
+  detrenders: number[];
+  fama: number;
+  i2: number;
+  im: number;
+  mama: number;
+  period: number;
+  phase: number;
+  prices: number[];
+  q2: number;
+  quadratures: number[];
+  re: number;
+  smoothed: number[];
+};
+
+/*
+ * Transfer response coefficients of Ehlers' Hilbert transform approximation. Together with the
+ * per-bar amplitude adjustment they keep the quadrature component's amplitude flat across the
+ * cycle periods the transform is tuned for (Ehlers, TASC September 2001).
+ */
+const HILBERT_A = 0.0962;
+const HILBERT_B = 0.5769;
+
+const RAD_TO_DEG = 180 / Math.PI;
+
+const lag = (history: readonly number[], bars: number) => history.at(-1 - bars) ?? 0;
+
+const pushCapped = (history: number[], value: number, maxLength: number) => {
+  history.push(value);
+
+  if (history.length > maxLength) {
+    history.shift();
+  }
+};
+
+/*
+ * Ehlers' one-sided Hilbert transform: a 4-tap filter over every other bar that shifts the series
+ * by 90 degrees. A series that has gone flat must cancel to an exact zero here — rounding dust
+ * would masquerade as a phase reading — so the summation pairs the taps exactly like the TA-Lib
+ * reference does.
+ */
+const hilbertTransform = (history: readonly number[], adjustment: number, delay: number = 0) => {
+  const transformed =
+    HILBERT_A * lag(history, delay) -
+    HILBERT_A * lag(history, delay + 6) -
+    HILBERT_B * lag(history, delay + 4) +
+    HILBERT_B * lag(history, delay + 2);
+
+  return transformed * adjustment;
+};
+
+/**
+ * MESA Adaptive Moving Average (MAMA)
+ * Type: Trend
+ *
+ * John Ehlers' MAMA ("MESA Adaptive Moving Averages", Technical Analysis of Stocks & Commodities,
+ * September 2001) is an exponential average whose smoothing factor adapts to the market's dominant
+ * cycle, measured in-line by a Hilbert transform with a homodyne discriminator. The average speeds
+ * up as the phase advances quickly (trending price) and slows to a crawl when the phase stalls
+ * (congestion), so it hugs trends with minimal lag yet barely wiggles through sideways chop.
+ * The companion FAMA (Following Adaptive Moving Average) applies half of MAMA's smoothing to the
+ * MAMA line itself, forming a slower signal line of the same adaptive nature.
+ *
+ * Interpretation: MAMA trading above FAMA signals bullish pressure, MAMA below FAMA bearish
+ * pressure. Because both lines freeze together in congestion, their crossovers happen close to
+ * price turns instead of several bars late as with fixed-length average pairs.
+ *
+ * @see https://www.mesasoftware.com/papers/MAMA.pdf
+ * @see https://github.com/TA-Lib/ta-lib/blob/main/src/ta_func/ta_MAMA.c
+ */
+export class MAMA extends TechnicalIndicator<MAMAResult, number, MAMAState> {
+  public readonly fastLimit: number;
+  public readonly slowLimit: number;
+  #previousResult?: MAMAResult;
+
+  protected override state: MAMAState = {
+    barsTotal: 0,
+    detrenders: [],
+    fama: 0,
+    i2: 0,
+    im: 0,
+    mama: 0,
+    period: 0,
+    phase: 0,
+    prices: [],
+    q2: 0,
+    quadratures: [],
+    re: 0,
+    smoothed: [],
+  };
+
+  constructor({fastLimit = 0.5, slowLimit = 0.05}: MAMAConfig = {}) {
+    super();
+    this.fastLimit = fastLimit;
+    this.slowLimit = slowLimit;
+  }
+
+  /**
+   * Mirrors the TA-Lib lookback of 32 bars: 12 bars reserved for the price smoother (kept for
+   * compatibility with the TradeStation implementation in Ehlers' book), 6 for the detrender,
+   * 6 for the quadrature component, 3 for advancing each component's phase, 1 for the homodyne
+   * discriminator and 1 for the phase delta. The recursive averages inside keep settling after
+   * the first emission, exactly as TA-Lib emits them with its default unstable period of zero.
+   */
+  override getRequiredInputs() {
+    return 33;
+  }
+
+  update(price: number, replace: boolean) {
+    this.trackState(replace);
+
+    const state = this.state;
+    state.barsTotal++;
+
+    pushCapped(state.prices, price, 4);
+
+    // The cycle measurement engages only once the price smoother's warm-up bars have passed
+    if (state.barsTotal <= 12) {
+      return null;
+    }
+
+    const adjustment = 0.075 * state.period + 0.54;
+
+    const smoothed =
+      (4 * lag(state.prices, 0) + 3 * lag(state.prices, 1) + 2 * lag(state.prices, 2) + lag(state.prices, 3)) / 10;
+    pushCapped(state.smoothed, smoothed, 7);
+
+    // Detrending exposes the cycle component by removing the trend the smoothed price rides on
+    const detrender = hilbertTransform(state.smoothed, adjustment);
+    pushCapped(state.detrenders, detrender, 10);
+
+    // The transform leads by 90 degrees, so it yields the quadrature; delaying the detrender yields the in-phase part
+    const q1 = hilbertTransform(state.detrenders, adjustment);
+    const i1 = lag(state.detrenders, 3);
+
+    // Advancing both components by 90 degrees allows averaging the phasor over adjacent bars
+    const jI = hilbertTransform(state.detrenders, adjustment, 3);
+    pushCapped(state.quadratures, q1, 7);
+    const jQ = hilbertTransform(state.quadratures, adjustment);
+
+    const previousI2 = state.i2;
+    const previousQ2 = state.q2;
+    state.i2 = 0.2 * (i1 - jQ) + 0.8 * previousI2;
+    state.q2 = 0.2 * (q1 + jI) + 0.8 * previousQ2;
+
+    /*
+     * Homodyne discriminator: multiplying the analytic signal by its one-bar-old conjugate leaves
+     * exactly the phase advanced during that bar, whose full turn is the dominant cycle period.
+     */
+    state.re = 0.8 * state.re + 0.2 * (state.i2 * previousI2 + state.q2 * previousQ2);
+    state.im = 0.8 * state.im + 0.2 * (state.i2 * previousQ2 - state.q2 * previousI2);
+
+    const previousPeriod = state.period;
+    let period = previousPeriod;
+
+    // A market without any cycle signal offers no angle to read, so the last measurement carries over
+    if (state.im * state.re !== 0) {
+      period = 360 / (Math.atan(state.im / state.re) * RAD_TO_DEG);
+    }
+
+    // The period estimate may neither jump more than 50% up or 33% down per bar, nor leave the 6-50 bar band
+    if (period > 1.5 * previousPeriod) {
+      period = 1.5 * previousPeriod;
+    }
+
+    if (period < 0.67 * previousPeriod) {
+      period = 0.67 * previousPeriod;
+    }
+
+    if (period < 6) {
+      period = 6;
+    }
+
+    if (period > 50) {
+      period = 50;
+    }
+
+    state.period = 0.2 * period + 0.8 * previousPeriod;
+
+    const previousPhase = state.phase;
+    state.phase = i1 !== 0 ? Math.atan(q1 / i1) * RAD_TO_DEG : 0;
+
+    /*
+     * The faster the phase advances, the faster the average is allowed to move. A phase advance
+     * below one degree counts as one, which caps the smoothing at the fast limit.
+     */
+    const deltaPhase = Math.max(previousPhase - state.phase, 1);
+    const alpha = Math.max(this.fastLimit / deltaPhase, this.slowLimit);
+
+    state.mama = alpha * price + (1 - alpha) * state.mama;
+    state.fama = 0.5 * alpha * state.mama + (1 - 0.5 * alpha) * state.fama;
+
+    if (state.barsTotal < this.getRequiredInputs()) {
+      return null;
+    }
+
+    if (replace) {
+      this.result = this.#previousResult;
+    }
+
+    this.#previousResult = this.result;
+
+    return (this.result = {
+      fama: state.fama,
+      mama: state.mama,
+    });
+  }
+
+  protected calculateSignal(result?: MAMAResult | null | undefined) {
+    const hasResult = result !== null && result !== undefined;
+    const isBullish = hasResult && result.mama > result.fama;
+    const isBearish = hasResult && result.mama < result.fama;
+
+    switch (true) {
+      case !hasResult:
+        return TradingSignal.UNKNOWN;
+      case isBullish:
+        return TradingSignal.BULLISH;
+      case isBearish:
+        return TradingSignal.BEARISH;
+      default:
+        return TradingSignal.SIDEWAYS;
+    }
+  }
+
+  getSignal(): {
+    state: (typeof TradingSignal)[keyof typeof TradingSignal];
+    hasChanged: boolean;
+  } {
+    const previousState = this.calculateSignal(this.#previousResult);
+    const state = this.calculateSignal(this.getResult());
+    const hasChanged = previousState !== state;
+
+    return {
+      hasChanged,
+      state,
+    };
+  }
+}

--- a/packages/trading-signals/src/trend/MD/McGinleyDynamic.test.ts
+++ b/packages/trading-signals/src/trend/MD/McGinleyDynamic.test.ts
@@ -1,0 +1,221 @@
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {NotEnoughDataError} from '../../error/index.js';
+import {EMA} from '../EMA/EMA.js';
+import {McGinleyDynamic} from './McGinleyDynamic.js';
+
+describe('McGinleyDynamic', () => {
+  /*
+   * Test data verified with the McGinley Dynamic(14) baseline of "Skender.Stock.Indicators" v3.0.0,
+   * which seeds the recursion with the first price and uses the published smoothing constant of 0.6.
+   * Prices are the first 20 closes of its reference quote history:
+   * https://github.com/DaveSkender/Stock.Indicators/blob/3.0.0/tests/indicators/_testdata/quotes/default.csv#L2-L21
+   * Expectations are its committed baseline results, rounded to 7 decimal places:
+   * https://github.com/DaveSkender/Stock.Indicators/blob/3.0.0/tests/indicators/_testdata/results/dynamic.standard.json#L54-L81
+   */
+  const prices = [
+    212.8, 214.06, 213.89, 214.66, 213.95, 213.95, 214.55, 214.02, 214.51, 213.75, 214.22, 213.43, 214.21, 213.66,
+    215.03, 216.89, 216.66, 216.32, 214.98, 214.96,
+  ] as const;
+  const expectations = [
+    '213.7675128',
+    '213.9143102',
+    '214.2495145',
+    '214.5239180',
+    '214.7307240',
+    '214.7602623',
+    '214.7839523',
+  ] as const;
+
+  describe('replace', () => {
+    it('re-seeds the average when the very first price is replaced', () => {
+      const interval = 5;
+      const md = new McGinleyDynamic(interval);
+      const mdWithReplace = new McGinleyDynamic(interval);
+      const firstPrice = prices[0];
+      const remainingPrices = prices.slice(1);
+
+      for (const price of prices) {
+        md.add(price);
+      }
+
+      mdWithReplace.add(90210);
+      mdWithReplace.replace(firstPrice);
+
+      for (const price of remainingPrices) {
+        mdWithReplace.add(price);
+      }
+
+      expect(mdWithReplace.getResultOrThrow()).toBe(md.getResultOrThrow());
+    });
+
+    it('replaces the most recently added value', () => {
+      const md = new McGinleyDynamic(5);
+
+      for (const price of [100, 110, 105, 90, 100] as const) {
+        md.add(price);
+      }
+
+      const originalValue = 120;
+      const replacedValue = 80;
+
+      const originalResult = md.add(originalValue);
+
+      expect(originalResult).toBe(100.08345697662284);
+
+      const replacedResult = md.replace(replacedValue);
+
+      expect(replacedResult).toBe(84.7939995580576);
+
+      const restoredResult = md.replace(originalValue);
+
+      expect(restoredResult).toBe(originalResult);
+    });
+
+    it('will simply add prices when there are no prices to replace', () => {
+      const md = new McGinleyDynamic(5);
+
+      md.replace(100);
+      md.add(110);
+      md.add(105);
+      md.add(90);
+      md.add(100);
+
+      expect(md.getResultOrThrow()).toBe(96.80902362839964);
+    });
+  });
+
+  describe('getResultOrThrow', () => {
+    it('is compatible with results from Skender.Stock.Indicators', () => {
+      const interval = 14;
+      const md = new McGinleyDynamic(interval);
+      const offset = md.getRequiredInputs() - 1;
+
+      expect(md.getRequiredInputs()).toBe(interval);
+
+      prices.forEach((price, i) => {
+        const result = md.add(price);
+
+        if (md.isStable && result) {
+          expect(result.toFixed(7)).toBe(expectations[i - offset]);
+        }
+      });
+
+      expect(md.getResultOrThrow().toFixed(7)).toBe('214.7839523');
+    });
+
+    it('follows the recursion of the published formula', () => {
+      /*
+       * Hand-derived: with an interval of 5 the tracking speed is 0.6 * 5 * ratio^4 = 3 * ratio^4,
+       * where the ratio divides the incoming price by the previous reading. The first price seeds
+       * the average:
+       * MD1 = 100
+       * MD2 = 100 + (110 - 100) / (3 * 1.1^4)                  = 100 + 10 / 4.3923...  = 102.2767115...
+       * MD3 = MD2 + (105 - MD2) / (3 * (105 / MD2)^4)          = MD2 + 5 / 3.3325...   = 103.0938999...
+       * MD4 = MD3 + (90 - MD3)  / (3 * (90 / MD3)^4)           = MD3 - 13.09 / 1.7424... = 95.5792353...
+       * MD5 = MD4 + (100 - MD4) / (3 * (100 / MD4)^4)          = MD4 + 4.42 / 3.5947... = 96.8090236...
+       */
+      const md = new McGinleyDynamic(5);
+
+      expect(md.add(100)).toBe(100);
+      expect(md.add(110)).toBe(102.27671151788357);
+      expect(md.add(105)).toBe(103.09389997105494);
+      expect(md.add(90)).toBe(95.57923535777324);
+      expect(md.add(100)).toBe(96.80902362839964);
+
+      expect(md.getResultOrThrow()).toBe(96.80902362839964);
+    });
+
+    it('stays exactly on the price level when the market is completely flat', () => {
+      const md = new McGinleyDynamic(5);
+
+      for (let i = 0; i < 7; i++) {
+        md.add(100);
+      }
+
+      expect(md.getResultOrThrow()).toBe(100);
+    });
+
+    it('tracks a sell-off faster and a rally slower than an EMA of the same interval', () => {
+      /*
+       * McGinley designed the tracking speed to be asymmetric: a price below the average shrinks
+       * the ratio term, so the average races after sell-offs, while a price above the average
+       * inflates it, so the average trails rallies. An EMA moves at the same speed in both
+       * directions, which makes it the published benchmark for this behavior.
+       */
+      const interval = 14;
+      const flatPrices = Array.from({length: interval}, () => 100);
+
+      const mdDown = new McGinleyDynamic(interval);
+      const emaDown = new EMA(interval);
+      const mdUp = new McGinleyDynamic(interval);
+      const emaUp = new EMA(interval);
+
+      for (const price of flatPrices) {
+        mdDown.add(price);
+        emaDown.add(price);
+        mdUp.add(price);
+        emaUp.add(price);
+      }
+
+      mdDown.add(80);
+      emaDown.add(80);
+
+      expect(mdDown.getResultOrThrow()).toBe(94.18712797619048);
+      expect(mdDown.getResultOrThrow()).toBeLessThan(emaDown.getResultOrThrow());
+
+      mdUp.add(120);
+      emaUp.add(120);
+
+      expect(mdUp.getResultOrThrow()).toBe(101.14822163433274);
+      expect(mdUp.getResultOrThrow()).toBeLessThan(emaUp.getResultOrThrow());
+    });
+
+    it('stays finite when every price is zero', () => {
+      const md = new McGinleyDynamic(3);
+
+      md.add(0);
+      md.add(0);
+      md.add(0);
+
+      expect(md.getResultOrThrow()).toBe(0);
+      expect(Number.isFinite(md.getResultOrThrow())).toBe(true);
+    });
+
+    it('pins the average at zero once the price level collapses to zero', () => {
+      const md = new McGinleyDynamic(3);
+
+      md.add(100);
+      md.add(100);
+      md.add(0);
+
+      expect(md.getResultOrThrow()).toBe(0);
+
+      md.add(50);
+
+      expect(md.getResultOrThrow()).toBe(0);
+    });
+
+    it('throws an error during the warm-up period although the recursion emits from the first price', () => {
+      const interval = 5;
+      const md = new McGinleyDynamic(interval);
+
+      for (const price of [100, 110, 105, 90] as const) {
+        expect(md.add(price)).not.toBeNull();
+        expect(md.isStable).toBe(false);
+        expect(md.getResult()).toBeNull();
+        expect(() => md.getResultOrThrow()).toThrow(NotEnoughDataError);
+      }
+
+      md.add(100);
+
+      expect(md.isStable).toBe(true);
+      expect(md.getResultOrThrow()).toBe(96.80902362839964);
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new McGinleyDynamic(5),
+  divergentInput: 1_000,
+  inputs: [81.59, 81.06, 82.87, 83.0, 83.61, 83.15],
+});

--- a/packages/trading-signals/src/trend/MD/McGinleyDynamic.ts
+++ b/packages/trading-signals/src/trend/MD/McGinleyDynamic.ts
@@ -1,0 +1,80 @@
+import {MovingAverage} from '../MA/MovingAverage.js';
+import {NotEnoughDataError} from '../../error/index.js';
+
+/**
+ * McGinley's published smoothing constant. It speeds the average up so an N-period Dynamic tracks
+ * price about as closely as an N-period EMA; sources that quote the formula without the constant
+ * describe a noticeably slower line for the same interval.
+ */
+const SMOOTHING_CONSTANT = 0.6;
+
+/**
+ * McGinley Dynamic (MD)
+ * Type: Trend
+ *
+ * Developed by John R. McGinley, a market technician of the Market Technicians Association, and
+ * published in its Journal of Technical Analysis in the 1990s. Where a fixed-period average always
+ * reacts at the same speed, the Dynamic adjusts its own smoothing to the speed of the market: it
+ * accelerates in falling markets to track sell-offs closely and decelerates in rising markets, so
+ * it hugs prices without the whipsaws and price separation that fixed-period averages suffer.
+ *
+ * Seeding of the recursion matches Skender.Stock.Indicators: the first price seeds the average.
+ *
+ * @see https://www.investopedia.com/terms/m/mcginley-dynamic.asp
+ * @see https://school.stockcharts.com/doku.php?id=technical_indicators:mcginley_dynamic
+ */
+export class McGinleyDynamic extends MovingAverage {
+  #pricesCounter = 0;
+
+  override getRequiredInputs() {
+    return this.interval;
+  }
+
+  update(price: number, replace: boolean) {
+    if (!replace || this.#pricesCounter === 0) {
+      this.#pricesCounter++;
+    }
+
+    /*
+     * The recursion continues from the reading that existed before the incoming price. A
+     * replacement of the very first price finds no such reading: that price seeded the average,
+     * so the average has to be seeded anew instead of continuing from the seed it replaces.
+     */
+    const previous = replace ? this.previousResult : this.result;
+
+    if (previous === undefined) {
+      return this.setResult(price, replace);
+    }
+
+    /*
+     * The tracking speed rests on the ratio of price to average, which degenerates once either
+     * side sits at zero: the formula would produce an infinite or undefined reading. A zero level
+     * instead pins the average at zero — an average of a worthless instrument is worthless, and it
+     * only recovers through a fresh seed, not through the recursion.
+     */
+    if (previous === 0 || price === 0) {
+      return this.setResult(0, replace);
+    }
+
+    const trackingSpeed = SMOOTHING_CONSTANT * this.interval * (price / previous) ** 4;
+
+    return this.setResult(previous + (price - previous) / trackingSpeed, replace);
+  }
+
+  override getResultOrThrow() {
+    if (this.#pricesCounter < this.interval) {
+      throw new NotEnoughDataError(this.getRequiredInputs());
+    }
+
+    return this.result!;
+  }
+
+  override get isStable() {
+    try {
+      this.getResultOrThrow();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/packages/trading-signals/src/trend/SUPERSMOOTHER/SuperSmoother.test.ts
+++ b/packages/trading-signals/src/trend/SUPERSMOOTHER/SuperSmoother.test.ts
@@ -1,0 +1,232 @@
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {NotEnoughDataError} from '../../error/index.js';
+import {SuperSmoother} from './SuperSmoother.js';
+
+describe('SuperSmoother', () => {
+  /*
+   * The SuperSmoother is not part of Tulip Indicators, so the reference values are hand-derived from
+   * Ehlers' published EasyLanguage code (Code Listing 1 in
+   * https://www.mesasoftware.com/papers/PredictiveIndicators.pdf, also printed in "Cycle Analytics
+   * for Traders" (2013), Chapter 3) with interval N = 4:
+   *
+   *   angle = √2·π / N       = 1.1107207345395915
+   *   a1 = e^(-angle)        = 0.32932152212461496
+   *   b1 = 2·a1·cos(angle)   = 0.2924479447673371
+   *   c2 = b1
+   *   c3 = -a1²              = -0.10845266493447327
+   *   c1 = 1 - c2 - c3       = 0.8160047201671361
+   *
+   *   Filt = c1·(Price + Price[1])/2 + c2·Filt[1] + c3·Filt[2], warm-started with Filt = Price on
+   *   the first two bars ("if currentbar < 3 then Filt = Close").
+   *
+   * The coefficients are transcendental, so the decimals below come from a scratch script running
+   * the very same arithmetic:
+   *
+   *   bar 1 (82): Filt = 82 (warm-start)
+   *   bar 2 (88): Filt = 88 (warm-start)
+   *   bar 3 (84): Filt = c1·(84 + 88)/2 + c2·88 + c3·82 = 87.0187
+   *   bar 4 (90): Filt = c1·(90 + 84)/2 + c2·87.0187 + c3·88 = 86.8970
+   *   bar 5 (86): Filt = c1·(86 + 90)/2 + c2·86.8970 + c3·87.0187 = 87.7839
+   *   bar 6 (89): Filt = c1·(89 + 86)/2 + c2·87.7839 + c3·86.8970 = 87.6484
+   *   bar 7 (87): Filt = c1·(87 + 89)/2 + c2·87.6484 + c3·87.7839 = 87.9206
+   *
+   * Results become visible once the interval is filled, so the expectations start at bar 4.
+   */
+  const prices = [82, 88, 84, 90, 86, 89, 87] as const;
+  const expectations = ['86.8970', '87.7839', '87.6484', '87.9206'] as const;
+
+  describe('getResultOrThrow', () => {
+    it('calculates the SuperSmoother filter over a period of 4', () => {
+      const interval = 4;
+      const superSmoother = new SuperSmoother(interval);
+      const offset = superSmoother.getRequiredInputs() - 1;
+
+      expect(superSmoother.getRequiredInputs()).toBe(interval);
+
+      prices.forEach((price, i) => {
+        superSmoother.add(price);
+
+        if (superSmoother.isStable) {
+          expect(superSmoother.getResultOrThrow().toFixed(4)).toBe(expectations[i - offset]);
+        }
+      });
+
+      expect(superSmoother.isStable).toBe(true);
+    });
+
+    it('produces the exact doubles of a reference recursion built from the same coefficients', () => {
+      const interval = 4;
+      const angle = (Math.SQRT2 * Math.PI) / interval;
+      const a1 = Math.exp(-angle);
+      const c2 = 2 * a1 * Math.cos(angle);
+      const c3 = -a1 * a1;
+      const c1 = 1 - c2 - c3;
+      const superSmoother = new SuperSmoother(interval);
+
+      let previousPrice: number | undefined;
+      let previousFilter: number | undefined;
+      let secondPreviousFilter: number | undefined;
+
+      for (const price of prices) {
+        const expected =
+          previousPrice === undefined || previousFilter === undefined || secondPreviousFilter === undefined
+            ? price
+            : c1 * ((price + previousPrice) / 2) + c2 * previousFilter + c3 * secondPreviousFilter;
+
+        expect(superSmoother.add(price)).toBe(expected);
+
+        secondPreviousFilter = previousFilter;
+        previousFilter = expected;
+        previousPrice = price;
+      }
+    });
+
+    it('throws before the interval is filled, although the recursion already runs from the third bar', () => {
+      const superSmoother = new SuperSmoother(5);
+
+      for (const price of [82, 88, 84, 90] as const) {
+        superSmoother.add(price);
+      }
+
+      expect(superSmoother.isStable).toBe(false);
+      expect(() => superSmoother.getResultOrThrow()).toThrow(NotEnoughDataError);
+
+      superSmoother.add(86);
+
+      expect(superSmoother.isStable).toBe(true);
+      expect(superSmoother.getResult()).not.toBeNull();
+    });
+
+    it('derives filter coefficients that sum to one', () => {
+      const intervals = [2, 4, 10, 50, 200] as const;
+
+      intervals.forEach(interval => {
+        const angle = (Math.SQRT2 * Math.PI) / interval;
+        const a1 = Math.exp(-angle);
+        const c2 = 2 * a1 * Math.cos(angle);
+        const c3 = -a1 * a1;
+        const c1 = 1 - c2 - c3;
+
+        /*
+         * c1 is defined as the complement of c2 and c3, so the sum can only be off by the single
+         * rounding step of re-adding what was subtracted — never more than one ulp around 1.
+         */
+        expect(c1 + c2 + c3).toBeCloseTo(1, 15);
+      });
+    });
+
+    it('converges to the constant when the market is completely flat', () => {
+      const superSmoother = new SuperSmoother(10);
+
+      for (let i = 0; i < 100; i++) {
+        superSmoother.add(123.45);
+      }
+
+      /*
+       * The filter weights sum to one within one ulp, so a flat series is a fixed point of the
+       * recursion up to floating-point rounding. 100 bars accumulate an error many orders of
+       * magnitude below the asserted nanometer-scale tolerance.
+       */
+      expect(superSmoother.getResultOrThrow()).toBeCloseTo(123.45, 9);
+    });
+
+    it('cancels a two-bar wave down to its midline', () => {
+      const superSmoother = new SuperSmoother(10);
+
+      for (let i = 0; i < 60; i++) {
+        superSmoother.add(i % 2 === 0 ? 105 : 95);
+      }
+
+      /*
+       * Averaging two adjacent prices zeroes out a wave that flips direction on every bar — the
+       * aliasing noise the SuperSmoother is designed to remove. Only the decaying imprint of the
+       * raw-price warm-start keeps the reading a hair away from the midline.
+       */
+      expect(superSmoother.getResultOrThrow()).toBeCloseTo(100, 7);
+    });
+  });
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const superSmoother = new SuperSmoother(4);
+
+      for (const price of prices) {
+        superSmoother.add(price);
+      }
+
+      const originalValue = 95;
+      const replacedValue = 80;
+
+      const originalResult = superSmoother.add(originalValue);
+
+      expect(originalResult?.toFixed(4)).toBe('90.4629');
+
+      const replacedResult = superSmoother.replace(replacedValue);
+
+      expect(replacedResult?.toFixed(4)).toBe('84.3429');
+
+      const restoredResult = superSmoother.replace(originalValue);
+
+      expect(restoredResult).toBe(originalResult);
+    });
+
+    it('recovers the exact add-only series when more prices follow a replacement', () => {
+      const lastPrice = prices[prices.length - 1];
+      const addOnly = new SuperSmoother(4);
+      const withReplace = new SuperSmoother(4);
+
+      for (const price of prices.slice(0, -1)) {
+        addOnly.add(price);
+        withReplace.add(price);
+      }
+
+      addOnly.add(lastPrice);
+      withReplace.add(1_000);
+      withReplace.replace(lastPrice);
+
+      /*
+       * The recursion carries the previous price and two prior readings across bars, so a stale
+       * leftover from the replaced price would surface within the next three additions.
+       */
+      for (const price of [91, 85, 93] as const) {
+        expect(withReplace.add(price)).toBe(addOnly.add(price));
+      }
+    });
+
+    it('re-seeds the filter when the very first price is replaced', () => {
+      const addOnly = new SuperSmoother(4);
+      const withReplace = new SuperSmoother(4);
+
+      for (const price of prices) {
+        addOnly.add(price);
+      }
+
+      withReplace.add(90_210);
+      withReplace.replace(prices[0]);
+
+      for (const price of prices.slice(1)) {
+        withReplace.add(price);
+      }
+
+      expect(withReplace.getResultOrThrow()).toBe(addOnly.getResultOrThrow());
+    });
+
+    it('simply adds the price when there is nothing to replace yet', () => {
+      const superSmoother = new SuperSmoother(4);
+
+      superSmoother.replace(prices[0]);
+
+      for (const price of prices.slice(1, 4)) {
+        superSmoother.add(price);
+      }
+
+      expect(superSmoother.getResultOrThrow().toFixed(4)).toBe('86.8970');
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new SuperSmoother(4),
+  divergentInput: 1_000,
+  inputs: [82, 88, 84, 90, 86, 89],
+});

--- a/packages/trading-signals/src/trend/SUPERSMOOTHER/SuperSmoother.ts
+++ b/packages/trading-signals/src/trend/SUPERSMOOTHER/SuperSmoother.ts
@@ -1,0 +1,107 @@
+import {MovingAverage} from '../MA/MovingAverage.js';
+import {NotEnoughDataError} from '../../error/index.js';
+
+type FilterState = {
+  previousFilter: number;
+  previousPrice: number;
+  secondPreviousFilter: number | undefined;
+};
+
+/**
+ * SuperSmoother Filter (SSF)
+ * Type: Trend
+ *
+ * John Ehlers designed the SuperSmoother as a replacement for moving-average smoothing: a 2-pole
+ * Butterworth low-pass filter fed with the average of the two most recent prices. Wave components
+ * shorter than the configured interval count as aliasing noise and are rejected almost completely,
+ * and the 2-bar price average cancels the shortest wave sampled data can carry before it even
+ * reaches the filter. The payoff over an SMA or EMA of comparable smoothness is considerably less
+ * lag, which is why Ehlers uses the SuperSmoother as the standard smoothing block inside his other
+ * indicators.
+ *
+ * The filter warm-starts on raw prices, following the convention of Ehlers' published code
+ * ("if currentbar < 3 then Filt = Close"): the first two readings equal the price itself, and the
+ * recursion takes over on the third bar, once two prior readings exist. Ehlers' listings use the
+ * rounded constants 1.414 and 3.14159; this implementation uses the square root of 2 and pi at
+ * full precision.
+ *
+ * @see https://www.mesasoftware.com/papers/PredictiveIndicators.pdf
+ * @see John F. Ehlers: "Cycle Analytics for Traders" (2013), Chapter 3
+ */
+export class SuperSmoother extends MovingAverage {
+  #pricesCounter = 0;
+  readonly #c1: number;
+  readonly #c2: number;
+  readonly #c3: number;
+  #state?: FilterState;
+  #previousState?: FilterState;
+
+  constructor(interval: number) {
+    super(interval);
+    const angle = (Math.SQRT2 * Math.PI) / interval;
+    const a1 = Math.exp(-angle);
+    this.#c2 = 2 * a1 * Math.cos(angle);
+    this.#c3 = -a1 * a1;
+    this.#c1 = 1 - this.#c2 - this.#c3;
+  }
+
+  override getRequiredInputs() {
+    return this.interval;
+  }
+
+  update(price: number, replace: boolean) {
+    if (!replace || this.#pricesCounter === 0) {
+      this.#pricesCounter++;
+    }
+
+    /*
+     * The recursion feeds on the price and the two filter readings that existed before the
+     * incoming price, so a replacement has to continue from the state before the replaced
+     * price instead of the state it produced.
+     */
+    if (replace) {
+      this.#state = this.#previousState;
+    } else {
+      this.#previousState = this.#state;
+    }
+
+    const state = this.#state;
+
+    let filter: number;
+
+    if (state === undefined || state.secondPreviousFilter === undefined) {
+      // Ehlers warm-starts on raw prices until two prior filter readings exist
+      filter = price;
+    } else {
+      filter =
+        this.#c1 * ((price + state.previousPrice) / 2) +
+        this.#c2 * state.previousFilter +
+        this.#c3 * state.secondPreviousFilter;
+    }
+
+    this.#state = {
+      previousFilter: filter,
+      previousPrice: price,
+      secondPreviousFilter: state?.previousFilter,
+    };
+
+    return this.setResult(filter, replace);
+  }
+
+  override getResultOrThrow() {
+    if (this.#pricesCounter < this.interval) {
+      throw new NotEnoughDataError(this.getRequiredInputs());
+    }
+
+    return this.result!;
+  }
+
+  override get isStable() {
+    try {
+      this.getResultOrThrow();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/packages/trading-signals/src/trend/index.ts
+++ b/packages/trading-signals/src/trend/index.ts
@@ -14,6 +14,7 @@ export * from './ICHIMOKU/IchimokuCloud.js';
 export * from './KAMA/KAMA.js';
 export * from './LINREG/LinearRegression.js';
 export * from './MA/MovingAverage.js';
+export * from './MD/McGinleyDynamic.js';
 export * from './PSAR/PSAR.js';
 export * from './RMA/RMA.js';
 export * from './SMA/SMA.js';

--- a/packages/trading-signals/src/trend/index.ts
+++ b/packages/trading-signals/src/trend/index.ts
@@ -19,6 +19,7 @@ export * from './PSAR/PSAR.js';
 export * from './RMA/RMA.js';
 export * from './SMA/SMA.js';
 export * from './SMA15/SMA15.js';
+export * from './SUPERSMOOTHER/SuperSmoother.js';
 export * from './SUPERTREND/SuperTrend.js';
 export * from './SWING_HIGH/SwingHigh.js';
 export * from './SWING_LOW/SwingLookback.js';

--- a/packages/trading-signals/src/trend/index.ts
+++ b/packages/trading-signals/src/trend/index.ts
@@ -14,6 +14,7 @@ export * from './ICHIMOKU/IchimokuCloud.js';
 export * from './KAMA/KAMA.js';
 export * from './LINREG/LinearRegression.js';
 export * from './MA/MovingAverage.js';
+export * from './MAMA/MAMA.js';
 export * from './MD/McGinleyDynamic.js';
 export * from './PSAR/PSAR.js';
 export * from './RMA/RMA.js';

--- a/packages/trading-signals/src/volatility/CHOP/CHOP.test.ts
+++ b/packages/trading-signals/src/volatility/CHOP/CHOP.test.ts
@@ -1,0 +1,212 @@
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {CHOP} from './CHOP.js';
+
+describe('CHOP', () => {
+  describe('constructor', () => {
+    it("uses E.W. Dreiss' 14-period window by default", () => {
+      const chop = new CHOP();
+
+      expect(chop.interval).toBe(14);
+      expect(chop.getRequiredInputs()).toBe(15);
+    });
+
+    it('rejects a window whose logarithm cannot normalize the reading', () => {
+      expect(() => new CHOP(1)).toThrowError('The interval has to be at least 2, but "1" was given.');
+      expect(() => new CHOP(0)).toThrowError('The interval has to be at least 2, but "0" was given.');
+    });
+  });
+
+  describe('getResultOrThrow', () => {
+    it('matches the Skender.Stock.Indicators reference results', () => {
+      /*
+       * The expectations are the Skender.Stock.Indicators v3.0.0 baseline for the Choppiness Index (14)
+       * over the first 32 candles of its default test quotes. The Choppiness Index only ever looks back
+       * one window plus the close seeding the first true range, so a leading slice of the series yields
+       * the same results as a full run.
+       *
+       * Quotes: https://raw.githubusercontent.com/facioquo/stock-indicators-dotnet/3.0.0/tests/indicators/_testdata/quotes/default.csv
+       * Results: https://raw.githubusercontent.com/facioquo/stock-indicators-dotnet/3.0.0/tests/indicators/_testdata/results/chop.standard.json
+       */
+      const candles = [
+        {close: 212.8, high: 213.35, low: 211.52},
+        {close: 214.06, high: 214.22, low: 213.15},
+        {close: 213.89, high: 214.06, low: 213.02},
+        {close: 214.66, high: 215.17, low: 213.42},
+        {close: 213.95, high: 214.53, low: 213.91},
+        {close: 213.95, high: 214.89, low: 213.52},
+        {close: 214.55, high: 214.55, low: 213.13},
+        {close: 214.02, high: 214.22, low: 212.53},
+        {close: 214.51, high: 214.84, low: 214.17},
+        {close: 213.75, high: 214.25, low: 213.33},
+        {close: 214.22, high: 214.27, low: 213.42},
+        {close: 213.43, high: 214.46, low: 212.96},
+        {close: 214.21, high: 214.75, low: 213.49},
+        {close: 213.66, high: 214.28, low: 212.83},
+        {close: 215.03, high: 215.48, low: 213.77},
+        {close: 216.89, high: 216.89, low: 215.89},
+        {close: 216.66, high: 217.02, low: 216.36},
+        {close: 216.32, high: 216.91, low: 216.12},
+        {close: 214.98, high: 215.59, low: 213.9},
+        {close: 214.96, high: 215.03, low: 213.82},
+        {close: 215.05, high: 215.96, low: 214.4},
+        {close: 215.19, high: 215.5, low: 214.29},
+        {close: 216.67, high: 216.87, low: 215.84},
+        {close: 216.28, high: 216.66, low: 215.92},
+        {close: 216.29, high: 216.97, low: 216.09},
+        {close: 216.58, high: 216.72, low: 215.7},
+        {close: 217.86, high: 218.19, low: 216.84},
+        {close: 218.72, high: 218.97, low: 217.88},
+        {close: 219.91, high: 220.19, low: 219.23},
+        {close: 220.79, high: 220.8, low: 219.33},
+        {close: 221.94, high: 222.15, low: 220.5},
+        {close: 221.75, high: 222.16, low: 220.93},
+      ] as const;
+      const expectations = [
+        '69.9966973',
+        '56.0742141',
+        '54.2014428',
+        '52.2121054',
+        '55.6083257',
+        '55.2958100',
+        '55.5694019',
+        '56.5787410',
+        '58.2869649',
+        '57.4424782',
+        '57.5020106',
+        '56.5380840',
+        '47.7918981',
+        '47.4598973',
+        '39.8426024',
+        '35.5579320',
+        '30.9045157',
+        '31.7342961',
+      ] as const;
+      const chop = new CHOP();
+      const offset = chop.getRequiredInputs() - 1;
+      let verifiedCandles = 0;
+
+      candles.forEach((candle, i) => {
+        const result = chop.add(candle);
+
+        if (result !== null) {
+          verifiedCandles++;
+          expect(result.toFixed(7)).toBe(expectations[i - offset]);
+        }
+      });
+
+      expect(verifiedCandles).toBe(expectations.length);
+    });
+
+    it('counts a gap in both the path and the window span', () => {
+      /*
+       * Hand-derived reference for a 2-bar window with a gap down. The first candle only seeds the close
+       * that the next true range extends to:
+       *
+       * candle             | true high        | true low         | true range
+       * (120, 118, c 119)  | —                | —                | — (seeds close 119)
+       * (110, 105, c 106)  | max(110,119)=119 | min(105,119)=105 | 14
+       * (108, 104, c 107)  | max(108,106)=108 | min(104,106)=104 | 4
+       *
+       * Path = 14 + 4 = 18; span = 119 − 104 = 15
+       * CHOP = 100 × log10(18/15) / log10(2) ≈ 26.3034
+       *
+       * Reading the span off the printed highs and lows instead (110 − 104 = 6) would count the gap in the
+       * path but not in the span and read 100 × log10(18/6) / log10(2) ≈ 158.4963 — beyond the 0–100 scale.
+       */
+      const candles = [
+        {close: 119, high: 120, low: 118},
+        {close: 106, high: 110, low: 105},
+        {close: 107, high: 108, low: 104},
+      ] as const;
+      const chop = new CHOP(2);
+
+      for (const candle of candles) {
+        chop.add(candle);
+      }
+
+      expect(chop.getResultOrThrow()).toBe(26.30344058337938);
+    });
+
+    it('reads a dead-flat window as maximal choppiness', () => {
+      // Without a span there is no path either, and the limit of same-centered shrinking candles reads 100
+      const chop = new CHOP(3);
+
+      for (let i = 0; i < 4; i++) {
+        chop.add({close: 100, high: 100, low: 100});
+      }
+
+      expect(chop.getResultOrThrow()).toBe(100);
+    });
+  });
+
+  describe('replace', () => {
+    it('replaces the most recently added candle', () => {
+      const chop = new CHOP(2);
+      const candles = [
+        {close: 119, high: 120, low: 118},
+        {close: 106, high: 110, low: 105},
+        {close: 107, high: 108, low: 104},
+      ] as const;
+
+      for (const candle of candles) {
+        chop.add(candle);
+      }
+
+      expect(chop.getResultOrThrow()).toBe(26.30344058337938);
+
+      // Window spans 104 to 112 with a path of 6 + 4 = 10 → 100 × log10(10/8) / log10(2)
+      const originalCandle = {close: 111, high: 112, low: 106} as const;
+      // Window spans 103 to 109 with the same path of 10 → 100 × log10(10/6) / log10(2)
+      const replacementCandle = {close: 104, high: 109, low: 103} as const;
+
+      const originalResult = chop.add(originalCandle);
+
+      expect(originalResult).toBe(32.19280948873624);
+
+      const replacedResult = chop.replace(replacementCandle);
+
+      expect(replacedResult).toBe(73.69655941662062);
+
+      const restoredResult = chop.replace(originalCandle);
+
+      expect(restoredResult).toBe(originalResult);
+    });
+
+    it('replaces the seed candle before the first true range exists', () => {
+      const seedReplacement = {close: 110, high: 111, low: 109} as const;
+      const candles = [
+        {close: 106, high: 110, low: 105},
+        {close: 107, high: 108, low: 104},
+      ] as const;
+
+      const replaced = new CHOP(2);
+      replaced.add({close: 119, high: 120, low: 118});
+      replaced.replace(seedReplacement);
+
+      const reference = new CHOP(2);
+      reference.add(seedReplacement);
+
+      for (const candle of candles) {
+        replaced.add(candle);
+        reference.add(candle);
+      }
+
+      expect(replaced.getResultOrThrow()).toBe(reference.getResultOrThrow());
+      expect(replaced.getResultOrThrow()).toBe(58.496250072115615);
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new CHOP(5),
+  divergentInput: {close: 500, high: 1000, low: 10},
+  inputs: [
+    {close: 212.8, high: 213.35, low: 211.52},
+    {close: 214.06, high: 214.22, low: 213.15},
+    {close: 213.89, high: 214.06, low: 213.02},
+    {close: 214.66, high: 215.17, low: 213.42},
+    {close: 213.95, high: 214.53, low: 213.91},
+    {close: 213.95, high: 214.89, low: 213.52},
+    {close: 214.55, high: 214.55, low: 213.13},
+  ],
+});

--- a/packages/trading-signals/src/volatility/CHOP/CHOP.ts
+++ b/packages/trading-signals/src/volatility/CHOP/CHOP.ts
@@ -1,0 +1,102 @@
+import type {HighLowClose} from '../../base/Candle.type.js';
+import {IndicatorSeries} from '../../base/Indicator.js';
+import {pushUpdate} from '../../util/pushUpdate.js';
+
+type TrueExtremes = {
+  trueHigh: number;
+  trueLow: number;
+};
+
+/**
+ * Choppiness Index (CHOP)
+ * Type: Volatility
+ *
+ * Developed by the Australian commodity trader E.W. Dreiss using ideas from chaos theory, the Choppiness
+ * Index tells apart a trending market from one chopping sideways by comparing the ground price actually
+ * covered (the sum of true ranges) with the span of the window, related on a logarithmic scale. A trend
+ * crosses its span once, so path and span nearly coincide and the reading approaches 0. A choppy market
+ * folds back over the same prices again and again, so the path dwarfs the span and the reading approaches
+ * 100. Candle ranges and window extremes are both extended to the previous close: a gap moves price without
+ * printing it inside a candle, and counting that ground in the path but not in the span would push readings
+ * off the 0–100 scale.
+ *
+ * Interpretation:
+ * Readings are commonly banded at the Fibonacci retracement levels: above 61.8 the market is consolidating
+ * (choppy — trend-following entries are prone to whipsaws), below 38.2 a strong trend is underway. The
+ * reading is direction-agnostic — a crash and a rally both read as trending — which is why this indicator
+ * emits no trading signal; direction has to come from a trend-following companion.
+ *
+ * @see https://www.tradingview.com/support/solutions/43000501980-choppiness-index-chop/
+ * @see https://school.stockcharts.com/doku.php?id=technical_indicators:choppiness_index
+ */
+export class CHOP extends IndicatorSeries<HighLowClose<number>> {
+  readonly #window: TrueExtremes[] = [];
+  #previousClose?: number;
+  #twoPreviousClose?: number;
+
+  public readonly interval: number;
+
+  constructor(interval: number = 14) {
+    super();
+
+    // A one-bar window cannot normalize the path: the logarithm of 1 is zero, which would divide the reading by zero
+    if (interval < 2) {
+      throw new Error(`The interval has to be at least 2, but "${interval}" was given.`);
+    }
+
+    this.interval = interval;
+  }
+
+  override getRequiredInputs() {
+    // The candle ahead of the window only contributes the closing price that the first true range extends to
+    return this.interval + 1;
+  }
+
+  update(candle: HighLowClose<number>, replace: boolean) {
+    if (replace) {
+      this.#previousClose = this.#twoPreviousClose;
+    }
+
+    if (this.#previousClose === undefined) {
+      this.#previousClose = candle.close;
+      return null;
+    }
+
+    const trueHigh = Math.max(candle.high, this.#previousClose);
+    const trueLow = Math.min(candle.low, this.#previousClose);
+
+    this.#twoPreviousClose = this.#previousClose;
+    this.#previousClose = candle.close;
+
+    pushUpdate({array: this.#window, item: {trueHigh, trueLow}, maxLength: this.interval, replace});
+
+    if (this.#window.length < this.interval) {
+      return null;
+    }
+
+    // A single pass over the window keeps the hot path free of per-candle array allocations
+    let trueRangeSum = 0;
+    let highest = this.#window[0].trueHigh;
+    let lowest = this.#window[0].trueLow;
+
+    for (const {trueHigh, trueLow} of this.#window) {
+      trueRangeSum += trueHigh - trueLow;
+      highest = Math.max(highest, trueHigh);
+      lowest = Math.min(lowest, trueLow);
+    }
+
+    const range = highest - lowest;
+
+    /*
+     * A dead-flat window is the one degenerate case: without a span there is no path either, because
+     * consecutive rangeless candles can only collapse onto the same price. Shrinking a window of candles
+     * centered on one price towards that state keeps the path pinned at the window length times the span,
+     * so the limit reads 100 — price went nowhere, which is maximal choppiness.
+     */
+    if (range === 0) {
+      return this.setResult(100, replace);
+    }
+
+    return this.setResult((100 * Math.log10(trueRangeSum / range)) / Math.log10(this.interval), replace);
+  }
+}

--- a/packages/trading-signals/src/volatility/CVI/CVI.test.ts
+++ b/packages/trading-signals/src/volatility/CVI/CVI.test.ts
@@ -1,0 +1,177 @@
+import {TradingSignal} from '../../base/Indicator.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {CVI} from './CVI.js';
+
+describe('CVI', () => {
+  /*
+   * Test data verified with:
+   * https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt#L131-L134
+   */
+  const highs = [
+    82.15, 81.89, 83.03, 83.3, 83.85, 83.9, 83.33, 84.3, 84.84, 85.0, 85.9, 86.58, 86.98, 88.0, 87.87,
+  ] as const;
+  const lows = [
+    81.29, 80.64, 81.31, 82.65, 83.07, 83.11, 82.49, 82.3, 84.15, 84.11, 84.03, 85.39, 85.76, 87.17, 87.01,
+  ] as const;
+  const expectations = ['5.682', '44.088', '43.317', '-0.494', '3.994', '1.824'] as const;
+
+  describe('getResultOrThrow', () => {
+    it('is compatible with results from Tulip Indicators (TI)', {tags: ['tulipindicators']}, () => {
+      const interval = 5;
+      const cvi = new CVI(interval);
+      const offset = cvi.getRequiredInputs() - 1;
+
+      highs.forEach((high, i) => {
+        const result = cvi.add({high, low: lows[i]});
+
+        if (result) {
+          expect(result.toFixed(3)).toBe(expectations[i - offset]);
+        }
+      });
+
+      expect(cvi.isStable).toBe(true);
+      expect(cvi.getRequiredInputs()).toBe(interval * 2);
+    });
+
+    it('defaults to the 10-bar setting popularized by Marc Chaikin', () => {
+      const cvi = new CVI();
+
+      expect(cvi.interval).toBe(10);
+      expect(cvi.getRequiredInputs()).toBe(20);
+    });
+
+    it('reports zero change in a dead-flat market instead of an undefined percentage', () => {
+      const cvi = new CVI(5);
+
+      for (let i = 0; i < 10; i++) {
+        cvi.add({high: 100, low: 100});
+      }
+
+      expect(cvi.getResultOrThrow()).toBe(0);
+      expect(cvi.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+    });
+
+    it('stays at zero when volatility appears without a baseline to compare against', () => {
+      const cvi = new CVI(5);
+
+      for (let i = 0; i < 9; i++) {
+        cvi.add({high: 100, low: 100});
+      }
+
+      cvi.add({high: 105, low: 95});
+
+      expect(cvi.getResultOrThrow()).toBe(0);
+    });
+  });
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const cvi = new CVI(5);
+
+      highs.forEach((high, i) => {
+        cvi.add({high, low: lows[i]});
+      });
+
+      const originalValue = {high: 90, low: 80} as const;
+      const replacedValue = {high: 88, low: 87.5} as const;
+
+      const originalResult = cvi.add(originalValue);
+
+      expect(originalResult?.toFixed(3)).toBe('210.296');
+
+      const replacedResult = cvi.replace(replacedValue);
+
+      expect(replacedResult?.toFixed(3)).toBe('-34.332');
+      expect(replacedResult).not.toBe(originalResult);
+
+      const restoredResult = cvi.replace(originalValue);
+
+      expect(restoredResult).toBe(originalResult);
+    });
+
+    it('simply adds a candle when there is no candle to replace', () => {
+      const cvi = new CVI(5);
+
+      cvi.replace({high: highs[0], low: lows[0]});
+
+      highs.slice(1, 10).forEach((high, i) => {
+        cvi.add({high, low: lows[i + 1]});
+      });
+
+      expect(cvi.getResultOrThrow().toFixed(3)).toBe('5.682');
+    });
+  });
+
+  describe('getSignal', () => {
+    it('returns UNKNOWN when there is no result', () => {
+      const cvi = new CVI(5);
+
+      expect(cvi.getSignal()).toEqual({
+        hasChanged: false,
+        state: TradingSignal.UNKNOWN,
+      });
+    });
+
+    it('returns BULLISH while trading ranges are widening', () => {
+      const cvi = new CVI(5);
+
+      for (let i = 0; i < 10; i++) {
+        cvi.add({high: 100 + i, low: 100 - i});
+      }
+
+      expect(cvi.getResultOrThrow()).toBeGreaterThan(0);
+      expect(cvi.getSignal().state).toBe(TradingSignal.BULLISH);
+    });
+
+    it('returns BEARISH while trading ranges are narrowing', () => {
+      const cvi = new CVI(5);
+
+      for (let i = 0; i < 10; i++) {
+        cvi.add({high: 100 + (20 - i), low: 100 - (20 - i)});
+      }
+
+      expect(cvi.getResultOrThrow()).toBeLessThan(0);
+      expect(cvi.getSignal().state).toBe(TradingSignal.BEARISH);
+    });
+
+    it('flags the flip from expanding to contracting volatility', () => {
+      const cvi = new CVI(5);
+
+      for (let i = 0; i < 10; i++) {
+        cvi.add({high: 100 + i, low: 100 - i});
+      }
+
+      expect(cvi.getSignal()).toEqual({
+        hasChanged: true,
+        state: TradingSignal.BULLISH,
+      });
+
+      cvi.add({high: 100.5, low: 99.5});
+
+      expect(cvi.getSignal()).toEqual({
+        hasChanged: false,
+        state: TradingSignal.BULLISH,
+      });
+
+      cvi.add({high: 100.5, low: 99.5});
+
+      expect(cvi.getSignal()).toEqual({
+        hasChanged: true,
+        state: TradingSignal.BEARISH,
+      });
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new CVI(3),
+  divergentInput: {high: 1_000, low: 900},
+  inputs: [
+    {high: 82.15, low: 81.29},
+    {high: 81.89, low: 80.64},
+    {high: 83.03, low: 81.31},
+    {high: 83.3, low: 82.65},
+    {high: 83.85, low: 83.07},
+    {high: 83.9, low: 83.11},
+  ],
+});

--- a/packages/trading-signals/src/volatility/CVI/CVI.ts
+++ b/packages/trading-signals/src/volatility/CVI/CVI.ts
@@ -1,0 +1,74 @@
+import type {HighLow} from '../../base/Candle.type.js';
+import {ZeroCrossSeries} from '../../base/Indicator.js';
+import {EMA} from '../../trend/EMA/EMA.js';
+import {pushUpdate} from '../../util/pushUpdate.js';
+
+/**
+ * Chaikin Volatility (CVI)
+ * Type: Volatility
+ *
+ * Marc Chaikin's volatility gauge measures widening-range momentum: it smooths the daily trading
+ * range (high minus low) and reports how much that smoothed range has grown or shrunk over the
+ * lookback, as a percentage. A positive reading means volatility is expanding, a negative reading
+ * means it is contracting, so a zero-cross flags a change of volatility regime.
+ *
+ * Interpretation: Range expansion carries no direction on its own — Chaikin's own reading pairs it
+ * with price direction: a volatility spike while prices fall often marks panic selling near a
+ * market bottom, whereas volatility that fades while prices rise points to a maturing, complacent
+ * uptrend nearing a top. A lookback of dead-flat candles offers no volatility baseline to measure
+ * growth against, so the reading is pinned to zero (sideways) instead of an undefined change.
+ *
+ * @see https://tulipindicators.org/cvi
+ * @see https://www.metastock.com/customer/resources/taaz/?p=120
+ */
+export class CVI extends ZeroCrossSeries<HighLow<number>> {
+  public readonly interval: number;
+  readonly #smoothedRange: EMA;
+  readonly #smoothedRangeHistory: number[];
+  readonly #historyLength: number;
+
+  constructor(interval: number = 10) {
+    super();
+    this.interval = interval;
+    this.#smoothedRange = new EMA(interval);
+    this.#smoothedRangeHistory = [];
+    this.#historyLength = interval + 1;
+  }
+
+  override getRequiredInputs() {
+    return this.interval * 2;
+  }
+
+  update({high, low}: HighLow<number>, replace: boolean) {
+    this.#smoothedRange.update(high - low, replace);
+
+    const smoothedRange = this.#smoothedRange.getResult();
+
+    if (smoothedRange === null) {
+      return null;
+    }
+
+    pushUpdate({
+      array: this.#smoothedRangeHistory,
+      item: smoothedRange,
+      maxLength: this.#historyLength,
+      replace,
+    });
+
+    if (this.#smoothedRangeHistory.length < this.#historyLength) {
+      return null;
+    }
+
+    const laggedRange = this.#smoothedRangeHistory[0];
+
+    /*
+     * A dead-flat lookback leaves no volatility baseline, so the reading pins to zero (sideways)
+     * rather than reporting an undefined percentage change.
+     */
+    if (laggedRange === 0) {
+      return this.setResult(0, replace);
+    }
+
+    return this.setResult((100 * (smoothedRange - laggedRange)) / laggedRange, replace);
+  }
+}

--- a/packages/trading-signals/src/volatility/SQUEEZE/TTMSqueeze.test.ts
+++ b/packages/trading-signals/src/volatility/SQUEEZE/TTMSqueeze.test.ts
@@ -1,0 +1,247 @@
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {TradingSignal} from '../../base/index.js';
+import {TTMSqueeze} from './TTMSqueeze.js';
+
+/*
+ * Hand-derived worksheet with interval 3 (config: BB(3, x2), KC(3, x1.5, ATR 3), momentum over 3):
+ *
+ * | Bar | High | Low | Close | HH3 | LL3 | SMA3 | Anchor = ((HH3+LL3)/2 + SMA3)/2 | Distance |
+ * |-----|------|-----|-------|-----|-----|------|---------------------------------|----------|
+ * | 1   | 102  | 96  | 99    | -   | -   | -    | -                               | -        |
+ * | 2   | 102  | 96  | 99    | -   | -   | -    | -                               | -        |
+ * | 3   | 102  | 96  | 99    | 102 | 96  | 99   | (99 + 99)/2 = 99                | 0        |
+ * | 4   | 104  | 98  | 102   | 104 | 96  | 100  | (100 + 100)/2 = 100             | 2        |
+ * | 5   | 106  | 94  | 105   | 106 | 94  | 102  | (100 + 102)/2 = 101             | 4        |
+ * | 6   | 144  | 100 | 138   | 144 | 94  | 115  | (119 + 115)/2 = 117             | 21       |
+ *
+ * Momentum is the least-squares line through the last 3 distances, read at the newest bar.
+ * For 3 points that is mean + (last - first)/2:
+ * - Bar 5: [0, 2, 4]  -> 6/3  + (4 - 0)/2  = 2 + 2   = 4
+ * - Bar 6: [2, 4, 21] -> 27/3 + (21 - 2)/2 = 9 + 9.5 = 18.5
+ *
+ * Squeeze state compares BB(3, x2) against KC(3, x1.5) with an EMA(3) middle line and a
+ * Wilder-smoothed ATR(3) width (True Ranges: 6, 6, 6, 6, 12, 44):
+ * - Bar 5: BB = 102 +/- 2*sqrt(6)     -> [97.10, 106.90] sits inside KC = 102.75  +/- 1.5*8 -> [90.75, 114.75]  => on
+ * - Bar 6: BB = 115 +/- 2*sqrt(266)   -> [82.38, 147.62] escapes KC     = 120.375 +/- 1.5*20 -> [90.375, 150.375] => off
+ */
+const worksheetCandles = [
+  {close: 99, high: 102, low: 96},
+  {close: 99, high: 102, low: 96},
+  {close: 99, high: 102, low: 96},
+  {close: 102, high: 104, low: 98},
+  {close: 105, high: 106, low: 94},
+  {close: 138, high: 144, low: 100},
+] as const;
+
+describe('TTMSqueeze', () => {
+  describe('update', () => {
+    it('detects the squeeze in a tight range and its release with rising momentum on the breakout', () => {
+      const expectations = [
+        {isSqueezed: true, momentum: 4},
+        {isSqueezed: false, momentum: 18.5},
+      ] as const;
+      const squeeze = new TTMSqueeze({bbInterval: 3, kcInterval: 3});
+      const offset = squeeze.getRequiredInputs() - 1;
+
+      worksheetCandles.forEach((candle, i) => {
+        const result = squeeze.add(candle);
+
+        if (result) {
+          expect(result).toEqual(expectations[i - offset]);
+        }
+      });
+
+      expect(squeeze.isStable).toBe(true);
+    });
+
+    it('mirrors the momentum sign when the same move plays out to the downside', () => {
+      /*
+       * The worksheet candles mirrored at 200 (close' = 200 - close, high' = 200 - low,
+       * low' = 200 - high): distances and momentum negate exactly, while both envelope
+       * widths are unaffected, so the squeeze states stay identical.
+       */
+      const mirroredCandles = worksheetCandles.map(({close, high, low}) => ({
+        close: 200 - close,
+        high: 200 - low,
+        low: 200 - high,
+      }));
+      const expectations = [
+        {isSqueezed: true, momentum: -4},
+        {isSqueezed: false, momentum: -18.5},
+      ] as const;
+      const squeeze = new TTMSqueeze({bbInterval: 3, kcInterval: 3});
+      const offset = squeeze.getRequiredInputs() - 1;
+
+      mirroredCandles.forEach((candle, i) => {
+        const result = squeeze.add(candle);
+
+        if (result) {
+          expect(result).toEqual(expectations[i - offset]);
+        }
+      });
+
+      expect(squeeze.getSignal().state).toBe(TradingSignal.BEARISH);
+    });
+
+    it('reports no squeeze when a dead market collapses both envelopes onto the price', () => {
+      /*
+       * Without any trading range the standard deviation and the ATR are both zero, so the
+       * Bollinger Bands and the Keltner Channel coincide on the close. A zero-width envelope
+       * cannot trade strictly inside another, so the market is not squeezed - it is dead.
+       */
+      const squeeze = new TTMSqueeze({bbInterval: 3, kcInterval: 3});
+
+      for (let i = 0; i < 5; i++) {
+        squeeze.add({close: 100, high: 100, low: 100});
+      }
+
+      expect(squeeze.getResultOrThrow()).toEqual({isSqueezed: false, momentum: 0});
+    });
+
+    it('keeps a wide Bollinger envelope from reporting a squeeze in the same tight range', () => {
+      const squeeze = new TTMSqueeze({bbInterval: 3, bbMultiplier: 6, kcInterval: 3, kcMultiplier: 1.5});
+
+      for (const candle of worksheetCandles.slice(0, 5)) {
+        squeeze.add(candle);
+      }
+
+      // BB = 102 +/- 6*sqrt(6) -> [87.30, 116.70] overlaps KC = [90.75, 114.75] on both sides
+      expect(squeeze.getResultOrThrow()).toEqual({isSqueezed: false, momentum: 4});
+    });
+
+    it('keeps the breakout inside a wide Keltner Channel', () => {
+      const squeeze = new TTMSqueeze({bbInterval: 3, bbMultiplier: 2, kcInterval: 3, kcMultiplier: 3});
+
+      for (const candle of worksheetCandles) {
+        squeeze.add(candle);
+      }
+
+      // BB = [82.38, 147.62] still fits into KC = 120.375 +/- 3*20 -> [60.375, 180.375]
+      expect(squeeze.getResultOrThrow()).toEqual({isSqueezed: true, momentum: 18.5});
+    });
+
+    it('waits for the Bollinger Bands when they warm up slower than the momentum', () => {
+      const squeeze = new TTMSqueeze({bbInterval: 6, kcInterval: 3});
+
+      expect(squeeze.getRequiredInputs()).toBe(6);
+
+      worksheetCandles.slice(0, 5).forEach(candle => {
+        expect(squeeze.add(candle)).toBeNull();
+      });
+
+      expect(squeeze.add(worksheetCandles[5])).not.toBeNull();
+    });
+
+    it('waits for the Keltner Channel when the Bollinger Bands are already stable', () => {
+      const squeeze = new TTMSqueeze({bbInterval: 2, kcInterval: 3});
+
+      squeeze.add(worksheetCandles[0]);
+
+      expect(squeeze.add(worksheetCandles[1])).toBeNull();
+    });
+  });
+
+  describe('getRequiredInputs', () => {
+    it('defaults to the interval of 20 candles popularized for the squeeze, warming up over 39 candles', () => {
+      expect(new TTMSqueeze().getRequiredInputs()).toBe(39);
+      expect(new TTMSqueeze({bbInterval: 3, kcInterval: 3}).getRequiredInputs()).toBe(5);
+    });
+  });
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const squeeze = new TTMSqueeze({bbInterval: 3, kcInterval: 3});
+
+      for (const candle of worksheetCandles.slice(0, 5)) {
+        squeeze.add(candle);
+      }
+
+      const originalCandle = worksheetCandles[5];
+      // Distances become [2, 4, 0] -> momentum = 6/3 + (0 - 2)/2 = 1, and the calm candle keeps the squeeze on
+      const replacementCandle = {close: 102, high: 108, low: 98} as const;
+
+      const originalResult = squeeze.add(originalCandle);
+
+      expect(originalResult).toEqual({isSqueezed: false, momentum: 18.5});
+
+      const replacedResult = squeeze.replace(replacementCandle);
+
+      expect(replacedResult).toEqual({isSqueezed: true, momentum: 1});
+
+      const restoredResult = squeeze.replace(originalCandle);
+
+      expect(restoredResult).toEqual({isSqueezed: false, momentum: 18.5});
+    });
+  });
+
+  describe('getSignal', () => {
+    it('returns UNKNOWN before the warm-up is complete', () => {
+      const squeeze = new TTMSqueeze({bbInterval: 3, kcInterval: 3});
+
+      expect(squeeze.getSignal()).toEqual({hasChanged: false, state: TradingSignal.UNKNOWN});
+
+      for (const candle of worksheetCandles.slice(0, 4)) {
+        squeeze.add(candle);
+      }
+
+      expect(squeeze.getSignal()).toEqual({hasChanged: false, state: TradingSignal.UNKNOWN});
+    });
+
+    it('returns BULLISH when the momentum is positive', () => {
+      const squeeze = new TTMSqueeze({bbInterval: 3, kcInterval: 3});
+
+      for (const candle of worksheetCandles.slice(0, 5)) {
+        squeeze.add(candle);
+      }
+
+      expect(squeeze.getResultOrThrow().momentum).toBe(4);
+      expect(squeeze.getSignal().state).toBe(TradingSignal.BULLISH);
+    });
+
+    it('returns BEARISH when the momentum is negative', () => {
+      const squeeze = new TTMSqueeze({bbInterval: 3, kcInterval: 3});
+
+      for (const {close, high, low} of worksheetCandles.slice(0, 5)) {
+        squeeze.add({close: 200 - close, high: 200 - low, low: 200 - high});
+      }
+
+      expect(squeeze.getResultOrThrow().momentum).toBe(-4);
+      expect(squeeze.getSignal().state).toBe(TradingSignal.BEARISH);
+    });
+
+    it('returns SIDEWAYS while a flat market drifts along its own anchor', () => {
+      const squeeze = new TTMSqueeze({bbInterval: 3, kcInterval: 3});
+
+      for (let i = 0; i < 5; i++) {
+        squeeze.add({close: 100, high: 101, low: 99});
+      }
+
+      expect(squeeze.getResultOrThrow()).toEqual({isSqueezed: true, momentum: 0});
+      expect(squeeze.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+    });
+
+    it('flags a change only when the signal switches its state', () => {
+      const squeeze = new TTMSqueeze({bbInterval: 3, kcInterval: 3});
+
+      for (let i = 0; i < 5; i++) {
+        squeeze.add({close: 100, high: 101, low: 99});
+      }
+
+      expect(squeeze.getSignal()).toEqual({hasChanged: true, state: TradingSignal.SIDEWAYS});
+
+      squeeze.add({close: 118, high: 120, low: 100});
+
+      expect(squeeze.getSignal()).toEqual({hasChanged: true, state: TradingSignal.BULLISH});
+
+      squeeze.add({close: 124, high: 125, low: 110});
+
+      expect(squeeze.getSignal()).toEqual({hasChanged: false, state: TradingSignal.BULLISH});
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new TTMSqueeze({bbInterval: 3, kcInterval: 3}),
+  divergentInput: {close: 1_000, high: 1_010, low: 990},
+  inputs: worksheetCandles,
+});

--- a/packages/trading-signals/src/volatility/SQUEEZE/TTMSqueeze.ts
+++ b/packages/trading-signals/src/volatility/SQUEEZE/TTMSqueeze.ts
@@ -1,0 +1,172 @@
+import type {HighLowClose} from '../../base/Candle.type.js';
+import {TechnicalIndicator, TradingSignal} from '../../base/Indicator.js';
+import {getAverage} from '../../util/getAverage.js';
+import {pushUpdate} from '../../util/pushUpdate.js';
+import {BollingerBands} from '../BBANDS/BollingerBands.js';
+import {KeltnerChannels} from '../KC/KeltnerChannels.js';
+
+export type TTMSqueezeResult = {
+  /** `true` while the Bollinger Bands trade strictly inside the Keltner Channel */
+  isSqueezed: boolean;
+  /** Histogram value whose sign names the side positioned to receive the move once the squeeze fires */
+  momentum: number;
+};
+
+export type TTMSqueezeConfig = {
+  /** Number of candles for the Bollinger Bands (default: 20) */
+  bbInterval?: number;
+  /** How many standard deviations the Bollinger Bands sit away from their middle line (default: 2) */
+  bbMultiplier?: number;
+  /** Number of candles for the Keltner Channel and the momentum histogram (default: 20) */
+  kcInterval?: number;
+  /** How many ATRs the Keltner Channel lines sit away from the middle line (default: 1.5) */
+  kcMultiplier?: number;
+};
+
+/**
+ * TTM Squeeze / Squeeze Momentum (SQUEEZE)
+ * Type: Volatility
+ *
+ * John Carter introduced the TTM Squeeze in "Mastering the Trade" to spot markets coiling up before
+ * an explosive move: when the Bollinger Bands contract until they trade strictly inside the Keltner
+ * Channel, volatility has compressed far below its usual range — the market is "squeezed". The
+ * accompanying momentum histogram anchors the close to the midpoint between the Donchian midline
+ * (average of highest high and lowest low) and the SMA, then fits a least-squares regression line
+ * through those distances and reads it at the newest candle. This implementation follows LazyBear's
+ * public Pine Script formulation of the momentum histogram; the envelopes reuse this library's
+ * Bollinger Bands and Keltner Channels, so the channel middle line is an EMA and its width follows
+ * a Wilder-smoothed ATR (LazyBear's port smooths both with SMAs instead).
+ *
+ * Interpretation: A squeeze marks the quiet phase that tends to precede an outsized move, not the
+ * move itself. The momentum histogram names the side positioned to receive that move — positive
+ * momentum reads as bullish pressure, negative as bearish. The squeeze state is reported in the
+ * result; the signal reflects only the momentum direction.
+ *
+ * @see https://www.tradingview.com/script/nqQ1DT5a-Squeeze-Momentum-Indicator-LazyBear/
+ * @see https://pastebin.com/UCpcX8d7
+ * @see https://school.stockcharts.com/doku.php?id=technical_indicators:ttm_squeeze
+ */
+export class TTMSqueeze extends TechnicalIndicator<TTMSqueezeResult, HighLowClose<number>> {
+  public readonly bbInterval: number;
+  public readonly bbMultiplier: number;
+  public readonly kcInterval: number;
+  public readonly kcMultiplier: number;
+
+  readonly #bollinger: BollingerBands;
+  readonly #keltner: KeltnerChannels;
+  readonly #candles: HighLowClose<number>[] = [];
+  readonly #anchoredDistances: number[] = [];
+  #previousResult?: TTMSqueezeResult;
+
+  constructor({bbInterval = 20, bbMultiplier = 2, kcInterval = 20, kcMultiplier = 1.5}: TTMSqueezeConfig = {}) {
+    super();
+    this.bbInterval = bbInterval;
+    this.bbMultiplier = bbMultiplier;
+    this.kcInterval = kcInterval;
+    this.kcMultiplier = kcMultiplier;
+    this.#bollinger = new BollingerBands(bbInterval, bbMultiplier);
+    this.#keltner = new KeltnerChannels({atrInterval: kcInterval, emaInterval: kcInterval, multiplier: kcMultiplier});
+  }
+
+  override getRequiredInputs() {
+    /*
+     * The histogram warms up last: its anchor needs a full candle window and the regression then
+     * needs a full window of anchored distances on top of that.
+     */
+    const momentumWarmUp = 2 * this.kcInterval - 1;
+
+    return Math.max(this.#bollinger.getRequiredInputs(), this.#keltner.getRequiredInputs(), momentumWarmUp);
+  }
+
+  /**
+   * Fits a least-squares line through the anchored distances and reads it at the newest candle.
+   * Computed locally instead of reusing the linear-regression indicator, because that one projects
+   * the line one candle ahead and short-circuits windows climbing in unit steps with a projection
+   * that lands one candle short — either quirk would distort the histogram of a steadily trending
+   * market.
+   */
+  #regressionValue(window: readonly number[]) {
+    const n = window.length;
+    let sumY = 0;
+    let sumXY = 0;
+
+    for (let x = 0; x < n; x++) {
+      sumY += window[x];
+      sumXY += x * window[x];
+    }
+
+    const sumX = ((n - 1) * n) / 2;
+    const sumXX = ((n - 1) * n * (2 * n - 1)) / 6;
+    const slope = (n * sumXY - sumX * sumY) / (n * sumXX - sumX * sumX);
+    const intercept = (sumY - slope * sumX) / n;
+
+    return slope * (n - 1) + intercept;
+  }
+
+  update(candle: HighLowClose<number>, replace: boolean) {
+    const bollinger = this.#bollinger.update(candle.close, replace);
+    const keltner = this.#keltner.update(candle, replace);
+
+    pushUpdate({array: this.#candles, item: candle, maxLength: this.kcInterval, replace: replace});
+
+    if (this.#candles.length === this.kcInterval) {
+      const highestHigh = Math.max(...this.#candles.map(({high}) => high));
+      const lowestLow = Math.min(...this.#candles.map(({low}) => low));
+      const donchianMidline = (highestHigh + lowestLow) / 2;
+      const averageClose = getAverage(this.#candles.map(({close}) => close));
+      const anchor = (donchianMidline + averageClose) / 2;
+      pushUpdate({
+        array: this.#anchoredDistances,
+        item: candle.close - anchor,
+        maxLength: this.kcInterval,
+        replace: replace,
+      });
+    }
+
+    if (bollinger === null || keltner === null || this.#anchoredDistances.length < this.kcInterval) {
+      return null;
+    }
+
+    if (replace) {
+      this.result = this.#previousResult;
+    }
+
+    this.#previousResult = this.result;
+
+    return (this.result = {
+      isSqueezed: bollinger.upper < keltner.upper && bollinger.lower > keltner.lower,
+      momentum: this.#regressionValue(this.#anchoredDistances),
+    });
+  }
+
+  protected calculateSignal(result?: TTMSqueezeResult | null | undefined) {
+    const hasResult = result !== null && result !== undefined;
+    const isBullish = hasResult && result.momentum > 0;
+    const isBearish = hasResult && result.momentum < 0;
+
+    switch (true) {
+      case !hasResult:
+        return TradingSignal.UNKNOWN;
+      case isBullish:
+        return TradingSignal.BULLISH;
+      case isBearish:
+        return TradingSignal.BEARISH;
+      default:
+        return TradingSignal.SIDEWAYS;
+    }
+  }
+
+  getSignal(): {
+    state: (typeof TradingSignal)[keyof typeof TradingSignal];
+    hasChanged: boolean;
+  } {
+    const previousState = this.calculateSignal(this.#previousResult);
+    const state = this.calculateSignal(this.getResult());
+    const hasChanged = previousState !== state;
+
+    return {
+      hasChanged,
+      state,
+    };
+  }
+}

--- a/packages/trading-signals/src/volatility/index.ts
+++ b/packages/trading-signals/src/volatility/index.ts
@@ -13,5 +13,6 @@ export * from './MI/MassIndex.js';
 export * from './NATR/NATR.js';
 export * from './PB/PercentB.js';
 export * from './PO/ProjectionOscillator.js';
+export * from './SQUEEZE/TTMSqueeze.js';
 export * from './TR/TR.js';
 export * from './UI/UlcerIndex.js';

--- a/packages/trading-signals/src/volatility/index.ts
+++ b/packages/trading-signals/src/volatility/index.ts
@@ -2,6 +2,7 @@ export * from './ABANDS/AccelerationBands.js';
 export * from './ATR/ATR.js';
 export * from './BBANDS/BollingerBands.js';
 export * from './BBW/BollingerBandsWidth.js';
+export * from './CVI/CVI.js';
 export * from './DC/DonchianChannels.js';
 export * from './GAPO/GAPO.js';
 export * from './IQR/IQR.js';

--- a/packages/trading-signals/src/volatility/index.ts
+++ b/packages/trading-signals/src/volatility/index.ts
@@ -2,6 +2,7 @@ export * from './ABANDS/AccelerationBands.js';
 export * from './ATR/ATR.js';
 export * from './BBANDS/BollingerBands.js';
 export * from './BBW/BollingerBandsWidth.js';
+export * from './CHOP/CHOP.js';
 export * from './CVI/CVI.js';
 export * from './DC/DonchianChannels.js';
 export * from './GAPO/GAPO.js';


### PR DESCRIPTION
## Summary

Sources [Jesse Trading Bot Indicators](https://docs.jesse.trade/docs/indicators/reference.html) — of its 161 entries, ~76 were already covered and ~60 fall to the established filter (MA zoo, stat/math primitives, Ehlers DSP filter set, chart/batch constructs, trivial derivations). The 9 established gaps land here, one commit each:

| Indicator | Class | Category | Reference verification |
|---|---|---|---|
| Chaikin Volatility | `CVI` | volatility | Tulip `untest.txt` L131–134 + `cvi.c` (bit-exact alignment via EMA stability) |
| Choppiness Index | `CHOP` | volatility | Skender v3.0.0 exact at 7 decimals — **after proving their true-extremes variant is the correct one** (naive extremes mismatch 59/488 and break the 0–100 bound) |
| McGinley Dynamic | `McGinleyDynamic` | trend | Skender v3.0.0 **bit-exact across all 502 bars** + asymmetry property tests |
| SuperSmoother Filter | `SuperSmoother` | trend | Ehlers' primary-source listing (mesasoftware PDF), Nyquist-cancellation property |
| WaveTrend | `WaveTrend` | momentum | LazyBear's published script, exact-fraction worksheet |
| Schaff Trend Cycle | `STC` | momentum | Hand-derived double-stochastic cascade — **Skender's STC is provably not Schaff's formula** (single stochastic pass, up to 86-point divergence; documented in the test) |
| TTM Squeeze | `TTMSqueeze` | volatility | LazyBear's pinned script; internal regression (avoids the known LINREG forecast bug) |
| Waddah Attar Explosion | `WaddahAttarExplosion` | momentum | SHK's published Pine source, dyadic-exact worksheet |
| MESA Adaptive MA | `MAMA` (+FAMA) | trend | **TA-Lib's published regression anchors** reproduced via an independent line-by-line `ta_MAMA.c` port agreeing bar-for-bar (≤4e-12 over 252 bars) |

## Notes

- `McGinleyDynamic` and `SuperSmoother` join the `MovingAverageTypes` union (16 injectable MAs now).
- `CHOP` is deliberately signal-free (choppiness is direction-agnostic — a threshold signal would fabricate direction).
- **Skipped by the popularity filter, available on request**: RVI (Dorsey), Laguerre RSI, Inverse-Fisher RSI, Chande Kroll Stop (Tier 2); RSX/JMA (proprietary Jurik, no honest reference), PFE, Williams A/D, VPCI, Ehlers reflex/trendflex/itrend (Tier 3).
- Final commit removes Jesse from the README Alternatives.

Stacked on #1292. Library sourcing: indicatorts ✓, Cloud9Trader ✓, technicalindicators ✓, Highcharts ✓, Jesse ✓ (this PR — library at 113 indicators); next: LEAN.