### PR TITLE
refactor(trading-signals): share the least-squares regression math via LINREG

### DIFF
--- a/packages/trading-signals/src/momentum/CFO/CFO.ts
+++ b/packages/trading-signals/src/momentum/CFO/CFO.ts
@@ -1,4 +1,5 @@
 import {ZeroCrossSeries} from '../../base/Indicator.js';
+import {calculateLinearRegression} from '../../trend/LINREG/LinearRegression.js';
 import {pushUpdate} from '../../util/pushUpdate.js';
 
 /**
@@ -35,30 +36,6 @@ export class CFO extends ZeroCrossSeries {
     return this.interval + 1;
   }
 
-  /**
-   * Projects the straight line through the given closes one bar ahead (the "time series forecast").
-   * Computed locally instead of reusing the linear-regression indicator, because that one
-   * short-circuits windows climbing in unit steps with a projection that lands one bar short —
-   * which would fake pressure here on a perfectly trending price.
-   */
-  #forecast(window: readonly number[]) {
-    const n = window.length;
-    let sumY = 0;
-    let sumXY = 0;
-
-    for (let x = 0; x < n; x++) {
-      sumY += window[x];
-      sumXY += x * window[x];
-    }
-
-    const sumX = ((n - 1) * n) / 2;
-    const sumXX = ((n - 1) * n * (2 * n - 1)) / 6;
-    const slope = (n * sumXY - sumX * sumY) / (n * sumXX - sumX * sumX);
-    const intercept = (sumY - slope * sumX) / n;
-
-    return slope * n + intercept;
-  }
-
   update(close: number, replace: boolean) {
     pushUpdate({array: this.#closes, item: close, maxLength: this.getRequiredInputs(), replace: replace});
 
@@ -72,7 +49,7 @@ export class CFO extends ZeroCrossSeries {
     }
 
     // The forecast for the newest bar is fitted over the closes that precede it
-    const forecast = this.#forecast(this.#closes.slice(0, this.interval));
+    const {prediction: forecast} = calculateLinearRegression(this.#closes.slice(0, this.interval));
 
     return this.setResult((100 * (close - forecast)) / close, replace);
   }

--- a/packages/trading-signals/src/trend/LINREG/LinearRegression.test.ts
+++ b/packages/trading-signals/src/trend/LINREG/LinearRegression.test.ts
@@ -1,5 +1,17 @@
 import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {LinearRegression} from '../../index.js';
+import {calculateLinearRegression} from './LinearRegression.js';
+
+describe('calculateLinearRegression', () => {
+  it('rejects windows with fewer than 2 values', () => {
+    expect(() => calculateLinearRegression([42])).toThrowError(
+      'The linear regression has to be fitted over at least 2 values, but "1" was given.'
+    );
+    expect(() => calculateLinearRegression([])).toThrowError(
+      'The linear regression has to be fitted over at least 2 values, but "0" was given.'
+    );
+  });
+});
 
 describe('LinearRegression', () => {
   describe('constructor', () => {

--- a/packages/trading-signals/src/trend/LINREG/LinearRegression.ts
+++ b/packages/trading-signals/src/trend/LINREG/LinearRegression.ts
@@ -11,6 +11,33 @@ export type LinearRegressionResult = {
 };
 
 /**
+ * Least-squares line through the given values. The fitted line at the newest value is
+ * `slope * (values.length - 1) + intercept`; the returned prediction extends it one bar ahead.
+ */
+export const calculateLinearRegression = (values: readonly number[]): LinearRegressionResult => {
+  const n = values.length;
+  let sumY = 0;
+  let sumXY = 0;
+
+  for (let x = 0; x < n; x++) {
+    sumY += values[x];
+    sumXY += x * values[x];
+  }
+
+  const sumX = ((n - 1) * n) / 2;
+  const sumXX = ((n - 1) * n * (2 * n - 1)) / 6;
+  const slope = (n * sumXY - sumX * sumY) / (n * sumXX - sumX * sumX);
+  const intercept = (sumY - slope * sumX) / n;
+  const prediction = slope * n + intercept;
+
+  return {
+    intercept,
+    prediction,
+    slope,
+  };
+};
+
+/**
  * Linear Regression (LINREG)
  * Type: Trend
  *
@@ -36,28 +63,6 @@ export class LinearRegression extends TechnicalIndicator<LinearRegressionResult,
     return this.interval;
   }
 
-  #calculateRegression(prices: number[]): LinearRegressionResult {
-    const n = prices.length;
-    const sumX = ((n - 1) * n) / 2; // sum of 0..n-1
-    const sumY = prices.reduce((a, b) => a + b, 0);
-    let sumXY = 0;
-    let sumXX = 0;
-    for (let i = 0; i < n; i++) {
-      sumXY += i * prices[i];
-      sumXX += i * i;
-    }
-
-    const slope = (n * sumXY - sumX * sumY) / (n * sumXX - sumX * sumX);
-    const intercept = (sumY - slope * sumX) / n;
-    const prediction = slope * n + intercept;
-
-    return {
-      intercept,
-      prediction,
-      slope,
-    };
-  }
-
   update(price: number, replace: boolean): LinearRegressionResult | null {
     pushUpdate({array: this.prices, item: price, maxLength: this.interval, replace: replace});
 
@@ -65,7 +70,7 @@ export class LinearRegression extends TechnicalIndicator<LinearRegressionResult,
       return null;
     }
 
-    return (this.result = this.#calculateRegression(this.prices));
+    return (this.result = calculateLinearRegression(this.prices));
   }
 
   override get isStable() {

--- a/packages/trading-signals/src/trend/LINREG/LinearRegression.ts
+++ b/packages/trading-signals/src/trend/LINREG/LinearRegression.ts
@@ -16,6 +16,12 @@ export type LinearRegressionResult = {
  */
 export const calculateLinearRegression = (values: readonly number[]): LinearRegressionResult => {
   const n = values.length;
+
+  // A single point cannot define a line, so a slope would be fabricated
+  if (n < 2) {
+    throw new Error(`The linear regression has to be fitted over at least 2 values, but "${n}" was given.`);
+  }
+
   let sumY = 0;
   let sumXY = 0;
 

--- a/packages/trading-signals/src/volatility/SQUEEZE/TTMSqueeze.ts
+++ b/packages/trading-signals/src/volatility/SQUEEZE/TTMSqueeze.ts
@@ -1,5 +1,6 @@
 import type {HighLowClose} from '../../base/Candle.type.js';
 import {TechnicalIndicator, TradingSignal} from '../../base/Indicator.js';
+import {calculateLinearRegression} from '../../trend/LINREG/LinearRegression.js';
 import {getAverage} from '../../util/getAverage.js';
 import {pushUpdate} from '../../util/pushUpdate.js';
 import {BollingerBands} from '../BBANDS/BollingerBands.js';
@@ -79,28 +80,14 @@ export class TTMSqueeze extends TechnicalIndicator<TTMSqueezeResult, HighLowClos
   }
 
   /**
-   * Fits a least-squares line through the anchored distances and reads it at the newest candle.
-   * Computed locally instead of reusing the linear-regression indicator, because that one projects
-   * the line one candle ahead and short-circuits windows climbing in unit steps with a projection
-   * that lands one candle short — either quirk would distort the histogram of a steadily trending
+   * Fits a least-squares line through the anchored distances and reads it at the newest candle —
+   * not the one-bar-ahead forecast, which would overstate the momentum of a steadily trending
    * market.
    */
   #regressionValue(window: readonly number[]) {
-    const n = window.length;
-    let sumY = 0;
-    let sumXY = 0;
+    const {intercept, slope} = calculateLinearRegression(window);
 
-    for (let x = 0; x < n; x++) {
-      sumY += window[x];
-      sumXY += x * window[x];
-    }
-
-    const sumX = ((n - 1) * n) / 2;
-    const sumXX = ((n - 1) * n * (2 * n - 1)) / 6;
-    const slope = (n * sumXY - sumX * sumY) / (n * sumXX - sumX * sumX);
-    const intercept = (sumY - slope * sumX) / n;
-
-    return slope * (n - 1) + intercept;
+    return slope * (window.length - 1) + intercept;
   }
 
   update(candle: HighLowClose<number>, replace: boolean) {


### PR DESCRIPTION
Part 3 of the jscpd-driven dedup series (stacked on #1301).

## What

CFO and TTM Squeeze each carried a private copy of the least-squares regression sums. The comments said why: both were written to dodge the LINREG forecast bug — which #1299 fixed. With the bug gone, the workaround loses its reason to exist.

- `calculateLinearRegression()` is now exported from `src/trend/LINREG/LinearRegression.ts` and consumed by all three call sites:
  - `LinearRegression.update()` — full `{prediction, slope, intercept}` result
  - `CFO` — the one-bar-ahead forecast (`prediction`, Tulip's tsf)
  - `TTMSqueeze` — the fitted line at the newest candle (`slope * (n-1) + intercept`), deliberately not the forecast; the comment now states that intent instead of the old workaround rationale
- The shared implementation keeps the identical summation order — all emissions are unchanged (Tulip-verified suites pass as-is).

## Testing

- LINREG 12, CFO 15, SQUEEZE 18 tests pass unchanged; `npm test` from root green (1688 tests, 100% coverage enforced); lint clean.