### PR TITLE
feat(trading-strategies): add indicator signals

### DIFF
--- a/packages/trading-strategies/src/index.ts
+++ b/packages/trading-strategies/src/index.ts
@@ -1,4 +1,5 @@
 export * from './backtest/index.js';
+export * from './signal/index.js';
 export * from './strategy/index.js';
 export * from './trader/index.js';
 export {BuyOnceStrategy, BuyOnceSchema, type BuyOnceConfig} from './strategy-buy-once/BuyOnceStrategy.js';

--- a/packages/trading-strategies/src/signal/CandleSignal.ts
+++ b/packages/trading-strategies/src/signal/CandleSignal.ts
@@ -1,0 +1,23 @@
+import type {BatchedCandle} from '@typedtrader/exchange';
+import type {SignalDefinition} from './SignalDefinition.js';
+
+export interface CandleSignalOptions {
+  id: string;
+  intervalInMillis: number;
+}
+
+export interface CandleSignalDefinition extends SignalDefinition<BatchedCandle> {
+  readonly intervalInMillis: number;
+  readonly kind: 'candle';
+}
+
+export function candleSignal(options: CandleSignalOptions): CandleSignalDefinition {
+  if (!Number.isFinite(options.intervalInMillis) || options.intervalInMillis <= 0) {
+    throw new Error('A candle signal interval must be a positive number of milliseconds');
+  }
+  return Object.freeze({
+    id: options.id,
+    intervalInMillis: options.intervalInMillis,
+    kind: 'candle',
+  });
+}

--- a/packages/trading-strategies/src/signal/SignalDefinition.ts
+++ b/packages/trading-strategies/src/signal/SignalDefinition.ts
@@ -1,0 +1,78 @@
+declare const signalValue: unique symbol;
+
+export interface SignalDefinition<Value> {
+  readonly id: string;
+  readonly kind: 'source' | 'candle' | 'indicator';
+  readonly [signalValue]?: Value;
+}
+
+export interface SourceSignalOptions {
+  id: string;
+}
+
+export interface SourceSignalDefinition<Value> extends SignalDefinition<Value> {
+  readonly kind: 'source';
+}
+
+export function sourceSignal<Value>(options: SourceSignalOptions): SourceSignalDefinition<Value> {
+  return Object.freeze({id: options.id, kind: 'source'});
+}
+
+export interface IncrementalIndicator<Input, Result> {
+  readonly isStable: boolean;
+
+  add(input: Input): Result | null;
+  replace(input: Input): Result | null;
+  getRequiredInputs(): number;
+  getResult(): Result | null;
+}
+
+export interface IndicatorSignalOptions<SourceValue, Input, Result> {
+  createIndicator(): IncrementalIndicator<Input, Result>;
+  id: string;
+  selectInput(value: SourceValue): Input;
+  source: SignalDefinition<SourceValue>;
+}
+
+export interface IndicatorSignalDefinition<SourceValue, Input, Result> extends SignalDefinition<Result> {
+  readonly createIndicator: () => IncrementalIndicator<Input, Result>;
+  readonly kind: 'indicator';
+  readonly selectInput: (value: SourceValue) => Input;
+  readonly source: SignalDefinition<SourceValue>;
+}
+
+export function indicatorSignal<SourceValue, Input, Result>(
+  options: IndicatorSignalOptions<SourceValue, Input, Result>
+): IndicatorSignalDefinition<SourceValue, Input, Result> {
+  return Object.freeze({
+    createIndicator: options.createIndicator,
+    id: options.id,
+    kind: 'indicator',
+    selectInput: options.selectInput,
+    source: options.source,
+  });
+}
+
+export type SignalReading<Value> =
+  | Readonly<{
+      receivedInputs: number;
+      requiredInputs: number;
+      status: 'warming';
+    }>
+  | Readonly<{
+      effectiveAt: number;
+      revision: number;
+      status: 'ready';
+      value: Value;
+    }>
+  | Readonly<{
+      lastValue?: Value;
+      reason?: string;
+      status: 'stale' | 'unavailable' | 'error';
+    }>;
+
+export interface SignalUpdate<Value> {
+  effectiveAt: number;
+  kind: 'append' | 'replace';
+  value: Value;
+}

--- a/packages/trading-strategies/src/signal/SignalRuntime.ts
+++ b/packages/trading-strategies/src/signal/SignalRuntime.ts
@@ -1,0 +1,206 @@
+import {CandleBatcher} from '@typedtrader/exchange';
+import type {OneMinuteBatchedCandle} from '@typedtrader/exchange';
+import type {CandleSignalDefinition} from './CandleSignal.js';
+import type {
+  IncrementalIndicator,
+  IndicatorSignalDefinition,
+  SignalDefinition,
+  SignalReading,
+  SignalUpdate,
+} from './SignalDefinition.js';
+
+type UnknownSignal = SignalDefinition<unknown>;
+type UnknownIndicatorDefinition = IndicatorSignalDefinition<unknown, unknown, unknown>;
+
+interface IndicatorState {
+  definition: UnknownIndicatorDefinition;
+  indicator: IncrementalIndicator<unknown, unknown>;
+  lastValue?: unknown;
+  reading: SignalReading<unknown>;
+  receivedInputs: number;
+  revision: number;
+}
+
+export class SignalSnapshot {
+  readonly #readings: ReadonlyMap<UnknownSignal, SignalReading<unknown>>;
+
+  constructor(readings: ReadonlyMap<UnknownSignal, SignalReading<unknown>>) {
+    this.#readings = readings;
+    Object.freeze(this);
+  }
+
+  get<Value>(definition: SignalDefinition<Value>): SignalReading<Value> {
+    const reading = this.#readings.get(definition);
+    if (!reading) {
+      throw new Error(`Signal "${definition.id}" is not loaded in this runtime`);
+    }
+    return reading as SignalReading<Value>;
+  }
+}
+
+export class SignalRuntime {
+  readonly #candleBatchers = new Map<CandleSignalDefinition, CandleBatcher>();
+  readonly #consumers = new Map<UnknownSignal, IndicatorState[]>();
+  readonly #ids = new Map<string, UnknownSignal>();
+  readonly #states = new Map<UnknownSignal, IndicatorState>();
+  #snapshot = new SignalSnapshot(new Map());
+
+  constructor(definitions: readonly UnknownSignal[]) {
+    for (const definition of definitions) {
+      this.#load(definition);
+    }
+    this.#publish();
+  }
+
+  get snapshot() {
+    return this.#snapshot;
+  }
+
+  update<Value>(source: SignalDefinition<Value>, update: SignalUpdate<Value>): SignalSnapshot {
+    const consumers = this.#consumers.get(source);
+    if (!consumers) {
+      throw new Error(`Signal source "${source.id}" is not loaded in this runtime`);
+    }
+
+    this.#updateConsumers(consumers, update);
+    this.#publish();
+    return this.#snapshot;
+  }
+
+  updateCandle(candle: OneMinuteBatchedCandle): SignalSnapshot {
+    for (const [source, batcher] of this.#candleBatchers) {
+      const batched = batcher.addToBatch(candle);
+      if (!batched) {
+        continue;
+      }
+      const consumers = this.#consumers.get(source) ?? [];
+      this.#updateConsumers(consumers, {
+        effectiveAt: batched.openTimeInMillis + batched.sizeInMillis,
+        kind: 'append',
+        value: batched,
+      });
+    }
+    this.#publish();
+    return this.#snapshot;
+  }
+
+  setSourceStatus<Value>(
+    source: SignalDefinition<Value>,
+    status: 'stale' | 'unavailable',
+    reason?: string
+  ): SignalSnapshot {
+    const consumers = this.#consumers.get(source);
+    if (!consumers) {
+      throw new Error(`Signal source "${source.id}" is not loaded in this runtime`);
+    }
+    this.#setConsumerStatus(consumers, status, reason);
+    this.#publish();
+    return this.#snapshot;
+  }
+
+  #load(definition: UnknownSignal): void {
+    const existing = this.#ids.get(definition.id);
+    if (existing && existing !== definition) {
+      throw new Error(`Signal id "${definition.id}" is already loaded by another definition`);
+    }
+    this.#ids.set(definition.id, definition);
+
+    if (definition.kind === 'candle' && !this.#candleBatchers.has(definition as CandleSignalDefinition)) {
+      const candleDefinition = definition as CandleSignalDefinition;
+      this.#candleBatchers.set(candleDefinition, new CandleBatcher(candleDefinition.intervalInMillis));
+    }
+
+    if (definition.kind !== 'indicator' || this.#states.has(definition)) {
+      return;
+    }
+
+    const indicatorDefinition = definition as unknown as UnknownIndicatorDefinition;
+    this.#load(indicatorDefinition.source);
+    const indicator = indicatorDefinition.createIndicator();
+    const state: IndicatorState = {
+      definition: indicatorDefinition,
+      indicator,
+      reading: Object.freeze({
+        receivedInputs: 0,
+        requiredInputs: indicator.getRequiredInputs(),
+        status: 'warming',
+      }),
+      receivedInputs: 0,
+      revision: 0,
+    };
+    this.#states.set(definition, state);
+
+    const consumers = this.#consumers.get(indicatorDefinition.source) ?? [];
+    consumers.push(state);
+    this.#consumers.set(indicatorDefinition.source, consumers);
+  }
+
+  #updateConsumers(consumers: readonly IndicatorState[], update: SignalUpdate<unknown>): void {
+    for (const state of consumers) {
+      const output = this.#updateIndicator(state, update);
+      if (output) {
+        this.#updateConsumers(this.#consumers.get(state.definition) ?? [], output);
+      }
+    }
+  }
+
+  #setConsumerStatus(consumers: readonly IndicatorState[], status: 'stale' | 'unavailable', reason?: string): void {
+    for (const state of consumers) {
+      state.reading = Object.freeze({
+        ...(state.lastValue === undefined ? {} : {lastValue: state.lastValue}),
+        ...(reason === undefined ? {} : {reason}),
+        status,
+      });
+      this.#setConsumerStatus(this.#consumers.get(state.definition) ?? [], status, reason);
+    }
+  }
+
+  #updateIndicator(state: IndicatorState, update: SignalUpdate<unknown>): SignalUpdate<unknown> | undefined {
+    try {
+      const input = state.definition.selectInput(update.value);
+      if (update.kind === 'append') {
+        state.indicator.add(input);
+        state.receivedInputs += 1;
+      } else {
+        state.indicator.replace(input);
+      }
+      state.revision += 1;
+
+      const value = state.indicator.getResult();
+      if (state.indicator.isStable && value !== null) {
+        state.lastValue = value;
+        state.reading = Object.freeze({
+          effectiveAt: update.effectiveAt,
+          revision: state.revision,
+          status: 'ready',
+          value,
+        });
+        return {
+          effectiveAt: update.effectiveAt,
+          kind: update.kind,
+          value,
+        };
+      }
+      state.reading = Object.freeze({
+        receivedInputs: state.receivedInputs,
+        requiredInputs: state.indicator.getRequiredInputs(),
+        status: 'warming',
+      });
+    } catch (error) {
+      state.reading = Object.freeze({
+        ...(state.lastValue === undefined ? {} : {lastValue: state.lastValue}),
+        reason: error instanceof Error ? error.message : String(error),
+        status: 'error',
+      });
+    }
+    return undefined;
+  }
+
+  #publish(): void {
+    const readings = new Map<UnknownSignal, SignalReading<unknown>>();
+    for (const [definition, state] of this.#states) {
+      readings.set(definition, state.reading);
+    }
+    this.#snapshot = new SignalSnapshot(readings);
+  }
+}

--- a/packages/trading-strategies/src/signal/index.ts
+++ b/packages/trading-strategies/src/signal/index.ts
@@ -1,0 +1,3 @@
+export * from './CandleSignal.js';
+export * from './SignalDefinition.js';
+export * from './SignalRuntime.js';

--- a/packages/trading-strategies/src/signal/indicatorSignal.test.ts
+++ b/packages/trading-strategies/src/signal/indicatorSignal.test.ts
@@ -1,0 +1,209 @@
+import {describe, expect, it, vi} from 'vitest';
+import {CandleBatcher} from '@typedtrader/exchange';
+import type {Candle, OneMinuteBatchedCandle} from '@typedtrader/exchange';
+import {SignalRuntime, candleSignal, indicatorSignal, sourceSignal, type IncrementalIndicator} from './index.js';
+
+const ONE_MINUTE_IN_MS = 60_000;
+
+function makeCandle(close: number, index: number): OneMinuteBatchedCandle {
+  const value = String(close);
+  const candle: Candle = {
+    base: 'BTC',
+    close: value,
+    counter: 'USD',
+    high: value,
+    low: value,
+    open: value,
+    openTimeInISO: new Date(index * ONE_MINUTE_IN_MS).toISOString(),
+    openTimeInMillis: index * ONE_MINUTE_IN_MS,
+    sizeInMillis: ONE_MINUTE_IN_MS,
+    volume: '1',
+  };
+  return CandleBatcher.createOneMinuteBatchedCandle([candle]);
+}
+
+class RollingMean implements IncrementalIndicator<number, number> {
+  readonly #period: number;
+  readonly #values: number[] = [];
+
+  constructor(period: number) {
+    this.#period = period;
+  }
+
+  get isStable() {
+    return this.#values.length >= this.#period;
+  }
+
+  add(input: number) {
+    this.#values.push(input);
+    return this.getResult();
+  }
+
+  replace(input: number) {
+    this.#values[this.#values.length - 1] = input;
+    return this.getResult();
+  }
+
+  getRequiredInputs() {
+    return this.#period;
+  }
+
+  getResult() {
+    if (!this.isStable) {
+      return null;
+    }
+    const values = this.#values.slice(-this.#period);
+    return values.reduce((sum, value) => sum + value, 0) / this.#period;
+  }
+}
+
+describe('indicatorSignal', () => {
+  it('is cold and creates a separate indicator for every runtime session', () => {
+    const createIndicator = vi.fn(() => new RollingMean(2));
+    const source = sourceSignal<number>({id: 'prices'});
+    const mean = indicatorSignal({createIndicator, id: 'mean-2', selectInput: value => value, source});
+
+    expect(createIndicator).not.toHaveBeenCalled();
+
+    new SignalRuntime([mean]);
+    new SignalRuntime([mean]);
+
+    expect(createIndicator).toHaveBeenCalledTimes(2);
+  });
+
+  it('publishes immutable warming and ready readings for append and replace updates', () => {
+    const source = sourceSignal<number>({id: 'prices'});
+    const add = vi.fn<(input: number) => number | null>();
+    const replace = vi.fn<(input: number) => number | null>();
+    const mean = indicatorSignal({
+      createIndicator: () => {
+        const indicator = new RollingMean(2);
+        add.mockImplementation(input => indicator.add(input));
+        replace.mockImplementation(input => indicator.replace(input));
+        return {
+          add,
+          getRequiredInputs: () => indicator.getRequiredInputs(),
+          getResult: () => indicator.getResult(),
+          get isStable() {
+            return indicator.isStable;
+          },
+          replace,
+        };
+      },
+      id: 'mean-2',
+      selectInput: value => value,
+      source,
+    });
+    const runtime = new SignalRuntime([mean]);
+
+    expect(runtime.snapshot.get(mean)).toEqual({receivedInputs: 0, requiredInputs: 2, status: 'warming'});
+
+    runtime.update(source, {effectiveAt: 1, kind: 'append', value: 2});
+    expect(runtime.snapshot.get(mean)).toEqual({receivedInputs: 1, requiredInputs: 2, status: 'warming'});
+
+    runtime.update(source, {effectiveAt: 2, kind: 'append', value: 4});
+    expect(runtime.snapshot.get(mean)).toEqual({effectiveAt: 2, revision: 2, status: 'ready', value: 3});
+
+    runtime.update(source, {effectiveAt: 2, kind: 'replace', value: 6});
+    const reading = runtime.snapshot.get(mean);
+    expect(reading).toEqual({effectiveAt: 2, revision: 3, status: 'ready', value: 4});
+    expect(Object.isFrozen(reading)).toBe(true);
+    expect(add).toHaveBeenCalledTimes(2);
+    expect(replace).toHaveBeenCalledOnce();
+  });
+
+  it('maps structured source values and shares one source across indicators', () => {
+    const candles = sourceSignal<{close: number; high: number; low: number}>({id: 'candles'});
+    const close = indicatorSignal({
+      createIndicator: () => new RollingMean(1),
+      id: 'close',
+      selectInput: candle => candle.close,
+      source: candles,
+    });
+    const range = indicatorSignal({
+      createIndicator: () => {
+        let result: number | null = null;
+        return {
+          add: input => (result = input.high - input.low),
+          getRequiredInputs: () => 1,
+          getResult: () => result,
+          get isStable() {
+            return result !== null;
+          },
+          replace: input => (result = input.high - input.low),
+        } satisfies IncrementalIndicator<{high: number; low: number}, number>;
+      },
+      id: 'range',
+      selectInput: candle => ({high: candle.high, low: candle.low}),
+      source: candles,
+    });
+    const runtime = new SignalRuntime([close, range]);
+
+    runtime.update(candles, {
+      effectiveAt: 10,
+      kind: 'append',
+      value: {close: 101, high: 105, low: 99},
+    });
+
+    expect(runtime.snapshot.get(close)).toMatchObject({status: 'ready', value: 101});
+    expect(runtime.snapshot.get(range)).toMatchObject({status: 'ready', value: 6});
+  });
+
+  it('keeps stale and unavailable distinct from warm-up and failure', () => {
+    const source = sourceSignal<number>({id: 'prices'});
+    const mean = indicatorSignal({
+      createIndicator: () => new RollingMean(1),
+      id: 'mean',
+      selectInput: value => value,
+      source,
+    });
+    const runtime = new SignalRuntime([mean]);
+
+    runtime.update(source, {effectiveAt: 1, kind: 'append', value: 4});
+    runtime.setSourceStatus(source, 'stale', 'feed delayed');
+    expect(runtime.snapshot.get(mean)).toEqual({lastValue: 4, reason: 'feed delayed', status: 'stale'});
+
+    runtime.setSourceStatus(source, 'unavailable');
+    expect(runtime.snapshot.get(mean)).toEqual({lastValue: 4, status: 'unavailable'});
+  });
+
+  it('batches a shared candle source once for multiple indicators', () => {
+    const bars2m = candleSignal({id: 'bars-2m', intervalInMillis: 2 * ONE_MINUTE_IN_MS});
+    const firstAdd = vi.fn<(input: number) => number | null>();
+    const secondAdd = vi.fn<(input: number) => number | null>();
+    const makeIndicator = (add: typeof firstAdd) => {
+      const indicator = new RollingMean(1);
+      add.mockImplementation(input => indicator.add(input));
+      return {
+        add,
+        getRequiredInputs: () => indicator.getRequiredInputs(),
+        getResult: () => indicator.getResult(),
+        get isStable() {
+          return indicator.isStable;
+        },
+        replace: (input: number) => indicator.replace(input),
+      };
+    };
+    const first = indicatorSignal({
+      createIndicator: () => makeIndicator(firstAdd),
+      id: 'first',
+      selectInput: bar => bar.close.toNumber(),
+      source: bars2m,
+    });
+    const second = indicatorSignal({
+      createIndicator: () => makeIndicator(secondAdd),
+      id: 'second',
+      selectInput: bar => bar.close.toNumber(),
+      source: bars2m,
+    });
+    const runtime = new SignalRuntime([first, second]);
+
+    runtime.updateCandle(makeCandle(10, 0));
+    expect(firstAdd).not.toHaveBeenCalled();
+    expect(secondAdd).not.toHaveBeenCalled();
+
+    runtime.updateCandle(makeCandle(12, 1));
+    expect(firstAdd).toHaveBeenCalledExactlyOnceWith(12);
+    expect(secondAdd).toHaveBeenCalledExactlyOnceWith(12);
+  });
+});

--- a/packages/trading-strategies/src/strategy-sma-crossover/SmaCrossoverStrategy.ts
+++ b/packages/trading-strategies/src/strategy-sma-crossover/SmaCrossoverStrategy.ts
@@ -1,9 +1,11 @@
 import type {StringValue} from 'ms';
 import {ms} from 'ms';
 import {z} from 'zod';
-import {CandleBatcher, OrderSide, OrderType} from '@typedtrader/exchange';
-import type {OneMinuteBatchedCandle} from '@typedtrader/exchange';
+import {OrderSide, OrderType} from '@typedtrader/exchange';
+import type {BatchedCandle, OneMinuteBatchedCandle} from '@typedtrader/exchange';
 import {SMA} from 'trading-signals';
+import {SignalRuntime, candleSignal, indicatorSignal} from '../signal/index.js';
+import type {IndicatorSignalDefinition} from '../signal/index.js';
 import {AllAvailableAmount} from '../trader/index.js';
 import type {OrderAdvice, TradingSessionState} from '../trader/index.js';
 import {MarketType} from '../strategy/MarketType.js';
@@ -47,10 +49,11 @@ export class SmaCrossoverStrategy extends Strategy {
   readonly #slowPeriod: number;
   readonly #fastTimeframe: string;
   readonly #slowTimeframe: string;
-  readonly #fast: SMA;
-  readonly #slow: SMA;
-  readonly #fastBatcher: CandleBatcher;
-  readonly #slowBatcher: CandleBatcher;
+  readonly #fast: IndicatorSignalDefinition<BatchedCandle, number, number>;
+  readonly #slow: IndicatorSignalDefinition<BatchedCandle, number, number>;
+  readonly #signals: SignalRuntime;
+  #fastRevision = 0;
+  #slowRevision = 0;
 
   /**
    * Whether the fast SMA sat above the slow SMA on the previous evaluated bar.
@@ -76,42 +79,53 @@ export class SmaCrossoverStrategy extends Strategy {
     this.#slowPeriod = parsed.slowPeriod;
     this.#fastTimeframe = parsed.fastTimeframe;
     this.#slowTimeframe = parsed.slowTimeframe;
-    this.#fast = new SMA(parsed.fastPeriod);
-    this.#slow = new SMA(parsed.slowPeriod);
-    this.#fastBatcher = new CandleBatcher(fastIntervalInMillis);
-    this.#slowBatcher = new CandleBatcher(slowIntervalInMillis);
+    const fastBars = candleSignal({id: `bars-${parsed.fastTimeframe}`, intervalInMillis: fastIntervalInMillis});
+    const slowBars =
+      slowIntervalInMillis === fastIntervalInMillis
+        ? fastBars
+        : candleSignal({id: `bars-${parsed.slowTimeframe}`, intervalInMillis: slowIntervalInMillis});
+    this.#fast = indicatorSignal({
+      createIndicator: () => new SMA(parsed.fastPeriod),
+      id: `sma-${parsed.fastPeriod}-${parsed.fastTimeframe}`,
+      selectInput: bar => bar.close.toNumber(),
+      source: fastBars,
+    });
+    this.#slow = indicatorSignal({
+      createIndicator: () => new SMA(parsed.slowPeriod),
+      id: `sma-${parsed.slowPeriod}-${parsed.slowTimeframe}`,
+      selectInput: bar => bar.close.toNumber(),
+      source: slowBars,
+    });
+    this.#signals = new SignalRuntime([this.#fast, this.#slow]);
   }
 
   /** Whether both SMAs have seen enough bars to produce a value. */
   get isWarmedUp() {
-    return this.#fast.isStable && this.#slow.isStable;
+    return (
+      this.#signals.snapshot.get(this.#fast).status === 'ready' &&
+      this.#signals.snapshot.get(this.#slow).status === 'ready'
+    );
   }
 
   protected override async processCandle(
     candle: OneMinuteBatchedCandle,
     _state: TradingSessionState
   ): Promise<OrderAdvice | void> {
-    // Strategies always receive 1-minute candles; roll them up to each SMA's own timeframe.
-    const fastBar = this.#fastBatcher.addToBatch(candle);
-    if (fastBar) {
-      this.#fast.add(fastBar.close.toNumber());
-    }
-    const slowBar = this.#slowBatcher.addToBatch(candle);
-    if (slowBar) {
-      this.#slow.add(slowBar.close.toNumber());
-    }
-
-    // No SMA advanced on this candle, so the relationship cannot have changed.
-    if (!fastBar && !slowBar) {
+    const snapshot = this.#signals.updateCandle(candle);
+    const fastReading = snapshot.get(this.#fast);
+    const slowReading = snapshot.get(this.#slow);
+    if (fastReading.status !== 'ready' || slowReading.status !== 'ready') {
       return;
     }
 
-    if (!this.isWarmedUp) {
+    if (fastReading.revision === this.#fastRevision && slowReading.revision === this.#slowRevision) {
       return;
     }
+    this.#fastRevision = fastReading.revision;
+    this.#slowRevision = slowReading.revision;
 
-    const fastValue = this.#fast.getResultOrThrow();
-    const slowValue = this.#slow.getResultOrThrow();
+    const fastValue = fastReading.value;
+    const slowValue = slowReading.value;
     const fastAboveSlow = fastValue > slowValue;
 
     // Detecting a *crossover* needs the previous relationship, not just this bar's.


### PR DESCRIPTION
## Summary

- add a cold, generic `indicatorSignal()` definition and per-session signal runtime
- centralize shared candle batching and publish transactional signal snapshots
- migrate `SmaCrossoverStrategy` to consume typed readings without changing its advice sequence

`SignalRuntime` creates independent mutable indicator instances for each
strategy session. It maps appended source values to `add()`, revisions to
`replace()`, and exposes frozen typed readings that distinguish warming, ready,
stale, unavailable, and error states. Candle signals are batched once per
runtime even when multiple indicators consume the same timeframe. All affected
indicators are advanced before a new snapshot is published, so a strategy
cannot observe a partially updated boundary.

The SMA crossover migration keeps its existing advice semantics and uses the
same `updateCandle()` path in live sessions and backtests. Focused tests cover
cold definitions, session isolation, numeric and structured inputs, revisions,
readiness states, and shared-source batching.

Closes #1310.

## Verification

- `npm run lint`
- `npm test` (160 test files, 1740 tests)
