### PR TITLE
feat(trading-signals): close the Pandas TA feature gap (8 indicators)

### DIFF
--- a/packages/trading-signals-docs/indicator-demos/momentum/PSL.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/PSL.demo.tsx
@@ -1,0 +1,20 @@
+import {PSL as PSLClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const PSL: IndicatorConfig = {
+  chartTitle: 'PSL (12)',
+  color: '#65a30d',
+  createIndicator: () => new PSLClass(),
+  description: 'Psychological Line',
+  details:
+    'Measures crowd sentiment as the percentage of the last 12 bars that closed above their previous close. Readings of 75 or above indicate overbought, 25 or below indicate oversold — the conventional bands on the Asian trading platforms where the indicator (also known as PSY) is a standard.',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
+  id: 'psl',
+  name: 'PSL',
+  processData: makeProcessData({rowInputs: ['close']}),
+  requiredInputs: 13,
+  type: 'single',
+  yAxisLabel: 'PSL',
+};

--- a/packages/trading-signals-docs/indicator-demos/momentum/QQE.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/QQE.demo.tsx
@@ -1,0 +1,151 @@
+import {Chart as HighchartsChart} from '@highcharts/react';
+import {QQE as QQEClass} from 'trading-signals';
+import type {ReactNode} from 'react';
+import type {Candle} from '@typedtrader/exchange';
+import {createSharedTooltipFormatter, type ChartDataPoint} from '../../components/Chart';
+import {NotAvailable} from '../../components/NotAvailable';
+import PriceChart, {type PriceData} from '../../components/PriceChart';
+import {SignalBadge} from '../../components/SignalBadge';
+import {formatDate} from '../../utils/formatDate';
+import {collectPriceData} from '../../utils/renderUtils';
+import type {IndicatorConfig} from '../../utils/types';
+
+// The fast preset of the original QQE (RSI 6, smoothing 3, factor 2.618) keeps the warm-up short enough for small datasets
+const createQQE = () => new QQEClass({fastFactor: 2.618, rsiInterval: 6, smoothInterval: 3});
+
+const renderQQE = (config: IndicatorConfig, selectedCandles: Candle[]) => {
+  const qqe = createQQE();
+  const chartDataRsiMa: ChartDataPoint[] = [];
+  const chartDataTrailingStop: ChartDataPoint[] = [];
+  const priceData: PriceData[] = [];
+  const sampleValues: {
+    period: number;
+    date: string;
+    close: number;
+    rsiMa: ReactNode;
+    trailingStop: ReactNode;
+    signal: string;
+  }[] = [];
+
+  selectedCandles.forEach((candle, idx) => {
+    const result = qqe.add(Number(candle.close));
+    const signal = qqe.getSignal();
+    chartDataRsiMa.push({x: idx + 1, y: result?.rsiMa ?? null});
+    chartDataTrailingStop.push({x: idx + 1, y: result?.trailingStop ?? null});
+
+    priceData.push(collectPriceData(candle, idx));
+
+    sampleValues.push({
+      close: Number(candle.close),
+      date: formatDate(candle.openTimeInISO),
+      period: idx + 1,
+      rsiMa: result ? result.rsiMa.toFixed(2) : <NotAvailable />,
+      signal: signal.state,
+      trailingStop: result ? result.trailingStop.toFixed(2) : <NotAvailable />,
+    });
+  });
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold text-white mb-2 select-text">
+          QQE({qqe.rsiInterval}, {qqe.smoothInterval}, {qqe.fastFactor}) / Required Inputs: {qqe.getRequiredInputs()}
+        </h2>
+        <p className="text-slate-300 select-text">{config.description}</p>
+        {config.details && <p className="text-slate-400 text-sm mt-2 select-text">{config.details}</p>}
+      </div>
+
+      <div className="bg-slate-800/50 border border-slate-700 rounded-lg p-4">
+        <HighchartsChart
+          options={{
+            chart: {backgroundColor: 'transparent', height: 300, type: 'line'},
+            credits: {enabled: false},
+            legend: {enabled: true, itemStyle: {color: '#e2e8f0'}},
+            plotOptions: {line: {lineWidth: 2, marker: {enabled: true, radius: 3}}},
+            series: [
+              {
+                color: config.color,
+                data: chartDataRsiMa.map(point => [point.x, point.y]),
+                marker: {fillColor: config.color},
+                name: 'RSI MA',
+                type: 'line',
+              },
+              {
+                color: '#38bdf8',
+                data: chartDataTrailingStop.map(point => [point.x, point.y]),
+                marker: {fillColor: '#38bdf8'},
+                name: 'Trailing Stop',
+                type: 'line',
+              },
+            ],
+            title: {style: {color: '#e2e8f0', fontSize: '16px', fontWeight: '600'}, text: 'QQE (6, 3, 2.618)'},
+            tooltip: {
+              backgroundColor: '#1e293b',
+              borderColor: '#475569',
+              formatter: createSharedTooltipFormatter(y => y.toFixed(2)),
+              shared: true,
+              style: {color: '#e2e8f0'},
+            },
+            xAxis: {
+              gridLineColor: '#334155',
+              labels: {style: {color: '#94a3b8'}},
+              title: {style: {color: '#94a3b8'}, text: 'Period'},
+            },
+            yAxis: {
+              gridLineColor: '#334155',
+              labels: {style: {color: '#94a3b8'}},
+              title: {style: {color: '#94a3b8'}, text: 'RSI'},
+            },
+          }}
+        />
+      </div>
+
+      <PriceChart title="Input Prices" data={priceData} />
+
+      <div className="bg-slate-800/50 border border-slate-700 rounded-lg p-4">
+        <h3 className="text-lg font-semibold text-white mb-3">All Sample Values</h3>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-slate-600">
+                <th className="text-left text-slate-300 py-2 px-3">Period</th>
+                <th className="text-left text-slate-300 py-2 px-3">Date</th>
+                <th className="text-left text-slate-300 py-2 px-3">Close</th>
+                <th className="text-left text-slate-300 py-2 px-3">RSI MA</th>
+                <th className="text-left text-slate-300 py-2 px-3">Trailing Stop</th>
+                <th className="text-left text-slate-300 py-2 px-3">Signal</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sampleValues.map(row => (
+                <tr key={row.period} className="border-b border-slate-700/50">
+                  <td className="text-slate-400 py-2 px-3">{row.period}</td>
+                  <td className="text-slate-300 py-2 px-3">{row.date}</td>
+                  <td className="text-slate-300 py-2 px-3">${row.close.toFixed(2)}</td>
+                  <td className="text-white font-mono py-2 px-3">{row.rsiMa}</td>
+                  <td className="text-white font-mono py-2 px-3">{row.trailingStop}</td>
+                  <td className="py-2 px-3">
+                    <SignalBadge signal={row.signal} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const QQE: IndicatorConfig = {
+  color: '#f59e0b',
+  createIndicator: createQQE,
+  customRender: renderQQE,
+  description: 'Quantitative Qualitative Estimation',
+  details:
+    'Smooths the RSI into a calmer line and trails a volatility-based stop behind it — the SuperTrend construction applied to the RSI instead of price. The side the smoothed RSI takes of its trailing stop names the momentum direction; a flip of the stop line marks a momentum reversal.',
+  id: 'qqe',
+  name: 'QQE',
+  requiredInputs: 30,
+  type: 'custom',
+};

--- a/packages/trading-signals-docs/indicator-demos/momentum/SMI.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/SMI.demo.tsx
@@ -1,0 +1,20 @@
+import {SMI as SMIClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const SMI: IndicatorConfig = {
+  chartTitle: 'SMI (10, 3, 3)',
+  color: '#0891b2',
+  createIndicator: () => new SMIClass(),
+  description: 'Stochastic Momentum Index',
+  details:
+    'Locates the close relative to the midpoint of the recent high/low range and double-smooths that distance with two EMAs, bounding readings between -100 and +100. Readings of +40 and above indicate an overbought market, -40 and below an oversold market.',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['high', 'low', 'close']}),
+  id: 'smi',
+  name: 'SMI',
+  processData: makeProcessData({rowInputs: ['high', 'low', 'close']}),
+  requiredInputs: 14,
+  type: 'single',
+  yAxisLabel: 'SMI',
+};

--- a/packages/trading-signals-docs/indicator-demos/momentum/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/index.tsx
@@ -26,6 +26,7 @@ import {PGO} from './PGO.demo';
 import {PMO} from './PMO.demo';
 import {PPO} from './PPO.demo';
 import {PremierStochastic} from './PremierStochastic.demo';
+import {PSL} from './PSL.demo';
 import {Qstick} from './Qstick.demo';
 import {REI} from './REI.demo';
 import {RVGI} from './RelativeVigorIndex.demo';
@@ -81,6 +82,7 @@ export const indicators: IndicatorConfig[] = [
   PGO,
   PMO,
   PremierStochastic,
+  PSL,
   RVGI,
   STC,
   TRIX,

--- a/packages/trading-signals-docs/indicator-demos/momentum/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/index.tsx
@@ -32,6 +32,7 @@ import {REI} from './REI.demo';
 import {RVGI} from './RelativeVigorIndex.demo';
 import {ROC} from './ROC.demo';
 import {RSI} from './RSI.demo';
+import {SMI} from './SMI.demo';
 import {STC} from './STC.demo';
 import {StochasticOscillator} from './StochasticOscillator.demo';
 import {StochasticRSI} from './StochasticRSI.demo';
@@ -84,6 +85,7 @@ export const indicators: IndicatorConfig[] = [
   PremierStochastic,
   PSL,
   RVGI,
+  SMI,
   STC,
   TRIX,
   TSI,

--- a/packages/trading-signals-docs/indicator-demos/momentum/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/momentum/index.tsx
@@ -27,6 +27,7 @@ import {PMO} from './PMO.demo';
 import {PPO} from './PPO.demo';
 import {PremierStochastic} from './PremierStochastic.demo';
 import {PSL} from './PSL.demo';
+import {QQE} from './QQE.demo';
 import {Qstick} from './Qstick.demo';
 import {REI} from './REI.demo';
 import {RVGI} from './RelativeVigorIndex.demo';
@@ -84,6 +85,7 @@ export const indicators: IndicatorConfig[] = [
   PMO,
   PremierStochastic,
   PSL,
+  QQE,
   RVGI,
   SMI,
   STC,

--- a/packages/trading-signals-docs/indicator-demos/trend/GannHiLo.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/GannHiLo.demo.tsx
@@ -1,0 +1,146 @@
+import {Chart as HighchartsChart} from '@highcharts/react';
+import {GannHiLo as GannHiLoClass, TradingSignal} from 'trading-signals';
+import type {ReactNode} from 'react';
+import type {Candle} from '@typedtrader/exchange';
+import {createSharedTooltipFormatter, type ChartDataPoint} from '../../components/Chart';
+import {NotAvailable} from '../../components/NotAvailable';
+import PriceChart, {type PriceData} from '../../components/PriceChart';
+import {formatDate} from '../../utils/formatDate';
+import {collectPriceData} from '../../utils/renderUtils';
+import type {IndicatorConfig} from '../../utils/types';
+
+const renderGannHiLo = (config: IndicatorConfig, selectedCandles: Candle[]) => {
+  const hilo = new GannHiLoClass();
+  const chartDataClose: ChartDataPoint[] = [];
+  const chartDataUptrend: ChartDataPoint[] = [];
+  const chartDataDowntrend: ChartDataPoint[] = [];
+  const priceData: PriceData[] = [];
+  const sampleValues: {period: number; date: string; close: number; line: ReactNode; trend: ReactNode}[] = [];
+
+  selectedCandles.forEach((candle, idx) => {
+    const result = hilo.add({close: Number(candle.close), high: Number(candle.high), low: Number(candle.low)});
+    chartDataClose.push({x: idx + 1, y: Number(candle.close)});
+    chartDataUptrend.push({x: idx + 1, y: result?.trend === TradingSignal.BULLISH ? result.line : null});
+    chartDataDowntrend.push({x: idx + 1, y: result?.trend === TradingSignal.BEARISH ? result.line : null});
+
+    priceData.push(collectPriceData(candle, idx));
+
+    sampleValues.push({
+      close: Number(candle.close),
+      date: formatDate(candle.openTimeInISO),
+      line: result ? result.line.toFixed(2) : <NotAvailable />,
+      period: idx + 1,
+      trend: result ? result.trend : <NotAvailable />,
+    });
+  });
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold text-white mb-2 select-text">
+          GannHiLo({hilo.highInterval}, {hilo.lowInterval}) / Required Inputs: {hilo.getRequiredInputs()}
+        </h2>
+        <p className="text-slate-300 select-text">{config.description}</p>
+        {config.details && <p className="text-slate-400 text-sm mt-2 select-text">{config.details}</p>}
+      </div>
+
+      <div className="bg-slate-800/50 border border-slate-700 rounded-lg p-4">
+        <HighchartsChart
+          options={{
+            chart: {backgroundColor: 'transparent', height: 300, type: 'line'},
+            credits: {enabled: false},
+            legend: {enabled: true, itemStyle: {color: '#e2e8f0'}},
+            plotOptions: {line: {lineWidth: 2, marker: {enabled: true, radius: 3}}},
+            series: [
+              {
+                color: '#94a3b8',
+                data: chartDataClose.map(point => [point.x, point.y]),
+                marker: {fillColor: '#94a3b8'},
+                name: 'Close',
+                type: 'line',
+              },
+              {
+                color: '#10b981',
+                data: chartDataUptrend.map(point => [point.x, point.y]),
+                marker: {fillColor: '#10b981'},
+                name: 'Uptrend (average of lows)',
+                type: 'line',
+              },
+              {
+                color: '#ef4444',
+                data: chartDataDowntrend.map(point => [point.x, point.y]),
+                marker: {fillColor: '#ef4444'},
+                name: 'Downtrend (average of highs)',
+                type: 'line',
+              },
+            ],
+            title: {
+              style: {color: '#e2e8f0', fontSize: '16px', fontWeight: '600'},
+              text: 'Gann HiLo Activator (13, 21)',
+            },
+            tooltip: {
+              backgroundColor: '#1e293b',
+              borderColor: '#475569',
+              formatter: createSharedTooltipFormatter(),
+              shared: true,
+              style: {color: '#e2e8f0'},
+            },
+            xAxis: {
+              gridLineColor: '#334155',
+              labels: {style: {color: '#94a3b8'}},
+              title: {style: {color: '#94a3b8'}, text: 'Period'},
+            },
+            yAxis: {
+              gridLineColor: '#334155',
+              labels: {style: {color: '#94a3b8'}},
+              title: {style: {color: '#94a3b8'}, text: 'Price'},
+            },
+          }}
+        />
+      </div>
+
+      <PriceChart title="Input Prices" data={priceData} />
+
+      <div className="bg-slate-800/50 border border-slate-700 rounded-lg p-4">
+        <h3 className="text-lg font-semibold text-white mb-3">All Sample Values</h3>
+        <div className="overflow-x-auto">
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-slate-600">
+                <th className="text-left py-2 px-3 text-slate-400 font-medium">Period</th>
+                <th className="text-left py-2 px-3 text-slate-400 font-medium">Date</th>
+                <th className="text-left py-2 px-3 text-slate-400 font-medium">Close</th>
+                <th className="text-left py-2 px-3 text-slate-400 font-medium">HiLo</th>
+                <th className="text-left py-2 px-3 text-slate-400 font-medium">Trend</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sampleValues.map((row, idx) => (
+                <tr key={idx} className="border-b border-slate-700/50">
+                  <td className="py-2 px-3 text-white font-mono">{row.period}</td>
+                  <td className="py-2 px-3 text-slate-300">{row.date}</td>
+                  <td className="py-2 px-3 text-slate-300">${row.close.toFixed(2)}</td>
+                  <td className="py-2 px-3 text-white font-mono">{row.line}</td>
+                  <td className="py-2 px-3 text-white font-mono">{row.trend}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const GannHiLo: IndicatorConfig = {
+  color: '#10b981',
+  createIndicator: () => new GannHiLoClass(),
+  customRender: renderGannHiLo,
+  description: 'Gann HiLo Activator',
+  details:
+    'Robert Krausz built his Gann swing trading plans around this activator: it tracks a simple moving average of the highs and one of the lows, and the close picks which of the two is plotted. Closing above the previous average of the highs activates the average of the lows as rising support, closing below the previous average of the lows activates the average of the highs as falling resistance, and between the two averages the line freezes, so a pullback never loosens the stop.',
+  id: 'gann-hilo',
+  name: 'Gann HiLo Activator',
+  requiredInputs: 21,
+  type: 'custom',
+};

--- a/packages/trading-signals-docs/indicator-demos/trend/VHF.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/VHF.demo.tsx
@@ -1,0 +1,20 @@
+import {VHF as VHFClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const VHF: IndicatorConfig = {
+  chartTitle: 'VHF (28)',
+  color: '#a855f7',
+  createIndicator: () => new VHFClass(28),
+  description: 'Vertical Horizontal Filter',
+  details:
+    'Relates the widest span between closing prices to the total ground those closes covered over the window, bounded between 0 and 1. Readings near 1 mark a market walking its span in a straight line (trending); readings near 0 mark a market crossing the same prices again and again (congesting). There is no fixed banding — the reading is compared against its own recent history, and it is direction-agnostic: a crash and a rally both read as trending, so the direction must come from a companion trend indicator.',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
+  id: 'vhf',
+  name: 'Vertical Horizontal Filter',
+  processData: makeProcessData({rowInputs: ['close']}),
+  requiredInputs: 29,
+  type: 'single',
+  yAxisLabel: 'VHF',
+};

--- a/packages/trading-signals-docs/indicator-demos/trend/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/index.tsx
@@ -14,6 +14,7 @@ import {McGinleyDynamic} from './McGinleyDynamic.demo';
 import {T3} from './T3.demo';
 import {TEMA} from './TEMA.demo';
 import {TRIMA} from './TRIMA.demo';
+import {VHF} from './VHF.demo';
 import {VIDYA} from './VIDYA.demo';
 import {VortexIndicator} from './VortexIndicator.demo';
 import {DMA} from './DMA.demo';
@@ -53,6 +54,7 @@ export const indicators: IndicatorConfig[] = [
   McGinleyDynamic,
   MAMA,
   SuperSmoother,
+  VHF,
   VortexIndicator,
   IchimokuCloud,
   Aroon,

--- a/packages/trading-signals-docs/indicator-demos/trend/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/index.tsx
@@ -6,6 +6,7 @@ import {ChandeKrollStop} from './ChandeKrollStop.demo';
 import {ChandelierExit} from './ChandelierExit.demo';
 import {DEMA} from './DEMA.demo';
 import {FRAMA} from './FRAMA.demo';
+import {GannHiLo} from './GannHiLo.demo';
 import {HMA} from './HMA.demo';
 import {IchimokuCloud} from './IchimokuCloud.demo';
 import {KAMA} from './KAMA.demo';
@@ -55,6 +56,7 @@ export const indicators: IndicatorConfig[] = [
   MAMA,
   SuperSmoother,
   VHF,
+  GannHiLo,
   VortexIndicator,
   IchimokuCloud,
   Aroon,

--- a/packages/trading-signals-docs/indicator-demos/volatility/RelativeVolatilityIndex.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volatility/RelativeVolatilityIndex.demo.tsx
@@ -1,0 +1,20 @@
+import {RelativeVolatilityIndex as RelativeVolatilityIndexClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const RelativeVolatilityIndex: IndicatorConfig = {
+  chartTitle: 'RVI (14, 10)',
+  color: '#eab308',
+  createIndicator: () => new RelativeVolatilityIndexClass(),
+  description: 'Relative Volatility Index',
+  details:
+    "Donald Dorsey's RSI-style oscillator over volatility instead of price change: the standard deviation of recent closes feeds an up stream when the close rises and a down stream when it falls, and Wilder-smoothing both streams yields the share of recent volatility that built up while prices were rising (0 to 100). Values above 60 indicate volatility building on the upside, below 40 on the downside. Dorsey designed it as a confirmation filter for other indicators, not a standalone signal.",
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
+  id: 'rvi',
+  name: 'RVI',
+  processData: makeProcessData({rowInputs: ['close']}),
+  requiredInputs: 23,
+  type: 'single',
+  yAxisLabel: 'RVI',
+};

--- a/packages/trading-signals-docs/indicator-demos/volatility/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volatility/index.tsx
@@ -13,6 +13,7 @@ import {MassIndex} from './MassIndex.demo';
 import {NATR} from './NATR.demo';
 import {PercentB} from './PercentB.demo';
 import {ProjectionOscillator} from './ProjectionOscillator.demo';
+import {RelativeVolatilityIndex} from './RelativeVolatilityIndex.demo';
 import {RogersSatchellVolatility} from './RogersSatchellVolatility.demo';
 import {TR} from './TR.demo';
 import {TTMSqueeze} from './TTMSqueeze.demo';
@@ -39,4 +40,5 @@ export const indicators: IndicatorConfig[] = [
   CHOP,
   TTMSqueeze,
   RogersSatchellVolatility,
+  RelativeVolatilityIndex,
 ];

--- a/packages/trading-signals-docs/indicator-demos/volume/MarketFacilitationIndex.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volume/MarketFacilitationIndex.demo.tsx
@@ -1,0 +1,20 @@
+import {MarketFacilitationIndex as MarketFacilitationIndexClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const MarketFacilitationIndex: IndicatorConfig = {
+  chartTitle: 'Market Facilitation Index',
+  color: '#f97316',
+  createIndicator: () => new MarketFacilitationIndexClass(),
+  description: 'Market Facilitation Index',
+  details:
+    "Bill Williams' Market Facilitation Index (BW MFI, unrelated to the Money Flow Index) divides each candle's trading range by its volume, showing how much price movement one unit of volume produced. Williams reads it only next to the volume change of the same candle — rising index on rising volume confirms participation, rising index on falling volume warns of a move without backing — so the value carries no standalone signal.",
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['high', 'low', 'volume']}),
+  id: 'marketfi',
+  name: 'MARKETFI',
+  processData: makeProcessData({addInputs: ['close', 'high', 'low', 'volume'], rowInputs: ['high', 'low', 'volume']}),
+  requiredInputs: 1,
+  type: 'single',
+  yAxisLabel: 'MARKETFI',
+};

--- a/packages/trading-signals-docs/indicator-demos/volume/WAD.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volume/WAD.demo.tsx
@@ -1,0 +1,23 @@
+import {WAD as WADClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const WAD: IndicatorConfig = {
+  chartTitle: 'Williams Accumulation/Distribution',
+  color: '#f97316',
+  createIndicator: () => new WADClass(),
+  description: 'Williams Accumulation/Distribution',
+  details:
+    "Larry Williams' cumulative line: an up-close adds the run from the true low to the close, a down-close subtracts the drop from the true high. Built from price alone — unlike Chaikin's AD, which weights by volume. Read against price for divergence: a price high the line refuses to confirm warns of distribution.",
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['close']}),
+  id: 'wad',
+  name: 'WAD',
+  processData: makeProcessData({
+    addInputs: ['close', 'high', 'low'],
+    rowInputs: ['close'],
+  }),
+  requiredInputs: 2,
+  type: 'single',
+  yAxisLabel: 'WAD',
+};

--- a/packages/trading-signals-docs/indicator-demos/volume/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volume/index.tsx
@@ -4,6 +4,7 @@ import {CMF} from './CMF.demo';
 import {EMV} from './EMV.demo';
 import {ForceIndex} from './ForceIndex.demo';
 import {KVO} from './KVO.demo';
+import {MarketFacilitationIndex} from './MarketFacilitationIndex.demo';
 import {NVI} from './NVI.demo';
 import {PVI} from './PVI.demo';
 import {PVO} from './PVO.demo';
@@ -21,6 +22,7 @@ export const indicators: IndicatorConfig[] = [
   EMV,
   ForceIndex,
   KVO,
+  MarketFacilitationIndex,
   NVI,
   PVI,
   PVO,

--- a/packages/trading-signals-docs/indicator-demos/volume/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/volume/index.tsx
@@ -10,6 +10,21 @@ import {PVO} from './PVO.demo';
 import {PVT} from './PVT.demo';
 import {VROC} from './VROC.demo';
 import {VWMA} from './VWMA.demo';
+import {WAD} from './WAD.demo';
 import type {IndicatorConfig} from '../../utils/types';
 
-export const indicators: IndicatorConfig[] = [AD, ADOSC, CMF, PVT, EMV, ForceIndex, KVO, NVI, PVI, PVO, VROC, VWMA];
+export const indicators: IndicatorConfig[] = [
+  AD,
+  ADOSC,
+  CMF,
+  PVT,
+  EMV,
+  ForceIndex,
+  KVO,
+  NVI,
+  PVI,
+  PVO,
+  VROC,
+  VWMA,
+  WAD,
+];

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -108,6 +108,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Schaff Trend Cycle (STC)
 1. Simple Moving Average (SMA)
 1. Spencer's 15-Point Moving Average (SMA15)
+1. Stochastic Momentum Index (SMI)
 1. Stochastic Oscillator (STOCH)
 1. Stochastic RSI (STOCHRSI)
 1. SuperSmoother Filter (SUPERSMOOTHER)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -123,6 +123,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Ulcer Index (UI)
 1. Ultimate Oscillator (ULTOSC)
 1. Variable Index Dynamic Average (VIDYA)
+1. Vertical Horizontal Filter (VHF)
 1. Volatility Stop (VSTOP)
 1. Volume Rate of Change (VROC)
 1. Volume-Weighted Average Price (VWAP)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -98,6 +98,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Projection Oscillator (PO)
 1. Psychological Line (PSL)
 1. Qstick (QSTICK)
+1. Quantitative Qualitative Estimation (QQE)
 1. Range Expansion Index (REI)
 1. Rate-of-Change (ROC)
 1. Relative Moving Average (RMA)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -238,7 +238,6 @@ console.log(sma.highest?.toFixed(2)); // "53.33"
 
 ## Alternatives
 
-- [Pandas TA (Python)](https://github.com/twopirllc/pandas-ta)
 - [Stock Indicators for .NET (C#)](https://github.com/DaveSkender/Stock.Indicators)
 - [StockSharp (C#)](https://github.com/StockSharp/StockSharp)
 - [ta-lib (C)](https://github.com/TA-Lib/ta-lib/tree/main/src/ta_func)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -102,6 +102,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Relative Moving Average (RMA)
 1. Relative Strength Index (RSI)
 1. Relative Vigor Index (RVGI)
+1. Relative Volatility Index (RVI)
 1. Relative Volume (RVOL)
 1. Rogers-Satchell Volatility (RSV)
 1. Schaff Trend Cycle (STC)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -131,6 +131,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Weighted Moving Average (WMA)
 1. Wilder's Smoothed Moving Average (WSMA / WWS / SMMA / MEMA)
 1. Williams %R (WILLR)
+1. Williams Accumulation/Distribution (WAD)
 1. Zero-Lag Exponential Moving Average (ZLEMA)
 1. Zig Zag Indicator (ZigZag)
 

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -75,6 +75,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Klinger Volume Oscillator (KVO)
 1. Know Sure Thing (KST)
 1. Linear Regression (LINREG)
+1. Market Facilitation Index (MARKETFI)
 1. Mass Index (MI)
 1. McGinley Dynamic (MD)
 1. Mean Absolute Deviation (MAD)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -65,6 +65,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Fisher Transform (FISHER)
 1. Force Index (FI)
 1. Fractal Adaptive Moving Average (FRAMA)
+1. Gann HiLo Activator (HILO)
 1. Gopalakrishnan Range Index (GAPO)
 1. Hull Moving Average (HMA)
 1. Ichimoku Cloud (ICHIMOKU)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -95,6 +95,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Price Momentum Oscillator (PMO)
 1. Price Volume Trend (PVT)
 1. Projection Oscillator (PO)
+1. Psychological Line (PSL)
 1. Qstick (QSTICK)
 1. Range Expansion Index (REI)
 1. Rate-of-Change (ROC)

--- a/packages/trading-signals/src/momentum/PSL/PSL.test.ts
+++ b/packages/trading-signals/src/momentum/PSL/PSL.test.ts
@@ -1,0 +1,224 @@
+import {TradingSignal} from '../../base/index.js';
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {PSL} from './PSL.js';
+
+describe('PSL', () => {
+  /*
+   * There is no Tulip Indicators entry for the Psychological Line, so the expectations are derived by hand
+   * from the published formula — 100 × (number of bars closing above their previous close) / interval — with
+   * rising-bar counts chosen so every reading divides exactly.
+   *
+   * Formula sources:
+   * @see https://github.com/xgboosted/pandas-ta-classic/blob/main/pandas_ta_classic/momentum/psl.py
+   * @see https://www.moomoo.com/us/support/topic3_814
+   *
+   * Worksheet (interval 4): the window spans the last 5 closes, i.e. 4 close-to-close comparisons.
+   *
+   * | Bar | Close | Direction | Rising in window | PSL          |
+   * | --- | ----- | --------- | ---------------- | ------------ |
+   * | 1   | 10    | —         | —                | —            |
+   * | 2   | 11    | up        | —                | —            |
+   * | 3   | 12    | up        | —                | —            |
+   * | 4   | 11    | down      | —                | —            |
+   * | 5   | 13    | up        | 3 of 4           | 300 / 4 = 75 |
+   * | 6   | 12    | down      | 2 of 4           | 200 / 4 = 50 |
+   * | 7   | 11    | down      | 1 of 4           | 100 / 4 = 25 |
+   * | 8   | 10    | down      | 1 of 4           | 100 / 4 = 25 |
+   * | 9   | 9     | down      | 0 of 4           | 0 / 4 = 0    |
+   */
+  const closes = [10, 11, 12, 11, 13, 12, 11, 10, 9] as const;
+
+  describe('getResultOrThrow', () => {
+    it('measures the share of bars that closed above their previous close', () => {
+      const expectations = [75, 50, 25, 25, 0] as const;
+      const psl = new PSL({interval: 4});
+      const offset = psl.getRequiredInputs() - 1;
+
+      closes.forEach((close, i) => {
+        const result = psl.add(close);
+
+        if (result !== null) {
+          expect(result).toBe(expectations[i - offset]);
+        }
+      });
+
+      expect(psl.isStable).toBe(true);
+    });
+
+    it('spans twelve close-to-close comparisons by default', () => {
+      // 9 rising bars followed by 3 falling bars: 900 / 12 = 75
+      const risingThenFalling = [100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 108, 107, 106] as const;
+      const psl = new PSL();
+
+      for (const close of risingThenFalling) {
+        psl.add(close);
+      }
+
+      expect(psl.getResultOrThrow()).toBe(75);
+    });
+
+    it('counts an unchanged close as a falling period', () => {
+      // Bars 2 and 4 close flat, so only bars 3 and 5 rise: 200 / 4 = 50
+      const tiedCloses = [10, 10, 11, 11, 12] as const;
+      const psl = new PSL({interval: 4});
+
+      for (const close of tiedCloses) {
+        psl.add(close);
+      }
+
+      expect(psl.getResultOrThrow()).toBe(50);
+    });
+
+    it('reads zero when every close in the window stays unchanged', () => {
+      const psl = new PSL({interval: 4});
+
+      for (let i = 0; i < 5; i++) {
+        psl.add(100);
+      }
+
+      expect(psl.getResultOrThrow()).toBe(0);
+    });
+  });
+
+  describe('getRequiredInputs', () => {
+    it('needs 13 closes by default to form twelve comparisons', () => {
+      const psl = new PSL();
+
+      expect(psl.getRequiredInputs()).toBe(13);
+    });
+
+    it('needs one close more than the configured interval', () => {
+      const psl = new PSL({interval: 4});
+
+      expect(psl.getRequiredInputs()).toBe(5);
+    });
+  });
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const psl = new PSL({interval: 4});
+
+      for (const close of closes.slice(0, 5)) {
+        psl.add(close);
+      }
+
+      /*
+       * The window closes become 11, 12, 11, 13 plus the newest bar: a close of 9 leaves 2 rising bars
+       * (50), a close of 15 leaves 3 rising bars (75).
+       */
+      const originalValue = 9;
+      const replacedValue = 15;
+
+      const originalResult = psl.add(originalValue);
+
+      expect(originalResult).toBe(50);
+
+      const replacedResult = psl.replace(replacedValue);
+
+      expect(replacedResult).toBe(75);
+
+      const restoredResult = psl.replace(originalValue);
+
+      expect(restoredResult).toBe(50);
+    });
+  });
+
+  describe('getSignal', () => {
+    it('returns UNKNOWN when there is no result', () => {
+      const psl = new PSL({interval: 4});
+      const signal = psl.getSignal();
+
+      expect(signal.state).toBe(TradingSignal.UNKNOWN);
+      expect(signal.hasChanged).toBe(false);
+    });
+
+    it('signals bullish pressure when every bar in the window closed higher', () => {
+      const psl = new PSL({interval: 4});
+
+      for (const close of [1, 2, 3, 4, 5] as const) {
+        psl.add(close);
+      }
+
+      expect(psl.getResultOrThrow()).toBe(100);
+
+      const signal = psl.getSignal();
+
+      expect(signal.state).toBe(TradingSignal.BULLISH);
+      expect(signal.hasChanged).toBe(true);
+    });
+
+    it('signals bearish pressure when every bar in the window closed lower', () => {
+      const psl = new PSL({interval: 4});
+
+      for (const close of [5, 4, 3, 2, 1] as const) {
+        psl.add(close);
+      }
+
+      expect(psl.getResultOrThrow()).toBe(0);
+
+      const signal = psl.getSignal();
+
+      expect(signal.state).toBe(TradingSignal.BEARISH);
+      expect(signal.hasChanged).toBe(true);
+    });
+
+    it('returns SIDEWAYS while the reading stays between the bands', () => {
+      // Both stable bars read 50, so the signal settles instead of flagging a change
+      const balancedCloses = [10, 11, 12, 11, 10, 11] as const;
+      const psl = new PSL({interval: 4});
+
+      for (const close of balancedCloses) {
+        psl.add(close);
+      }
+
+      expect(psl.getResultOrThrow()).toBe(50);
+
+      const signal = psl.getSignal();
+
+      expect(signal.state).toBe(TradingSignal.SIDEWAYS);
+      expect(signal.hasChanged).toBe(false);
+    });
+
+    it('turns bullish exactly at the overbought threshold', () => {
+      const defaults = new PSL({interval: 4});
+      const custom = new PSL({interval: 4, signalThresholds: {overbought: 80, oversold: 20}});
+      // 3 rising bars out of 4 comparisons: 300 / 4 = 75, exactly on the conventional band
+      const risingCloses = [10, 11, 12, 13, 12] as const;
+
+      for (const psl of [defaults, custom]) {
+        for (const close of risingCloses) {
+          psl.add(close);
+        }
+
+        expect(psl.getResultOrThrow()).toBe(75);
+      }
+
+      expect(defaults.getSignal().state).toBe(TradingSignal.BULLISH);
+      expect(custom.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+    });
+
+    it('turns bearish exactly at the oversold threshold', () => {
+      const defaults = new PSL({interval: 4});
+      const custom = new PSL({interval: 4, signalThresholds: {overbought: 80, oversold: 20}});
+      // 1 rising bar out of 4 comparisons: 100 / 4 = 25, exactly on the conventional band
+      const fallingCloses = [10, 11, 10, 9, 8] as const;
+
+      for (const psl of [defaults, custom]) {
+        for (const close of fallingCloses) {
+          psl.add(close);
+        }
+
+        expect(psl.getResultOrThrow()).toBe(25);
+      }
+
+      expect(defaults.getSignal().state).toBe(TradingSignal.BEARISH);
+      expect(custom.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new PSL({interval: 4}),
+  divergentInput: 1_000,
+  inputs: [10, 11, 12, 11, 13, 12],
+});

--- a/packages/trading-signals/src/momentum/PSL/PSL.ts
+++ b/packages/trading-signals/src/momentum/PSL/PSL.ts
@@ -1,0 +1,84 @@
+import {TradingSignal, TrendIndicatorSeries} from '../../base/Indicator.js';
+import type {SignalThresholds} from '../../base/SignalThresholds.type.js';
+import {pushUpdate} from '../../util/pushUpdate.js';
+
+export type PSLConfig = {
+  /** Number of close-to-close comparisons in the window; the warm-up needs one close more than this */
+  interval?: number;
+  signalThresholds?: SignalThresholds;
+};
+
+/**
+ * Psychological Line (PSL)
+ * Type: Momentum
+ *
+ * The Psychological Line reads crowd sentiment straight off the tape: it is the percentage of the last N bars
+ * (12 by default) that closed above their previous close, oscillating between 0 and 100. It originated as a
+ * sentiment gauge in East Asian markets and remains a standard indicator on Asian trading platforms (often
+ * labeled PSY): when nearly every recent bar closed higher, optimism is judged to be overheating; when almost
+ * none did, panic selling is considered exhausted.
+ *
+ * Only a strictly higher close counts as a rising period — an unchanged close is treated as a falling one,
+ * matching the pandas-ta reference implementation.
+ *
+ * Interpretation:
+ * A PSL of 75 or above (at least 9 of the default 12 bars closed up) indicates an overbought condition, 25 or
+ * below (at most 3 of 12) indicates an oversold condition (both thresholds can be customized via the
+ * constructor). These are the conventional bands on the Asian platforms where the indicator is canonical.
+ *
+ * @see https://github.com/xgboosted/pandas-ta-classic/blob/main/pandas_ta_classic/momentum/psl.py
+ * @see https://www.moomoo.com/us/support/topic3_814
+ * @see https://www.quantshare.com/item-851-psychological-line
+ */
+export class PSL extends TrendIndicatorSeries {
+  readonly #closes: number[] = [];
+  readonly #overbought: number;
+  readonly #oversold: number;
+  public readonly interval: number;
+
+  constructor({interval = 12, signalThresholds: {overbought = 75, oversold = 25} = {}}: PSLConfig = {}) {
+    super();
+    this.interval = interval;
+    this.#overbought = overbought;
+    this.#oversold = oversold;
+  }
+
+  override getRequiredInputs() {
+    return this.interval + 1;
+  }
+
+  update(close: number, replace: boolean) {
+    pushUpdate({array: this.#closes, item: close, maxLength: this.getRequiredInputs(), replace: replace});
+
+    if (this.#closes.length < this.getRequiredInputs()) {
+      return null;
+    }
+
+    let risingPeriods = 0;
+
+    for (let i = 1; i < this.#closes.length; i++) {
+      if (this.#closes[i] > this.#closes[i - 1]) {
+        risingPeriods++;
+      }
+    }
+
+    return this.setResult((100 * risingPeriods) / this.interval, replace);
+  }
+
+  protected calculateSignalState(result: number | null | undefined) {
+    const hasResult = result !== null && result !== undefined;
+    const isOversold = hasResult && result <= this.#oversold;
+    const isOverbought = hasResult && result >= this.#overbought;
+
+    switch (true) {
+      case !hasResult:
+        return TradingSignal.UNKNOWN;
+      case isOversold:
+        return TradingSignal.BEARISH;
+      case isOverbought:
+        return TradingSignal.BULLISH;
+      default:
+        return TradingSignal.SIDEWAYS;
+    }
+  }
+}

--- a/packages/trading-signals/src/momentum/QQE/QQE.test.ts
+++ b/packages/trading-signals/src/momentum/QQE/QQE.test.ts
@@ -1,0 +1,249 @@
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {QQE} from './QQE.js';
+import {TradingSignal} from '../../base/index.js';
+
+describe('QQE', () => {
+  const config = {fastFactor: 1, rsiInterval: 2, smoothInterval: 2} as const;
+  /*
+   * Zigzag warm-up, climb, crash and V-shaped recovery, so the trailing stop ratchets on both
+   * sides and flips in both directions.
+   */
+  const prices = [81, 83, 82, 84, 83, 85, 86, 88, 90, 92, 84, 74, 70, 68, 80, 90, 89, 91] as const;
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const qqe = new QQE(config);
+
+      for (const price of prices) {
+        qqe.add(price);
+      }
+
+      const originalValue = 94;
+      const replacedValue = 60;
+
+      const originalResult = qqe.add(originalValue);
+
+      expect(originalResult?.rsiMa.toFixed(4)).toBe('89.6587');
+      expect(originalResult?.trailingStop.toFixed(4)).toBe('78.5118');
+      expect(qqe.getSignal().state).toBe(TradingSignal.BULLISH);
+
+      const replacedResult = qqe.replace(replacedValue);
+
+      expect(replacedResult?.rsiMa.toFixed(4)).toBe('33.7798');
+      expect(replacedResult?.trailingStop.toFixed(4)).toBe('56.0174');
+      expect(qqe.getSignal().state).toBe(TradingSignal.BEARISH);
+
+      const restoredResult = qqe.replace(originalValue);
+
+      expect(restoredResult).toEqual(originalResult);
+      expect(qqe.getSignal().state).toBe(TradingSignal.BULLISH);
+    });
+  });
+
+  describe('getRequiredInputs', () => {
+    it('requires 72 candles with the documented default configuration', () => {
+      const qqe = new QQE();
+
+      expect(qqe.getRequiredInputs()).toBe(72);
+      expect(qqe.fastFactor).toBe(4.236);
+      expect(qqe.rsiInterval).toBe(14);
+      expect(qqe.smoothInterval).toBe(5);
+    });
+  });
+
+  describe('getResultOrThrow', () => {
+    /*
+     * Formula from Roman Ignatov's QQE for MetaTrader 4, as formulated by its open-source
+     * TradingView ports (RSI smoothed by an EMA, its absolute change double-smoothed over
+     * 2 x RSI interval - 1 readings, scaled bands with SuperTrend-style flips):
+     * https://www.tradingview.com/script/0vn4HZ7O-Quantitative-Qualitative-Estimation-QQE/
+     * https://www.tradingview.com/script/34U0KMEK-QQE-MT4-Glaz-modified-by-JustUncleL/
+     *
+     * External reference fixtures are not reproducible here because every smoothing stage in this
+     * library seeds with its first input, so the expectations are hand-derived with the RSI and
+     * smoothing intervals set to 2 (Wilder smoothing factor 1/2, EMA weights 2/3 and 1/2), a fast
+     * factor of 1, and verified through an independent batch recomputation:
+     *
+     * price | RSI(2)  | rsiMa    | |change| | EMA(3)   | EMA(3)  | longband | shortband | side | stop
+     *    81 | -       | -        | -        | -        | -       | -        | -         | -    | -
+     *    83 | -       | -        | -        | -        | -       | -        | -         | -    | -
+     *    82 | 66.6667 | 66.6667* | -        | -        | -       | -        | -         | -    | -
+     *    84 | 85.7143 | 79.3651  | -        | -        | -       | -        | -         | -    | -
+     *    83 | 54.5455 | 62.8187  | 16.5464  | 16.5464* | -       | -        | -         | -    | -
+     *    85 | 81.4815 | 75.2605  | 12.4419  | 14.4941  | -       | -        | -         | -    | -
+     *    86 | 88.3721 | 84.0016  |  8.7410  | 11.6176  | 11.6176*| -        | -         | -    | -
+     *    88 | 95.3271 | 91.5519  |  7.5504  |  9.5840  | 10.6008 | -        | -         | -    | -
+     *    90 | 97.8723 | 95.7655  |  4.2136  |  6.8988  |  8.7498 | 87.0158  | 104.5153  | up   | 87.0158
+     *    92 | 98.9817 | 97.9096  |  2.1441  |  4.5214  |  6.6356 | 91.2740  | 104.5153  | up   | 91.2740
+     *    84 | 19.1414 | 45.3975  | 52.5122  | 28.5168  | 17.5762 | 27.8213  |  62.9737  | down | 62.9737
+     *    74 |  6.3455 | 19.3628  | 26.0347  | 27.2757  | 22.4260 | -3.0632  |  41.7888  | down | 41.7888
+     *    70 |  4.1344 |  9.2105  | 10.1523  | 18.7140  | 20.5700 | -3.0632  |  29.7805  | down | 29.7805
+     *    68 |  3.0661 |  5.1142  |  4.0963  | 11.4052  | 15.9876 | -3.0632  |  21.1018  | down | 21.1018
+     *    80 | 76.3626 | 52.6132  | 47.4989  | 29.4521  | 22.7198 | 29.8933  |  75.3330  | up   | 29.8933
+     *    90 | 89.5421 | 77.2325  | 24.6193  | 27.0357  | 24.8777 | 52.3547  | 102.1102  | up   | 52.3547
+     *    89 | 80.5587 | 79.4500  |  2.2175  | 14.6266  | 19.7522 | 59.6978  |  99.2021  | up   | 59.6978
+     *    91 | 86.1263 | 83.9009  |  4.4509  |  9.5387  | 14.6455 | 69.2554  |  98.5463  | up   | 69.2554
+     *
+     * (*) seed reading: the stage turns stable one reading later and only then feeds the next
+     * stage. The bands equal the smoothed RSI plus/minus the last EMA(3) column. The crash bar
+     * (84) breaks the long band and flips the side down, after which the short band only
+     * ratchets lower and the long band freezes at -3.0632 until the recovery bar (80) breaks
+     * the short band and flips the side back up.
+     */
+    it('trails a stop behind the smoothed RSI and flips sides when the line breaks through it', () => {
+      const expectations = [
+        ['95.7655', '87.0158'],
+        ['97.9096', '91.2740'],
+        ['45.3975', '62.9737'],
+        ['19.3628', '41.7888'],
+        ['9.2105', '29.7805'],
+        ['5.1142', '21.1018'],
+        ['52.6132', '29.8933'],
+        ['77.2325', '52.3547'],
+        ['79.4500', '59.6978'],
+        ['83.9009', '69.2554'],
+      ] as const;
+      const qqe = new QQE(config);
+      const offset = qqe.getRequiredInputs() - 1;
+
+      prices.forEach((price, i) => {
+        const result = qqe.add(price);
+
+        if (result) {
+          const [expectedRsiMa, expectedTrailingStop] = expectations[i - offset];
+          expect(result.rsiMa.toFixed(4)).toBe(expectedRsiMa);
+          expect(result.trailingStop.toFixed(4)).toBe(expectedTrailingStop);
+        }
+      });
+
+      expect(qqe.isStable).toBe(true);
+      expect(qqe.getRequiredInputs()).toBe(9);
+    });
+  });
+
+  describe('getSignal', () => {
+    it('returns UNKNOWN when there is no result', () => {
+      const qqe = new QQE(config);
+
+      expect(qqe.getSignal()).toEqual({
+        hasChanged: false,
+        state: TradingSignal.UNKNOWN,
+      });
+    });
+
+    it('returns BULLISH when the smoothed RSI holds above its trailing stop', () => {
+      const qqe = new QQE(config);
+
+      for (const price of [81, 83, 82, 84, 83, 85, 86, 88, 90] as const) {
+        qqe.add(price);
+      }
+
+      const result = qqe.getResultOrThrow();
+
+      expect(result.rsiMa).toBeGreaterThan(result.trailingStop);
+      expect(qqe.getSignal()).toEqual({
+        hasChanged: true,
+        state: TradingSignal.BULLISH,
+      });
+    });
+
+    it('returns BEARISH when the smoothed RSI drops below its trailing stop', () => {
+      const qqe = new QQE(config);
+
+      for (const price of [81, 83, 82, 84, 83, 85, 86, 88, 90, 92, 84] as const) {
+        qqe.add(price);
+      }
+
+      const result = qqe.getResultOrThrow();
+
+      expect(result.rsiMa).toBeLessThan(result.trailingStop);
+      expect(qqe.getSignal()).toEqual({
+        hasChanged: true,
+        state: TradingSignal.BEARISH,
+      });
+    });
+
+    it('returns SIDEWAYS when a dead-flat market pins the trailing stop onto the smoothed RSI', () => {
+      const qqe = new QQE(config);
+
+      /*
+       * A flat series produces no average loss, which this library's RSI reads as maximal
+       * strength (100). A constant smoothed RSI has zero volatility, so both bands collapse
+       * onto the line itself and neither side is in control.
+       */
+      for (let i = 0; i < 12; i++) {
+        qqe.add(100);
+      }
+
+      expect(qqe.getResultOrThrow()).toEqual({rsiMa: 100, trailingStop: 100});
+      expect(qqe.getSignal()).toEqual({
+        hasChanged: false,
+        state: TradingSignal.SIDEWAYS,
+      });
+    });
+
+    it('flips from BULLISH to BEARISH and back as the smoothed RSI breaks each side of the stop', () => {
+      const qqe = new QQE(config);
+      const signals: string[] = [];
+
+      for (const price of prices) {
+        qqe.add(price);
+        signals.push(qqe.getSignal().state);
+      }
+
+      expect(signals).toEqual([
+        TradingSignal.UNKNOWN,
+        TradingSignal.UNKNOWN,
+        TradingSignal.UNKNOWN,
+        TradingSignal.UNKNOWN,
+        TradingSignal.UNKNOWN,
+        TradingSignal.UNKNOWN,
+        TradingSignal.UNKNOWN,
+        TradingSignal.UNKNOWN,
+        TradingSignal.BULLISH,
+        TradingSignal.BULLISH,
+        TradingSignal.BEARISH,
+        TradingSignal.BEARISH,
+        TradingSignal.BEARISH,
+        TradingSignal.BEARISH,
+        TradingSignal.BULLISH,
+        TradingSignal.BULLISH,
+        TradingSignal.BULLISH,
+        TradingSignal.BULLISH,
+      ]);
+    });
+
+    it('reports a signal change only when the smoothed RSI switches sides', () => {
+      const qqe = new QQE(config);
+
+      for (const price of [81, 83, 82, 84, 83, 85, 86, 88, 90, 92] as const) {
+        qqe.add(price);
+      }
+
+      expect(qqe.getSignal()).toEqual({
+        hasChanged: false,
+        state: TradingSignal.BULLISH,
+      });
+
+      qqe.add(84);
+
+      expect(qqe.getSignal()).toEqual({
+        hasChanged: true,
+        state: TradingSignal.BEARISH,
+      });
+
+      qqe.add(74);
+
+      expect(qqe.getSignal()).toEqual({
+        hasChanged: false,
+        state: TradingSignal.BEARISH,
+      });
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new QQE({fastFactor: 1, rsiInterval: 2, smoothInterval: 2}),
+  divergentInput: 1_000,
+  inputs: [81, 83, 82, 84, 83, 85, 86, 88, 90, 92, 84, 74, 70, 68, 80, 90, 89, 91],
+});

--- a/packages/trading-signals/src/momentum/QQE/QQE.ts
+++ b/packages/trading-signals/src/momentum/QQE/QQE.ts
@@ -1,0 +1,219 @@
+import {TechnicalIndicator, TradingSignal} from '../../base/Indicator.js';
+import {EMA} from '../../trend/EMA/EMA.js';
+import {RSI} from '../RSI/RSI.js';
+
+export type QQEConfig = {
+  /**
+   * How many units of the smoothed RSI's own volatility the trailing stop lags behind it
+   * (default: 4.236, the Fibonacci-derived "fast" factor of the original)
+   */
+  fastFactor?: number;
+  /** Number of candles for the underlying Wilder-smoothed RSI (default: 14) */
+  rsiInterval?: number;
+  /** Number of readings for the smoothing that turns the raw RSI into the RSI MA line (default: 5) */
+  smoothInterval?: number;
+};
+
+export type QQEResult = {
+  /** Smoothed RSI line the indicator is built around; the side it takes of the trailing stop names the momentum direction */
+  rsiMa: number;
+  /** Volatility-based stop the smoothed RSI trails against: support below it in bullish phases, resistance above it in bearish phases */
+  trailingStop: number;
+};
+
+type QQEBands = {
+  isUp: boolean;
+  longband: number;
+  shortband: number;
+};
+
+type QQEState = {
+  bands?: QQEBands;
+  previousBands?: QQEBands;
+  rsiMa?: number;
+};
+
+/**
+ * Quantitative Qualitative Estimation (QQE)
+ * Type: Momentum
+ *
+ * Roman Ignatov published the QQE for MetaTrader 4 as an RSI a trend follower can hold on to: the
+ * raw RSI is smoothed into a calmer "RSI MA" line, and that line's own volatility — its absolute
+ * change, Wilder-smoothed twice — is scaled by a factor and trailed behind it as a stop line. It
+ * is the SuperTrend construction applied to the RSI instead of price: the stop ratchets toward
+ * the smoothed RSI while a move lasts and switches sides once the line breaks through it.
+ *
+ * Interpretation:
+ * Momentum is BULLISH while the smoothed RSI rides above its trailing stop and BEARISH while the
+ * stop caps it from above, so a flip of the stop line marks a momentum reversal without relying
+ * on fixed overbought/oversold levels. Like every trend-following overlay it whipsaws when the
+ * market goes quiet and dies down.
+ *
+ * Every smoothing stage seeds with its first input and starts only once the stage before it is
+ * stable (this library's convention, shared with DOSC, TEMA and T3), so early readings differ
+ * slightly from platforms that seed their smoothing differently.
+ *
+ * @see https://www.tradingview.com/script/0vn4HZ7O-Quantitative-Qualitative-Estimation-QQE/
+ * @see https://www.tradingview.com/script/34U0KMEK-QQE-MT4-Glaz-modified-by-JustUncleL/
+ */
+export class QQE extends TechnicalIndicator<QQEResult, number, QQEState> {
+  readonly #rsi: RSI;
+  readonly #rsiSmoothing: EMA;
+  readonly #firstVolatilitySmoothing: EMA;
+  readonly #secondVolatilitySmoothing: EMA;
+  /**
+   * An EMA over "2n - 1" readings weights new data exactly like Wilder's smoothing over "n"
+   * readings, which is how the original formulates its two volatility stages.
+   */
+  readonly #wilderInterval: number;
+  #previousResult?: QQEResult;
+
+  public readonly fastFactor: number;
+  public readonly rsiInterval: number;
+  public readonly smoothInterval: number;
+
+  constructor({fastFactor = 4.236, rsiInterval = 14, smoothInterval = 5}: QQEConfig = {}) {
+    super();
+    this.fastFactor = fastFactor;
+    this.rsiInterval = rsiInterval;
+    this.smoothInterval = smoothInterval;
+    this.#wilderInterval = 2 * rsiInterval - 1;
+    this.#rsi = new RSI(rsiInterval);
+    this.#rsiSmoothing = new EMA(smoothInterval);
+    this.#firstVolatilitySmoothing = new EMA(this.#wilderInterval);
+    this.#secondVolatilitySmoothing = new EMA(this.#wilderInterval);
+  }
+
+  override getRequiredInputs() {
+    /*
+     * The first candle only anchors the RSI's first gain/loss reading, the volatility measurement
+     * consumes one further reading for the first change of the smoothed RSI, and every smoothing
+     * stage begins with the first stable reading of the stage before it.
+     */
+    return this.rsiInterval + this.smoothInterval + 2 * this.#wilderInterval - 1;
+  }
+
+  update(price: number, replace: boolean) {
+    this.trackState(replace);
+
+    const rsi = this.#rsi.update(price, replace);
+
+    if (rsi === null) {
+      return null;
+    }
+
+    const rsiMa = this.#rsiSmoothing.update(rsi, replace);
+
+    if (!this.#rsiSmoothing.isStable) {
+      return null;
+    }
+
+    const previousRsiMa = this.state.rsiMa;
+    this.state.rsiMa = rsiMa;
+
+    if (previousRsiMa === undefined) {
+      return null;
+    }
+
+    const volatility = Math.abs(rsiMa - previousRsiMa);
+    const onceSmoothed = this.#firstVolatilitySmoothing.update(volatility, replace);
+
+    if (!this.#firstVolatilitySmoothing.isStable) {
+      return null;
+    }
+
+    const twiceSmoothed = this.#secondVolatilitySmoothing.update(onceSmoothed, replace);
+
+    if (!this.#secondVolatilitySmoothing.isStable) {
+      return null;
+    }
+
+    const bandOffset = twiceSmoothed * this.fastFactor;
+    const newLongband = rsiMa - bandOffset;
+    const newShortband = rsiMa + bandOffset;
+
+    const previousBands = this.state.bands;
+    const penultimateBands = this.state.previousBands;
+
+    let bands: QQEBands;
+
+    if (previousBands === undefined) {
+      // The very first pair of bands has no history to trail against, and the reference formulation starts long
+      bands = {isUp: true, longband: newLongband, shortband: newShortband};
+    } else {
+      // Each band only ratchets toward the smoothed RSI while the line stays on its side; any break resets it
+      const longband =
+        previousRsiMa > previousBands.longband && rsiMa > previousBands.longband
+          ? Math.max(previousBands.longband, newLongband)
+          : newLongband;
+      const shortband =
+        previousRsiMa < previousBands.shortband && rsiMa < previousBands.shortband
+          ? Math.min(previousBands.shortband, newShortband)
+          : newShortband;
+
+      /*
+       * The trend flips when the smoothed RSI crosses the band of the bar before, which compares
+       * the current reading against the band values of the two preceding bars. A cross of the
+       * upper band flips long before a cross of the lower band is considered, matching the
+       * precedence of the reference formulation.
+       */
+      const hasCrossedShortband =
+        penultimateBands !== undefined &&
+        ((rsiMa > previousBands.shortband && previousRsiMa <= penultimateBands.shortband) ||
+          (rsiMa < previousBands.shortband && previousRsiMa >= penultimateBands.shortband));
+      const hasCrossedLongband =
+        penultimateBands !== undefined &&
+        ((rsiMa > previousBands.longband && previousRsiMa <= penultimateBands.longband) ||
+          (rsiMa < previousBands.longband && previousRsiMa >= penultimateBands.longband));
+
+      const isUp = hasCrossedShortband ? true : hasCrossedLongband ? false : previousBands.isUp;
+
+      bands = {isUp, longband, shortband};
+    }
+
+    this.state.previousBands = previousBands;
+    this.state.bands = bands;
+
+    if (replace) {
+      this.result = this.#previousResult;
+    }
+
+    this.#previousResult = this.result;
+
+    return (this.result = {
+      rsiMa,
+      trailingStop: bands.isUp ? bands.longband : bands.shortband,
+    });
+  }
+
+  protected calculateSignal(result?: QQEResult | null | undefined) {
+    const hasResult = result !== null && result !== undefined;
+    const isBullish = hasResult && result.rsiMa > result.trailingStop;
+    const isBearish = hasResult && result.rsiMa < result.trailingStop;
+
+    switch (true) {
+      case !hasResult:
+        return TradingSignal.UNKNOWN;
+      case isBullish:
+        return TradingSignal.BULLISH;
+      case isBearish:
+        return TradingSignal.BEARISH;
+      default:
+        return TradingSignal.SIDEWAYS;
+    }
+  }
+
+  getSignal(): {
+    state: (typeof TradingSignal)[keyof typeof TradingSignal];
+    hasChanged: boolean;
+  } {
+    const previousState = this.calculateSignal(this.#previousResult);
+    const state = this.calculateSignal(this.getResult());
+    const hasChanged = previousState !== state;
+
+    return {
+      hasChanged,
+      state,
+    };
+  }
+}

--- a/packages/trading-signals/src/momentum/SMI/SMI.test.ts
+++ b/packages/trading-signals/src/momentum/SMI/SMI.test.ts
@@ -1,0 +1,183 @@
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {SMI} from './SMI.js';
+import {TradingSignal} from '../../base/index.js';
+
+describe('SMI', () => {
+  /*
+   * Hand-derived worksheet for interval=2, smooth1=2, smooth2=2. Both EMAs weight new inputs
+   * with 2/3 and seed with their first input, so every intermediate value stays an exact fraction:
+   *
+   * | Candle          | HH | LL | Midpoint | Distance | Range |
+   * | {h:10,l:8,c:9}  | window not full yet                   |
+   * | {h:12,l:9,c:11} | 12 |  8 | 10       | +1       | 4     |
+   * | {h:13,l:10,c:12}| 13 |  9 | 11       | +1       | 4     |
+   * | {h:11,l:7,c:8}  | 13 |  7 | 10       | -2       | 6     |
+   * | {h:12,l:9,c:10} | 12 |  7 | 9.5      | +0.5     | 5     |
+   *
+   * First smoothing of distance: 1, 1, -1, 0 — of range: 4, 4, 16/3, 46/9.
+   * Second smoothing (starts once the first is stable) of distance: 1, -1/3, -1/9 — of range: 4, 44/9, 136/27.
+   *
+   * Candle 4: SMI = 100 * (-1/3) / (0.5 * 44/9)  = -150/11 ≈ -13.636364
+   * Candle 5: SMI = 100 * (-1/9) / (0.5 * 136/27) = -75/17  ≈ -4.411765
+   */
+  const worksheetCandles = [
+    {close: 9, high: 10, low: 8},
+    {close: 11, high: 12, low: 9},
+    {close: 12, high: 13, low: 10},
+    {close: 8, high: 11, low: 7},
+    {close: 10, high: 12, low: 9},
+  ] as const;
+
+  describe('getResultOrThrow', () => {
+    it('locates the close relative to the midpoint of the high/low range', () => {
+      const expectations = ['-13.636364', '-4.411765'] as const;
+      const smi = new SMI({interval: 2, smooth1: 2, smooth2: 2});
+      const offset = smi.getRequiredInputs() - 1;
+
+      worksheetCandles.forEach((candle, i) => {
+        const result = smi.add(candle);
+
+        if (result !== null) {
+          expect(result.toFixed(6)).toBe(expectations[i - offset]);
+        }
+      });
+
+      expect(smi.isStable).toBe(true);
+      expect(smi.getRequiredInputs()).toBe(4);
+    });
+
+    it('needs one range window plus both smoothing warm-ups by default', () => {
+      const smi = new SMI();
+
+      expect(smi.getRequiredInputs()).toBe(14);
+    });
+
+    it('reports the extremes when every close pins the top or bottom of its range', () => {
+      const topPinned = new SMI();
+      const bottomPinned = new SMI();
+
+      for (let i = 0; i < 14; i++) {
+        topPinned.add({close: 10 + i, high: 10 + i, low: 9 + i});
+        bottomPinned.add({close: 99 - i, high: 100 - i, low: 99 - i});
+      }
+
+      expect(topPinned.getResultOrThrow()).toBe(100);
+      expect(bottomPinned.getResultOrThrow()).toBe(-100);
+    });
+
+    it('returns a neutral reading instead of dividing by zero when the window is perfectly flat', () => {
+      const smi = new SMI({interval: 2, smooth1: 2, smooth2: 2});
+      const flatCandle = {close: 50, high: 50, low: 50} as const;
+
+      for (let i = 0; i < 4; i++) {
+        smi.add(flatCandle);
+      }
+
+      expect(smi.getResultOrThrow()).toBe(0);
+    });
+  });
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      /*
+       * Worksheet continued: the original candle widens the range to HH=14/LL=9 (midpoint 11.5,
+       * distance +1.5, range 5) and yields exactly 100 * (17/27) / (0.5 * 136/27) = 25. Its
+       * replacement drops the range to HH=12/LL=6 (midpoint 9, distance -2, range 6) and yields
+       * 100 * (-25/27) / (0.5 * 148/27) = -1250/37 ≈ -33.783784.
+       */
+      const smi = new SMI({interval: 2, smooth1: 2, smooth2: 2});
+
+      for (const candle of worksheetCandles) {
+        smi.add(candle);
+      }
+
+      const originalValue = {close: 13, high: 14, low: 10} as const;
+      const replacedValue = {close: 7, high: 12, low: 6} as const;
+
+      const originalResult = smi.add(originalValue);
+
+      expect(originalResult?.toFixed(6)).toBe('25.000000');
+
+      const replacedResult = smi.replace(replacedValue);
+
+      expect(replacedResult?.toFixed(6)).toBe('-33.783784');
+      expect(replacedResult).not.toBe(originalResult);
+
+      const restoredResult = smi.replace(originalValue);
+
+      expect(restoredResult).toBe(originalResult);
+    });
+  });
+
+  describe('getSignal', () => {
+    it('returns UNKNOWN when there is no result', () => {
+      const smi = new SMI();
+
+      expect(smi.getSignal().state).toBe(TradingSignal.UNKNOWN);
+    });
+
+    it('returns BULLISH when the SMI indicates an overbought market', () => {
+      const smi = new SMI();
+
+      for (let i = 0; i < 14; i++) {
+        smi.add({close: 10 + i, high: 10 + i, low: 9 + i});
+      }
+
+      expect(smi.getResultOrThrow()).toBeGreaterThanOrEqual(40);
+      expect(smi.getSignal().state).toBe(TradingSignal.BULLISH);
+    });
+
+    it('returns BEARISH when the SMI indicates an oversold market', () => {
+      const smi = new SMI();
+
+      for (let i = 0; i < 14; i++) {
+        smi.add({close: 99 - i, high: 100 - i, low: 99 - i});
+      }
+
+      expect(smi.getResultOrThrow()).toBeLessThanOrEqual(-40);
+      expect(smi.getSignal().state).toBe(TradingSignal.BEARISH);
+    });
+
+    it('returns SIDEWAYS when the SMI is between the oversold and overbought thresholds', () => {
+      const smi = new SMI({interval: 2, smooth1: 2, smooth2: 2});
+      const flatCandle = {close: 50, high: 50, low: 50} as const;
+
+      for (let i = 0; i < 4; i++) {
+        smi.add(flatCandle);
+      }
+
+      expect(smi.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+    });
+
+    it('treats a reading exactly at a custom threshold as overbought or oversold', () => {
+      const bullishAtBoundary = new SMI({interval: 2, smooth1: 2, smooth2: 2}, {overbought: 100});
+      const bearishAtBoundary = new SMI({interval: 2, smooth1: 2, smooth2: 2}, {oversold: -100});
+
+      for (let i = 0; i < 4; i++) {
+        bullishAtBoundary.add({close: 10 + i, high: 10 + i, low: 9 + i});
+        bearishAtBoundary.add({close: 99 - i, high: 100 - i, low: 99 - i});
+      }
+
+      expect(bullishAtBoundary.getResultOrThrow()).toBe(100);
+      expect(bullishAtBoundary.getSignal().state).toBe(TradingSignal.BULLISH);
+
+      expect(bearishAtBoundary.getResultOrThrow()).toBe(-100);
+      expect(bearishAtBoundary.getSignal().state).toBe(TradingSignal.BEARISH);
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new SMI({interval: 5, smooth1: 2, smooth2: 2}),
+  divergentInput: {close: 500, high: 500, low: 400},
+  inputs: [
+    {close: 81.59, high: 82.15, low: 81.29},
+    {close: 81.06, high: 81.89, low: 80.64},
+    {close: 82.87, high: 83.03, low: 81.31},
+    {close: 83.0, high: 83.3, low: 82.65},
+    {close: 83.61, high: 83.85, low: 83.07},
+    {close: 83.15, high: 83.9, low: 83.11},
+    {close: 82.84, high: 83.33, low: 82.49},
+    {close: 83.99, high: 84.3, low: 82.3},
+  ],
+});

--- a/packages/trading-signals/src/momentum/SMI/SMI.ts
+++ b/packages/trading-signals/src/momentum/SMI/SMI.ts
@@ -1,0 +1,117 @@
+import type {HighLowClose} from '../../base/Candle.type.js';
+import {TradingSignal, TrendIndicatorSeries} from '../../base/Indicator.js';
+import type {SignalThresholds} from '../../base/SignalThresholds.type.js';
+import {EMA} from '../../trend/EMA/EMA.js';
+import {pushUpdate} from '../../util/pushUpdate.js';
+
+export type SMIConfig = {
+  /** Number of candles for the highest-high/lowest-low range (default: 10) */
+  interval?: number;
+  /** Number of candles for the first smoothing of the close's distance from the range midpoint (default: 3) */
+  smooth1?: number;
+  /** Number of candles for the second smoothing (default: 3) */
+  smooth2?: number;
+};
+
+/**
+ * Stochastic Momentum Index (SMI)
+ * Type: Momentum
+ *
+ * The SMI was introduced by William Blau in the January 1993 issue of "Technical Analysis of Stocks & Commodities".
+ * It refines the Stochastic Oscillator by locating the close relative to the midpoint of the recent high/low range
+ * instead of relative to the range's low, so the sign alone tells which half of the range the market closes in.
+ * Double-smoothing that distance with two EMAs and dividing by the equally smoothed half-range bounds the reading
+ * between -100 and +100: at the extremes every close in memory pinned the top (or bottom) of its range.
+ *
+ * Interpretation: Blau reads +40 and above as an overbought market and -40 and below as an oversold market (both
+ * thresholds can be customized via the constructor). The default configuration (10-candle range, two 3-candle
+ * smoothings) follows the built-in SMI of charting platforms such as TradingView.
+ *
+ * A perfectly flat window has no range to locate the close in, so the indicator reports 0 instead of dividing zero
+ * by zero.
+ *
+ * The EMAs seed with their first input (this library's convention). Implementations that seed differently (e.g.
+ * Skender.Stock.Indicators) report different readings until the seeding transient has decayed.
+ *
+ * @see https://www.tradingview.com/support/solutions/43000707882-stochastic-momentum-index-smi/
+ * @see https://www.fmlabs.com/reference/SMI.htm
+ */
+export class SMI extends TrendIndicatorSeries<HighLowClose<number>> {
+  readonly #candles: HighLowClose<number>[] = [];
+  readonly #smoothedDistance: EMA;
+  readonly #smoothedRange: EMA;
+  readonly #doubleSmoothedDistance: EMA;
+  readonly #doubleSmoothedRange: EMA;
+  readonly #overbought: number;
+  readonly #oversold: number;
+
+  public readonly interval: number;
+  public readonly smooth1: number;
+  public readonly smooth2: number;
+
+  constructor(
+    {interval = 10, smooth1 = 3, smooth2 = 3}: SMIConfig = {},
+    {overbought = 40, oversold = -40}: SignalThresholds = {}
+  ) {
+    super();
+    this.interval = interval;
+    this.smooth1 = smooth1;
+    this.smooth2 = smooth2;
+    this.#smoothedDistance = new EMA(smooth1);
+    this.#smoothedRange = new EMA(smooth1);
+    this.#doubleSmoothedDistance = new EMA(smooth2);
+    this.#doubleSmoothedRange = new EMA(smooth2);
+    this.#overbought = overbought;
+    this.#oversold = oversold;
+  }
+
+  override getRequiredInputs() {
+    return this.interval + this.smooth1 + this.smooth2 - 2;
+  }
+
+  update(candle: HighLowClose<number>, replace: boolean) {
+    pushUpdate({array: this.#candles, item: candle, maxLength: this.interval, replace: replace});
+
+    if (this.#candles.length < this.interval) {
+      return null;
+    }
+
+    const highestHigh = Math.max(...this.#candles.map(candle => candle.high));
+    const lowestLow = Math.min(...this.#candles.map(candle => candle.low));
+    const distance = candle.close - (highestHigh + lowestLow) / 2;
+    const range = highestHigh - lowestLow;
+
+    const smoothedDistance = this.#smoothedDistance.update(distance, replace);
+    const smoothedRange = this.#smoothedRange.update(range, replace);
+
+    if (this.#smoothedDistance.isStable) {
+      const doubleSmoothedDistance = this.#doubleSmoothedDistance.update(smoothedDistance, replace);
+      const doubleSmoothedRange = this.#doubleSmoothedRange.update(smoothedRange, replace);
+
+      if (this.#doubleSmoothedDistance.isStable) {
+        const halfRange = doubleSmoothedRange / 2;
+
+        return this.setResult(halfRange === 0 ? 0 : (100 * doubleSmoothedDistance) / halfRange, replace);
+      }
+    }
+
+    return null;
+  }
+
+  protected calculateSignalState(result: number | null | undefined) {
+    const hasResult = result !== null && result !== undefined;
+    const isOversold = hasResult && result <= this.#oversold;
+    const isOverbought = hasResult && result >= this.#overbought;
+
+    switch (true) {
+      case !hasResult:
+        return TradingSignal.UNKNOWN;
+      case isOversold:
+        return TradingSignal.BEARISH;
+      case isOverbought:
+        return TradingSignal.BULLISH;
+      default:
+        return TradingSignal.SIDEWAYS;
+    }
+  }
+}

--- a/packages/trading-signals/src/momentum/index.ts
+++ b/packages/trading-signals/src/momentum/index.ts
@@ -33,6 +33,7 @@ export * from './RSI/RSI.js';
 export * from './RVGI/RelativeVigorIndex.js';
 export * from './SI/AccumulativeSwingIndex.js';
 export * from './SI/SwingIndex.js';
+export * from './SMI/SMI.js';
 export * from './STC/STC.js';
 export * from './STOCH/StochasticOscillator.js';
 export * from './STOCHRSI/StochasticRSI.js';

--- a/packages/trading-signals/src/momentum/index.ts
+++ b/packages/trading-signals/src/momentum/index.ts
@@ -24,6 +24,7 @@ export * from './OBV/OBV.js';
 export * from './PGO/PGO.js';
 export * from './PMO/PMO.js';
 export * from './PPO/PPO.js';
+export * from './PSL/PSL.js';
 export * from './PSO/PremierStochastic.js';
 export * from './QSTICK/Qstick.js';
 export * from './REI/REI.js';

--- a/packages/trading-signals/src/momentum/index.ts
+++ b/packages/trading-signals/src/momentum/index.ts
@@ -26,6 +26,7 @@ export * from './PMO/PMO.js';
 export * from './PPO/PPO.js';
 export * from './PSL/PSL.js';
 export * from './PSO/PremierStochastic.js';
+export * from './QQE/QQE.js';
 export * from './QSTICK/Qstick.js';
 export * from './REI/REI.js';
 export * from './ROC/ROC.js';

--- a/packages/trading-signals/src/trend/HILO/GannHiLo.test.ts
+++ b/packages/trading-signals/src/trend/HILO/GannHiLo.test.ts
@@ -1,0 +1,327 @@
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {GannHiLo} from './GannHiLo.js';
+import {TradingSignal} from '../../base/index.js';
+
+describe('GannHiLo', () => {
+  describe('update', () => {
+    it('follows the average of the lows in an uptrend, freezes between the averages, and jumps to the average of the highs on a downside break', () => {
+      /*
+       * Formula (Robert Krausz, "A W.D. Gann Treasure Discovered"; pandas-ta-classic hilo.py):
+       * close > SMA(high, hi)[prev] -> line = SMA(low, lo), trend up
+       * close < SMA(low, lo)[prev]  -> line = SMA(high, hi), trend down
+       * otherwise                   -> line freezes, trend persists
+       * https://github.com/xgboosted/pandas-ta-classic/blob/main/pandas_ta_classic/overlap/hilo.py
+       *
+       * The expectations below are derived by hand with highInterval 3 and lowInterval 5:
+       *
+       * | Bar | High | Low | Close | SMA3(high) | SMA5(low) | Breakout          | Line          | Trend   |
+       * |-----|------|-----|-------|------------|-----------|-------------------|---------------|---------|
+       * | 1   | 12   | 8   | 10    | -          | -         | -                 | -             | -       |
+       * | 2   | 13   | 9   | 11    | -          | -         | -                 | -             | -       |
+       * | 3   | 14   | 10  | 12    | 13         | -         | -                 | -             | -       |
+       * | 4   | 15   | 11  | 14    | 14         | -         | 14 > 13, up       | - (no SMA5)   | -       |
+       * | 5   | 16   | 12  | 15    | 15         | 10        | 15 > 14, up       | 10            | BULLISH |
+       * | 6   | 17   | 13  | 16    | 16         | 11        | 16 > 15, up       | 11            | BULLISH |
+       * | 7   | 16   | 12  | 14    | 49/3       | 11.6      | none, freeze      | 11            | BULLISH |
+       * | 8   | 13   | 9   | 10    | 46/3       | 11.4      | 10 < 11.6, down   | 46/3 = 15.33  | BEARISH |
+       * | 9   | 12   | 8   | 9     | 41/3       | 10.8      | 9 < 11.4, down    | 41/3 = 13.67  | BEARISH |
+       * | 10  | 13   | 10  | 12    | 38/3       | 10.4      | none, freeze      | 41/3 = 13.67  | BEARISH |
+       * | 11  | 15   | 12  | 14    | 40/3       | 10.2      | 14 > 38/3, up     | 10.2          | BULLISH |
+       * | 12  | 16   | 13  | 15    | 44/3       | 10.4      | 15 > 40/3, up     | 10.4          | BULLISH |
+       */
+      const candles = [
+        {close: 10, high: 12, low: 8},
+        {close: 11, high: 13, low: 9},
+        {close: 12, high: 14, low: 10},
+        {close: 14, high: 15, low: 11},
+        {close: 15, high: 16, low: 12},
+        {close: 16, high: 17, low: 13},
+        {close: 14, high: 16, low: 12},
+        {close: 10, high: 13, low: 9},
+        {close: 9, high: 12, low: 8},
+        {close: 12, high: 13, low: 10},
+        {close: 14, high: 15, low: 12},
+        {close: 15, high: 16, low: 13},
+      ] as const;
+      const expectations = [
+        {line: '10.00', trend: TradingSignal.BULLISH},
+        {line: '11.00', trend: TradingSignal.BULLISH},
+        {line: '11.00', trend: TradingSignal.BULLISH},
+        {line: '15.33', trend: TradingSignal.BEARISH},
+        {line: '13.67', trend: TradingSignal.BEARISH},
+        {line: '13.67', trend: TradingSignal.BEARISH},
+        {line: '10.20', trend: TradingSignal.BULLISH},
+        {line: '10.40', trend: TradingSignal.BULLISH},
+      ] as const;
+      const hilo = new GannHiLo({highInterval: 3, lowInterval: 5});
+      const offset = hilo.getRequiredInputs() - 1;
+      let verifiedBars = 0;
+
+      candles.forEach((candle, i) => {
+        const result = hilo.add(candle);
+
+        if (result) {
+          verifiedBars++;
+          const expected = expectations[i - offset];
+          expect(result.line.toFixed(2)).toBe(expected.line);
+          expect(result.trend).toBe(expected.trend);
+        }
+      });
+
+      expect(verifiedBars).toBe(expectations.length);
+      expect(hilo.isStable).toBe(true);
+    });
+
+    it('plots nothing when price breaks out before the average of the lows has formed', () => {
+      /*
+       * With a short high interval, the close can clear the average of the highs while the average
+       * of the lows still lacks candles. The reference implementation leaves those bars empty, so
+       * the first line only appears once the activated average can name a level.
+       */
+      const warmUpCandles = [
+        {close: 8, high: 10, low: 6},
+        {close: 9, high: 11, low: 7},
+        {close: 12, high: 13, low: 9},
+        {close: 10, high: 12, low: 8},
+      ] as const;
+      const hilo = new GannHiLo({highInterval: 2, lowInterval: 5});
+
+      for (const candle of warmUpCandles) {
+        expect(hilo.add(candle)).toBeNull();
+      }
+
+      expect(hilo.add({close: 13, high: 13, low: 9})).toEqual({line: 7.8, trend: TradingSignal.BULLISH});
+    });
+
+    it('plots nothing when price breaks down before the average of the highs has formed', () => {
+      const warmUpCandles = [
+        {close: 18, high: 20, low: 16},
+        {close: 17, high: 19, low: 15},
+        {close: 12, high: 18, low: 10},
+        {close: 10, high: 14, low: 9},
+      ] as const;
+      const hilo = new GannHiLo({highInterval: 5, lowInterval: 2});
+
+      for (const candle of warmUpCandles) {
+        expect(hilo.add(candle)).toBeNull();
+      }
+
+      expect(hilo.add({close: 9, high: 13, low: 8})).toEqual({line: 16.8, trend: TradingSignal.BEARISH});
+    });
+
+    it('gives the upside breakout precedence when a candle clears both averages at once', () => {
+      /*
+       * After a crash, the long average of the lows still carries the old price level while the
+       * short average of the highs already reflects the sell-off, so a recovery candle can close
+       * above the highs average and below the lows average at the same time. The upside rule wins,
+       * matching the reference implementation.
+       */
+      const candles = [
+        {close: 95, high: 100, low: 90},
+        {close: 90, high: 98, low: 88},
+        {close: 35, high: 40, low: 30},
+        {close: 36, high: 38, low: 28},
+        {close: 45, high: 50, low: 40},
+      ] as const;
+      const hilo = new GannHiLo({highInterval: 2, lowInterval: 4});
+
+      for (const candle of candles) {
+        hilo.add(candle);
+      }
+
+      expect(hilo.getResultOrThrow()).toEqual({line: 46.5, trend: TradingSignal.BULLISH});
+    });
+
+    it('does not flip up when the close only touches the average of the highs', () => {
+      const hilo = new GannHiLo({highInterval: 2, lowInterval: 2});
+
+      hilo.add({close: 9, high: 10, low: 8});
+      hilo.add({close: 11, high: 12, low: 9});
+
+      // The average of the highs sits exactly at the close, so there is no breakout
+      expect(hilo.add({close: 11, high: 12, low: 10})).toBeNull();
+
+      expect(hilo.add({close: 13, high: 13, low: 11})).toEqual({line: 10.5, trend: TradingSignal.BULLISH});
+    });
+
+    it('does not flip down when the close only touches the average of the lows', () => {
+      const hilo = new GannHiLo({highInterval: 2, lowInterval: 2});
+
+      hilo.add({close: 9, high: 10, low: 8});
+      hilo.add({close: 8, high: 10, low: 7});
+
+      // The average of the lows sits exactly at the close, so there is no breakdown
+      expect(hilo.add({close: 7.5, high: 9, low: 7})).toBeNull();
+
+      expect(hilo.add({close: 6, high: 8, low: 5})).toEqual({line: 8.5, trend: TradingSignal.BEARISH});
+    });
+  });
+
+  describe('getRequiredInputs', () => {
+    it('defaults to the intervals popularized by pandas-ta: 13 highs and 21 lows', () => {
+      const hilo = new GannHiLo();
+
+      expect(hilo.highInterval).toBe(13);
+      expect(hilo.lowInterval).toBe(21);
+      expect(hilo.getRequiredInputs()).toBe(21);
+    });
+
+    it('lets the longer interval dominate the warm-up and adds the breakout candle when both intervals match', () => {
+      expect(new GannHiLo({highInterval: 3, lowInterval: 5}).getRequiredInputs()).toBe(5);
+      expect(new GannHiLo({highInterval: 5, lowInterval: 2}).getRequiredInputs()).toBe(5);
+      expect(new GannHiLo({highInterval: 2, lowInterval: 2}).getRequiredInputs()).toBe(3);
+    });
+  });
+
+  describe('replace', () => {
+    it('rewinds an upside flip when the replacement candle breaks down instead', () => {
+      const candles = [
+        {close: 10, high: 12, low: 8},
+        {close: 11, high: 13, low: 9},
+        {close: 12, high: 14, low: 10},
+        {close: 14, high: 15, low: 11},
+        {close: 15, high: 16, low: 12},
+        {close: 16, high: 17, low: 13},
+        {close: 14, high: 16, low: 12},
+        {close: 10, high: 13, low: 9},
+        {close: 9, high: 12, low: 8},
+        {close: 12, high: 13, low: 10},
+      ] as const;
+      const hilo = new GannHiLo({highInterval: 3, lowInterval: 5});
+
+      for (const candle of candles) {
+        hilo.add(candle);
+      }
+
+      const originalCandle = {close: 14, high: 15, low: 12} as const;
+      const replacementCandle = {close: 8, high: 12, low: 9} as const;
+
+      const originalResult = hilo.add(originalCandle);
+
+      expect(originalResult?.line.toFixed(2)).toBe('10.20');
+      expect(originalResult?.trend).toBe(TradingSignal.BULLISH);
+
+      const replacedResult = hilo.replace(replacementCandle);
+
+      expect(replacedResult?.line.toFixed(2)).toBe('12.33');
+      expect(replacedResult?.trend).toBe(TradingSignal.BEARISH);
+
+      const restoredResult = hilo.replace(originalCandle);
+
+      expect(restoredResult?.line.toFixed(2)).toBe('10.20');
+      expect(restoredResult?.trend).toBe(TradingSignal.BULLISH);
+    });
+
+    it('rewinds a downside flip when the replacement candle breaks out instead', () => {
+      const candles = [
+        {close: 10, high: 12, low: 8},
+        {close: 11, high: 13, low: 9},
+        {close: 12, high: 14, low: 10},
+        {close: 14, high: 15, low: 11},
+        {close: 15, high: 16, low: 12},
+        {close: 16, high: 17, low: 13},
+        {close: 14, high: 16, low: 12},
+      ] as const;
+      const hilo = new GannHiLo({highInterval: 3, lowInterval: 5});
+
+      for (const candle of candles) {
+        hilo.add(candle);
+      }
+
+      const originalCandle = {close: 10, high: 13, low: 9} as const;
+      const replacementCandle = {close: 17, high: 18, low: 13} as const;
+
+      const originalResult = hilo.add(originalCandle);
+
+      expect(originalResult?.line.toFixed(2)).toBe('15.33');
+      expect(originalResult?.trend).toBe(TradingSignal.BEARISH);
+
+      const replacedResult = hilo.replace(replacementCandle);
+
+      expect(replacedResult?.line.toFixed(2)).toBe('12.20');
+      expect(replacedResult?.trend).toBe(TradingSignal.BULLISH);
+
+      const restoredResult = hilo.replace(originalCandle);
+
+      expect(restoredResult?.line.toFixed(2)).toBe('15.33');
+      expect(restoredResult?.trend).toBe(TradingSignal.BEARISH);
+    });
+  });
+
+  describe('getSignal', () => {
+    it('returns UNKNOWN before the warm-up is complete', () => {
+      const hilo = new GannHiLo({highInterval: 3, lowInterval: 5});
+
+      expect(hilo.getSignal()).toEqual({hasChanged: false, state: TradingSignal.UNKNOWN});
+
+      hilo.add({close: 10, high: 12, low: 8});
+      hilo.add({close: 11, high: 13, low: 9});
+
+      expect(hilo.getSignal()).toEqual({hasChanged: false, state: TradingSignal.UNKNOWN});
+    });
+
+    it('returns BULLISH once the line supports price from below', () => {
+      const hilo = new GannHiLo({highInterval: 2, lowInterval: 2});
+
+      hilo.add({close: 9, high: 10, low: 8});
+      hilo.add({close: 11, high: 12, low: 9});
+      hilo.add({close: 12, high: 13, low: 10});
+
+      expect(hilo.getSignal()).toEqual({hasChanged: true, state: TradingSignal.BULLISH});
+    });
+
+    it('returns BEARISH once the line caps price from above', () => {
+      const hilo = new GannHiLo({highInterval: 2, lowInterval: 2});
+
+      hilo.add({close: 12, high: 13, low: 10});
+      hilo.add({close: 11, high: 12, low: 9});
+      hilo.add({close: 8, high: 10, low: 7});
+
+      expect(hilo.getSignal()).toEqual({hasChanged: true, state: TradingSignal.BEARISH});
+    });
+
+    it('flags a change only when the trend flips sides', () => {
+      const hilo = new GannHiLo({highInterval: 3, lowInterval: 5});
+
+      hilo.add({close: 10, high: 12, low: 8});
+      hilo.add({close: 11, high: 13, low: 9});
+      hilo.add({close: 12, high: 14, low: 10});
+      hilo.add({close: 14, high: 15, low: 11});
+      hilo.add({close: 15, high: 16, low: 12});
+
+      expect(hilo.getSignal()).toEqual({hasChanged: true, state: TradingSignal.BULLISH});
+
+      hilo.add({close: 16, high: 17, low: 13});
+
+      expect(hilo.getSignal()).toEqual({hasChanged: false, state: TradingSignal.BULLISH});
+
+      // The close holds between both averages, so the frozen line keeps the bullish signal
+      hilo.add({close: 14, high: 16, low: 12});
+
+      expect(hilo.getSignal()).toEqual({hasChanged: false, state: TradingSignal.BULLISH});
+
+      hilo.add({close: 10, high: 13, low: 9});
+
+      expect(hilo.getSignal()).toEqual({hasChanged: true, state: TradingSignal.BEARISH});
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new GannHiLo({highInterval: 3, lowInterval: 5}),
+  divergentInput: {close: 1_000, high: 1_010, low: 990},
+  inputs: [
+    {close: 10, high: 12, low: 8},
+    {close: 11, high: 13, low: 9},
+    {close: 12, high: 14, low: 10},
+    {close: 14, high: 15, low: 11},
+    {close: 15, high: 16, low: 12},
+    {close: 16, high: 17, low: 13},
+    {close: 14, high: 16, low: 12},
+    {close: 10, high: 13, low: 9},
+    {close: 9, high: 12, low: 8},
+    {close: 12, high: 13, low: 10},
+    {close: 14, high: 15, low: 12},
+    {close: 15, high: 16, low: 13},
+  ],
+});

--- a/packages/trading-signals/src/trend/HILO/GannHiLo.ts
+++ b/packages/trading-signals/src/trend/HILO/GannHiLo.ts
@@ -1,0 +1,134 @@
+import type {HighLowClose} from '../../base/Candle.type.js';
+import {TechnicalIndicator, TradingSignal} from '../../base/Indicator.js';
+import {SMA} from '../SMA/SMA.js';
+
+export type GannHiLoResult = {
+  /** The activator level price trails against: the average of the lows supports price in an uptrend, the average of the highs caps it in a downtrend */
+  line: number;
+  /** BULLISH while the line rides below price, BEARISH while it caps price from above */
+  trend: typeof TradingSignal.BULLISH | typeof TradingSignal.BEARISH;
+};
+
+export type GannHiLoConfig = {
+  /** Number of candles for the average of the highs that a close must clear to flip the trend up (default: 13) */
+  highInterval?: number;
+  /** Number of candles for the average of the lows that a close must break to flip the trend down (default: 21) */
+  lowInterval?: number;
+};
+
+/**
+ * Everything a replacement needs to rerun the latest candle: the averages that candle originally
+ * broke out against and the line it would otherwise extend.
+ */
+type GannHiLoState = {
+  hilo: GannHiLoResult | null;
+  previousHighSma: number | null;
+  previousHilo: GannHiLoResult | null;
+  previousLowSma: number | null;
+};
+
+/**
+ * Gann HiLo Activator (HILO)
+ * Type: Trend
+ *
+ * Robert Krausz introduced the Gann HiLo Activator in a 1998 issue of "Technical Analysis of Stocks & Commodities"
+ * and built his Gann swing trading plans around it in "A W.D. Gann Treasure Discovered". It tracks two simple moving
+ * averages — one of the highs, one of the lows — and lets the close pick which of the two is plotted: a close above
+ * the previous average of the highs activates the average of the lows as rising support, a close below the previous
+ * average of the lows activates the average of the highs as falling resistance, and between the two averages the
+ * line freezes at its last level, so a pullback never loosens the stop.
+ *
+ * Interpretation:
+ * The trend is BULLISH while the line trails below price and BEARISH while it caps price from above. The line only
+ * switches sides when the close breaks the opposite average, so a flip marks a potential trend change and the line
+ * itself serves as a trailing stop-and-reverse level. Lengthening the high interval while shortening the low
+ * interval favors short trades; the reverse favors longs.
+ *
+ * @see https://github.com/xgboosted/pandas-ta-classic/blob/main/pandas_ta_classic/overlap/hilo.py
+ * @see https://www.sierrachart.com/index.php?page=doc/StudiesReference.php&ID=447&Name=Gann_HiLo_Activator
+ */
+export class GannHiLo extends TechnicalIndicator<GannHiLoResult, HighLowClose<number>, GannHiLoState> {
+  readonly #highSma: SMA;
+  readonly #lowSma: SMA;
+
+  public readonly highInterval: number;
+  public readonly lowInterval: number;
+
+  protected override state: GannHiLoState = {
+    hilo: null,
+    previousHighSma: null,
+    previousHilo: null,
+    previousLowSma: null,
+  };
+
+  constructor({highInterval = 13, lowInterval = 21}: GannHiLoConfig = {}) {
+    super();
+    this.highInterval = highInterval;
+    this.lowInterval = lowInterval;
+    this.#highSma = new SMA(highInterval);
+    this.#lowSma = new SMA(lowInterval);
+  }
+
+  override getRequiredInputs() {
+    /*
+     * The line first appears on a breakout candle: the broken average must be complete one candle
+     * earlier, while the opposite average must be complete on the breakout candle itself to supply
+     * the level. Whichever flip direction can complete first defines the warm-up.
+     */
+    const bullishBreakout = Math.max(this.highInterval + 1, this.lowInterval);
+    const bearishBreakout = Math.max(this.lowInterval + 1, this.highInterval);
+
+    return Math.min(bullishBreakout, bearishBreakout);
+  }
+
+  update(candle: HighLowClose<number>, replace: boolean) {
+    this.trackState(replace);
+
+    const {hilo: previousHilo, previousHighSma, previousLowSma} = this.state;
+    const highSma = this.#highSma.update(candle.high, replace);
+    const lowSma = this.#lowSma.update(candle.low, replace);
+
+    const brokeAboveHighAverage = previousHighSma !== null && candle.close > previousHighSma;
+    const brokeBelowLowAverage = previousLowSma !== null && candle.close < previousLowSma;
+
+    let hilo: GannHiLoResult | null;
+
+    /*
+     * An upside breakout takes precedence over a downside one, and a breakout whose activated
+     * average has not formed yet plots nothing — the warm-up zone stays empty instead of
+     * guessing a level, matching the reference implementation.
+     */
+    if (brokeAboveHighAverage) {
+      hilo = lowSma === null ? null : {line: lowSma, trend: TradingSignal.BULLISH};
+    } else if (brokeBelowLowAverage) {
+      hilo = highSma === null ? null : {line: highSma, trend: TradingSignal.BEARISH};
+    } else {
+      // The close stayed between both averages, so the active side keeps control and the line freezes
+      hilo = previousHilo;
+    }
+
+    this.state = {hilo, previousHighSma: highSma, previousHilo, previousLowSma: lowSma};
+    this.result = hilo ?? undefined;
+
+    return hilo;
+  }
+
+  protected calculateSignal(result: GannHiLoResult | null) {
+    if (result === null) {
+      return TradingSignal.UNKNOWN;
+    }
+
+    return result.trend;
+  }
+
+  getSignal() {
+    const previousState = this.calculateSignal(this.state.previousHilo);
+    const state = this.calculateSignal(this.getResult());
+    const hasChanged = previousState !== state;
+
+    return {
+      hasChanged,
+      state,
+    };
+  }
+}

--- a/packages/trading-signals/src/trend/VHF/VHF.test.ts
+++ b/packages/trading-signals/src/trend/VHF/VHF.test.ts
@@ -1,0 +1,140 @@
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {VHF} from './VHF.js';
+
+describe('VHF', () => {
+  describe('constructor', () => {
+    it("uses Adam White's 28-period window by default", () => {
+      const vhf = new VHF();
+
+      expect(vhf.interval).toBe(28);
+      expect(vhf.getRequiredInputs()).toBe(29);
+    });
+
+    it('rejects a window that cannot hold a single close', () => {
+      expect(() => new VHF(0)).toThrowError('The interval has to be at least 1, but "0" was given.');
+      expect(() => new VHF(-3)).toThrowError('The interval has to be at least 1, but "-3" was given.');
+    });
+  });
+
+  describe('getResultOrThrow', () => {
+    it('matches the Tulip Indicators reference results', {tags: ['tulipindicators']}, () => {
+      /*
+       * Test data verified with:
+       * https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt#L450-L452
+       *
+       * Tulip's first reading appears one close after the window fills: the span reads off the last
+       * five closes while the path already includes the move that carried price into them.
+       */
+      const closes = [
+        81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84, 83.99, 84.55, 84.36, 85.53, 86.54, 86.89, 87.77, 87.29,
+      ] as const;
+      const expectations = [
+        '0.720',
+        '0.232',
+        '0.432',
+        '0.553',
+        '0.640',
+        '0.796',
+        '0.625',
+        '0.771',
+        '0.947',
+        '0.576',
+      ] as const;
+      const vhf = new VHF(5);
+      const offset = vhf.getRequiredInputs() - 1;
+
+      closes.forEach((close, i) => {
+        const result = vhf.add(close);
+
+        if (i < offset) {
+          expect(result).toBeNull();
+        } else {
+          expect(result?.toFixed(3)).toBe(expectations[i - offset]);
+        }
+      });
+
+      expect(vhf.isStable).toBe(true);
+    });
+
+    it('reads a dead-flat market as having no trend to measure', () => {
+      // Price that never moved has neither a span nor a path, so the reading is pinned at 0
+      const vhf = new VHF(3);
+
+      for (let i = 0; i < 4; i++) {
+        vhf.add(100);
+      }
+
+      expect(vhf.getResultOrThrow()).toBe(0);
+    });
+
+    it('reads a window price merely settled into as trendless', () => {
+      // The drop into the window still counts toward the path, but the settled closes have no span
+      const closes = [110, 100, 100, 100] as const;
+      const vhf = new VHF(3);
+
+      for (const close of closes) {
+        vhf.add(close);
+      }
+
+      expect(vhf.getResultOrThrow()).toBe(0);
+    });
+  });
+
+  describe('replace', () => {
+    it('replaces the most recently added close', () => {
+      const closes = [10, 12, 11, 14] as const;
+      const vhf = new VHF(3);
+
+      for (const close of closes) {
+        vhf.add(close);
+      }
+
+      // Span 11 to 14 over a path of 2 + 1 + 3
+      expect(vhf.getResultOrThrow()).toBe(0.5);
+
+      // Span 11 to 20 = 9 over a path of 1 + 3 + 6 = 10
+      const originalClose = 20;
+      // Span 11 to 14 = 3 over a path of 1 + 3 + 2 = 6
+      const replacementClose = 12;
+
+      const originalResult = vhf.add(originalClose);
+
+      expect(originalResult).toBe(0.9);
+
+      const replacedResult = vhf.replace(replacementClose);
+
+      expect(replacedResult).toBe(0.5);
+
+      const restoredResult = vhf.replace(originalClose);
+
+      expect(restoredResult).toBe(originalResult);
+    });
+
+    it('replaces the seed close before the first move exists', () => {
+      const seedReplacement = 15;
+      const closes = [12, 11, 14] as const;
+
+      const replaced = new VHF(3);
+      replaced.add(10);
+      replaced.replace(seedReplacement);
+
+      const reference = new VHF(3);
+      reference.add(seedReplacement);
+
+      for (const close of closes) {
+        replaced.add(close);
+        reference.add(close);
+      }
+
+      // Span 11 to 14 = 3 over a path of 3 + 1 + 3 = 7
+      expect(replaced.getResultOrThrow()).toBe(reference.getResultOrThrow());
+      expect(replaced.getResultOrThrow()).toBe(0.42857142857142855);
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new VHF(5),
+  divergentInput: 1_000,
+  inputs: [81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84],
+});

--- a/packages/trading-signals/src/trend/VHF/VHF.ts
+++ b/packages/trading-signals/src/trend/VHF/VHF.ts
@@ -1,0 +1,91 @@
+import {IndicatorSeries} from '../../base/Indicator.js';
+import {getMaximum} from '../../util/getMaximum.js';
+import {getMinimum} from '../../util/getMinimum.js';
+import {pushUpdate} from '../../util/pushUpdate.js';
+
+/**
+ * Vertical Horizontal Filter (VHF)
+ * Type: Trend
+ *
+ * Created by the trader Adam White (Futures magazine, 1991), the Vertical Horizontal Filter tells a
+ * trending market from a congesting one by relating the widest span between closing prices (the
+ * vertical component) to the ground those closes actually covered on the way (the horizontal
+ * component). A trend walks its span nearly in a straight line, so span and path almost coincide
+ * and the reading approaches 1. A congesting market crosses the same prices again and again, so the
+ * path dwarfs the span and the reading approaches 0.
+ *
+ * Interpretation:
+ * There is no fixed banding — the reading is compared against its own recent history: rising values
+ * mark a strengthening trend (favor trend-following tools), falling values mark developing
+ * congestion (favor oscillators). The reading is direction-agnostic — a crash and a rally both read
+ * as trending — which is why this indicator emits no trading signal; direction has to come from a
+ * trend-following companion.
+ *
+ * @see https://tulipindicators.org/vhf
+ * @see https://www.incrediblecharts.com/indicators/vertical_horizontal_filter.php
+ */
+export class VHF extends IndicatorSeries {
+  readonly #closes: number[] = [];
+  readonly #changes: number[] = [];
+  #previousClose?: number;
+  #twoPreviousClose?: number;
+
+  public readonly interval: number;
+
+  constructor(interval: number = 28) {
+    super();
+
+    // Without a single close in the window there is neither a span nor a path to relate
+    if (interval < 1) {
+      throw new Error(`The interval has to be at least 1, but "${interval}" was given.`);
+    }
+
+    this.interval = interval;
+  }
+
+  override getRequiredInputs() {
+    // The close ahead of the window only contributes the move that carries price into the window
+    return this.interval + 1;
+  }
+
+  update(close: number, replace: boolean) {
+    if (replace) {
+      this.#previousClose = this.#twoPreviousClose;
+    }
+
+    if (this.#previousClose === undefined) {
+      this.#previousClose = close;
+      return null;
+    }
+
+    const change = Math.abs(close - this.#previousClose);
+
+    this.#twoPreviousClose = this.#previousClose;
+    this.#previousClose = close;
+
+    // The span reads off the closes inside the window, while the path also counts the move that carried price into it
+    pushUpdate({array: this.#closes, item: close, maxLength: this.interval, replace});
+    pushUpdate({array: this.#changes, item: change, maxLength: this.interval, replace});
+
+    if (this.#changes.length < this.interval) {
+      return null;
+    }
+
+    let path = 0;
+
+    for (const move of this.#changes) {
+      path += move;
+    }
+
+    /*
+     * A dead-flat stretch is the one degenerate case: price that never moved has neither a span nor
+     * a path, and relating nothing to nothing yields no number at all. No movement also means there
+     * is no trend to measure, so the reading is pinned at 0 — the congested end of the scale.
+     */
+    if (path === 0) {
+      return this.setResult(0, replace);
+    }
+
+    return this.setResult((getMaximum(this.#closes) - getMinimum(this.#closes)) / path, replace);
+  }
+}

--- a/packages/trading-signals/src/trend/index.ts
+++ b/packages/trading-signals/src/trend/index.ts
@@ -29,6 +29,7 @@ export * from './SWING_LOW/SwingLow.js';
 export * from './T3/T3.js';
 export * from './TEMA/TEMA.js';
 export * from './TRIMA/TRIMA.js';
+export * from './VHF/VHF.js';
 export * from './VI/VortexIndicator.js';
 export * from './VIDYA/VIDYA.js';
 export * from './VSTOP/VolatilityStop.js';

--- a/packages/trading-signals/src/trend/index.ts
+++ b/packages/trading-signals/src/trend/index.ts
@@ -10,6 +10,7 @@ export * from './DX/DX.js';
 export * from './EMA/EMA.js';
 export * from './FRAMA/FRAMA.js';
 export * from './HIGHER_LOW_TRAIL/HigherLowTrail.js';
+export * from './HILO/GannHiLo.js';
 export * from './HMA/HMA.js';
 export * from './ICHIMOKU/IchimokuCloud.js';
 export * from './KAMA/KAMA.js';

--- a/packages/trading-signals/src/volatility/RVI/RelativeVolatilityIndex.test.ts
+++ b/packages/trading-signals/src/volatility/RVI/RelativeVolatilityIndex.test.ts
@@ -1,0 +1,162 @@
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {RelativeVolatilityIndex} from './RelativeVolatilityIndex.js';
+import {TradingSignal} from '../../base/index.js';
+
+describe('RelativeVolatilityIndex', () => {
+  /*
+   * Hand-derived worksheet for Donald Dorsey's RVI (Technical Analysis of Stocks & Commodities,
+   * June 1993, refined 1995) with a 3-close deviation window and 3-bar Wilder smoothing:
+   * https://www.tradingview.com/support/solutions/43000594684-relative-volatility-index/
+   *
+   * "σ" is the population standard deviation of the window. A rising close assigns σ to "U",
+   * a falling close assigns σ to "D", an unchanged close assigns it to neither (bar 7 — both
+   * averages decay by the same factor, so the reading stays put). Both averages seed with the
+   * plain average of their first 3 inputs and continue as avg + (x - avg) / 3.
+   *
+   * bar | close | window     |      σ |      U |      D |   avgU |   avgD | RVI = 100 × avgU / (avgU + avgD)
+   *   1 |    10 | [10]       |      - |      - |      - |      - |      - |     -
+   *   2 |    12 | [10,12]    |      - |      - |      - |      - |      - |     -
+   *   3 |    11 | [10,12,11] | 0.8165 | 0      | 0.8165 |      - |      - |     -
+   *   4 |    13 | [12,11,13] | 0.8165 | 0.8165 | 0      |      - |      - |     -
+   *   5 |    14 | [11,13,14] | 1.2472 | 1.2472 | 0      | 0.6879 | 0.2722 | 71.65
+   *   6 |    12 | [13,14,12] | 0.8165 | 0      | 0.8165 | 0.4586 | 0.4536 | 50.27
+   *   7 |    12 | [14,12,12] | 0.9428 | 0      | 0      | 0.3057 | 0.3024 | 50.27
+   *   8 |    15 | [12,12,15] | 1.4142 | 1.4142 | 0      | 0.6752 | 0.2016 | 77.01
+   */
+  const prices = [10, 12, 11, 13, 14, 12, 12, 15] as const;
+  const expectations = ['71.65', '50.27', '50.27', '77.01'] as const;
+
+  describe('getResultOrThrow', () => {
+    it('matches the hand-derived Dorsey worksheet', () => {
+      const rvi = new RelativeVolatilityIndex({interval: 3, stddevInterval: 3});
+      const offset = rvi.getRequiredInputs() - 1;
+
+      prices.forEach((price, i) => {
+        const result = rvi.add(price);
+
+        if (result) {
+          expect(result.toFixed(2)).toBe(expectations[i - offset]);
+        }
+      });
+
+      expect(rvi.isStable).toBe(true);
+    });
+
+    it('reads neutral when a dead market produces no volatility to attribute to either side', () => {
+      const rvi = new RelativeVolatilityIndex({interval: 3, stddevInterval: 3});
+
+      for (let i = 0; i < 6; i++) {
+        rvi.add(100);
+      }
+
+      expect(rvi.getResultOrThrow()).toBe(50);
+    });
+  });
+
+  describe('getRequiredInputs', () => {
+    it('spans the deviation window plus the smoothing warm-up', () => {
+      expect(new RelativeVolatilityIndex().getRequiredInputs()).toBe(23);
+      expect(new RelativeVolatilityIndex({interval: 3, stddevInterval: 3}).getRequiredInputs()).toBe(5);
+    });
+  });
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const rvi = new RelativeVolatilityIndex({interval: 3, stddevInterval: 3});
+
+      for (const price of prices) {
+        rvi.add(price);
+      }
+
+      // Swinging the bar from an up-move to a down-move rolls back the deviation window and both smoothings
+      const originalResult = rvi.add(16);
+
+      expect(originalResult?.toFixed(2)).toBe('88.32');
+
+      const replacedResult = rvi.replace(9);
+
+      expect(replacedResult?.toFixed(2)).toBe('32.13');
+
+      const restoredResult = rvi.replace(16);
+
+      expect(restoredResult).toBe(originalResult);
+    });
+  });
+
+  describe('getSignal', () => {
+    it('returns UNKNOWN when there is no result', () => {
+      const rvi = new RelativeVolatilityIndex({interval: 3, stddevInterval: 3});
+
+      expect(rvi.getSignal().state).toBe(TradingSignal.UNKNOWN);
+    });
+
+    it('returns BULLISH when all volatility builds on the upside', () => {
+      const rvi = new RelativeVolatilityIndex({interval: 3, stddevInterval: 3});
+
+      for (const price of [1, 2, 3, 4, 5] as const) {
+        rvi.add(price);
+      }
+
+      expect(rvi.getResultOrThrow()).toBe(100);
+      expect(rvi.getSignal().state).toBe(TradingSignal.BULLISH);
+    });
+
+    it('returns BEARISH when all volatility builds on the downside', () => {
+      const rvi = new RelativeVolatilityIndex({interval: 3, stddevInterval: 3});
+
+      for (const price of [9, 8, 7, 6, 5] as const) {
+        rvi.add(price);
+      }
+
+      expect(rvi.getResultOrThrow()).toBe(0);
+      expect(rvi.getSignal().state).toBe(TradingSignal.BEARISH);
+    });
+
+    it('returns SIDEWAYS when the volatility mix sits between the thresholds', () => {
+      const rvi = new RelativeVolatilityIndex({interval: 3, stddevInterval: 3});
+
+      for (const price of [10, 12, 11, 13, 14, 12] as const) {
+        rvi.add(price);
+      }
+
+      expect(rvi.getResultOrThrow().toFixed(2)).toBe('50.27');
+      expect(rvi.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+    });
+
+    it('treats a reading exactly on the overbought threshold as BULLISH', () => {
+      const rvi = new RelativeVolatilityIndex({
+        interval: 3,
+        signalThresholds: {overbought: 100},
+        stddevInterval: 3,
+      });
+
+      for (const price of [1, 2, 3, 4, 5] as const) {
+        rvi.add(price);
+      }
+
+      expect(rvi.getResultOrThrow()).toBe(100);
+      expect(rvi.getSignal().state).toBe(TradingSignal.BULLISH);
+    });
+
+    it('treats a reading exactly on the oversold threshold as BEARISH', () => {
+      const rvi = new RelativeVolatilityIndex({
+        interval: 3,
+        signalThresholds: {oversold: 0},
+        stddevInterval: 3,
+      });
+
+      for (const price of [9, 8, 7, 6, 5] as const) {
+        rvi.add(price);
+      }
+
+      expect(rvi.getResultOrThrow()).toBe(0);
+      expect(rvi.getSignal().state).toBe(TradingSignal.BEARISH);
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new RelativeVolatilityIndex({interval: 3, stddevInterval: 3}),
+  divergentInput: 1_000,
+  inputs: [10, 12, 11, 13, 14, 12, 12, 15],
+});

--- a/packages/trading-signals/src/volatility/RVI/RelativeVolatilityIndex.test.ts
+++ b/packages/trading-signals/src/volatility/RVI/RelativeVolatilityIndex.test.ts
@@ -26,6 +26,14 @@ describe('RelativeVolatilityIndex', () => {
   const prices = [10, 12, 11, 13, 14, 12, 12, 15] as const;
   const expectations = ['71.65', '50.27', '50.27', '77.01'] as const;
 
+  describe('constructor', () => {
+    it('rejects a deviation window that cannot form a comparison', () => {
+      expect(() => new RelativeVolatilityIndex({stddevInterval: 1})).toThrowError(
+        'The stddevInterval has to be at least 2, but "1" was given.'
+      );
+    });
+  });
+
   describe('getResultOrThrow', () => {
     it('matches the hand-derived Dorsey worksheet', () => {
       const rvi = new RelativeVolatilityIndex({interval: 3, stddevInterval: 3});

--- a/packages/trading-signals/src/volatility/RVI/RelativeVolatilityIndex.ts
+++ b/packages/trading-signals/src/volatility/RVI/RelativeVolatilityIndex.ts
@@ -52,6 +52,12 @@ export class RelativeVolatilityIndex extends TrendIndicatorSeries {
     stddevInterval = 10,
   }: RelativeVolatilityIndexConfig = {}) {
     super();
+
+    // A single close carries no deviation and leaves no previous close to compare against
+    if (stddevInterval < 2) {
+      throw new Error(`The stddevInterval has to be at least 2, but "${stddevInterval}" was given.`);
+    }
+
     this.interval = interval;
     this.stddevInterval = stddevInterval;
     this.#avgUpVolatility = new WSMA(interval);

--- a/packages/trading-signals/src/volatility/RVI/RelativeVolatilityIndex.ts
+++ b/packages/trading-signals/src/volatility/RVI/RelativeVolatilityIndex.ts
@@ -1,0 +1,113 @@
+import {TradingSignal, TrendIndicatorSeries} from '../../base/Indicator.js';
+import type {SignalThresholds} from '../../base/SignalThresholds.type.js';
+import {WSMA} from '../../trend/WSMA/WSMA.js';
+import {getStandardDeviation, pushUpdate} from '../../util/index.js';
+
+export type RelativeVolatilityIndexConfig = {
+  /** Number of bars in the smoothing of the up/down volatility streams */
+  interval?: number;
+  signalThresholds?: SignalThresholds;
+  /** Number of closes in the rolling window whose standard deviation is measured */
+  stddevInterval?: number;
+};
+
+/**
+ * Relative Volatility Index (RVI)
+ * Type: Volatility
+ *
+ * Developed by Donald Dorsey and published in Technical Analysis of Stocks & Commodities (June 1993,
+ * refined in 1995), the Relative Volatility Index applies the RSI recipe to volatility instead of price
+ * change: each bar assigns the standard deviation of recent closes to an up stream when the close rises
+ * and to a down stream when it falls (an unchanged close feeds neither), and both streams are smoothed
+ * with Wilder's technique. The reading oscillates between 0 and 100 and expresses the share of recent
+ * volatility that built up while prices were rising. Dorsey designed it as a confirmation filter that
+ * qualifies signals of other indicators rather than generating trades on its own. Not to be confused
+ * with the Relative Vigor Index (RVGI) or Relative Volume (RVOL).
+ *
+ * The deviation window uses the population standard deviation, matching TradingView's built-in RVI
+ * (pandas-ta defaults to the sample variant and to EMA smoothing, so its readings differ slightly).
+ *
+ * Interpretation:
+ * A value of 60 or above indicates volatility building on the upside (bullish pressure), a value of 40
+ * or below volatility building on the downside (bearish pressure); both thresholds can be customized
+ * via the constructor. A dead market produces no volatility in either direction, which offers nothing
+ * to attribute to either side, so the reading is neutral (50).
+ *
+ * @see https://www.tradingview.com/support/solutions/43000594684-relative-volatility-index/
+ * @see https://docs.motivewave.com/studies/q-r#relative-volatility-index
+ */
+export class RelativeVolatilityIndex extends TrendIndicatorSeries {
+  readonly #closes: number[] = [];
+  readonly #avgUpVolatility: WSMA;
+  readonly #avgDownVolatility: WSMA;
+  readonly #overbought: number;
+  readonly #oversold: number;
+
+  public readonly interval: number;
+  public readonly stddevInterval: number;
+
+  constructor({
+    interval = 14,
+    signalThresholds: {overbought = 60, oversold = 40} = {},
+    stddevInterval = 10,
+  }: RelativeVolatilityIndexConfig = {}) {
+    super();
+    this.interval = interval;
+    this.stddevInterval = stddevInterval;
+    this.#avgUpVolatility = new WSMA(interval);
+    this.#avgDownVolatility = new WSMA(interval);
+    this.#overbought = overbought;
+    this.#oversold = oversold;
+  }
+
+  override getRequiredInputs() {
+    // The smoothing only starts receiving volatility once the deviation window is full
+    return this.stddevInterval + this.#avgUpVolatility.getRequiredInputs() - 1;
+  }
+
+  update(close: number, replace: boolean) {
+    pushUpdate({array: this.#closes, item: close, maxLength: this.stddevInterval, replace});
+
+    if (this.#closes.length < this.stddevInterval) {
+      return null;
+    }
+
+    const previousClose = this.#closes[this.#closes.length - 2];
+    const stddev = getStandardDeviation(this.#closes);
+
+    this.#avgUpVolatility.update(close > previousClose ? stddev : 0, replace);
+    this.#avgDownVolatility.update(close < previousClose ? stddev : 0, replace);
+
+    if (this.#avgUpVolatility.isStable) {
+      const upVolatility = this.#avgUpVolatility.getResultOrThrow();
+      const downVolatility = this.#avgDownVolatility.getResultOrThrow();
+      const totalVolatility = upVolatility + downVolatility;
+
+      // A dead market offers no volatility to attribute to either side, so the reading is neutral
+      if (totalVolatility === 0) {
+        return this.setResult(50, replace);
+      }
+
+      return this.setResult((100 * upVolatility) / totalVolatility, replace);
+    }
+
+    return null;
+  }
+
+  protected calculateSignalState(result: number | null | undefined) {
+    const hasResult = result !== null && result !== undefined;
+    const isOversold = hasResult && result <= this.#oversold;
+    const isOverbought = hasResult && result >= this.#overbought;
+
+    switch (true) {
+      case !hasResult:
+        return TradingSignal.UNKNOWN;
+      case isOversold:
+        return TradingSignal.BEARISH;
+      case isOverbought:
+        return TradingSignal.BULLISH;
+      default:
+        return TradingSignal.SIDEWAYS;
+    }
+  }
+}

--- a/packages/trading-signals/src/volatility/index.ts
+++ b/packages/trading-signals/src/volatility/index.ts
@@ -14,6 +14,7 @@ export * from './NATR/NATR.js';
 export * from './PB/PercentB.js';
 export * from './PO/ProjectionOscillator.js';
 export * from './RSV/RogersSatchellVolatility.js';
+export * from './RVI/RelativeVolatilityIndex.js';
 export * from './SQUEEZE/TTMSqueeze.js';
 export * from './TR/TR.js';
 export * from './UI/UlcerIndex.js';

--- a/packages/trading-signals/src/volume/MARKETFI/MarketFacilitationIndex.test.ts
+++ b/packages/trading-signals/src/volume/MARKETFI/MarketFacilitationIndex.test.ts
@@ -1,0 +1,116 @@
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {MarketFacilitationIndex} from './MarketFacilitationIndex.js';
+
+describe('MarketFacilitationIndex', () => {
+  /*
+   * Test data verified with:
+   * https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt#L248-L252
+   */
+  const candles = [
+    {close: 81.59, high: 82.15, low: 81.29, volume: 5_653_100},
+    {close: 81.06, high: 81.89, low: 80.64, volume: 6_447_400},
+    {close: 82.87, high: 83.03, low: 81.31, volume: 7_690_900},
+    {close: 83.0, high: 83.3, low: 82.65, volume: 3_831_400},
+    {close: 83.61, high: 83.85, low: 83.07, volume: 4_455_100},
+    {close: 83.15, high: 83.9, low: 83.11, volume: 3_798_000},
+    {close: 82.84, high: 83.33, low: 82.49, volume: 3_936_200},
+    {close: 83.99, high: 84.3, low: 82.3, volume: 4_732_000},
+    {close: 84.55, high: 84.84, low: 84.15, volume: 4_841_300},
+    {close: 84.36, high: 85.0, low: 84.11, volume: 3_915_300},
+    {close: 85.53, high: 85.9, low: 84.03, volume: 6_830_800},
+    {close: 86.54, high: 86.58, low: 85.39, volume: 6_694_100},
+    {close: 86.89, high: 86.98, low: 85.76, volume: 5_293_600},
+    {close: 87.77, high: 88.0, low: 87.17, volume: 7_985_800},
+    {close: 87.29, high: 87.87, low: 87.01, volume: 4_807_900},
+  ] as const;
+
+  describe('getResultOrThrow', () => {
+    it('is compatible with results from Tulip Indicators (TI)', {tags: ['tulipindicators']}, () => {
+      /*
+       * Tulip publishes its expectations rounded to three decimals, which flattens every reading of this dataset
+       * to "0.000" — dollar-wide ranges against multi-million volumes land near 1e-7. The exponential
+       * expectations pin the same values at a precision where a broken formula actually fails.
+       */
+      const expectations = [
+        '1.52129e-7',
+        '1.93877e-7',
+        '2.23641e-7',
+        '1.69651e-7',
+        '1.75080e-7',
+        '2.08004e-7',
+        '2.13404e-7',
+        '4.22654e-7',
+        '1.42524e-7',
+        '2.27313e-7',
+        '2.73760e-7',
+        '1.77768e-7',
+        '2.30467e-7',
+        '1.03934e-7',
+        '1.78872e-7',
+      ] as const;
+      const marketfi = new MarketFacilitationIndex();
+
+      candles.forEach((candle, i) => {
+        const result = marketfi.add(candle);
+
+        expect(result?.toFixed(3)).toBe('0.000');
+        expect(result?.toExponential(5)).toBe(expectations[i]);
+      });
+
+      expect(marketfi.isStable).toBe(true);
+      expect(marketfi.getRequiredInputs()).toBe(1);
+    });
+
+    it('measures how much price range one unit of volume moved', () => {
+      const marketfi = new MarketFacilitationIndex();
+
+      expect(marketfi.add({close: 100, high: 110, low: 90, volume: 100})).toBe(0.2);
+      expect(marketfi.add({close: 100, high: 105, low: 95, volume: 200})).toBe(0.05);
+    });
+
+    it('reads a candle nobody traded as zero facilitation instead of dividing by zero', () => {
+      /*
+       * The Tulip reference divides regardless and would emit a non-finite value here; this implementation
+       * deliberately reports zero facilitation for a volume-less candle.
+       */
+      const marketfi = new MarketFacilitationIndex();
+
+      expect(marketfi.add({close: 100, high: 101, low: 99, volume: 0})).toBe(0);
+      expect(marketfi.isStable).toBe(true);
+      expect(marketfi.getResultOrThrow()).toBe(0);
+    });
+  });
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const marketfi = new MarketFacilitationIndex();
+
+      marketfi.add({close: 100, high: 105, low: 95, volume: 200});
+
+      const originalValue = {close: 101, high: 110, low: 90, volume: 100} as const;
+      const replacedValue = {close: 99, high: 104, low: 96, volume: 400} as const;
+
+      const originalResult = marketfi.add(originalValue);
+
+      expect(originalResult).toBe(0.2);
+
+      const replacedResult = marketfi.replace(replacedValue);
+
+      expect(replacedResult).toBe(0.02);
+
+      const restoredResult = marketfi.replace(originalValue);
+
+      expect(restoredResult).toBe(0.2);
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new MarketFacilitationIndex(),
+  divergentInput: {close: 90, high: 95, low: 82, volume: 99_000_000},
+  inputs: [
+    {close: 81.59, high: 82.15, low: 81.29, volume: 5_653_100},
+    {close: 81.06, high: 81.89, low: 80.64, volume: 6_447_400},
+    {close: 82.87, high: 83.03, low: 81.31, volume: 7_690_900},
+  ],
+});

--- a/packages/trading-signals/src/volume/MARKETFI/MarketFacilitationIndex.ts
+++ b/packages/trading-signals/src/volume/MARKETFI/MarketFacilitationIndex.ts
@@ -1,0 +1,41 @@
+import type {HighLowCloseVolume} from '../../base/Candle.type.js';
+import {IndicatorSeries} from '../../base/Indicator.js';
+
+/**
+ * Market Facilitation Index (MARKETFI)
+ * Type: Volume
+ *
+ * Bill Williams introduced this index in "Trading Chaos" as the "Market Facilitation Index" — traders abbreviate it
+ * "BW MFI" because the plain "MFI" acronym already belongs to the unrelated Money Flow Index (see `MFI` in this
+ * library). It divides a candle's trading range by its volume, telling a trader how much price movement a single
+ * unit of volume was able to produce: a market that travels far on little volume facilitates trade easily, while a
+ * market that absorbs heavy volume without moving is fighting over its current level. The close plays no role in
+ * the formula; the shared candle type is reused instead of introducing a one-off high/low/volume shape.
+ *
+ * Interpretation: Williams never reads the value on its own — he pairs the index change with the volume change of
+ * the same candle to classify it into his four windows: both rising ("green") confirms genuine participation, both
+ * falling ("fade") marks a dying market, index up on falling volume ("fake") warns of a move without backing, and
+ * index down on rising volume ("squat") flags a battle that often precedes a breakout. Because every reading only
+ * gains meaning next to the volume bar, this indicator deliberately emits no standalone trading signal.
+ *
+ * @see https://en.wikipedia.org/wiki/Market_facilitation_index
+ * @see https://tulipindicators.org/marketfi
+ */
+export class MarketFacilitationIndex extends IndicatorSeries<HighLowCloseVolume> {
+  override getRequiredInputs() {
+    return 1;
+  }
+
+  override update(candle: HighLowCloseVolume, replace: boolean) {
+    /*
+     * A candle nobody traded facilitates no price movement, so its reading is zero. This deliberately deviates
+     * from the Tulip Indicators reference, which divides regardless and emits a non-finite value that no chart or
+     * strategy can act on (same reasoning as the zero-range guard in KVO).
+     */
+    if (candle.volume === 0) {
+      return this.setResult(0, replace);
+    }
+
+    return this.setResult((candle.high - candle.low) / candle.volume, replace);
+  }
+}

--- a/packages/trading-signals/src/volume/WAD/WAD.test.ts
+++ b/packages/trading-signals/src/volume/WAD/WAD.test.ts
@@ -1,0 +1,125 @@
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {WAD} from './WAD.js';
+
+describe('WAD', () => {
+  describe('getResultOrThrow', () => {
+    it('is compatible with results from Tulip Indicators (TI)', {tags: ['tulipindicators']}, () => {
+      /*
+       * Test data verified with:
+       * https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt#L471-L475
+       */
+      const candles = [
+        {close: 81.59, high: 82.15, low: 81.29},
+        {close: 81.06, high: 81.89, low: 80.64},
+        {close: 82.87, high: 83.03, low: 81.31},
+        {close: 83.0, high: 83.3, low: 82.65},
+        {close: 83.61, high: 83.85, low: 83.07},
+        {close: 83.15, high: 83.9, low: 83.11},
+        {close: 82.84, high: 83.33, low: 82.49},
+        {close: 83.99, high: 84.3, low: 82.3},
+        {close: 84.55, high: 84.84, low: 84.15},
+        {close: 84.36, high: 85.0, low: 84.11},
+        {close: 85.53, high: 85.9, low: 84.03},
+        {close: 86.54, high: 86.58, low: 85.39},
+        {close: 86.89, high: 86.98, low: 85.76},
+        {close: 87.77, high: 88.0, low: 87.17},
+        {close: 87.29, high: 87.87, low: 87.01},
+      ] as const;
+      const expectations = [
+        '-0.830',
+        '0.980',
+        '1.330',
+        '1.940',
+        '1.190',
+        '0.700',
+        '2.390',
+        '2.950',
+        '2.310',
+        '3.810',
+        '4.960',
+        '6.090',
+        '6.970',
+        '6.390',
+      ] as const;
+      const wad = new WAD();
+      const offset = wad.getRequiredInputs() - 1;
+
+      candles.forEach((candle, i) => {
+        const result = wad.add(candle);
+
+        if (result !== null) {
+          expect(result.toFixed(3)).toBe(expectations[i - offset]);
+        }
+      });
+
+      expect(wad.isStable).toBe(true);
+      expect(wad.getRequiredInputs()).toBe(2);
+    });
+
+    it('keeps the line flat when the close matches the previous close', () => {
+      const wad = new WAD();
+
+      wad.add({close: 10, high: 11, low: 9});
+      wad.add({close: 12, high: 13, low: 10});
+
+      expect(wad.add({close: 12, high: 14, low: 11})).toBe(2);
+    });
+  });
+
+  describe('replace', () => {
+    it('rolls back the accumulation when an up-close is replaced by a down-close', () => {
+      const wad = new WAD();
+
+      wad.add({close: 100, high: 101, low: 99});
+      wad.add({close: 102, high: 103, low: 100});
+
+      const originalValue = {close: 105, high: 106, low: 103} as const;
+      const replacedValue = {close: 99, high: 104, low: 98} as const;
+
+      const originalResult = wad.add(originalValue);
+
+      expect(originalResult).toBe(5);
+
+      const replacedResult = wad.replace(replacedValue);
+
+      expect(replacedResult).toBe(-3);
+
+      const restoredResult = wad.replace(originalValue);
+
+      expect(restoredResult).toBe(5);
+    });
+
+    it('applies the accumulation when a down-close is replaced by an up-close', () => {
+      const wad = new WAD();
+
+      wad.add({close: 100, high: 101, low: 99});
+      wad.add({close: 98, high: 100, low: 97});
+
+      const originalValue = {close: 96, high: 99, low: 95} as const;
+      const replacedValue = {close: 103, high: 104, low: 97} as const;
+
+      const originalResult = wad.add(originalValue);
+
+      expect(originalResult).toBe(-5);
+
+      const replacedResult = wad.replace(replacedValue);
+
+      expect(replacedResult).toBe(4);
+
+      const restoredResult = wad.replace(originalValue);
+
+      expect(restoredResult).toBe(-5);
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new WAD(),
+  divergentInput: {close: 500, high: 500, low: 500},
+  inputs: [
+    {close: 81.59, high: 82.15, low: 81.29},
+    {close: 81.06, high: 81.89, low: 80.64},
+    {close: 82.87, high: 83.03, low: 81.31},
+    {close: 83.0, high: 83.3, low: 82.65},
+  ],
+});

--- a/packages/trading-signals/src/volume/WAD/WAD.ts
+++ b/packages/trading-signals/src/volume/WAD/WAD.ts
@@ -1,0 +1,67 @@
+import type {HighLowClose} from '../../base/Candle.type.js';
+import {IndicatorSeries} from '../../base/Indicator.js';
+
+type WADState = {
+  previousClose: number | null;
+  wad: number;
+};
+
+/**
+ * Williams Accumulation/Distribution (WAD)
+ * Type: Volume
+ *
+ * Developed by Larry Williams, this cumulative line tracks which side won each bar: buyers who managed to
+ * close the bar higher get credited with the full run from the bar's true low up to the close, sellers who
+ * closed it lower get charged the drop from the true high down to the close.
+ *
+ * Despite the shared name, it is unrelated to Chaikin's Accumulation/Distribution (AD): Chaikin weights each
+ * bar by volume and by where the close sits inside the high-low range, whereas Williams' line is built from
+ * price alone. "Accumulation/Distribution" here is Williams' reading of who controlled the bar, which is why
+ * the indicator is conventionally filed with the accumulation/distribution (volume) tools even though it
+ * consumes no volume.
+ *
+ * Formula:
+ * A close above the previous close adds the distance from the true low (the lower of the current low and the
+ * previous close) up to the close. A close below the previous close subtracts the distance from the true high
+ * (the higher of the current high and the previous close) down to the close. An unchanged close leaves the
+ * line untouched.
+ *
+ * Interpretation:
+ * The absolute level carries no meaning — the line is read against price for divergence. A fresh price high
+ * that the line refuses to confirm warns of distribution, while a fresh price low against a rising line hints
+ * at accumulation. Compare the line's direction with price — this class does not emit a standalone signal.
+ *
+ * @see https://tulipindicators.org/wad
+ * @see https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/indicators/wad.c
+ */
+export class WAD extends IndicatorSeries<HighLowClose<number>, WADState> {
+  protected override state: WADState = {previousClose: null, wad: 0};
+
+  override getRequiredInputs() {
+    return 2;
+  }
+
+  update(candle: HighLowClose<number>, replace: boolean) {
+    /*
+     * WAD accumulates onto a running total, so a replacement has to build on the total from
+     * before the replaced candle.
+     */
+    this.trackState(replace);
+
+    const previousClose = this.state.previousClose;
+    this.state.previousClose = candle.close;
+
+    if (previousClose === null) {
+      return null;
+    }
+
+    // An unchanged close means neither side won the bar, so the line stays flat
+    if (candle.close > previousClose) {
+      this.state.wad += candle.close - Math.min(candle.low, previousClose);
+    } else if (candle.close < previousClose) {
+      this.state.wad += candle.close - Math.max(candle.high, previousClose);
+    }
+
+    return this.setResult(this.state.wad, replace);
+  }
+}

--- a/packages/trading-signals/src/volume/index.ts
+++ b/packages/trading-signals/src/volume/index.ts
@@ -11,3 +11,4 @@ export * from './PVT/PVT.js';
 export * from './RVOL/RVOL.js';
 export * from './VROC/VROC.js';
 export * from './VWMA/VWMA.js';
+export * from './WAD/WAD.js';

--- a/packages/trading-signals/src/volume/index.ts
+++ b/packages/trading-signals/src/volume/index.ts
@@ -4,6 +4,7 @@ export * from './CMF/CMF.js';
 export * from './EMV/EMV.js';
 export * from './FI/ForceIndex.js';
 export * from './KVO/KVO.js';
+export * from './MARKETFI/MarketFacilitationIndex.js';
 export * from './NVI/NVI.js';
 export * from './PVI/PVI.js';
 export * from './PVO/PVO.js';


### PR DESCRIPTION
## Summary

Sources [Pandas TA](https://github.com/twopirllc/pandas-ta) (~130 indicators + ~40 fork additions) — the mainstream set was already fully covered after the previous batches (their `bias` = our DisparityIndex, `kdj` = STOCH %J, `mcgd` = McGinley, `ssf` = SuperSmoother, `amat` = DMA, `squeeze` = TTMSqueeze — all verified in code). The 8 defensible gaps land here, one commit each:

| Indicator | Class | Category | Reference verification |
|---|---|---|---|
| QQE | `QQE` | momentum | Pine source pinned verbatim (glaz/JustUncleL MT4 port incl. bidirectional `cross()` + band ratchets); dual-implementation verification |
| Stochastic Momentum Index | `SMI` | momentum | Blau TASC 1/1993; exact-fraction worksheet (Skender seeding transient proven, for the record) |
| Vertical Horizontal Filter | `VHF` | trend | Tulip `untest.txt` L450–452 + `vhf.c` window alignment |
| Relative Volatility Index | `RelativeVolatilityIndex` | volatility | Dorsey TASC 6/1993; population-stddev convention verified against TradingView; **re-promoted after appearing in a second source library** |
| Psychological Line | `PSL` | momentum | pandas-ta-pinned semantics (unchanged closes count down); exact counts |
| Gann HiLo Activator | `GannHiLo` | trend | pandas-ta `_hilo_loop` ported + cross-checked verbatim (incl. line-freeze persistence and warm-up NaN semantics) |
| Williams A/D | `WAD` | volume | Tulip `untest.txt` L471–475 + `wad.c` |
| Market Facilitation Index | `MarketFacilitationIndex` | volume | Tulip L248–252; zero-volume guard is a documented deviation (Tulip divides into NaN); test defeats Tulip's all-zeros rounding trap with unrounded assertions |

## Notes

- **Skipped with reasons documented**: CTI/Thermo/Inertia/BRAR/VFI/PMAX/LRSI (niche or Ehlers-DSP-adjacent), Holt-Winters/aberration/pdist (stat constructs), rsx/jma (Jurik proprietary — no honest reference data exists), squeeze_pro/adxr/ttm_trend (trivial derivations). Shout if any should come back.
- Final commit removes Pandas TA from the README Alternatives.

Stacked on #1294. Library sourcing: 8 of 10 done (library at 132 indicators); remaining: Stock Indicators .NET, StockSharp, ta-lib.