### PR TITLE
refactor(trading-signals): promote linear regression to a documented utility

### DIFF
--- a/packages/trading-signals/README.md
+++ b/packages/trading-signals/README.md
@@ -155,12 +155,17 @@ Utility Methods:
 
 1. Average / Mean
 1. Grid Sizing (for [grid trading bots](https://b2broker.com/news/understanding-grid-trading-purpose-pros-cons/))
+1. Linear Regression (least squares, with one-bar-ahead forecast)
 1. Maximum
 1. Median
 1. Minimum
+1. Percentage Change (get & apply)
 1. Quartile
+1. Share (percentage of a total)
+1. Sliding Window Update (`pushUpdate`)
 1. Standard Deviation
 1. Streaks
+1. Typical Price (HLC/3)
 1. Weekday
 
 ## Installation

--- a/packages/trading-signals/src/momentum/CFO/CFO.test.ts
+++ b/packages/trading-signals/src/momentum/CFO/CFO.test.ts
@@ -3,6 +3,13 @@ import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {CFO} from './CFO.js';
 
 describe('CFO', () => {
+  describe('constructor', () => {
+    it('rejects an interval below 2', () => {
+      expect(() => new CFO(1)).toThrowError('The interval has to be at least 2, but "1" was given.');
+      expect(() => new CFO(Number.NaN)).toThrowError('The interval has to be at least 2, but "NaN" was given.');
+    });
+  });
+
   describe('update', () => {
     it('replaces the most recently added value', () => {
       const cfo = new CFO(5);

--- a/packages/trading-signals/src/momentum/CFO/CFO.ts
+++ b/packages/trading-signals/src/momentum/CFO/CFO.ts
@@ -29,6 +29,12 @@ export class CFO extends ZeroCrossSeries {
 
   constructor(interval: number = 14) {
     super();
+
+    // A single point cannot define a trend line to project, so a forecast would be fabricated
+    if (!Number.isFinite(interval) || interval < 2) {
+      throw new Error(`The interval has to be at least 2, but "${interval}" was given.`);
+    }
+
     this.interval = interval;
   }
 

--- a/packages/trading-signals/src/momentum/CFO/CFO.ts
+++ b/packages/trading-signals/src/momentum/CFO/CFO.ts
@@ -1,5 +1,5 @@
 import {ZeroCrossSeries} from '../../base/Indicator.js';
-import {calculateLinearRegression} from '../../trend/LINREG/LinearRegression.js';
+import {getLinearRegression} from '../../util/getLinearRegression.js';
 import {pushUpdate} from '../../util/pushUpdate.js';
 
 /**
@@ -49,7 +49,7 @@ export class CFO extends ZeroCrossSeries {
     }
 
     // The forecast for the newest bar is fitted over the closes that precede it
-    const {prediction: forecast} = calculateLinearRegression(this.#closes.slice(0, this.interval));
+    const {prediction: forecast} = getLinearRegression(this.#closes.slice(0, this.interval));
 
     return this.setResult((100 * (close - forecast)) / close, replace);
   }

--- a/packages/trading-signals/src/trend/LINREG/LinearRegression.test.ts
+++ b/packages/trading-signals/src/trend/LINREG/LinearRegression.test.ts
@@ -1,17 +1,5 @@
 import {testIndicatorContract} from '../../fixtures/testIndicatorContract.js';
 import {LinearRegression} from '../../index.js';
-import {calculateLinearRegression} from './LinearRegression.js';
-
-describe('calculateLinearRegression', () => {
-  it('rejects windows with fewer than 2 values', () => {
-    expect(() => calculateLinearRegression([42])).toThrowError(
-      'The linear regression has to be fitted over at least 2 values, but "1" was given.'
-    );
-    expect(() => calculateLinearRegression([])).toThrowError(
-      'The linear regression has to be fitted over at least 2 values, but "0" was given.'
-    );
-  });
-});
 
 describe('LinearRegression', () => {
   describe('constructor', () => {

--- a/packages/trading-signals/src/trend/LINREG/LinearRegression.ts
+++ b/packages/trading-signals/src/trend/LINREG/LinearRegression.ts
@@ -1,47 +1,7 @@
 import {TechnicalIndicator} from '../../base/Indicator.js';
+import type {LinearRegressionResult} from '../../util/getLinearRegression.js';
+import {getLinearRegression} from '../../util/getLinearRegression.js';
 import {pushUpdate} from '../../util/pushUpdate.js';
-
-export type LinearRegressionResult = {
-  // The one-bar-ahead forecast (equivalent to TulipCharts' tsf)
-  prediction: number;
-  // The slope (equivalent to TulipCharts' linregslope)
-  slope: number;
-  // The y-intercept (equivalent to TulipCharts' linregintercept)
-  intercept: number;
-};
-
-/**
- * Least-squares line through the given values. The fitted line at the newest value is
- * `slope * (values.length - 1) + intercept`; the returned prediction extends it one bar ahead.
- */
-export const calculateLinearRegression = (values: readonly number[]): LinearRegressionResult => {
-  const n = values.length;
-
-  // A single point cannot define a line, so a slope would be fabricated
-  if (n < 2) {
-    throw new Error(`The linear regression has to be fitted over at least 2 values, but "${n}" was given.`);
-  }
-
-  let sumY = 0;
-  let sumXY = 0;
-
-  for (let x = 0; x < n; x++) {
-    sumY += values[x];
-    sumXY += x * values[x];
-  }
-
-  const sumX = ((n - 1) * n) / 2;
-  const sumXX = ((n - 1) * n * (2 * n - 1)) / 6;
-  const slope = (n * sumXY - sumX * sumY) / (n * sumXX - sumX * sumX);
-  const intercept = (sumY - slope * sumX) / n;
-  const prediction = slope * n + intercept;
-
-  return {
-    intercept,
-    prediction,
-    slope,
-  };
-};
 
 /**
  * Linear Regression (LINREG)
@@ -76,7 +36,7 @@ export class LinearRegression extends TechnicalIndicator<LinearRegressionResult,
       return null;
     }
 
-    return (this.result = calculateLinearRegression(this.prices));
+    return (this.result = getLinearRegression(this.prices));
   }
 
   override get isStable() {

--- a/packages/trading-signals/src/util/getLinearRegression.test.ts
+++ b/packages/trading-signals/src/util/getLinearRegression.test.ts
@@ -1,0 +1,22 @@
+import {getLinearRegression} from './getLinearRegression.js';
+
+describe('getLinearRegression', () => {
+  it('fits a straight line and projects it one value ahead', () => {
+    const values = [10, 11, 12, 13, 14] as const;
+
+    const result = getLinearRegression(values);
+
+    expect(result.slope).toBe(1);
+    expect(result.intercept).toBe(10);
+    expect(result.prediction).toBe(15);
+  });
+
+  it('rejects windows with fewer than 2 values', () => {
+    expect(() => getLinearRegression([42])).toThrowError(
+      'The linear regression has to be fitted over at least 2 values, but "1" was given.'
+    );
+    expect(() => getLinearRegression([])).toThrowError(
+      'The linear regression has to be fitted over at least 2 values, but "0" was given.'
+    );
+  });
+});

--- a/packages/trading-signals/src/util/getLinearRegression.ts
+++ b/packages/trading-signals/src/util/getLinearRegression.ts
@@ -1,0 +1,43 @@
+export type LinearRegressionResult = {
+  // The one-bar-ahead forecast (equivalent to TulipCharts' tsf)
+  prediction: number;
+  // The slope (equivalent to TulipCharts' linregslope)
+  slope: number;
+  // The y-intercept (equivalent to TulipCharts' linregintercept)
+  intercept: number;
+};
+
+/**
+ * Least-squares line through the given values. The fitted line at the newest value is
+ * `slope * (values.length - 1) + intercept`; the returned prediction extends it one bar ahead.
+ *
+ * @throws If fewer than 2 values are given, because a single point cannot define a line.
+ */
+export const getLinearRegression = (values: readonly number[]): LinearRegressionResult => {
+  const n = values.length;
+
+  // A single point cannot define a line, so a slope would be fabricated
+  if (n < 2) {
+    throw new Error(`The linear regression has to be fitted over at least 2 values, but "${n}" was given.`);
+  }
+
+  let sumY = 0;
+  let sumXY = 0;
+
+  for (let x = 0; x < n; x++) {
+    sumY += values[x];
+    sumXY += x * values[x];
+  }
+
+  const sumX = ((n - 1) * n) / 2;
+  const sumXX = ((n - 1) * n * (2 * n - 1)) / 6;
+  const slope = (n * sumXY - sumX * sumY) / (n * sumXX - sumX * sumX);
+  const intercept = (sumY - slope * sumX) / n;
+  const prediction = slope * n + intercept;
+
+  return {
+    intercept,
+    prediction,
+    slope,
+  };
+};

--- a/packages/trading-signals/src/util/index.ts
+++ b/packages/trading-signals/src/util/index.ts
@@ -1,6 +1,7 @@
 export * from './addPercentageChange.js';
 export * from './getAverage.js';
 export * from './getGrid.js';
+export * from './getLinearRegression.js';
 export * from './getMaximum.js';
 export * from './getMedian.js';
 export * from './getMinimum.js';

--- a/packages/trading-signals/src/volatility/SQUEEZE/TTMSqueeze.test.ts
+++ b/packages/trading-signals/src/volatility/SQUEEZE/TTMSqueeze.test.ts
@@ -34,6 +34,17 @@ const worksheetCandles = [
 ] as const;
 
 describe('TTMSqueeze', () => {
+  describe('constructor', () => {
+    it('rejects a kcInterval below 2', () => {
+      expect(() => new TTMSqueeze({kcInterval: 1})).toThrowError(
+        'The kcInterval has to be at least 2, but "1" was given.'
+      );
+      expect(() => new TTMSqueeze({kcInterval: Number.NaN})).toThrowError(
+        'The kcInterval has to be at least 2, but "NaN" was given.'
+      );
+    });
+  });
+
   describe('update', () => {
     it('detects the squeeze in a tight range and its release with rising momentum on the breakout', () => {
       const expectations = [

--- a/packages/trading-signals/src/volatility/SQUEEZE/TTMSqueeze.ts
+++ b/packages/trading-signals/src/volatility/SQUEEZE/TTMSqueeze.ts
@@ -1,6 +1,6 @@
 import type {HighLowClose} from '../../base/Candle.type.js';
 import {TradingSignal, TrendIndicator} from '../../base/Indicator.js';
-import {calculateLinearRegression} from '../../trend/LINREG/LinearRegression.js';
+import {getLinearRegression} from '../../util/getLinearRegression.js';
 import {getAverage} from '../../util/getAverage.js';
 import {pushUpdate} from '../../util/pushUpdate.js';
 import {BollingerBands} from '../BBANDS/BollingerBands.js';
@@ -84,7 +84,7 @@ export class TTMSqueeze extends TrendIndicator<TTMSqueezeResult, HighLowClose<nu
    * market.
    */
   #regressionValue(window: readonly number[]) {
-    const {intercept, slope} = calculateLinearRegression(window);
+    const {intercept, slope} = getLinearRegression(window);
 
     return slope * (window.length - 1) + intercept;
   }

--- a/packages/trading-signals/src/volatility/SQUEEZE/TTMSqueeze.ts
+++ b/packages/trading-signals/src/volatility/SQUEEZE/TTMSqueeze.ts
@@ -60,6 +60,12 @@ export class TTMSqueeze extends TrendIndicator<TTMSqueezeResult, HighLowClose<nu
 
   constructor({bbInterval = 20, bbMultiplier = 2, kcInterval = 20, kcMultiplier = 1.5}: TTMSqueezeConfig = {}) {
     super();
+
+    // The momentum histogram fits a regression over a window of this length, and a single point cannot define a line
+    if (!Number.isFinite(kcInterval) || kcInterval < 2) {
+      throw new Error(`The kcInterval has to be at least 2, but "${kcInterval}" was given.`);
+    }
+
     this.bbInterval = bbInterval;
     this.bbMultiplier = bbMultiplier;
     this.kcInterval = kcInterval;


### PR DESCRIPTION
Follow-up to #1302, closing the gap between the exported utility surface and the README.

## What

- `calculateLinearRegression` → **`getLinearRegression`**, moved from `src/trend/LINREG/` to `src/util/getLinearRegression.ts` — matching the `get*` naming of its 13 siblings. `LinearRegressionResult` moves with it (still re-exported from the package root, so the public import path is unchanged). The rename is free: the function was merged today and never published to npm.
- LINREG, CFO, and TTM Squeeze now import from `util/`; the regression test gains a co-located `getLinearRegression.test.ts` (positive fit + guard cases).
- README "Utility Methods" now lists the full exported surface — **Linear Regression, Percentage Change, Share, Sliding Window Update (`pushUpdate`), and Typical Price** were exported but undocumented.

## Testing

- `npm test` from root green (knip + 1691 tests in trading-signals, 100% coverage), lint clean.