### PR TITLE
fix(@typedtrader/exchange): include zero-volume candles when batching

### DIFF
--- a/.claude/rules/vitest-expect-messages.md
+++ b/.claude/rules/vitest-expect-messages.md
@@ -1,0 +1,14 @@
+# Put test expectations in `expect` messages, not comments
+
+When an assertion needs an explanation, pass it as the message argument — `expect(actual, message)` — instead of writing a comment above the line. A comment is invisible at the moment it matters most: when the test fails, the comment stays in the source while the terminal shows only the raw value mismatch. The message prints in the failure output, right where you debug.
+
+```ts
+// ❌ Bad: the explanation is lost at failure time
+// The zero-volume candle stays in the batch instead of being dropped
+expect(batchedCandles.length).toBe(1);
+
+// ✅ Good: the explanation prints when the assertion fails
+expect(batchedCandles.length, 'zero-volume candle stays in the batch instead of being dropped').toBe(1);
+```
+
+The message states the expectation or invariant being protected — never the mechanics (`'length should be 1'` adds nothing the diff doesn't show). Not every `expect` needs a message: add one exactly where you would otherwise have written a comment.

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -5,4 +5,4 @@ description: Repository coding standards for reviewing pull requests. Apply when
 
 # Code Review Standards
 
-This repository's coding standards live in [`.claude/rules/`](../../../.claude/rules/). Read the rule files relevant to the changed code and enforce them during review.
+This repository's coding standards live in [`.claude/rules/`](../../rules/). Read the rule files relevant to the changed code and enforce them during review.

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -6,3 +6,17 @@ description: Repository coding standards for reviewing pull requests. Apply when
 # Code Review Standards
 
 This repository's coding standards live in [`.claude/rules/`](../../../.claude/rules/). Read the rule files relevant to the changed code and enforce them during review.
+
+## Verify test quality with mutation testing
+
+Every changed test must be able to fail. Flag assertions that would still pass if the change under review were reverted, and name the mutation that survives.
+
+When a test's discriminating power is unclear, run Stryker on the file under test instead of guessing (set up in `packages/exchange`):
+
+```sh
+cd packages/exchange
+npm run test:mutation                                   # full package (~16s)
+npx stryker run --mutate src/candle/CandleBatcher.ts    # scoped to the file under review
+```
+
+Surviving mutants in the changed code are test gaps — report each one with its file, line, and the mutation that survived.

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-review
-description: Repository coding standards for reviewing pull requests. Apply when reviewing TypeScript code, tests, comments/JSDoc, or Playwright e2e specs in this repository.
+description: Repository coding standards for reviewing pull requests. Apply when reviewing TypeScript code.
 ---
 
 # Code Review Standards

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -5,20 +5,4 @@ description: Repository coding standards for reviewing pull requests. Apply when
 
 # Code Review Standards
 
-This repository's coding standards live in `.claude/rules/` (shared with Claude Code). That directory is the single source of truth — do not restate its rules here. Read the rule files relevant to the changed code and enforce them during review.
-
-## Rule index
-
-| Rule file | Applies to |
-| --- | --- |
-| [`.claude/rules/no-non-null-assertion-on-getResult.md`](../../../.claude/rules/no-non-null-assertion-on-getResult.md) | Any indicator usage: `getResult()!` is never acceptable — require a branch on `undefined` or `getResultOrThrow()`. |
-| [`.claude/rules/comments-add-intent-not-implementation.md`](../../../.claude/rules/comments-add-intent-not-implementation.md) | Any changed comments or JSDoc: comments must add intent or context, never restate the implementation, parameters, or types. |
-| [`.claude/rules/vitest-mocking.md`](../../../.claude/rules/vitest-mocking.md) | Any `*.test.ts`/`*.test.tsx` changes: typed `vi.fn()` signatures, `vi.mock(import(...))` form, automock vs. factory choice, narrow per-export casts, no manual mock restoration. |
-| [`.claude/rules/docs-e2e.md`](../../../.claude/rules/docs-e2e.md) | Changes under `packages/trading-signals-docs/e2e/`: E2E specs only for cross-cutting browser behavior, class-based page objects, ~3-line test bodies. |
-
-If `.claude/rules/` contains files not listed above, apply them too — the table is an index, not a filter.
-
-## Review expectations
-
-- Only flag clear violations of these rules; do not raise stylistic preferences the rules don't cover.
-- When flagging a violation, name the rule file so the author can read the full rationale.
+This repository's coding standards live in [`.claude/rules/`](../../../.claude/rules/). Read the rule files relevant to the changed code and enforce them during review.

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: code-review
+description: Repository coding standards for reviewing pull requests. Apply when reviewing TypeScript code, tests, comments/JSDoc, or Playwright e2e specs in this repository.
+---
+
+# Code Review Standards
+
+This repository's coding standards live in `.claude/rules/` (shared with Claude Code). That directory is the single source of truth — do not restate its rules here. Read the rule files relevant to the changed code and enforce them during review.
+
+## Rule index
+
+| Rule file | Applies to |
+| --- | --- |
+| [`.claude/rules/no-non-null-assertion-on-getResult.md`](../../../.claude/rules/no-non-null-assertion-on-getResult.md) | Any indicator usage: `getResult()!` is never acceptable — require a branch on `undefined` or `getResultOrThrow()`. |
+| [`.claude/rules/comments-add-intent-not-implementation.md`](../../../.claude/rules/comments-add-intent-not-implementation.md) | Any changed comments or JSDoc: comments must add intent or context, never restate the implementation, parameters, or types. |
+| [`.claude/rules/vitest-mocking.md`](../../../.claude/rules/vitest-mocking.md) | Any `*.test.ts`/`*.test.tsx` changes: typed `vi.fn()` signatures, `vi.mock(import(...))` form, automock vs. factory choice, narrow per-export casts, no manual mock restoration. |
+| [`.claude/rules/docs-e2e.md`](../../../.claude/rules/docs-e2e.md) | Changes under `packages/trading-signals-docs/e2e/`: E2E specs only for cross-cutting browser behavior, class-based page objects, ~3-line test bodies. |
+
+If `.claude/rules/` contains files not listed above, apply them too — the table is an index, not a filter.
+
+## Review expectations
+
+- Only flag clear violations of these rules; do not raise stylistic preferences the rules don't cover.
+- When flagging a violation, name the rule file so the author can read the full rationale.

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -5,4 +5,4 @@ description: Repository coding standards for reviewing pull requests. Apply when
 
 # Code Review Standards
 
-This repository's coding standards live in [`.claude/rules/`](../../rules/). Read the rule files relevant to the changed code and enforce them during review.
+This repository's coding standards live in [`.claude/rules/`](../../../.claude/rules/). Read the rule files relevant to the changed code and enforce them during review.

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -11,12 +11,10 @@ This repository's coding standards live in [`.claude/rules/`](../../../.claude/r
 
 Every changed test must be able to fail. Flag assertions that would still pass if the change under review were reverted, and name the mutation that survives.
 
-When a test's discriminating power is unclear, run Stryker on the file under test instead of guessing (set up in `packages/exchange`):
+When a test's discriminating power is unclear, run Stryker on the file under test instead of guessing:
 
 ```sh
-cd packages/exchange
-npm run test:mutation                                   # full package (~16s)
-npx stryker run --mutate src/candle/CandleBatcher.ts    # scoped to the file under review
+npx stryker run --mutate <file>
 ```
 
-Surviving mutants in the changed code are test gaps — report each one with its file, line, and the mutation that survived.
+Surviving mutants in the changed code are test gaps. Please report each one with its file, line, and the mutation that survived.

--- a/packages/exchange/src/candle/CandleBatcher.test.ts
+++ b/packages/exchange/src/candle/CandleBatcher.test.ts
@@ -136,16 +136,17 @@ describe('CandleBatcher', () => {
         }
       });
 
-      // The zero-volume candle stays in the batch instead of being dropped
-      expect(batchedCandles.length).toBe(1);
+      expect(batchedCandles.length, 'zero-volume candle stays in the batch instead of being dropped').toBe(1);
       const [batch] = batchedCandles;
       expect(batch.open.toString()).toBe('50000');
       expect(batch.high.toString()).toBe('50300');
       expect(batch.low.toString()).toBe('49900');
       expect(batch.close.toString()).toBe('50200');
       expect(batch.volume.toString()).toBe('25');
-      // Weighted median only counts traded volume: (10 * 50000 + 0 + 15 * 50200) / 25
-      expect(batch.weightedMedianPrice.toString()).toBe('50120');
+      expect(
+        batch.weightedMedianPrice.toString(),
+        'weighted median only counts traded volume: (10 * 50000 + 0 + 15 * 50200) / 25'
+      ).toBe('50120');
     });
 
     it('produces a batched candle from a single zero-volume candle', () => {
@@ -166,8 +167,10 @@ describe('CandleBatcher', () => {
 
       expect(batch.volume.toString()).toBe('0');
       expect(batch.close.toString()).toBe('50000');
-      // Zero total volume falls back to the close price instead of dividing by zero
-      expect(batch.weightedMedianPrice.toString()).toBe('50000');
+      expect(
+        batch.weightedMedianPrice.toString(),
+        'zero total volume falls back to the close price instead of dividing by zero'
+      ).toBe('50000');
     });
 
     it('does not batch candles which are already part of the batch', () => {

--- a/packages/exchange/src/candle/CandleBatcher.test.ts
+++ b/packages/exchange/src/candle/CandleBatcher.test.ts
@@ -102,27 +102,28 @@ describe('CandleBatcher', () => {
         },
         {
           base: 'BTC',
-          close: '50100',
+          close: '50200',
           counter: 'USDT',
-          high: '50200',
+          high: '50300',
           low: '50000',
           open: '50000',
           openTimeInISO: '2021-01-01T00:01:00.000Z',
           openTimeInMillis: 1609459260000,
           sizeInMillis: 60000,
-          volume: '0',
+          volume: '15',
         },
+        // A quiet final minute: no trades, OHLC flat at the last traded price
         {
           base: 'BTC',
           close: '50200',
           counter: 'USDT',
-          high: '50300',
-          low: '50100',
-          open: '50100',
+          high: '50200',
+          low: '50200',
+          open: '50200',
           openTimeInISO: '2021-01-01T00:02:00.000Z',
           openTimeInMillis: 1609459320000,
           sizeInMillis: 60000,
-          volume: '15',
+          volume: '0',
         },
       ];
 
@@ -136,17 +137,17 @@ describe('CandleBatcher', () => {
         }
       });
 
-      expect(batchedCandles.length, 'zero-volume candle stays in the batch instead of being dropped').toBe(1);
+      expect(batchedCandles.length, 'zero-volume candle completes the interval instead of being dropped').toBe(1);
       const [batch] = batchedCandles;
       expect(batch.open.toString()).toBe('50000');
       expect(batch.high.toString()).toBe('50300');
       expect(batch.low.toString()).toBe('49900');
-      expect(batch.close.toString()).toBe('50200');
+      expect(batch.close.toString(), 'close comes from the zero-volume candle').toBe('50200');
       expect(batch.volume.toString()).toBe('25');
       expect(
         batch.weightedMedianPrice.toString(),
-        'weighted median only counts traded volume: (10 * 50000 + 0 + 15 * 50200) / 25'
-      ).toBe('50120');
+        'weighted median only counts traded volume: (10 * 50000 + 15 * 50150 + 0) / 25'
+      ).toBe('50090');
     });
 
     it('produces a batched candle from a single zero-volume candle', () => {

--- a/packages/exchange/src/candle/CandleBatcher.test.ts
+++ b/packages/exchange/src/candle/CandleBatcher.test.ts
@@ -86,7 +86,7 @@ describe('CandleBatcher', () => {
       expect(daysInHours.length).toBe(48);
     });
 
-    it('does not batch candles with zero volume', () => {
+    it('includes zero-volume candles when batching, matching exchange-native aggregation', () => {
       const candles: Candle[] = [
         {
           base: 'BTC',
@@ -126,7 +126,7 @@ describe('CandleBatcher', () => {
         },
       ];
 
-      const cb = new CandleBatcher(ms('5m'));
+      const cb = new CandleBatcher(ms('3m'));
       const batchedCandles: BatchedCandle[] = [];
 
       candles.forEach(candle => {
@@ -136,9 +136,38 @@ describe('CandleBatcher', () => {
         }
       });
 
-      expect(batchedCandles.length).toBe(0);
-      // Zero-volume candles are filtered out, so only 2 candles remain in the batch
-      expect(cb.present).toBe(2);
+      // The zero-volume candle stays in the batch instead of being dropped
+      expect(batchedCandles.length).toBe(1);
+      const [batch] = batchedCandles;
+      expect(batch.open.toString()).toBe('50000');
+      expect(batch.high.toString()).toBe('50300');
+      expect(batch.low.toString()).toBe('49900');
+      expect(batch.close.toString()).toBe('50200');
+      expect(batch.volume.toString()).toBe('25');
+      // Weighted median only counts traded volume: (10 * 50000 + 0 + 15 * 50200) / 25
+      expect(batch.weightedMedianPrice.toString()).toBe('50120');
+    });
+
+    it('produces a batched candle from a single zero-volume candle', () => {
+      const zeroVolumeCandle: Candle = {
+        base: 'BTC',
+        close: '50000',
+        counter: 'USDT',
+        high: '50000',
+        low: '50000',
+        open: '50000',
+        openTimeInISO: '2021-01-01T00:00:00.000Z',
+        openTimeInMillis: 1609459200000,
+        sizeInMillis: 60000,
+        volume: '0',
+      };
+
+      const batch = CandleBatcher.toBatchedCandle(zeroVolumeCandle);
+
+      expect(batch.volume.toString()).toBe('0');
+      expect(batch.close.toString()).toBe('50000');
+      // Zero total volume falls back to the close price instead of dividing by zero
+      expect(batch.weightedMedianPrice.toString()).toBe('50000');
     });
 
     it('does not batch candles which are already part of the batch', () => {

--- a/packages/exchange/src/candle/CandleBatcher.ts
+++ b/packages/exchange/src/candle/CandleBatcher.ts
@@ -181,12 +181,6 @@ export class CandleBatcher extends EventEmitter<EventMap> {
     currentBatchArray: Candle[];
     newBatch: BatchedCandle | undefined;
   } {
-    if (new Big(candle.volume).eq(0)) {
-      return {
-        currentBatchArray: currentBatchArray,
-        newBatch: undefined,
-      };
-    }
     if (currentBatchArray.length === 0) {
       const adjustedCandle = CandleBatcher.adjustCandle(candle, desiredIntervalInMillis);
       currentBatchArray.push(adjustedCandle);


### PR DESCRIPTION
## Problem

`CandleBatcher.add()` silently dropped zero-volume candles. That caused two real defects:

1. **Live/backtest divergence.** `BacktestExecutor` builds candles via `createOneMinuteBatchedCandle()`, which bypasses the guard — so strategies received zero-volume candles in backtests but never live. Same candle series, different strategy inputs.
2. **Live crash path.** `TradingSession.#onCandle` routes raw candles through `toBatchedCandle()`, which returned `undefined` for a zero-volume candle despite its `BatchedCandle` return type. The subsequent `.sizeInMillis` access threw, so every zero-volume live candle became an `'error'` event and the strategy never ran on it.

Dropping these candles also makes batched candles diverge from exchange-native aggregates: an exchange's 15-minute bar includes flat minutes, skewing `weightedMedianPrice` and batch-completion timing on thin markets.

## Change

- Remove the zero-volume guard from `CandleBatcher.add()`. Aggregation already handles it: `weightedMedianPrice` falls back to the close price when total volume is zero.
- Flip the test to assert inclusion, and add a regression test for the previous `toBatchedCandle()` `undefined` hole (single zero-volume candle).

## Where the guard went

Nowhere, deliberately. The only legitimate reason to drop a zero-volume candle is a feed emitting garbage OHLC on empty bars — a per-broker concern for that broker's mapper. Audited the current sources: Alpaca omits empty bars entirely (stream and historical), Trading212 has no market-data API. The batcher stays a pure aggregator.

## Tests

- `packages/exchange`: 95 passed
- `packages/trading-strategies` (consumes `CandleBatcher` in `TradingSession`, MeanReversion, SmaCrossover): 261 passed
- `tsc --noEmit` clean

## Also in this PR

`.github/skills/code-review/SKILL.md` — Copilot code review agent skill (now GA) that points at `.claude/rules/` as the single source of truth, so Copilot's PR reviews enforce the same standards Claude Code applies. No rules are duplicated; the skill is an index.