### PR TITLE
refactor(trading-strategies): align --slippage-clamp flag with broker config key

### DIFF
--- a/packages/trading-strategies/src/start/runBacktest.ts
+++ b/packages/trading-strategies/src/start/runBacktest.ts
@@ -20,7 +20,6 @@ config({path: '../../.env'});
 config({path: '../exchange/.env'});
 
 const {values} = parseArgs({
-  // Lets `--no-slippage-clamp` write `false` into `slippage-clamp`, so the flag name matches the broker's config key.
   allowNegative: true,
   options: {
     balance: {default: '10000', short: 'b', type: 'string'},

--- a/packages/trading-strategies/src/start/runBacktest.ts
+++ b/packages/trading-strategies/src/start/runBacktest.ts
@@ -20,11 +20,13 @@ config({path: '../../.env'});
 config({path: '../exchange/.env'});
 
 const {values} = parseArgs({
+  // Lets `--no-slippage-clamp` write `false` into `slippage-clamp`, so the flag name matches the broker's config key.
+  allowNegative: true,
   options: {
     balance: {default: '10000', short: 'b', type: 'string'},
     config: {default: '{}', short: 'c', type: 'string'},
     data: {short: 'd', type: 'string'},
-    'no-slippage-clamp': {default: false, type: 'boolean'},
+    'slippage-clamp': {default: true, type: 'boolean'},
     'slippage-rate': {default: '0', type: 'string'},
     strategy: {short: 's', type: 'string'},
   },
@@ -32,16 +34,16 @@ const {values} = parseArgs({
 
 if (!values.data || !values.strategy) {
   console.log(
-    'Usage: tsx src/start/runBacktest.ts --data <candles.json> --strategy <name> [--config <json>] [--balance <amount>] [--slippage-rate <rate>]'
+    'Usage: tsx src/start/runBacktest.ts --data <candles.json> --strategy <name> [--config <json>] [--balance <amount>] [--slippage-rate <rate>] [--no-slippage-clamp]'
   );
   console.log('');
   console.log('Options:');
-  console.log('  --data, -d       Path to candle JSON file');
-  console.log('  --strategy, -s   Strategy name from registry');
-  console.log('  --config, -c     Strategy config as JSON (default: {})');
-  console.log('  --balance, -b    Starting cash in counter currency (default: 10000)');
-  console.log('  --slippage-rate  Market-order slippage rate, e.g. 0.001 for 0.1% (default: 0)');
-  console.log('  --no-slippage-clamp  Let slipped fills leave the candle range (default: clamped)');
+  console.log('  --data, -d             Path to candle JSON file');
+  console.log('  --strategy, -s         Strategy name from registry');
+  console.log('  --config, -c           Strategy config as JSON (default: {})');
+  console.log('  --balance, -b          Starting cash in counter currency (default: 10000)');
+  console.log('  --slippage-rate        Market-order slippage rate, e.g. 0.001 for 0.1% (default: 0)');
+  console.log('  --[no-]slippage-clamp  Keep slipped fills inside the candle range (default: on)');
   console.log('');
   console.log('Available strategies:');
   for (const name of getStrategyNames()) {
@@ -79,7 +81,7 @@ const lastCandle = candles[candles.length - 1];
 const tradingPair = new TradingPair(firstCandle.base, firstCandle.counter);
 const startingBalance = new Big(values.balance);
 const slippageRate = new Big(values['slippage-rate']);
-const clampSlippage = !values['no-slippage-clamp'];
+const slippageClamp = values['slippage-clamp'];
 const counter = tradingPair.counter;
 
 console.log(`Candles:   ${candles.length} from ${values.data}`);
@@ -89,7 +91,7 @@ console.log(`Open:      ${firstCandle.open} ${counter}  Close: ${lastCandle.clos
 console.log(`Strategy:  ${values.strategy}`);
 console.log(`Config:    ${values.config}`);
 console.log(`Balance:   ${startingBalance.toFixed(2)} ${counter}`);
-console.log(`Slippage:  ${slippageRate.mul(100).toFixed(2)}%${clampSlippage ? ' (clamped to candle range)' : ''}`);
+console.log(`Slippage:  ${slippageRate.mul(100).toFixed(2)}%${slippageClamp ? ' (clamped to candle range)' : ''}`);
 console.log('---');
 
 // 2. Create strategy from registry
@@ -106,7 +108,7 @@ const exchange = new AlpacaBrokerMock({
     [OrderType.LIMIT]: new Big(0),
     [OrderType.MARKET]: new Big(0),
   },
-  slippage: {clamp: clampSlippage, rate: slippageRate},
+  slippage: {clamp: slippageClamp, rate: slippageRate},
 });
 
 /*


### PR DESCRIPTION
## Why

The backtest CLI declared a `no-slippage-clamp` boolean and inverted it by hand:

```ts
'no-slippage-clamp': {default: false, type: 'boolean'},
// ...
const clampSlippage = !values['no-slippage-clamp'];
```

So the CLI name, the local constant, and the `slippage.clamp` key it ultimately feeds were three different spellings of one setting. The flag was named negatively because `parseArgs` booleans are presence-only — `--slippage-clamp=false` throws `ERR_PARSE_ARGS_INVALID_OPTION_VALUE`, and `--slippage-clamp false` throws `ERR_PARSE_ARGS_UNEXPECTED_POSITIONAL` — so a `default: true` option had no way to be switched off.

`parseArgs` has a built-in answer for exactly this: `allowNegative` (added in v22.4.0 / v20.16.0).

## What

Declare the option under its positive name and let the parser handle negation:

```ts
allowNegative: true,
// ...
'slippage-clamp': {default: true, type: 'boolean'},
// ...
const slippageClamp = values['slippage-clamp'];
```

`--no-slippage-clamp` is normalized to `slippage-clamp: false` during tokenization, so nothing downstream inverts anything and there is never a `no-slippage-clamp` key.

| Invocation | Result |
| --- | --- |
| *(nothing)* | `clamp: true` |
| `--slippage-clamp` | `clamp: true` — previously an unknown-option error |
| `--no-slippage-clamp` | `clamp: false` — unchanged |

Also fixed two help-text nits: the usage line omitted the flag entirely, and its options-block entry broke the description column the other five align to.

## Compatibility

No breaking change. `--no-slippage-clamp` behaves exactly as before; `--slippage-clamp` becomes newly valid.

## Verification

Ran against a real backtest at `--slippage-rate 0.05` to confirm the flag reaches `BrokerMock` rather than only the log line:

```
--slippage-clamp      P&L: -2697.95 USDT   Portfolio: 10000.00 → 7302.05 USDT
--no-slippage-clamp   P&L: -9990.87 USDT   Portfolio: 10000.00 →     9.13 USDT
```

Default and explicit-on both print `Slippage: 5.00% (clamped to candle range)`; the negated form omits it. `oxlint` and `oxfmt --list-different` are clean.