### PR TITLE
feat(trading-strategies): add performance risk metrics

### DIFF
--- a/packages/trading-strategies/src/backtest/BacktestExecutor.test.ts
+++ b/packages/trading-strategies/src/backtest/BacktestExecutor.test.ts
@@ -113,8 +113,8 @@ describe('BacktestExecutor', () => {
       }).execute();
 
       expect(result.performance.maxDrawdownPercentage.toNumber()).toBeCloseTo(25, 8);
-      expect(result.performance.sharpeRatio.toNumber()).toBeCloseTo(0.235702, 6);
-      expect(result.performance.sortinoRatio.toNumber()).toBeCloseTo(0.34641, 6);
+      expect(result.performance.sharpeRatio?.toNumber()).toBeCloseTo(0.235702, 6);
+      expect(result.performance.sortinoRatio?.toNumber()).toBeCloseTo(0.34641, 6);
     });
 
     it('executes a buy with 1-candle delay when price drops below the buyBelow threshold', async () => {
@@ -369,7 +369,11 @@ describe('BacktestExecutor', () => {
       expect(result.trades).toHaveLength(0);
       expect(result.finalCounterBalance.toFixed(2)).toBe('1000.00');
       expect(result.performance.maxDrawdownPercentage.toFixed()).toBe('0');
-      expect(result.performance.sharpeRatio.toFixed()).toBe('0');
+      expect(
+        result.performance.sharpeRatio,
+        'an untouched portfolio has a flat equity curve, so there is no deviation to divide by'
+      ).toBeUndefined();
+      expect(result.performance.sortinoRatio, 'a flat equity curve never declined').toBeUndefined();
     });
 
     it('tracks the total number of candles processed', async () => {

--- a/packages/trading-strategies/src/backtest/BacktestExecutor.test.ts
+++ b/packages/trading-strategies/src/backtest/BacktestExecutor.test.ts
@@ -88,6 +88,35 @@ describe('BacktestExecutor', () => {
       expect(result.profitOrLoss.toFixed(2)).toBe('0.00');
     });
 
+    it('derives risk-adjusted metrics from the candle-by-candle portfolio equity curve', async () => {
+      class NoOpStrategy extends Strategy {
+        static override NAME = 'NoOp';
+
+        protected override async processCandle(
+          _candle: OneMinuteBatchedCandle,
+          _state: TradingSessionState
+        ): Promise<OrderAdvice | void> {
+          return undefined;
+        }
+      }
+
+      const candles = [
+        createCandle({close: '120', open: '100'}),
+        createCandle({close: '90', open: '120'}),
+        createCandle({close: '108', open: '90'}),
+      ];
+      const result = await new BacktestExecutor({
+        broker: createMockExchange({baseBalance: '1', counterBalance: '0'}),
+        candles,
+        strategy: new NoOpStrategy(),
+        tradingPair,
+      }).execute();
+
+      expect(result.performance.maxDrawdownPercentage.toNumber()).toBeCloseTo(25, 8);
+      expect(result.performance.sharpeRatio.toNumber()).toBeCloseTo(0.235702, 6);
+      expect(result.performance.sortinoRatio.toNumber()).toBeCloseTo(0.34641, 6);
+    });
+
     it('executes a buy with 1-candle delay when price drops below the buyBelow threshold', async () => {
       const strategy = new BuyBelowSellAboveStrategy({buyBelow: '100'});
 
@@ -339,6 +368,8 @@ describe('BacktestExecutor', () => {
        */
       expect(result.trades).toHaveLength(0);
       expect(result.finalCounterBalance.toFixed(2)).toBe('1000.00');
+      expect(result.performance.maxDrawdownPercentage.toFixed()).toBe('0');
+      expect(result.performance.sharpeRatio.toFixed()).toBe('0');
     });
 
     it('tracks the total number of candles processed', async () => {

--- a/packages/trading-strategies/src/backtest/BacktestExecutor.test.ts
+++ b/packages/trading-strategies/src/backtest/BacktestExecutor.test.ts
@@ -372,8 +372,8 @@ describe('BacktestExecutor', () => {
       expect(
         result.performance.sharpeRatio,
         'an untouched portfolio has a flat equity curve, so there is no deviation to divide by'
-      ).toBeUndefined();
-      expect(result.performance.sortinoRatio, 'a flat equity curve never declined').toBeUndefined();
+      ).toBeNull();
+      expect(result.performance.sortinoRatio, 'a flat equity curve never declined').toBeNull();
     });
 
     it('tracks the total number of candles processed', async () => {

--- a/packages/trading-strategies/src/backtest/BacktestExecutor.ts
+++ b/packages/trading-strategies/src/backtest/BacktestExecutor.ts
@@ -38,6 +38,9 @@ export class BacktestExecutor {
     const trades: BacktestTrade[] = [];
     const skippedAdvices: BacktestSkippedAdvice[] = [];
     let totalFees = new Big(0);
+    const firstOpenPrice = candles.length > 0 ? new Big(candles[0].open) : new Big(0);
+    const initialPortfolioValue = initialBaseBalance.mul(firstOpenPrice).plus(initialCounterBalance);
+    const equityCurve = [initialPortfolioValue];
 
     for (const candle of candles) {
       // Step 1: Match pending orders from previous iteration against this candle
@@ -67,6 +70,7 @@ export class BacktestExecutor {
       const batchedCandle = CandleBatcher.createOneMinuteBatchedCandle([candle]);
       const state = await this.#buildState(tradingPair, tradingRules, feeRates);
       const advice = await strategy.onCandle(batchedCandle, state);
+      equityCurve.push(await this.#calculatePortfolioValue(new Big(candle.close)));
 
       if (!advice) {
         continue;
@@ -99,14 +103,18 @@ export class BacktestExecutor {
     await exchange.cancelOpenOrders(tradingPair);
 
     const finalBalances = await exchange.getAvailableBalances(tradingPair);
-    const firstOpenPrice = candles.length > 0 ? new Big(candles[0].open) : new Big(0);
     const lastClosePrice = candles.length > 0 ? new Big(candles[candles.length - 1].close) : new Big(0);
 
-    const initialPortfolioValue = initialBaseBalance.mul(firstOpenPrice).plus(initialCounterBalance);
     const finalPortfolioValue = finalBalances.base.mul(lastClosePrice).plus(finalBalances.counter);
     const profitOrLoss = finalPortfolioValue.minus(initialPortfolioValue);
 
-    const performance = this.#buildPerformanceSummary(trades, candles, initialPortfolioValue, finalPortfolioValue);
+    const performance = this.#buildPerformanceSummary(
+      trades,
+      candles,
+      equityCurve,
+      initialPortfolioValue,
+      finalPortfolioValue
+    );
 
     return {
       finalBaseBalance: finalBalances.base,
@@ -148,9 +156,20 @@ export class BacktestExecutor {
     };
   }
 
+  async #calculatePortfolioValue(price: Big): Promise<Big> {
+    const {broker, tradingPair} = this.#config;
+    const balances = await broker.listBalances();
+    const total = (currency: string) => {
+      const balance = balances.find(item => item.currency === currency);
+      return new Big(balance?.available ?? 0).plus(balance?.hold ?? 0);
+    };
+    return total(tradingPair.base).mul(price).plus(total(tradingPair.counter));
+  }
+
   #buildPerformanceSummary(
     trades: BacktestTrade[],
     candles: Candle[],
+    equityCurve: Big[],
     initialPortfolioValue: Big,
     finalPortfolioValue: Big
   ): BacktestPerformanceSummary {
@@ -160,15 +179,21 @@ export class BacktestExecutor {
 
     const winRate = PerformanceCalculator.calculateWinRate(trades);
     const buyAndHoldReturnPercentage = PerformanceCalculator.calculateBuyAndHoldReturn(candles);
+    const maxDrawdownPercentage = PerformanceCalculator.calculateMaxDrawdown(equityCurve);
+    const sharpeRatio = PerformanceCalculator.calculateSharpeRatio(equityCurve);
+    const sortinoRatio = PerformanceCalculator.calculateSortinoRatio(equityCurve);
     const {maxLossStreak, maxWinStreak} = PerformanceCalculator.calculateStreaks(trades);
 
     return {
       buyAndHoldReturnPercentage,
       finalPortfolioValue,
       initialPortfolioValue,
+      maxDrawdownPercentage,
       maxLossStreak,
       maxWinStreak,
       returnPercentage,
+      sharpeRatio,
+      sortinoRatio,
       totalTrades: trades.length,
       winRate,
     };

--- a/packages/trading-strategies/src/backtest/BacktestExecutor.ts
+++ b/packages/trading-strategies/src/backtest/BacktestExecutor.ts
@@ -12,6 +12,15 @@ import type {
 } from './BacktestResult.js';
 import {PerformanceCalculator} from './PerformanceCalculator.js';
 
+interface PerformanceSummaryConfig {
+  candles: Candle[];
+  /** Portfolio value at the initial open, followed by one entry per processed candle. */
+  equityCurve: readonly Big[];
+  finalPortfolioValue: Big;
+  initialPortfolioValue: Big;
+  trades: BacktestTrade[];
+}
+
 export class BacktestExecutor {
   readonly #config: BacktestConfig;
 
@@ -108,13 +117,13 @@ export class BacktestExecutor {
     const finalPortfolioValue = finalBalances.base.mul(lastClosePrice).plus(finalBalances.counter);
     const profitOrLoss = finalPortfolioValue.minus(initialPortfolioValue);
 
-    const performance = this.#buildPerformanceSummary(
-      trades,
+    const performance = this.#buildPerformanceSummary({
       candles,
       equityCurve,
+      finalPortfolioValue,
       initialPortfolioValue,
-      finalPortfolioValue
-    );
+      trades,
+    });
 
     return {
       finalBaseBalance: finalBalances.base,
@@ -166,13 +175,13 @@ export class BacktestExecutor {
     return total(tradingPair.base).mul(price).plus(total(tradingPair.counter));
   }
 
-  #buildPerformanceSummary(
-    trades: BacktestTrade[],
-    candles: Candle[],
-    equityCurve: Big[],
-    initialPortfolioValue: Big,
-    finalPortfolioValue: Big
-  ): BacktestPerformanceSummary {
+  #buildPerformanceSummary({
+    candles,
+    equityCurve,
+    finalPortfolioValue,
+    initialPortfolioValue,
+    trades,
+  }: PerformanceSummaryConfig): BacktestPerformanceSummary {
     const returnPercentage = initialPortfolioValue.gt(0)
       ? finalPortfolioValue.minus(initialPortfolioValue).div(initialPortfolioValue).mul(100)
       : new Big(0);

--- a/packages/trading-strategies/src/backtest/BacktestResult.ts
+++ b/packages/trading-strategies/src/backtest/BacktestResult.ts
@@ -33,15 +33,15 @@ export interface BacktestPerformanceSummary {
   /** Return on investment as a percentage (e.g. "12.5" means 12.5%). */
   returnPercentage: Big;
   /**
-   * Mean candle-to-candle portfolio return divided by its standard deviation, or `undefined` when
-   * the equity curve leaves no deviation to divide by.
+   * Mean candle-to-candle portfolio return divided by its standard deviation, or `null` when the
+   * equity curve leaves no deviation to divide by.
    */
-  sharpeRatio: Big | undefined;
+  sharpeRatio: Big | null;
   /**
-   * Mean candle-to-candle portfolio return divided by its downside deviation, or `undefined` when
-   * the equity curve never declined.
+   * Mean candle-to-candle portfolio return divided by its downside deviation, or `null` when the
+   * equity curve never declined.
    */
-  sortinoRatio: Big | undefined;
+  sortinoRatio: Big | null;
   /** Total number of trades (buys + sells). */
   totalTrades: number;
   /** Ratio of profitable round-trip cycles (buy followed by sell at a higher effective price). */

--- a/packages/trading-strategies/src/backtest/BacktestResult.ts
+++ b/packages/trading-strategies/src/backtest/BacktestResult.ts
@@ -32,10 +32,16 @@ export interface BacktestPerformanceSummary {
   maxWinStreak: number;
   /** Return on investment as a percentage (e.g. "12.5" means 12.5%). */
   returnPercentage: Big;
-  /** Mean candle-to-candle portfolio return divided by its standard deviation. */
-  sharpeRatio: Big;
-  /** Mean candle-to-candle portfolio return divided by its downside deviation. */
-  sortinoRatio: Big;
+  /**
+   * Mean candle-to-candle portfolio return divided by its standard deviation, or `undefined` when
+   * the equity curve leaves no deviation to divide by.
+   */
+  sharpeRatio: Big | undefined;
+  /**
+   * Mean candle-to-candle portfolio return divided by its downside deviation, or `undefined` when
+   * the equity curve never declined.
+   */
+  sortinoRatio: Big | undefined;
   /** Total number of trades (buys + sells). */
   totalTrades: number;
   /** Ratio of profitable round-trip cycles (buy followed by sell at a higher effective price). */

--- a/packages/trading-strategies/src/backtest/BacktestResult.ts
+++ b/packages/trading-strategies/src/backtest/BacktestResult.ts
@@ -24,12 +24,18 @@ export interface BacktestPerformanceSummary {
   finalPortfolioValue: Big;
   /** Initial portfolio value in counter currency (base * firstOpen + counter). */
   initialPortfolioValue: Big;
+  /** Largest peak-to-trough decline of the portfolio equity curve, as a positive percentage. */
+  maxDrawdownPercentage: Big;
   /** Longest consecutive losing streak (round-trip cycles). */
   maxLossStreak: number;
   /** Longest consecutive winning streak (round-trip cycles). */
   maxWinStreak: number;
   /** Return on investment as a percentage (e.g. "12.5" means 12.5%). */
   returnPercentage: Big;
+  /** Mean candle-to-candle portfolio return divided by its standard deviation. */
+  sharpeRatio: Big;
+  /** Mean candle-to-candle portfolio return divided by its downside deviation. */
+  sortinoRatio: Big;
   /** Total number of trades (buys + sells). */
   totalTrades: number;
   /** Ratio of profitable round-trip cycles (buy followed by sell at a higher effective price). */

--- a/packages/trading-strategies/src/backtest/PerformanceCalculator.test.ts
+++ b/packages/trading-strategies/src/backtest/PerformanceCalculator.test.ts
@@ -6,8 +6,8 @@ describe('PerformanceCalculator risk-adjusted metrics', () => {
   it('calculates Sharpe and Sortino from consecutive equity returns', () => {
     const equityCurve = ['100', '110', '99', '118.8'].map(value => new Big(value));
 
-    expect(PerformanceCalculator.calculateSharpeRatio(equityCurve).toNumber()).toBeCloseTo(0.534522, 6);
-    expect(PerformanceCalculator.calculateSortinoRatio(equityCurve).toNumber()).toBeCloseTo(1.154701, 6);
+    expect(PerformanceCalculator.calculateSharpeRatio(equityCurve)?.toNumber()).toBeCloseTo(0.534522, 6);
+    expect(PerformanceCalculator.calculateSortinoRatio(equityCurve)?.toNumber()).toBeCloseTo(1.154701, 6);
   });
 
   it('calculates the largest peak-to-trough drawdown as a positive percentage', () => {
@@ -16,12 +16,47 @@ describe('PerformanceCalculator risk-adjusted metrics', () => {
     expect(PerformanceCalculator.calculateMaxDrawdown(equityCurve).toNumber()).toBeCloseTo(33.333333, 6);
   });
 
-  it('returns finite zeroes when a risk ratio has insufficient or zero-variance data', () => {
+  it('reports no risk ratio when insufficient or zero-variance data leaves nothing to divide by', () => {
     const flatEquityCurve = ['100', '100', '100'].map(value => new Big(value));
 
-    expect(PerformanceCalculator.calculateSharpeRatio([]).toFixed()).toBe('0');
-    expect(PerformanceCalculator.calculateSharpeRatio(flatEquityCurve).toFixed()).toBe('0');
-    expect(PerformanceCalculator.calculateSortinoRatio(flatEquityCurve).toFixed()).toBe('0');
-    expect(PerformanceCalculator.calculateMaxDrawdown(flatEquityCurve).toFixed()).toBe('0');
+    expect(
+      PerformanceCalculator.calculateSharpeRatio([]),
+      'a curve with fewer than two points yields no returns to measure'
+    ).toBeUndefined();
+    expect(
+      PerformanceCalculator.calculateSharpeRatio(flatEquityCurve),
+      'zero variance has no deviation'
+    ).toBeUndefined();
+    expect(
+      PerformanceCalculator.calculateSortinoRatio(flatEquityCurve),
+      'zero downside deviation has nothing to divide by'
+    ).toBeUndefined();
+    expect(
+      PerformanceCalculator.calculateMaxDrawdown(flatEquityCurve).toFixed(),
+      'a flat curve genuinely never declines, so zero is a real drawdown rather than a missing value'
+    ).toBe('0');
+  });
+
+  it('never ranks a curve without losses below one that lost money', () => {
+    const flawless = ['100', '101', '102', '103', '104'].map(value => new Big(value));
+    const lossy = ['100', '104', '99', '106', '104'].map(value => new Big(value));
+
+    expect(
+      PerformanceCalculator.calculateSortinoRatio(flawless),
+      'no losing candle means no downside deviation, so the ratio is absent rather than zero'
+    ).toBeUndefined();
+    expect(
+      PerformanceCalculator.calculateSortinoRatio(lossy)?.toNumber(),
+      'a curve that did lose money has a measurable downside, so it stays comparable'
+    ).toBeCloseTo(0.423669, 6);
+  });
+
+  it('reports no Sharpe ratio for a perfectly steady winner', () => {
+    const steadyGain = ['100', '110', '121'].map(value => new Big(value));
+
+    expect(
+      PerformanceCalculator.calculateSharpeRatio(steadyGain),
+      'a constant +10% per candle has zero variance, and zero would read as no edge at all'
+    ).toBeUndefined();
   });
 });

--- a/packages/trading-strategies/src/backtest/PerformanceCalculator.test.ts
+++ b/packages/trading-strategies/src/backtest/PerformanceCalculator.test.ts
@@ -1,0 +1,27 @@
+import Big from 'big.js';
+import {describe, expect, it} from 'vitest';
+import {PerformanceCalculator} from './PerformanceCalculator.js';
+
+describe('PerformanceCalculator risk-adjusted metrics', () => {
+  it('calculates Sharpe and Sortino from consecutive equity returns', () => {
+    const equityCurve = ['100', '110', '99', '118.8'].map(value => new Big(value));
+
+    expect(PerformanceCalculator.calculateSharpeRatio(equityCurve).toNumber()).toBeCloseTo(0.534522, 6);
+    expect(PerformanceCalculator.calculateSortinoRatio(equityCurve).toNumber()).toBeCloseTo(1.154701, 6);
+  });
+
+  it('calculates the largest peak-to-trough drawdown as a positive percentage', () => {
+    const equityCurve = ['100', '120', '90', '108', '80', '100'].map(value => new Big(value));
+
+    expect(PerformanceCalculator.calculateMaxDrawdown(equityCurve).toNumber()).toBeCloseTo(33.333333, 6);
+  });
+
+  it('returns finite zeroes when a risk ratio has insufficient or zero-variance data', () => {
+    const flatEquityCurve = ['100', '100', '100'].map(value => new Big(value));
+
+    expect(PerformanceCalculator.calculateSharpeRatio([]).toFixed()).toBe('0');
+    expect(PerformanceCalculator.calculateSharpeRatio(flatEquityCurve).toFixed()).toBe('0');
+    expect(PerformanceCalculator.calculateSortinoRatio(flatEquityCurve).toFixed()).toBe('0');
+    expect(PerformanceCalculator.calculateMaxDrawdown(flatEquityCurve).toFixed()).toBe('0');
+  });
+});

--- a/packages/trading-strategies/src/backtest/PerformanceCalculator.test.ts
+++ b/packages/trading-strategies/src/backtest/PerformanceCalculator.test.ts
@@ -22,15 +22,12 @@ describe('PerformanceCalculator risk-adjusted metrics', () => {
     expect(
       PerformanceCalculator.calculateSharpeRatio([]),
       'a curve with fewer than two points yields no returns to measure'
-    ).toBeUndefined();
-    expect(
-      PerformanceCalculator.calculateSharpeRatio(flatEquityCurve),
-      'zero variance has no deviation'
-    ).toBeUndefined();
+    ).toBeNull();
+    expect(PerformanceCalculator.calculateSharpeRatio(flatEquityCurve), 'zero variance has no deviation').toBeNull();
     expect(
       PerformanceCalculator.calculateSortinoRatio(flatEquityCurve),
       'zero downside deviation has nothing to divide by'
-    ).toBeUndefined();
+    ).toBeNull();
     expect(
       PerformanceCalculator.calculateMaxDrawdown(flatEquityCurve).toFixed(),
       'a flat curve genuinely never declines, so zero is a real drawdown rather than a missing value'
@@ -44,7 +41,7 @@ describe('PerformanceCalculator risk-adjusted metrics', () => {
     expect(
       PerformanceCalculator.calculateSortinoRatio(flawless),
       'no losing candle means no downside deviation, so the ratio is absent rather than zero'
-    ).toBeUndefined();
+    ).toBeNull();
     expect(
       PerformanceCalculator.calculateSortinoRatio(lossy)?.toNumber(),
       'a curve that did lose money has a measurable downside, so it stays comparable'
@@ -57,6 +54,6 @@ describe('PerformanceCalculator risk-adjusted metrics', () => {
     expect(
       PerformanceCalculator.calculateSharpeRatio(steadyGain),
       'a constant +10% per candle has zero variance, and zero would read as no edge at all'
-    ).toBeUndefined();
+    ).toBeNull();
   });
 });

--- a/packages/trading-strategies/src/backtest/PerformanceCalculator.ts
+++ b/packages/trading-strategies/src/backtest/PerformanceCalculator.ts
@@ -5,6 +5,57 @@ import type {BacktestTrade} from './BacktestResult.js';
 
 export class PerformanceCalculator {
   /**
+   * Calculates the unannualized Sharpe ratio from consecutive portfolio equity returns.
+   */
+  static calculateSharpeRatio(equityCurve: readonly Big[]): Big {
+    const returns = PerformanceCalculator.#calculateReturns(equityCurve);
+    if (returns.length === 0) {
+      return new Big(0);
+    }
+
+    const mean = PerformanceCalculator.#mean(returns);
+    const variance = returns.reduce((sum, value) => sum.plus(value.minus(mean).pow(2)), new Big(0)).div(returns.length);
+    return variance.eq(0) ? new Big(0) : mean.div(variance.sqrt());
+  }
+
+  /**
+   * Calculates the unannualized Sortino ratio using zero as the target return.
+   */
+  static calculateSortinoRatio(equityCurve: readonly Big[]): Big {
+    const returns = PerformanceCalculator.#calculateReturns(equityCurve);
+    if (returns.length === 0) {
+      return new Big(0);
+    }
+
+    const downsideVariance = returns
+      .reduce((sum, value) => sum.plus(value.lt(0) ? value.pow(2) : 0), new Big(0))
+      .div(returns.length);
+    return downsideVariance.eq(0) ? new Big(0) : PerformanceCalculator.#mean(returns).div(downsideVariance.sqrt());
+  }
+
+  /**
+   * Calculates the largest peak-to-trough portfolio decline as a positive percentage.
+   */
+  static calculateMaxDrawdown(equityCurve: readonly Big[]): Big {
+    let peak: Big | undefined;
+    let maxDrawdown = new Big(0);
+
+    for (const value of equityCurve) {
+      if (!peak || value.gt(peak)) {
+        peak = value;
+      }
+      if (peak.gt(0)) {
+        const drawdown = peak.minus(value).div(peak);
+        if (drawdown.gt(maxDrawdown)) {
+          maxDrawdown = drawdown;
+        }
+      }
+    }
+
+    return maxDrawdown.mul(100);
+  }
+
+  /**
    * Calculates win rate by pairing buy trades with subsequent sell trades into round-trip cycles.
    * A cycle is "won" when the volume-weighted average sell price exceeds the volume-weighted average buy price.
    */
@@ -84,5 +135,21 @@ export class PerformanceCalculator {
     }
 
     return cycles;
+  }
+
+  static #calculateReturns(equityCurve: readonly Big[]): Big[] {
+    const returns: Big[] = [];
+    for (let index = 1; index < equityCurve.length; index++) {
+      const previous = equityCurve[index - 1];
+      if (previous.eq(0)) {
+        continue;
+      }
+      returns.push(equityCurve[index].minus(previous).div(previous));
+    }
+    return returns;
+  }
+
+  static #mean(values: readonly Big[]): Big {
+    return values.reduce((sum, value) => sum.plus(value), new Big(0)).div(values.length);
   }
 }

--- a/packages/trading-strategies/src/backtest/PerformanceCalculator.ts
+++ b/packages/trading-strategies/src/backtest/PerformanceCalculator.ts
@@ -7,38 +7,38 @@ export class PerformanceCalculator {
   /**
    * Calculates the unannualized Sharpe ratio from consecutive portfolio equity returns.
    *
-   * Undefined when there is no deviation to divide by: fewer than two equity points, or a curve
-   * whose returns never vary. Zero is not a usable stand-in, because zero already reads as "no
-   * edge" — it would score a perfectly steady winner the same as a strategy that never traded.
+   * `null` when there is no deviation to divide by: fewer than two equity points, or a curve whose
+   * returns never vary. Zero is not a usable stand-in, because zero already reads as "no edge" — it
+   * would score a perfectly steady winner the same as a strategy that never traded.
    */
-  static calculateSharpeRatio(equityCurve: readonly Big[]): Big | undefined {
+  static calculateSharpeRatio(equityCurve: readonly Big[]): Big | null {
     const returns = PerformanceCalculator.#calculateReturns(equityCurve);
     if (returns.length === 0) {
-      return undefined;
+      return null;
     }
 
     const mean = PerformanceCalculator.#mean(returns);
     const variance = returns.reduce((sum, value) => sum.plus(value.minus(mean).pow(2)), new Big(0)).div(returns.length);
-    return variance.eq(0) ? undefined : mean.div(variance.sqrt());
+    return variance.eq(0) ? null : mean.div(variance.sqrt());
   }
 
   /**
    * Calculates the unannualized Sortino ratio using zero as the target return.
    *
-   * Undefined when the curve has no downside deviation to divide by. Zero is not a usable stand-in:
-   * a curve without a single losing candle would rank below one that lost money, inverting the
+   * `null` when the curve has no downside deviation to divide by. Zero is not a usable stand-in: a
+   * curve without a single losing candle would rank below one that lost money, inverting the
    * comparison this metric exists to make.
    */
-  static calculateSortinoRatio(equityCurve: readonly Big[]): Big | undefined {
+  static calculateSortinoRatio(equityCurve: readonly Big[]): Big | null {
     const returns = PerformanceCalculator.#calculateReturns(equityCurve);
     if (returns.length === 0) {
-      return undefined;
+      return null;
     }
 
     const downsideVariance = returns
       .reduce((sum, value) => sum.plus(value.lt(0) ? value.pow(2) : 0), new Big(0))
       .div(returns.length);
-    return downsideVariance.eq(0) ? undefined : PerformanceCalculator.#mean(returns).div(downsideVariance.sqrt());
+    return downsideVariance.eq(0) ? null : PerformanceCalculator.#mean(returns).div(downsideVariance.sqrt());
   }
 
   /**

--- a/packages/trading-strategies/src/backtest/PerformanceCalculator.ts
+++ b/packages/trading-strategies/src/backtest/PerformanceCalculator.ts
@@ -6,31 +6,39 @@ import type {BacktestTrade} from './BacktestResult.js';
 export class PerformanceCalculator {
   /**
    * Calculates the unannualized Sharpe ratio from consecutive portfolio equity returns.
+   *
+   * Undefined when there is no deviation to divide by: fewer than two equity points, or a curve
+   * whose returns never vary. Zero is not a usable stand-in, because zero already reads as "no
+   * edge" — it would score a perfectly steady winner the same as a strategy that never traded.
    */
-  static calculateSharpeRatio(equityCurve: readonly Big[]): Big {
+  static calculateSharpeRatio(equityCurve: readonly Big[]): Big | undefined {
     const returns = PerformanceCalculator.#calculateReturns(equityCurve);
     if (returns.length === 0) {
-      return new Big(0);
+      return undefined;
     }
 
     const mean = PerformanceCalculator.#mean(returns);
     const variance = returns.reduce((sum, value) => sum.plus(value.minus(mean).pow(2)), new Big(0)).div(returns.length);
-    return variance.eq(0) ? new Big(0) : mean.div(variance.sqrt());
+    return variance.eq(0) ? undefined : mean.div(variance.sqrt());
   }
 
   /**
    * Calculates the unannualized Sortino ratio using zero as the target return.
+   *
+   * Undefined when the curve has no downside deviation to divide by. Zero is not a usable stand-in:
+   * a curve without a single losing candle would rank below one that lost money, inverting the
+   * comparison this metric exists to make.
    */
-  static calculateSortinoRatio(equityCurve: readonly Big[]): Big {
+  static calculateSortinoRatio(equityCurve: readonly Big[]): Big | undefined {
     const returns = PerformanceCalculator.#calculateReturns(equityCurve);
     if (returns.length === 0) {
-      return new Big(0);
+      return undefined;
     }
 
     const downsideVariance = returns
       .reduce((sum, value) => sum.plus(value.lt(0) ? value.pow(2) : 0), new Big(0))
       .div(returns.length);
-    return downsideVariance.eq(0) ? new Big(0) : PerformanceCalculator.#mean(returns).div(downsideVariance.sqrt());
+    return downsideVariance.eq(0) ? undefined : PerformanceCalculator.#mean(returns).div(downsideVariance.sqrt());
   }
 
   /**


### PR DESCRIPTION
## Summary

- track portfolio equity at the initial open and after every processed candle
- add Sharpe ratio, Sortino ratio, and maximum drawdown to the backtest performance summary
- include held balances in equity so pending orders do not create artificial drawdowns

The ratios use consecutive candle-to-candle portfolio returns and remain
unannualized because the executor accepts arbitrary candle intervals. Sortino
uses zero as its target return, while maximum drawdown is reported as a positive
peak-to-trough percentage. Degenerate inputs return finite zeroes instead of
`NaN` or infinity.

Tests cover closed-form metric examples, flat and insufficient curves, the
executor's candle-by-candle integration, and valuation while an order balance
is held.

Closes #1196.

## Verification

- `npm run lint`
- `npm test` (160 test files, 1740 tests)
