### PR TITLE
feat(trading-signals): finish the alternatives sourcing campaign (RWI, ADXR)

### DIFF
--- a/packages/trading-signals-docs/indicator-demos/trend/ADXR.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/ADXR.demo.tsx
@@ -1,0 +1,20 @@
+import {ADXR as ADXRClass} from 'trading-signals';
+import {makeProcessData} from '../../utils/processData';
+import {buildTableColumns} from '../../utils/tableColumns';
+import type {IndicatorConfig} from '../../utils/types';
+
+export const ADXR: IndicatorConfig = {
+  chartTitle: 'ADXR (14)',
+  color: '#f97316',
+  createIndicator: () => new ADXRClass(14),
+  description: 'Average Directional Movement Index Rating',
+  details:
+    'Averages the current ADX with its reading from one interval earlier, smoothing out ADX spikes. Wilder used it to rate how trendy a market is: high ratings mark instruments in sustained trends, low ratings mark directionless ones. Like the ADX, it measures only trend strength, never direction.',
+  getTableColumns: indicator => buildTableColumns({indicator, inputs: ['high', 'low', 'close']}),
+  id: 'adxr',
+  name: 'ADXR',
+  processData: makeProcessData({rowInputs: ['high', 'low', 'close']}),
+  requiredInputs: 40,
+  type: 'single',
+  yAxisLabel: 'ADXR',
+};

--- a/packages/trading-signals-docs/indicator-demos/trend/RandomWalkIndex.demo.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/RandomWalkIndex.demo.tsx
@@ -1,0 +1,149 @@
+import {Chart as HighchartsChart} from '@highcharts/react';
+import {RandomWalkIndex as RandomWalkIndexClass} from 'trading-signals';
+import type {ReactNode} from 'react';
+import type {Candle} from '@typedtrader/exchange';
+import {createSharedTooltipFormatter, type ChartDataPoint} from '../../components/Chart';
+import {NotAvailable} from '../../components/NotAvailable';
+import PriceChart, {type PriceData} from '../../components/PriceChart';
+import {SignalBadge} from '../../components/SignalBadge';
+import {formatDate} from '../../utils/formatDate';
+import {collectPriceData} from '../../utils/renderUtils';
+import type {IndicatorConfig} from '../../utils/types';
+
+const renderRandomWalkIndex = (config: IndicatorConfig, selectedCandles: Candle[]) => {
+  const rwi = new RandomWalkIndexClass(14);
+  const chartDataHigh: ChartDataPoint[] = [];
+  const chartDataLow: ChartDataPoint[] = [];
+  const priceData: PriceData[] = [];
+  const sampleValues: {
+    period: number;
+    date: string;
+    close: number;
+    high: ReactNode;
+    low: ReactNode;
+    signal: string;
+  }[] = [];
+
+  selectedCandles.forEach((candle, idx) => {
+    const result = rwi.add({close: Number(candle.close), high: Number(candle.high), low: Number(candle.low)});
+    const trendSignal = rwi.getSignal();
+    chartDataHigh.push({x: idx + 1, y: result?.high ?? null});
+    chartDataLow.push({x: idx + 1, y: result?.low ?? null});
+
+    priceData.push(collectPriceData(candle, idx));
+
+    sampleValues.push({
+      close: Number(candle.close),
+      date: formatDate(candle.openTimeInISO),
+      high: result ? result.high.toFixed(4) : <NotAvailable />,
+      low: result ? result.low.toFixed(4) : <NotAvailable />,
+      period: idx + 1,
+      signal: trendSignal.state,
+    });
+  });
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold text-white mb-2 select-text">
+          Random Walk Index({rwi.interval}) / Required Inputs: {rwi.getRequiredInputs()}
+        </h2>
+        <p className="text-slate-300 select-text">{config.description}</p>
+        {config.details && <p className="text-slate-400 text-sm mt-2 select-text">{config.details}</p>}
+      </div>
+
+      <div className="bg-slate-800/50 border border-slate-700 rounded-lg p-4">
+        <HighchartsChart
+          options={{
+            chart: {backgroundColor: 'transparent', height: 300, type: 'line'},
+            credits: {enabled: false},
+            legend: {enabled: true, itemStyle: {color: '#e2e8f0'}},
+            plotOptions: {line: {lineWidth: 2, marker: {enabled: true, radius: 3}}},
+            series: [
+              {
+                color: '#10b981',
+                data: chartDataHigh.map(point => [point.x, point.y]),
+                marker: {fillColor: '#10b981'},
+                name: 'RWI High',
+                type: 'line',
+              },
+              {
+                color: '#ef4444',
+                data: chartDataLow.map(point => [point.x, point.y]),
+                marker: {fillColor: '#ef4444'},
+                name: 'RWI Low',
+                type: 'line',
+              },
+            ],
+            title: {style: {color: '#e2e8f0', fontSize: '16px', fontWeight: '600'}, text: 'Random Walk Index (14)'},
+            tooltip: {
+              backgroundColor: '#1e293b',
+              borderColor: '#475569',
+              formatter: createSharedTooltipFormatter(y => y.toFixed(4)),
+              shared: true,
+              style: {color: '#e2e8f0'},
+            },
+            xAxis: {
+              gridLineColor: '#334155',
+              labels: {style: {color: '#94a3b8'}},
+              title: {style: {color: '#94a3b8'}, text: 'Period'},
+            },
+            yAxis: {
+              gridLineColor: '#334155',
+              labels: {style: {color: '#94a3b8'}},
+              plotLines: [{color: '#94a3b8', dashStyle: 'Dash', value: 1, width: 1}],
+              title: {style: {color: '#94a3b8'}, text: 'Random Walk Index'},
+            },
+          }}
+        />
+      </div>
+
+      <PriceChart title="Input Prices" data={priceData} />
+
+      <div className="bg-slate-800/50 border border-slate-700 rounded-lg p-4">
+        <h3 className="text-lg font-semibold text-white mb-3">All Sample Values</h3>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-slate-600">
+                <th className="text-left text-slate-300 py-2 px-3">Period</th>
+                <th className="text-left text-slate-300 py-2 px-3">Date</th>
+                <th className="text-left text-slate-300 py-2 px-3">Close</th>
+                <th className="text-left text-slate-300 py-2 px-3">RWI High</th>
+                <th className="text-left text-slate-300 py-2 px-3">RWI Low</th>
+                <th className="text-left text-slate-300 py-2 px-3">Signal</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sampleValues.map(row => (
+                <tr key={row.period} className="border-b border-slate-700/50">
+                  <td className="text-slate-400 py-2 px-3">{row.period}</td>
+                  <td className="text-slate-300 py-2 px-3">{row.date}</td>
+                  <td className="text-slate-300 py-2 px-3">${row.close.toFixed(2)}</td>
+                  <td className="text-white font-mono py-2 px-3">{row.high}</td>
+                  <td className="text-white font-mono py-2 px-3">{row.low}</td>
+                  <td className="py-2 px-3">
+                    <SignalBadge signal={row.signal} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const RandomWalkIndex: IndicatorConfig = {
+  color: '#10b981',
+  createIndicator: () => new RandomWalkIndexClass(14),
+  customRender: renderRandomWalkIndex,
+  description: 'Random Walk Index',
+  details:
+    'Compares how far price actually travelled against how far a random walk would drift. Readings above 1 mark non-random, trending movement; the greater line names the side in control.',
+  id: 'rwi',
+  name: 'Random Walk Index',
+  requiredInputs: 15,
+  type: 'custom',
+};

--- a/packages/trading-signals-docs/indicator-demos/trend/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/index.tsx
@@ -1,4 +1,5 @@
 import {ADX} from './ADX.demo';
+import {ADXR} from './ADXR.demo';
 import {Alligator} from './Alligator.demo';
 import {ALMA} from './ALMA.demo';
 import {Aroon} from './Aroon.demo';
@@ -71,6 +72,7 @@ export const indicators: IndicatorConfig[] = [
   WSMA,
   VWAP,
   ADX,
+  ADXR,
   DX,
   PSAR,
   DMA,

--- a/packages/trading-signals-docs/indicator-demos/trend/index.tsx
+++ b/packages/trading-signals-docs/indicator-demos/trend/index.tsx
@@ -15,6 +15,7 @@ import {IchimokuCloud} from './IchimokuCloud.demo';
 import {KAMA} from './KAMA.demo';
 import {MAMA} from './MAMA.demo';
 import {McGinleyDynamic} from './McGinleyDynamic.demo';
+import {RandomWalkIndex} from './RandomWalkIndex.demo';
 import {T3} from './T3.demo';
 import {TEMA} from './TEMA.demo';
 import {TRIMA} from './TRIMA.demo';
@@ -62,6 +63,7 @@ export const indicators: IndicatorConfig[] = [
   VHF,
   GannHiLo,
   Alligator,
+  RandomWalkIndex,
   VortexIndicator,
   IchimokuCloud,
   Aroon,

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -105,6 +105,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Psychological Line (PSL)
 1. Qstick (QSTICK)
 1. Quantitative Qualitative Estimation (QQE)
+1. Random Walk Index (RWI)
 1. Range Expansion Index (REI)
 1. Rank Correlation Index (RCI)
 1. Rate-of-Change (ROC)

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -245,14 +245,6 @@ console.log(sma.highest?.toFixed(2)); // "53.33"
 - Indicators: Have no upper or lower limits
 - Oscillators: Move within a fixed range (e.g. 0-100, –1 to +1)
 
-## Alternatives
-
-- [ta-math (TypeScript)](https://github.com/munrocket/ta-math)
-- [ta4j (Java)](https://github.com/ta4j/ta4j)
-- [Technical Analysis for Rust (Rust)](https://github.com/greyblake/ta-rs)
-- [Technical Analysis Library using Pandas and Numpy (Python)](https://github.com/bukosabino/ta)
-- [Tulip Indicators (ANSI C)](https://github.com/TulipCharts/tulipindicators)
-
 ## Maintainers
 
 [![Benny Neugebauer on Stack Exchange][stack_exchange_bennycode_badge]][stack_exchange_bennycode_url]

--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -33,6 +33,7 @@ All indicators can be updated over time by streaming data (prices or [candles](h
 1. Arnaud Legoux Moving Average (ALMA)
 1. Aroon (AROON)
 1. Average Directional Index (ADX)
+1. Average Directional Index Rating (ADXR)
 1. Average True Range (ATR)
 1. Awesome Oscillator (AO)
 1. Balance of Power (BOP)

--- a/packages/trading-signals/src/trend/ADXR/ADXR.test.ts
+++ b/packages/trading-signals/src/trend/ADXR/ADXR.test.ts
@@ -1,0 +1,146 @@
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {ADX} from '../ADX/ADX.js';
+import {ADXR} from './ADXR.js';
+
+describe('ADXR', () => {
+  /*
+   * Test data verified with:
+   * https://tulipindicators.org/adxr
+   * https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt#L40-L42
+   */
+  const candles = [
+    {close: 81.59, high: 82.15, low: 81.29},
+    {close: 81.06, high: 81.89, low: 80.64},
+    {close: 82.87, high: 83.03, low: 81.31},
+    {close: 83.0, high: 83.3, low: 82.65},
+    {close: 83.61, high: 83.85, low: 83.07},
+    {close: 83.15, high: 83.9, low: 83.11},
+    {close: 82.84, high: 83.33, low: 82.49},
+    {close: 83.99, high: 84.3, low: 82.3},
+    {close: 84.55, high: 84.84, low: 84.15},
+    {close: 84.36, high: 85.0, low: 84.11},
+    {close: 85.53, high: 85.9, low: 84.03},
+    {close: 86.54, high: 86.58, low: 85.39},
+    {close: 86.89, high: 86.98, low: 85.76},
+    {close: 87.77, high: 88.0, low: 87.17},
+    {close: 87.29, high: 87.87, low: 87.01},
+  ] as const;
+
+  // https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt#L43
+  const expectations = ['50.685', '54.790', '58.389'] as const;
+
+  describe('getResultOrThrow', () => {
+    it('calculates the Average Directional Movement Index Rating (ADXR)', {tags: ['tulipindicators']}, () => {
+      const interval = 5;
+      const adxr = new ADXR(interval);
+      const offset = adxr.getRequiredInputs() - 1;
+
+      candles.forEach((candle, i) => {
+        adxr.add(candle);
+
+        if (adxr.isStable) {
+          const expected = expectations[i - offset];
+          expect(adxr.getResultOrThrow().toFixed(3)).toBe(expected);
+        }
+      });
+
+      expect(adxr.isStable).toBe(true);
+      expect(adxr.getRequiredInputs()).toBe(13);
+      expect(adxr.getResultOrThrow().toFixed(3)).toBe('58.389');
+    });
+
+    it('stays below the ADX while trend strength is building, because half of the rating is an older reading', () => {
+      const interval = 5;
+      const adx = new ADX(interval);
+      const adxr = new ADXR(interval);
+
+      for (const candle of candles) {
+        adx.add(candle);
+        adxr.add(candle);
+      }
+
+      /*
+       * The series trends harder with every candle, so blending in the older, weaker reading
+       * keeps the rating below the current trend strength.
+       */
+      expect(adxr.getResultOrThrow()).toBeLessThan(adx.getResultOrThrow());
+    });
+  });
+
+  describe('constructor', () => {
+    it("defaults to Wilder's suggested interval of 14", () => {
+      const adxr = new ADXR();
+
+      expect(adxr.interval).toBe(14);
+      expect(adxr.getRequiredInputs()).toBe(40);
+    });
+  });
+
+  describe('replace', () => {
+    it('replaces the most recently added value and restores the original on demand', () => {
+      const interval = 5;
+      const adxr = new ADXR(interval);
+
+      for (const candle of candles.slice(0, -1)) {
+        adxr.add(candle);
+      }
+
+      const originalCandle = {close: 87.29, high: 87.87, low: 87.01} as const;
+      const divergentCandle = {close: 1_000, high: 1_000, low: 1_000} as const;
+
+      const originalResult = adxr.add(originalCandle);
+
+      expect(originalResult?.toFixed(3)).toBe('58.389');
+
+      const replacedResult = adxr.replace(divergentCandle);
+
+      expect(replacedResult?.toFixed(3)).toBe('60.824');
+
+      const restoredResult = adxr.replace(originalCandle);
+
+      expect(restoredResult?.toFixed(3)).toBe('58.389');
+    });
+  });
+
+  describe('isStable', () => {
+    it('requires at least (3x interval - 2) candles to collect one full interval of ADX readings', () => {
+      const interval = 5;
+      const necessaryCandlesAmount = 3 * interval - 2;
+      const initialCandles = candles.slice(0, necessaryCandlesAmount - 1);
+      const adxr = new ADXR(interval);
+
+      for (const candle of initialCandles) {
+        adxr.add(candle);
+      }
+
+      // The underlying ADX has been stable for a while, but the rating still lacks history
+      expect(adxr.isStable).toBe(false);
+
+      adxr.add({close: 10, high: 11, low: 9});
+
+      expect(adxr.isStable).toBe(true);
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new ADXR(5),
+  divergentInput: {close: 1_000, high: 1_000, low: 1_000},
+  inputs: [
+    {close: 81.59, high: 82.15, low: 81.29},
+    {close: 81.06, high: 81.89, low: 80.64},
+    {close: 82.87, high: 83.03, low: 81.31},
+    {close: 83.0, high: 83.3, low: 82.65},
+    {close: 83.61, high: 83.85, low: 83.07},
+    {close: 83.15, high: 83.9, low: 83.11},
+    {close: 82.84, high: 83.33, low: 82.49},
+    {close: 83.99, high: 84.3, low: 82.3},
+    {close: 84.55, high: 84.84, low: 84.15},
+    {close: 84.36, high: 85.0, low: 84.11},
+    {close: 85.53, high: 85.9, low: 84.03},
+    {close: 86.54, high: 86.58, low: 85.39},
+    {close: 86.89, high: 86.98, low: 85.76},
+    {close: 87.77, high: 88.0, low: 87.17},
+    {close: 87.29, high: 87.87, low: 87.01},
+  ],
+});

--- a/packages/trading-signals/src/trend/ADXR/ADXR.ts
+++ b/packages/trading-signals/src/trend/ADXR/ADXR.ts
@@ -1,0 +1,69 @@
+import {ADX} from '../ADX/ADX.js';
+import {IndicatorSeries} from '../../base/Indicator.js';
+import type {HighLowClose} from '../../base/Candle.type.js';
+import type {MovingAverageTypes} from '../MA/MovingAverageTypes.js';
+import {pushUpdate} from '../../util/pushUpdate.js';
+import {WSMA} from '../WSMA/WSMA.js';
+
+/**
+ * Average Directional Movement Index Rating (ADXR)
+ * Type: Trend (strength only)
+ *
+ * The ADXR was developed by John Welles Wilder (Jr.) as a companion to his ADX. It averages the
+ * latest ADX with the ADX reading from one interval (minus one candle) earlier, which dampens the
+ * spikes of the raw ADX. Wilder designed it as a rating to compare how trendy different markets
+ * are: instruments with a high rating hold sustained trends and suit trend-following systems,
+ * while instruments with a low rating drift without direction.
+ *
+ * Like the ADX itself, the rating measures only the strength of a trend, never its direction —
+ * a strong downtrend and a strong uptrend produce the same reading, so no directional signal can
+ * be derived from it.
+ *
+ * Interpretation:
+ * The rating shares the ADX scale: readings below 20 indicate a weak or absent trend, and
+ * readings above 40 indicate a strong trend. Because it blends in an older reading, the rating
+ * reacts more slowly than the ADX — a divergence between the two shows whether trend strength is
+ * currently building (ADX above its rating) or fading (ADX below its rating).
+ *
+ * @see https://tulipindicators.org/adxr
+ * @see https://www.fmlabs.com/reference/ADXR.htm
+ */
+export class ADXR extends IndicatorSeries<HighLowClose<number>> {
+  readonly #adx: ADX;
+  readonly #adxHistory: number[] = [];
+
+  public readonly interval: number;
+
+  constructor(interval: number = 14, SmoothingIndicator: MovingAverageTypes = WSMA) {
+    super();
+    this.interval = interval;
+    this.#adx = new ADX(interval, SmoothingIndicator);
+  }
+
+  override getRequiredInputs() {
+    return this.interval * 3 - 2;
+  }
+
+  update(candle: HighLowClose<number>, replace: boolean) {
+    const adx = this.#adx.update(candle, replace);
+
+    if (adx === null) {
+      return null;
+    }
+
+    pushUpdate({
+      array: this.#adxHistory,
+      item: adx,
+      maxLength: this.interval,
+      replace,
+    });
+
+    if (this.#adxHistory.length === this.interval) {
+      const laggedAdx = this.#adxHistory[0];
+
+      return this.setResult((adx + laggedAdx) / 2, replace);
+    }
+
+    return null;
+  }
+}

--- a/packages/trading-signals/src/trend/RWI/RandomWalkIndex.test.ts
+++ b/packages/trading-signals/src/trend/RWI/RandomWalkIndex.test.ts
@@ -1,0 +1,200 @@
+import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
+import {RandomWalkIndex} from './RandomWalkIndex.js';
+import {TradingSignal} from '../../base/index.js';
+
+describe('RandomWalkIndex', () => {
+  describe('update', () => {
+    it('reads above 1 when price covers more ground than a random walk would drift', () => {
+      /*
+       * Formula (Michael Poulos, "Of Trends And Random Walks", Technical Analysis of Stocks &
+       * Commodities, 1991), scanning formulation as implemented by ta4j:
+       * RWI High = max over k in 2..interval of (High - Low[k-1 candles ago]) / (ATR(k) * sqrt(k))
+       * RWI Low  = max over k in 2..interval of (High[k-1 candles ago] - Low) / (ATR(k) * sqrt(k))
+       * https://rtmath.net/helpFinAnalysis/html/934563a8-9171-42d2-8444-486691234b1d.html
+       *
+       * The expectations below are derived by hand with interval 3. Every candle climbs by 1
+       * and every true range is 2, so ATR(2) = ATR(3) = 2 throughout:
+       *
+       * | Bar | High | Low | k=2 High          | k=3 High          | k=2 Low           | k=3 Low          |
+       * |-----|------|-----|-------------------|-------------------|-------------------|------------------|
+       * | 4   | 6    | 4   | (6-3)/(2√2)=1.061 | (6-2)/(2√3)=1.155 | (5-4)/(2√2)=0.354 | (4-4)/(2√3)=0    |
+       * | 5   | 7    | 5   | (7-4)/(2√2)=1.061 | (7-3)/(2√3)=1.155 | (6-5)/(2√2)=0.354 | (5-5)/(2√3)=0    |
+       *
+       * Both lines report the strongest stretch: RWI High = 4/(2√3), RWI Low = 1/(2√2). The
+       * steady climb keeps RWI High above 1, which is exactly the non-random reading the
+       * indicator exists to flag.
+       */
+      const candles = [
+        {close: 2, high: 3, low: 1},
+        {close: 3, high: 4, low: 2},
+        {close: 4, high: 5, low: 3},
+        {close: 5, high: 6, low: 4},
+        {close: 6, high: 7, low: 5},
+      ] as const;
+      const expectations = [
+        {high: 1.1547005383792517, low: 0.35355339059327373},
+        {high: 1.1547005383792517, low: 0.35355339059327373},
+      ] as const;
+      const rwi = new RandomWalkIndex(3);
+      const offset = rwi.getRequiredInputs() - 1;
+
+      candles.forEach((candle, i) => {
+        const result = rwi.add(candle);
+
+        if (result) {
+          expect(result).toEqual(expectations[i - offset]);
+        }
+      });
+
+      expect(rwi.isStable).toBe(true);
+      expect(rwi.getResultOrThrow().high).toBeGreaterThan(1);
+    });
+
+    it('reports the strongest stretch on each line independently', () => {
+      /*
+       * The two lines may pick different stretch lengths: with a pullback candle the upward
+       * path stretches best over the full interval (k=3: (15-10)/(4√3)) while the downward
+       * path stretches best over the short one (k=2: (16-11)/(4√2)). A single-lag formulation
+       * would miss one of the two.
+       */
+      const rwi = new RandomWalkIndex(3);
+
+      rwi.add({close: 10, high: 12, low: 8});
+      rwi.add({close: 12, high: 14, low: 10});
+      rwi.add({close: 14, high: 16, low: 12});
+      rwi.add({close: 12, high: 15, low: 11});
+
+      expect(rwi.getResultOrThrow()).toEqual({high: 0.7216878364870323, low: 0.8838834764831843});
+    });
+
+    it('reports zero on both lines when the market never moved', () => {
+      const rwi = new RandomWalkIndex(2);
+
+      rwi.add({close: 10, high: 10, low: 10});
+      rwi.add({close: 10, high: 10, low: 10});
+      rwi.add({close: 10, high: 10, low: 10});
+
+      expect(rwi.getResultOrThrow()).toEqual({high: 0, low: 0});
+      expect(rwi.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+    });
+  });
+
+  describe('getRequiredInputs', () => {
+    it('needs one candle more than the interval, which defaults to 14 periods', () => {
+      expect(new RandomWalkIndex().getRequiredInputs()).toBe(15);
+      expect(new RandomWalkIndex(3).getRequiredInputs()).toBe(4);
+    });
+  });
+
+  describe('replace', () => {
+    it('replaces the most recently added value', () => {
+      const rwi = new RandomWalkIndex(3);
+
+      rwi.add({close: 10, high: 12, low: 8});
+      rwi.add({close: 12, high: 14, low: 10});
+      rwi.add({close: 14, high: 16, low: 12});
+
+      const originalCandle = {close: 12, high: 15, low: 11} as const;
+      const replacementCandle = {close: 18, high: 20, low: 16} as const;
+
+      const originalResult = rwi.add(originalCandle);
+
+      expect(originalResult).toEqual({high: 0.7216878364870323, low: 0.8838834764831843});
+
+      /*
+       * The breakout candle widens the true range, so Wilder's smoothing lifts ATR(2) to 5 and
+       * ATR(3) to 14/3. Its low sits above the previous highs, which drives the raw downward
+       * ratios to zero and below — the reported RWI Low is the strongest of them, exactly 0.
+       */
+      const replacedResult = rwi.replace(replacementCandle);
+
+      expect(replacedResult).toEqual({high: 1.2371791482634837, low: 0});
+
+      const restoredResult = rwi.replace(originalCandle);
+
+      expect(restoredResult).toEqual({high: 0.7216878364870323, low: 0.8838834764831843});
+    });
+  });
+
+  describe('getSignal', () => {
+    it('returns UNKNOWN before the warm-up is complete', () => {
+      const rwi = new RandomWalkIndex(2);
+
+      expect(rwi.getSignal()).toEqual({hasChanged: false, state: TradingSignal.UNKNOWN});
+
+      rwi.add({close: 10, high: 11, low: 9});
+      rwi.add({close: 10, high: 11, low: 9});
+
+      expect(rwi.getSignal()).toEqual({hasChanged: false, state: TradingSignal.UNKNOWN});
+    });
+
+    it('returns BULLISH when the upward line trades above the downward one', () => {
+      const rwi = new RandomWalkIndex(3);
+
+      rwi.add({close: 2, high: 3, low: 1});
+      rwi.add({close: 3, high: 4, low: 2});
+      rwi.add({close: 4, high: 5, low: 3});
+      rwi.add({close: 5, high: 6, low: 4});
+
+      expect(rwi.getResultOrThrow()).toEqual({high: 1.1547005383792517, low: 0.35355339059327373});
+      expect(rwi.getSignal().state).toBe(TradingSignal.BULLISH);
+    });
+
+    it('returns BEARISH when the downward line trades above the upward one', () => {
+      const rwi = new RandomWalkIndex(3);
+
+      rwi.add({close: 6, high: 7, low: 5});
+      rwi.add({close: 5, high: 6, low: 4});
+      rwi.add({close: 4, high: 5, low: 3});
+      rwi.add({close: 3, high: 4, low: 2});
+
+      expect(rwi.getResultOrThrow()).toEqual({high: 0.35355339059327373, low: 1.1547005383792517});
+      expect(rwi.getSignal().state).toBe(TradingSignal.BEARISH);
+    });
+
+    it('returns SIDEWAYS when both lines are equal', () => {
+      /*
+       * Identical candles with a real trading range keep both paths symmetric: the reach from
+       * the current high down to a past low equals the reach from a past high down to the
+       * current low, so neither side gains an edge even though the market is moving.
+       */
+      const rwi = new RandomWalkIndex(2);
+
+      rwi.add({close: 10, high: 11, low: 9});
+      rwi.add({close: 10, high: 11, low: 9});
+      rwi.add({close: 10, high: 11, low: 9});
+
+      expect(rwi.getResultOrThrow()).toEqual({high: 0.7071067811865475, low: 0.7071067811865475});
+      expect(rwi.getSignal().state).toBe(TradingSignal.SIDEWAYS);
+    });
+
+    it('flags a change only when the signal switches its state', () => {
+      const rwi = new RandomWalkIndex(2);
+
+      rwi.add({close: 10, high: 11, low: 9});
+      rwi.add({close: 10, high: 11, low: 9});
+      rwi.add({close: 10, high: 11, low: 9});
+
+      expect(rwi.getSignal()).toEqual({hasChanged: true, state: TradingSignal.SIDEWAYS});
+
+      rwi.add({close: 18, high: 20, low: 14});
+
+      expect(rwi.getSignal()).toEqual({hasChanged: true, state: TradingSignal.BULLISH});
+
+      rwi.add({close: 24, high: 26, low: 20});
+
+      expect(rwi.getSignal()).toEqual({hasChanged: false, state: TradingSignal.BULLISH});
+    });
+  });
+});
+
+testIndicatorContract({
+  create: () => new RandomWalkIndex(2),
+  divergentInput: {close: 1_000, high: 1_010, low: 990},
+  inputs: [
+    {close: 10, high: 12, low: 8},
+    {close: 12, high: 14, low: 10},
+    {close: 14, high: 16, low: 12},
+    {close: 12, high: 15, low: 11},
+  ],
+});

--- a/packages/trading-signals/src/trend/RWI/RandomWalkIndex.ts
+++ b/packages/trading-signals/src/trend/RWI/RandomWalkIndex.ts
@@ -50,6 +50,12 @@ export class RandomWalkIndex extends TechnicalIndicator<RandomWalkIndexResult, H
     }
   }
 
+  /*
+   * The longest stretch measures a full interval of true ranges, and the very first candle only
+   * seeds the range comparison without contributing one — so one candle more than the interval
+   * has to arrive before every stretch is measurable. The reference implementation emits its
+   * first reading on exactly that candle.
+   */
   override getRequiredInputs() {
     return this.interval + 1;
   }

--- a/packages/trading-signals/src/trend/RWI/RandomWalkIndex.ts
+++ b/packages/trading-signals/src/trend/RWI/RandomWalkIndex.ts
@@ -1,0 +1,141 @@
+import type {HighLowClose} from '../../base/Candle.type.js';
+import {TechnicalIndicator, TradingSignal} from '../../base/Indicator.js';
+import {pushUpdate} from '../../util/pushUpdate.js';
+import {ATR} from '../../volatility/ATR/ATR.js';
+
+export type RandomWalkIndexResult = {
+  /** Trend strength of the upward path (RWI High) */
+  high: number;
+  /** Trend strength of the downward path (RWI Low) */
+  low: number;
+};
+
+/**
+ * Random Walk Index (RWI)
+ * Type: Trend
+ *
+ * The Random Walk Index was developed by Michael Poulos and published in the 1991 "Technical Analysis of Stocks &
+ * Commodities" article "Of Trends And Random Walks". It asks whether price covered more ground than a random walk
+ * would have: over a stretch of candles, random noise drifts about the Average True Range times the square root of
+ * the stretch length. RWI High relates the current high to the low at the start of a stretch, RWI Low relates the
+ * current low to the high at the start of a stretch, and each line reports the strongest such ratio among all
+ * stretches from two candles up to the configured interval (the scanning formulation, matching ta4j).
+ *
+ * Interpretation: Readings above 1 mark non-random movement — price travelled further than a random walk would
+ * drift, so a trend is in force. The greater line names the side in control: an uptrend when RWI High trades above
+ * RWI Low, a downtrend when RWI Low trades above RWI High.
+ *
+ * Note: The Average True Range in this implementation seeds Wilder's smoothing with a simple average of the first
+ * true ranges, while ta4j seeds with the first true range alone. Both smoothings converge, but readings close to
+ * the warm-up can differ slightly from ta4j.
+ *
+ * @see https://rtmath.net/helpFinAnalysis/html/934563a8-9171-42d2-8444-486691234b1d.html
+ * @see https://github.com/ta4j/ta4j/blob/master/ta4j-core/src/main/java/org/ta4j/core/indicators/RWIHighIndicator.java
+ * @see https://github.com/ta4j/ta4j/blob/master/ta4j-core/src/main/java/org/ta4j/core/indicators/RWILowIndicator.java
+ */
+export class RandomWalkIndex extends TechnicalIndicator<RandomWalkIndexResult, HighLowClose<number>> {
+  public readonly interval: number;
+  readonly #candles: HighLowClose<number>[] = [];
+  readonly #atrs: ATR[] = [];
+  readonly #randomWalkDrifts: number[] = [];
+  #previousResult?: RandomWalkIndexResult;
+
+  constructor(interval: number = 14) {
+    super();
+    this.interval = interval;
+
+    for (let stretch = 2; stretch <= interval; stretch++) {
+      this.#atrs.push(new ATR(stretch));
+      this.#randomWalkDrifts.push(Math.sqrt(stretch));
+    }
+  }
+
+  override getRequiredInputs() {
+    return this.interval + 1;
+  }
+
+  update(candle: HighLowClose<number>, replace: boolean) {
+    pushUpdate({array: this.#candles, item: candle, maxLength: this.interval + 1, replace: replace});
+
+    for (const atr of this.#atrs) {
+      atr.update(candle, replace);
+    }
+
+    if (this.#candles.length <= this.interval) {
+      return null;
+    }
+
+    if (replace) {
+      this.result = this.#previousResult;
+    }
+
+    this.#previousResult = this.result;
+
+    let high: number | undefined;
+    let low: number | undefined;
+
+    this.#atrs.forEach((atr, i) => {
+      const averageTrueRange = atr.getResultOrThrow();
+
+      /*
+       * A market whose true range never moved has no volatility to walk with, so no stretch of
+       * that market can be measured against a random walk. Skipping such stretches keeps a dead
+       * market from fabricating a direction out of a division by zero.
+       */
+      if (averageTrueRange === 0) {
+        return;
+      }
+
+      const stretch = i + 2;
+      const expectedDrift = averageTrueRange * this.#randomWalkDrifts[i];
+      const stretchStart = this.#candles[this.#candles.length - stretch];
+      const rwiHigh = (candle.high - stretchStart.low) / expectedDrift;
+      const rwiLow = (stretchStart.high - candle.low) / expectedDrift;
+      high = high === undefined ? rwiHigh : Math.max(high, rwiHigh);
+      low = low === undefined ? rwiLow : Math.max(low, rwiLow);
+    });
+
+    if (high === undefined || low === undefined) {
+      return (this.result = {
+        high: 0,
+        low: 0,
+      });
+    }
+
+    return (this.result = {
+      high,
+      low,
+    });
+  }
+
+  protected calculateSignal(result?: RandomWalkIndexResult | null | undefined) {
+    const hasResult = result !== null && result !== undefined;
+    const isBullish = hasResult && result.high > result.low;
+    const isBearish = hasResult && result.low > result.high;
+
+    switch (true) {
+      case !hasResult:
+        return TradingSignal.UNKNOWN;
+      case isBullish:
+        return TradingSignal.BULLISH;
+      case isBearish:
+        return TradingSignal.BEARISH;
+      default:
+        return TradingSignal.SIDEWAYS;
+    }
+  }
+
+  getSignal(): {
+    state: (typeof TradingSignal)[keyof typeof TradingSignal];
+    hasChanged: boolean;
+  } {
+    const previousState = this.calculateSignal(this.#previousResult);
+    const state = this.calculateSignal(this.getResult());
+    const hasChanged = previousState !== state;
+
+    return {
+      hasChanged,
+      state,
+    };
+  }
+}

--- a/packages/trading-signals/src/trend/index.ts
+++ b/packages/trading-signals/src/trend/index.ts
@@ -1,4 +1,5 @@
 export * from './ADX/ADX.js';
+export * from './ADXR/ADXR.js';
 export * from './ALLIGATOR/Alligator.js';
 export * from './ALLIGATOR/GatorOscillator.js';
 export * from './ALMA/ALMA.js';

--- a/packages/trading-signals/src/trend/index.ts
+++ b/packages/trading-signals/src/trend/index.ts
@@ -24,6 +24,7 @@ export * from './MAMA/MAMA.js';
 export * from './MD/McGinleyDynamic.js';
 export * from './PSAR/PSAR.js';
 export * from './RMA/RMA.js';
+export * from './RWI/RandomWalkIndex.js';
 export * from './SMA/SMA.js';
 export * from './SMA15/SMA15.js';
 export * from './SUPERSMOOTHER/SuperSmoother.js';


### PR DESCRIPTION
## Summary

The closing PR of the 15-library sourcing campaign. The final pass swept the last five list entries — **ta-math, ta4j, ta-rs, bukosabino/ta, and Tulip Indicators** — plus ta-lib (de-listed on #1296 after a 168-function sweep found zero gaps). Four of the five are fully covered; ta4j and Tulip surfaced the last two genuine items:

| Indicator | Class | Category | Reference verification |
|---|---|---|---|
| Random Walk Index | `RandomWalkIndex` | trend | ta4j's scan-max variant pinned from source (not the simplified single-lag form); hand-derived worksheet + independent scan-algorithm cross-check |
| ADX Rating | `ADXR` | trend | Tulip `untest.txt` L40–43 reproduced exactly via composition over the Tulip-verified ADX — closes **full Tulip parity** (all 104 functions now covered or excluded) |

## Campaign result

- **All 15 alternative libraries sourced**; the README Alternatives section is now empty and removed (final commit).
- Library grew **57 → 142 indicators** (~85 added), every one with 100% coverage, contract-fixture registration, exact-value replace tests, and verified or worksheet-derived reference data.
- Skipped-by-filter items are documented per-PR (patterns, chart constructs, stats, proprietary formulas, trivial derivations — RAVI noted here as PPO-with-SMA, expressible if PPO ever gains an injectable MA like DisparityIndex has).

Stacked on #1296. Full stack: #1290 → #1291 → #1292 → #1293 → #1294 → #1295 → #1296 → this.