### PR TITLE
chore: move the Vitest transform target from esbuild to oxc

### DIFF
--- a/vitest.shared.ts
+++ b/vitest.shared.ts
@@ -1,11 +1,13 @@
 import {transform} from 'esbuild';
 import {defineConfig} from 'vitest/config';
+import tsconfig from './tsconfig.lib.json';
 
 /*
- * Keeps tests on the same language level that ships in `dist` (the `target` in tsconfig.lib.json)
- * rather than Vitest's older default, and keeps the decorator transform below in step with it.
+ * Keeps tests on the same language level that ships in `dist` rather than Vitest's older default,
+ * and keeps the decorator transform below in step with it. Read from the tsconfig so the two
+ * cannot drift apart.
  */
-const target = 'es2022';
+const target = tsconfig.compilerOptions.target;
 
 export default defineConfig({
   oxc: {

--- a/vitest.shared.ts
+++ b/vitest.shared.ts
@@ -2,13 +2,13 @@ import {transform} from 'esbuild';
 import {defineConfig} from 'vitest/config';
 
 /*
- * Allows using the "accessor" keyword in TypeScript:
- * https://github.com/vitest-dev/vitest/issues/5976#issuecomment-2190804966
+ * Keeps tests on the same language level that ships in `dist` (the `target` in tsconfig.lib.json)
+ * rather than Vitest's older default, and keeps the decorator transform below in step with it.
  */
 const target = 'es2022';
 
 export default defineConfig({
-  esbuild: {
+  oxc: {
     target,
   },
   plugins: [

--- a/vitest.shared.ts
+++ b/vitest.shared.ts
@@ -1,6 +1,6 @@
 import {transform} from 'esbuild';
 import {defineConfig} from 'vitest/config';
-import tsconfig from './tsconfig.lib.json';
+import tsconfig from './tsconfig.lib.json' with {type: 'json'};
 
 /*
  * Keeps tests on the same language level that ships in `dist` rather than Vitest's older default,


### PR DESCRIPTION
## Why

Vitest 4 transforms with oxc, which ignores the `esbuild` block entirely — every test run printed:

```
Both esbuild and oxc options were set. oxc options will be used and esbuild options will be ignored.
The following esbuild options were set: `{ target: 'es2022' }`
```

So the target was dead config, and the `accessor` keyword its comment pointed at is no longer used anywhere in the repo.

## What

Vite deprecates the `esbuild` option in favour of `oxc`, so the target moves there. It now actually applies: with `oxc`, a bad target fails the bundler (`BUNDLER_INITIALIZE_ERROR`), where the `esbuild` block silently discarded it.

The value is no longer hardcoded: it is imported from `tsconfig.lib.json`, so the test transform and the shipped `dist/` cannot drift apart when the tsconfig target is bumped. The decorator pre-transform plugin added in #1348 reads the same constant, so both transforms stay in step.

`vitest.shared.ts` is not covered by any `tsc` project (there is no root `tsconfig.json`), and oxc types `target` as `string | string[]`, so the JSON import needs no extra typing.

## Verified

Warning gone, tests green across all packages, lint and knip clean. Confirmed the option is live both ways: a bad target in `tsconfig.lib.json` now fails the run with `BUNDLER_INITIALIZE_ERROR`, where the old `esbuild` block swallowed it.
