### PR TITLE
fix(trading-signals): LINREG one-bar-ahead forecast + RSI declared warm-up

### DIFF
--- a/packages/trading-signals/src/momentum/RSI/RSI.test.ts
+++ b/packages/trading-signals/src/momentum/RSI/RSI.test.ts
@@ -21,6 +21,19 @@ describe('RSI', () => {
       expect(rsi.isStable).toBe(true);
       expect(rsi.getResultOrThrow().toFixed(2)).toBe('75.94');
     });
+
+    it('yields its first reading exactly at the declared warm-up count', () => {
+      const rsi = new RSI(5);
+      const prices = [81.59, 81.06, 82.87, 83.0, 83.61, 83.15] as const;
+
+      expect(prices.length).toBe(rsi.getRequiredInputs());
+
+      prices.forEach((price, index) => {
+        const result = rsi.add(price);
+        const isWarmedUp = index >= rsi.getRequiredInputs() - 1;
+        expect(result !== null).toBe(isWarmedUp);
+      });
+    });
   });
 
   describe('getResultOrThrow', () => {
@@ -47,7 +60,7 @@ describe('RSI', () => {
 
       const interval = 5;
       const rsi = new RSI(interval);
-      const offset = rsi.getRequiredInputs();
+      const offset = rsi.getRequiredInputs() - 1;
 
       prices.forEach((price, i) => {
         rsi.add(price);
@@ -58,7 +71,7 @@ describe('RSI', () => {
       });
 
       expect(rsi.isStable).toBe(true);
-      expect(rsi.getRequiredInputs()).toBe(interval);
+      expect(rsi.getRequiredInputs()).toBe(interval + 1);
       expect(rsi.getResultOrThrow().toFixed(2)).toBe('78.50');
     });
 

--- a/packages/trading-signals/src/momentum/RSI/RSI.ts
+++ b/packages/trading-signals/src/momentum/RSI/RSI.ts
@@ -44,7 +44,8 @@ export class RSI extends TrendIndicatorSeries {
   }
 
   override getRequiredInputs() {
-    return this.#avgGain.getRequiredInputs();
+    // The first price only anchors the change measurement and yields no gain or loss reading.
+    return this.#avgGain.getRequiredInputs() + 1;
   }
 
   update(price: number, replace: boolean) {

--- a/packages/trading-signals/src/momentum/STOCHRSI/StochasticRSI.ts
+++ b/packages/trading-signals/src/momentum/STOCHRSI/StochasticRSI.ts
@@ -61,7 +61,8 @@ export class StochasticRSI extends TrendIndicatorSeries {
   }
 
   override getRequiredInputs() {
-    return this.#rsi.getRequiredInputs() + this.#period.getRequiredInputs();
+    // The first stable RSI reading already counts toward the stochastic window, so it is not paid for twice.
+    return this.#rsi.getRequiredInputs() + this.#period.getRequiredInputs() - 1;
   }
 
   update(price: number, replace: boolean) {

--- a/packages/trading-signals/src/trend/LINREG/LinearRegression.test.ts
+++ b/packages/trading-signals/src/trend/LINREG/LinearRegression.test.ts
@@ -41,8 +41,45 @@ describe('LinearRegression', () => {
     });
   });
 
+  describe('prediction (tsf)', () => {
+    it('forecasts the value one bar ahead of the regression window', {tags: ['tulipindicators']}, () => {
+      /*
+       * Test data verified with:
+       * https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt#L430-L432
+       */
+      const period = 5;
+      const prices = [
+        81.59, 81.06, 82.87, 83.0, 83.61, 83.15, 82.84, 83.99, 84.55, 84.36, 85.53, 86.54, 86.89, 87.77, 87.29,
+      ] as const;
+      const expected = [
+        '84.220',
+        '84.214',
+        '83.121',
+        '83.681',
+        '84.444',
+        '85.017',
+        '85.979',
+        '86.818',
+        '87.632',
+        '88.672',
+        '88.229',
+      ] as const;
+
+      const linreg = new LinearRegression(period);
+      const offset = period - 1;
+
+      prices.forEach((price, index) => {
+        linreg.add(price);
+        if (index >= offset) {
+          const result = linreg.getResultOrThrow();
+          expect(result.prediction.toFixed(3)).toBe(expected[index - offset]);
+        }
+      });
+    });
+  });
+
   describe('getResultOrThrow', () => {
-    it('calculates regression values correctly', () => {
+    it('projects a perfect linear trend one bar beyond the window', () => {
       const prices = [10, 11, 12, 13, 14] as const;
       const linreg = new LinearRegression(prices.length);
 
@@ -50,8 +87,8 @@ describe('LinearRegression', () => {
       const result = linreg.getResultOrThrow();
 
       expect(result.slope).toBe(1);
-      expect(result.intercept).toBe(9);
-      expect(result.prediction).toBe(14);
+      expect(result.intercept).toBe(10);
+      expect(result.prediction).toBe(15);
     });
 
     it('handles non-perfect linear relationships', () => {
@@ -61,9 +98,9 @@ describe('LinearRegression', () => {
       prices.forEach(price => linreg.add(price));
       const result = linreg.getResultOrThrow();
 
-      expect(result.prediction).toBeDefined();
-      expect(result.slope).toBeDefined();
-      expect(result.intercept).toBeDefined();
+      expect(result.slope.toFixed(2)).toBe('0.23');
+      expect(result.intercept.toFixed(2)).toBe('10.60');
+      expect(result.prediction.toFixed(2)).toBe('11.75');
     });
   });
 

--- a/packages/trading-signals/src/trend/LINREG/LinearRegression.test.ts
+++ b/packages/trading-signals/src/trend/LINREG/LinearRegression.test.ts
@@ -2,6 +2,15 @@ import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {LinearRegression} from '../../index.js';
 
 describe('LinearRegression', () => {
+  describe('constructor', () => {
+    it('rejects an interval below 2', () => {
+      expect(() => new LinearRegression(1)).toThrowError('The interval has to be at least 2, but "1" was given.');
+      expect(() => new LinearRegression(Number.NaN)).toThrowError(
+        'The interval has to be at least 2, but "NaN" was given.'
+      );
+    });
+  });
+
   describe('intercept (linregintercept)', () => {
     it('calculates the intercept values correctly', {tags: ['tulipindicators']}, () => {
       /*

--- a/packages/trading-signals/src/trend/LINREG/LinearRegression.ts
+++ b/packages/trading-signals/src/trend/LINREG/LinearRegression.ts
@@ -23,6 +23,12 @@ export class LinearRegression extends TechnicalIndicator<LinearRegressionResult,
 
   constructor(interval: number) {
     super();
+
+    // A single point cannot define a line, so a slope would be fabricated.
+    if (!Number.isFinite(interval) || interval < 2) {
+      throw new Error(`The interval has to be at least 2, but "${interval}" was given.`);
+    }
+
     this.interval = interval;
   }
 

--- a/packages/trading-signals/src/trend/LINREG/LinearRegression.ts
+++ b/packages/trading-signals/src/trend/LINREG/LinearRegression.ts
@@ -2,7 +2,7 @@ import {TechnicalIndicator} from '../../base/Indicator.js';
 import {pushUpdate} from '../../util/pushUpdate.js';
 
 export type LinearRegressionResult = {
-  // The predicted value (equivalent to TulipCharts' linreg)
+  // The one-bar-ahead forecast (equivalent to TulipCharts' tsf)
   prediction: number;
   // The slope (equivalent to TulipCharts' linregslope)
   slope: number;
@@ -32,22 +32,6 @@ export class LinearRegression extends TechnicalIndicator<LinearRegressionResult,
 
   #calculateRegression(prices: number[]): LinearRegressionResult {
     const n = prices.length;
-    const isPerfectLinearTrend = prices.every((price, i) => {
-      if (i === 0) {
-        return true;
-      }
-      return Math.abs(price - prices[i - 1] - 1) < 1e-10;
-    });
-
-    if (isPerfectLinearTrend) {
-      const slope = 1;
-      const intercept = prices[0] - slope; // Subtract slope to get true intercept
-      const nextX = n; // Predict the next value
-      const prediction = slope * nextX + intercept;
-      return {intercept, prediction, slope};
-    }
-
-    // Otherwise fall back to standard least squares regression
     const sumX = ((n - 1) * n) / 2; // sum of 0..n-1
     const sumY = prices.reduce((a, b) => a + b, 0);
     let sumXY = 0;


### PR DESCRIPTION
Follow-up fixes for two bugs documented during the indicator sourcing campaign (#1290–#1297).

## LINREG: perfect linear trends returned the wrong forecast

`LinearRegression` had a special case for windows rising in steps of exactly +1 that returned the window's **last value** as the prediction and understated the intercept by one step:

- Window `[10, 11, 12, 13, 14]` → prediction `14`, intercept `9` (wrong)
- Correct: prediction `15`, intercept `10` — the general least-squares branch already produces exactly this

The shortcut is removed; the general branch handles perfectly linear data exactly. Existing tests that baked in the buggy values are corrected, and a new Tulip-verified test asserts `prediction` against all 11 `tsf 5` reference values ([untest.txt#L430-L432](https://github.com/TulipCharts/tulipindicators/blob/v0.9.1/tests/untest.txt#L430-L432)). The result type comment also mislabeled `prediction` as Tulip's `linreg` (fit at the current bar) — it is Tulip's `tsf` (one-bar-ahead forecast).

CFO and TTM Squeeze compute their regressions internally to sidestep this bug; with LINREG fixed they could reuse it in a later refactor (not part of this PR).

## RSI: declared warm-up understated by one

`RSI.getRequiredInputs()` returned `interval`, but the first price only anchors the change measurement and yields no gain/loss reading — the first RSI value arrives after `interval + 1` prices. Downstream indicators (ConnorsRSI, DOSC, QQE) already derived their warm-ups independently because of this; STOCHRSI now composes the corrected value minus the one-reading overlap between its stages, so its declared total is unchanged.

A new test pins the first reading to exactly the declared warm-up count.

## Testing

- `npm test` from root: knip + all suites green (1687 tests in trading-signals), 100% coverage
- `npm run lint`: oxlint + oxfmt clean