### PR TITLE
refactor(exchange): declare Trading212 retry policy per endpoint with a @retry decorator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@types/node": "^26.1.0",
         "@vitest/coverage-v8": "^4.0.18",
         "conventional-changelog-conventionalcommits": "^10.4.0",
+        "esbuild": ">=0.25.0",
         "github-actionlint": "^1.7.12",
         "jsdom": "^30.0.0",
         "knip": "^6.29.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@types/node": "^26.1.0",
     "@vitest/coverage-v8": "^4.0.18",
     "conventional-changelog-conventionalcommits": "^10.4.0",
+    "esbuild": ">=0.25.0",
     "github-actionlint": "^1.7.12",
     "jsdom": "^30.0.0",
     "knip": "^6.29.0",

--- a/packages/exchange/src/broker/trading212/api/Trading212API.ts
+++ b/packages/exchange/src/broker/trading212/api/Trading212API.ts
@@ -1,6 +1,6 @@
-import axios, {type AxiosDefaults, type AxiosError, type AxiosInstance} from 'axios';
-import axiosRetry from 'axios-retry';
+import axios, {type AxiosDefaults, type AxiosInstance} from 'axios';
 import {z} from 'zod';
+import {retry} from '../../../util/retry.js';
 import {simplifyError} from '../../../util/simplifyError.js';
 import {AccountCashSchema, AccountInfoSchema} from './schema/AccountSchema.js';
 import {HistoryOrderPageSchema, type HistoryOrder} from './schema/HistoryOrderSchema.js';
@@ -26,42 +26,11 @@ const URL = {
 } as const;
 
 /**
- * Per-endpoint retry delays (ms) calibrated to Trading212's documented rate limits.
+ * The `@retry` delay on each method is calibrated to Trading212's documented rate limit
+ * for that endpoint.
  *
  * @see https://t212public-api-docs.redoc.ly/
  */
-function getRetryDelay(retryCount: number, error: AxiosError) {
-  const url = error.config?.url ?? '';
-  const method = error.config?.method;
-
-  if (method === 'get' && url.startsWith(`${URL.ORDERS}/`)) {
-    return 1_000;
-  }
-
-  /*
-   * HISTORY_ORDERS pagination follows vendor-supplied `nextPagePath` URLs that include a
-   * query string (e.g. "/api/v0/equity/history/orders?cursor=…"), so a strict `===` match
-   * would miss every page after the first and fall through to the 1s default.
-   */
-  if (url.startsWith(URL.HISTORY_ORDERS)) {
-    return 60_000;
-  }
-
-  switch (url) {
-    case URL.ACCOUNT_CASH:
-      return 2_000;
-    case URL.ORDERS:
-    case URL.PORTFOLIO:
-      return 5_000;
-    case URL.ACCOUNT_INFO:
-      return 30_000;
-    case URL.METADATA_INSTRUMENTS:
-      return 50_000;
-    default:
-      return retryCount * 1_000;
-  }
-}
-
 export class Trading212API {
   static readonly URL = URL;
 
@@ -82,14 +51,6 @@ export class Trading212API {
       return config;
     });
 
-    axiosRetry(this.#httpClient, {
-      retries: Infinity,
-      retryCondition: (error: AxiosError) => {
-        return axiosRetry.isRetryableError(error);
-      },
-      retryDelay: getRetryDelay,
-    });
-
     simplifyError(this.#httpClient);
   }
 
@@ -102,47 +63,55 @@ export class Trading212API {
   }
 
   /** @see https://t212public-api-docs.redoc.ly/#operation/accountCash */
+  @retry({delayMs: 2_000})
   async getAccountCash() {
     const response = await this.#httpClient.get(URL.ACCOUNT_CASH);
     return AccountCashSchema.parse(response.data);
   }
 
   /** @see https://t212public-api-docs.redoc.ly/#operation/account */
+  @retry({delayMs: 30_000})
   async getAccountInfo() {
     const response = await this.#httpClient.get(URL.ACCOUNT_INFO);
     return AccountInfoSchema.parse(response.data);
   }
 
   /** @see https://t212public-api-docs.redoc.ly/#operation/portfolio */
+  @retry({delayMs: 5_000})
   async getPositions() {
     const response = await this.#httpClient.get(URL.PORTFOLIO);
     return z.array(PositionSchema).parse(response.data);
   }
 
   /** @see https://t212public-api-docs.redoc.ly/#operation/positionByTicker */
+  @retry()
   async getPositionByTicker(ticker: string) {
     const response = await this.#httpClient.get(`${URL.PORTFOLIO}/${ticker}`);
     return PositionSchema.parse(response.data);
   }
 
   /** @see https://t212public-api-docs.redoc.ly/#operation/orders */
+  @retry({delayMs: 5_000})
   async getOrders() {
     const response = await this.#httpClient.get(URL.ORDERS);
     return z.array(OrderSchema).parse(response.data);
   }
 
   /** @see https://t212public-api-docs.redoc.ly/#operation/orderById */
+  @retry({delayMs: 1_000})
   async getOrderById(id: number) {
     const response = await this.#httpClient.get(`${URL.ORDERS}/${id}`);
     return OrderSchema.parse(response.data);
   }
 
   /** @see https://t212public-api-docs.redoc.ly/#operation/cancelOrder */
+  @retry()
   async cancelOrder(id: number): Promise<void> {
     await this.#httpClient.delete(`${URL.ORDERS}/${id}`);
   }
 
   /** @see https://t212public-api-docs.redoc.ly/#operation/placeMarketOrder */
+  @retry()
   async placeMarketOrder(request: PlaceMarketOrderRequest) {
     const validated = PlaceMarketOrderRequestSchema.parse(request);
     const response = await this.#httpClient.post(URL.ORDERS_MARKET, validated);
@@ -150,6 +119,7 @@ export class Trading212API {
   }
 
   /** @see https://t212public-api-docs.redoc.ly/#operation/placeLimitOrder */
+  @retry()
   async placeLimitOrder(request: PlaceLimitOrderRequest) {
     const validated = PlaceLimitOrderRequestSchema.parse(request);
     const response = await this.#httpClient.post(URL.ORDERS_LIMIT, validated);
@@ -157,6 +127,7 @@ export class Trading212API {
   }
 
   /** @see https://t212public-api-docs.redoc.ly/#operation/instruments */
+  @retry({delayMs: 50_000})
   async getInstruments() {
     const response = await this.#httpClient.get(URL.METADATA_INSTRUMENTS);
     return z.array(InstrumentSchema).parse(response.data);
@@ -169,6 +140,7 @@ export class Trading212API {
    *
    * @see https://t212public-api-docs.redoc.ly/#operation/orders_1
    */
+  @retry({delayMs: 60_000})
   async getHistoryOrdersPage(options?: {nextPath?: string; ticker?: string}) {
     if (options?.nextPath) {
       const response = await this.#httpClient.get(options.nextPath);
@@ -183,25 +155,20 @@ export class Trading212API {
   }
 
   /**
-   * Fetches all historical orders (auto-paginates via `nextPagePath`).
+   * Fetches all historical orders (auto-paginates via `nextPagePath`). Deliberately not decorated
+   * with `@retry` - each page is fetched through {@link getHistoryOrdersPage}, so a transient
+   * failure retries only the affected page instead of restarting the whole pagination.
    *
    * @see https://t212public-api-docs.redoc.ly/#operation/orders_1
    */
   async getHistoryOrders(ticker?: string): Promise<HistoryOrder[]> {
     const items: HistoryOrder[] = [];
-    let nextPath: string | null = null;
-    const params: Record<string, string> = {limit: '50'};
-    if (ticker) {
-      params.ticker = ticker;
-    }
+    let nextPath: string | undefined = undefined;
 
     do {
-      const response = nextPath
-        ? await this.#httpClient.get(nextPath)
-        : await this.#httpClient.get(URL.HISTORY_ORDERS, {params});
-      const page = HistoryOrderPageSchema.parse(response.data);
+      const page = await this.getHistoryOrdersPage({nextPath, ticker});
       items.push(...page.items);
-      nextPath = page.nextPagePath;
+      nextPath = page.nextPagePath ?? undefined;
     } while (nextPath);
 
     return items;

--- a/packages/exchange/src/util/retry.test.ts
+++ b/packages/exchange/src/util/retry.test.ts
@@ -1,0 +1,156 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {retry} from './retry.js';
+import {SimplifiedHttpError} from './SimplifiedHttpError.js';
+
+function rateLimitError() {
+  return new SimplifiedHttpError({data: 'Too Many Requests', status: 429});
+}
+
+// Sequential: fake timers are process-global, so concurrently running tests would advance each other's clocks.
+describe.sequential('retry', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('retries transient failures until the method succeeds', async () => {
+    const attempts = vi.fn();
+
+    class Api {
+      @retry({delayMs: 1_000})
+      async load() {
+        attempts();
+        if (attempts.mock.calls.length < 3) {
+          throw rateLimitError();
+        }
+        return 'ok';
+      }
+    }
+
+    const pending = new Api().load();
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    await expect(pending).resolves.toBe('ok');
+    expect(attempts).toHaveBeenCalledTimes(3);
+  });
+
+  it('retries network failures, which arrive with status 0', async () => {
+    const attempts = vi.fn();
+
+    class Api {
+      @retry({delayMs: 1_000})
+      async load() {
+        attempts();
+        if (attempts.mock.calls.length < 2) {
+          throw new SimplifiedHttpError({data: 'EAI_AGAIN', status: undefined});
+        }
+        return 'ok';
+      }
+    }
+
+    const pending = new Api().load();
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await expect(pending).resolves.toBe('ok');
+    expect(attempts).toHaveBeenCalledTimes(2);
+  });
+
+  it('rethrows non-retryable errors without retrying', async () => {
+    const attempts = vi.fn();
+    const badRequest = new SimplifiedHttpError({data: 'Bad Request', status: 400});
+
+    class Api {
+      @retry()
+      async load() {
+        attempts();
+        throw badRequest;
+      }
+    }
+
+    await expect(new Api().load()).rejects.toBe(badRequest);
+    expect(attempts, 'a 400 is a client mistake that repeating cannot fix').toHaveBeenCalledTimes(1);
+  });
+
+  it('gives up once the retry limit is exhausted', async () => {
+    const attempts = vi.fn();
+
+    class Api {
+      @retry({delayMs: 10, retries: 2})
+      async load() {
+        attempts();
+        throw rateLimitError();
+      }
+    }
+
+    const pending = new Api().load();
+    const assertion = expect(pending).rejects.toBeInstanceOf(SimplifiedHttpError);
+    await vi.advanceTimersByTimeAsync(20);
+
+    await assertion;
+    expect(attempts, 'the initial call plus two retries').toHaveBeenCalledTimes(3);
+  });
+
+  it('waits according to the attempt-based delay function', async () => {
+    const attempts = vi.fn();
+
+    class Api {
+      @retry({delayMs: attempt => attempt * 500})
+      async load() {
+        attempts();
+        if (attempts.mock.calls.length < 3) {
+          throw rateLimitError();
+        }
+        return 'ok';
+      }
+    }
+
+    const pending = new Api().load();
+
+    await vi.advanceTimersByTimeAsync(499);
+    expect(attempts, 'the first retry waits 500 ms').toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(attempts).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await expect(pending).resolves.toBe('ok');
+    expect(attempts, 'the second retry waits 1000 ms').toHaveBeenCalledTimes(3);
+  });
+
+  it('honors a custom retry predicate', async () => {
+    const attempts = vi.fn();
+
+    class Api {
+      @retry({delayMs: 10, isRetryable: error => error instanceof RangeError, retries: 5})
+      async load() {
+        attempts();
+        if (attempts.mock.calls.length < 2) {
+          throw new RangeError('out of range');
+        }
+        return 'ok';
+      }
+    }
+
+    const pending = new Api().load();
+    await vi.advanceTimersByTimeAsync(10);
+
+    await expect(pending).resolves.toBe('ok');
+    expect(attempts).toHaveBeenCalledTimes(2);
+  });
+
+  it('preserves access to private fields of the decorated instance', async () => {
+    class Api {
+      readonly #token = 'secret';
+
+      @retry()
+      async whoAmI() {
+        return this.#token;
+      }
+    }
+
+    await expect(new Api().whoAmI()).resolves.toBe('secret');
+  });
+});

--- a/packages/exchange/src/util/retry.ts
+++ b/packages/exchange/src/util/retry.ts
@@ -1,0 +1,54 @@
+import {SimplifiedHttpError} from './SimplifiedHttpError.js';
+
+type AsyncMethod<This, Args extends unknown[], Result> = (this: This, ...args: Args) => Promise<Result>;
+
+export interface RetryOptions {
+  /** Fixed delay in milliseconds, or a function of the attempt number (starting at 1). Defaults to `attempt * 1_000`. */
+  delayMs?: number | ((attempt: number) => number);
+  /** Defaults to retrying transient HTTP failures: network errors, 429 rate limits and 5xx responses. */
+  isRetryable?: (error: unknown) => boolean;
+  /** Defaults to `Infinity`. */
+  retries?: number;
+}
+
+/**
+ * Transient failures as normalized by `simplifyError`: network errors (status `0`), 429 rate limits
+ * and 5xx responses.
+ */
+function isTransientHttpError(error: unknown) {
+  if (!(error instanceof SimplifiedHttpError)) {
+    return false;
+  }
+  return error.status === 0 || error.status === 429 || (error.status >= 500 && error.status <= 599);
+}
+
+/**
+ * Method decorator (TC39 standard mode) that retries transient failures. It lets each API method
+ * declare its own rate limit policy right where the endpoint is called, instead of maintaining a
+ * URL matching table in a shared HTTP interceptor that can silently fall out of sync with the
+ * methods it covers.
+ */
+export function retry({
+  delayMs = attempt => attempt * 1_000,
+  isRetryable = isTransientHttpError,
+  retries = Infinity,
+}: RetryOptions = {}) {
+  return function <This, Args extends unknown[], Result>(
+    target: AsyncMethod<This, Args, Result>,
+    _context: ClassMethodDecoratorContext<This, AsyncMethod<This, Args, Result>>
+  ): AsyncMethod<This, Args, Result> {
+    return async function (this: This, ...args: Args): Promise<Result> {
+      for (let attempt = 1; ; attempt++) {
+        try {
+          return await target.apply(this, args);
+        } catch (error) {
+          if (attempt > retries || !isRetryable(error)) {
+            throw error;
+          }
+          const delay = typeof delayMs === 'function' ? delayMs(attempt) : delayMs;
+          await new Promise(resolve => setTimeout(resolve, delay));
+        }
+      }
+    };
+  };
+}

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -1,9 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "emitDecoratorMetadata": false,
     "erasableSyntaxOnly": true,
-    "experimentalDecorators": true,
     "forceConsistentCasingInFileNames": true,
     "lib": ["es2025"],
     "module": "node20",

--- a/vitest.shared.ts
+++ b/vitest.shared.ts
@@ -1,13 +1,35 @@
+import {transform} from 'esbuild';
 import {defineConfig} from 'vitest/config';
+
+/*
+ * Allows using the "accessor" keyword in TypeScript:
+ * https://github.com/vitest-dev/vitest/issues/5976#issuecomment-2190804966
+ */
+const target = 'es2022';
 
 export default defineConfig({
   esbuild: {
-    /*
-     * Allows using the "accessor" keyword in TypeScript:
-     * https://github.com/vitest-dev/vitest/issues/5976#issuecomment-2190804966
-     */
-    target: 'es2022',
+    target,
   },
+  plugins: [
+    {
+      enforce: 'pre',
+      name: 'standard-decorators',
+      /*
+       * oxc (the transformer behind Vitest 4) can only downlevel legacy `experimentalDecorators`,
+       * not TC39 standard decorators, so decorator-bearing files would reach Node as raw decorator
+       * syntax and fail to parse. esbuild (already installed via tsx) downlevels them; scoped to
+       * files that actually use decorators so everything else stays on oxc. Drop this plugin once
+       * oxc ships standard-decorator support.
+       */
+      async transform(code, id) {
+        if (!/\.tsx?$/.test(id) || !/^\s*@[A-Za-z_$]/m.test(code)) {
+          return null;
+        }
+        return transform(code, {loader: 'ts', sourcefile: id, sourcemap: true, target});
+      },
+    },
+  ],
   test: {
     bail: 1,
     coverage: {

--- a/vitest.shared.ts
+++ b/vitest.shared.ts
@@ -19,8 +19,11 @@ export default defineConfig({
        * oxc (the transformer behind Vitest 4) can only downlevel legacy `experimentalDecorators`,
        * not TC39 standard decorators, so decorator-bearing files would reach Node as raw decorator
        * syntax and fail to parse. esbuild (already installed via tsx) downlevels them; scoped to
-       * files that actually use decorators so everything else stays on oxc. Drop this plugin once
-       * oxc ships standard-decorator support.
+       * files that actually use decorators so everything else stays on oxc.
+       *
+       * This is not a short-lived bridge: oxc has deferred standard decorators until the spec
+       * stabilizes, and the proposal has since moved back to Stage 2.7. Drop the plugin when
+       * https://github.com/oxc-project/oxc/issues/9170 closes.
        */
       async transform(code, id) {
         if (!/\.tsx?$/.test(id) || !/^\s*@[A-Za-z_$]/m.test(code)) {


### PR DESCRIPTION
## Why

`Trading212API` configured retries through an `axios-retry` interceptor whose `getRetryDelay` had to reverse-map a failed request's URL back to a policy. That design already produced one silent bug — a strict `===` match missed the paginated `nextPagePath` URLs, which is why the function carried an apology comment — and every new endpoint risked quietly falling through to the default delay.

## What

Each method now declares its own rate limit policy right where the endpoint is called, using a `@retry` method decorator (TC39 standard mode, `packages/exchange/src/util/retry.ts`):

```ts
/** @see https://t212public-api-docs.redoc.ly/#operation/accountCash */
@retry({delayMs: 2_000})
async getAccountCash() { ... }
```

- The per-endpoint delays are carried over 1:1 from the old table.
- The default retry predicate matches the old `axiosRetry.isRetryableError` set — network errors, 429, 5xx — expressed as `SimplifiedHttpError` statuses, since `simplifyError` normalizes errors at the interceptor level.
- `getHistoryOrders` pages through the decorated `getHistoryOrdersPage` instead of duplicating the pagination loop. A transient failure now retries only the affected page rather than restarting the whole pagination.

`AlpacaAPI` and `isEarningsDay` are untouched and keep using `axios-retry`, so the dependency stays.

## Toolchain

- Dropped `experimentalDecorators` and the vestigial `emitDecoratorMetadata` from `tsconfig.lib.json`. No legacy decorators exist in the repo, and the flag forces legacy semantics that break standard-mode decorators.
- Added a scoped pre-transform plugin to `vitest.shared.ts`: oxc (the transformer behind Vitest 4) cannot downlevel standard decorators, so decorator-bearing files route through esbuild, which is now a declared devDependency instead of a transitive one. Without it the decorated tests die with `SyntaxError: Invalid or unexpected token`, since V8 has no native decorator support either. oxc has deferred standard decorators until the spec stabilizes (oxc-project/oxc#9170) and the proposal has since moved back to Stage 2.7, so the plugin stays until that issue closes. `tsc` handles the decorators on its own, so the published `dist/` is unaffected.

## Behavior notes

- Order placement and cancellation keep the previous default backoff of `attempt × 1s`.
- `ECONNABORTED` timeouts now retry where `axios-retry` excluded them. Moot, since the client configures no timeout.

## Verified

Typecheck and tests green across all packages, eslint and knip clean, `tsc` emit plus a runtime smoke test of the built `dist/` class against a local server that returns 429 twice (retried with the right delays) and then 400 (rejected immediately), and `tsx` demo scripts still load the decorated class.

