### PR TITLE
fix(@typedtrader/exchange): report crypto commissions on Alpaca fills

### DIFF
--- a/packages/exchange/src/broker/Broker.ts
+++ b/packages/exchange/src/broker/Broker.ts
@@ -318,7 +318,8 @@ export abstract class Broker extends EventEmitter {
   async estimateFee(
     pair: TradingPair,
     orderType: OrderType,
-    notional: Big
+    notional: Big,
+    side: OrderSide
   ): Promise<{commission: Big; currencyConversion: Big; total: Big; feeAsset: string}> {
     const rates = await this.getFeeRates(pair);
     const commission = notional.times(rates[orderType]);
@@ -327,7 +328,7 @@ export abstract class Broker extends EventEmitter {
     return {
       commission,
       currencyConversion,
-      feeAsset: await this.getFeeAsset(pair),
+      feeAsset: await this.getFeeAsset(pair, side),
       total: commission.plus(currencyConversion),
     };
   }
@@ -336,8 +337,11 @@ export abstract class Broker extends EventEmitter {
    * The currency in which broker fees are debited. Defaults to `pair.counter`; brokers
    * with cross-currency accounts (e.g. Trading212 EUR account trading USD instruments)
    * override this to return the account currency.
+   *
+   * `side` matters on venues that bill out of the asset you are credited with: Alpaca takes a
+   * crypto BUY fee in the base asset and a SELL fee in the counter.
    */
-  protected async getFeeAsset(pair: TradingPair) {
+  protected async getFeeAsset(pair: TradingPair, _side: OrderSide) {
     return pair.counter;
   }
 

--- a/packages/exchange/src/broker/Broker.ts
+++ b/packages/exchange/src/broker/Broker.ts
@@ -95,15 +95,6 @@ export interface FeeRate {
   CURRENCY_CONVERSION_FEE?: Big;
 }
 
-export interface FeeEstimateRequest {
-  orderType: OrderType;
-  /** Expected execution price, in counter units per base unit. */
-  price: Big.BigSource;
-  /** Order size in base units. */
-  quantity: Big.BigSource;
-  side: OrderSide;
-}
-
 export const OrderPosition = {
   LONG: 'LONG',
   SHORT: 'SHORT',
@@ -311,47 +302,6 @@ export abstract class Broker extends EventEmitter {
   async getFeeRate(pair: TradingPair, orderType: OrderType): Promise<Big> {
     const feeRate = await this.getFeeRates(pair);
     return feeRate[orderType];
-  }
-
-  /**
-   * Expected cost of one order leg, so a strategy can decide whether a price move covers the
-   * round trip.
-   *
-   * **Always denominated in `pair.counter`, whatever asset the broker actually debits.** Some
-   * venues take the fee out of the asset they credit you with — Alpaca bills a crypto BUY in the
-   * base asset — but a cost estimate is only useful when every leg is expressed in one currency,
-   * so those are converted at `price` rather than reported in their native unit. Ask
-   * {@link getFeeAsset} for the asset a fee is charged in.
-   *
-   * This is the *expected* fee. Realised fees arrive on `Fill.fee` and may differ (broker-side
-   * spreads, FX variation, maker/taker classification).
-   */
-  async estimateFee(
-    pair: TradingPair,
-    request: FeeEstimateRequest
-  ): Promise<{commission: Big; currencyConversion: Big; total: Big; feeAsset: string}> {
-    const rates = await this.getFeeRates(pair);
-    const notional = new Big(request.quantity).times(request.price);
-    const commission = notional.times(rates[request.orderType]);
-    const conversionRate = rates.CURRENCY_CONVERSION_FEE;
-    const currencyConversion = conversionRate ? notional.times(conversionRate) : new Big(0);
-    return {
-      commission,
-      currencyConversion,
-      feeAsset: pair.counter,
-      total: commission.plus(currencyConversion),
-    };
-  }
-
-  /**
-   * The asset a fee is debited from, which is not always `pair.counter`.
-   *
-   * Brokers with cross-currency accounts (a Trading212 EUR account trading USD instruments) charge
-   * in the account currency, and venues that bill out of the credited asset depend on the side —
-   * Alpaca takes a crypto BUY fee in the base asset and a SELL fee in the counter.
-   */
-  async getFeeAsset(pair: TradingPair, _side: OrderSide) {
-    return pair.counter;
   }
 
   /**

--- a/packages/exchange/src/broker/Broker.ts
+++ b/packages/exchange/src/broker/Broker.ts
@@ -95,6 +95,15 @@ export interface FeeRate {
   CURRENCY_CONVERSION_FEE?: Big;
 }
 
+export interface FeeEstimateRequest {
+  orderType: OrderType;
+  /** Expected execution price, in counter units per base unit. */
+  price: Big.BigSource;
+  /** Order size in base units. */
+  quantity: Big.BigSource;
+  side: OrderSide;
+}
+
 export const OrderPosition = {
   LONG: 'LONG',
   SHORT: 'SHORT',
@@ -305,43 +314,43 @@ export abstract class Broker extends EventEmitter {
   }
 
   /**
-   * Estimate the per-leg fee for a single order before placing it. Strategies use this to
-   * decide whether an expected price move covers round-trip costs. The estimate combines
-   * the order-type commission rate and (when applicable) the currency-conversion rate.
+   * Expected cost of one order leg, so a strategy can decide whether a price move covers the
+   * round trip.
    *
-   * `feeAsset` is the currency the fee will actually be debited in — typically the account
-   * currency, which can differ from `pair.counter` on cross-currency accounts.
+   * **Always denominated in `pair.counter`, whatever asset the broker actually debits.** Some
+   * venues take the fee out of the asset they credit you with — Alpaca bills a crypto BUY in the
+   * base asset — but a cost estimate is only useful when every leg is expressed in one currency,
+   * so those are converted at `price` rather than reported in their native unit. Ask
+   * {@link getFeeAsset} for the asset a fee is charged in.
    *
-   * Returns the *expected* fee. Actual realised fees come back on `Fill.fee` after the
-   * order executes and may differ slightly (broker-side spreads, FX rate variation).
+   * This is the *expected* fee. Realised fees arrive on `Fill.fee` and may differ (broker-side
+   * spreads, FX variation, maker/taker classification).
    */
   async estimateFee(
     pair: TradingPair,
-    orderType: OrderType,
-    notional: Big,
-    side: OrderSide
+    request: FeeEstimateRequest
   ): Promise<{commission: Big; currencyConversion: Big; total: Big; feeAsset: string}> {
     const rates = await this.getFeeRates(pair);
-    const commission = notional.times(rates[orderType]);
+    const notional = new Big(request.quantity).times(request.price);
+    const commission = notional.times(rates[request.orderType]);
     const conversionRate = rates.CURRENCY_CONVERSION_FEE;
     const currencyConversion = conversionRate ? notional.times(conversionRate) : new Big(0);
     return {
       commission,
       currencyConversion,
-      feeAsset: await this.getFeeAsset(pair, side),
+      feeAsset: pair.counter,
       total: commission.plus(currencyConversion),
     };
   }
 
   /**
-   * The currency in which broker fees are debited. Defaults to `pair.counter`; brokers
-   * with cross-currency accounts (e.g. Trading212 EUR account trading USD instruments)
-   * override this to return the account currency.
+   * The asset a fee is debited from, which is not always `pair.counter`.
    *
-   * `side` matters on venues that bill out of the asset you are credited with: Alpaca takes a
-   * crypto BUY fee in the base asset and a SELL fee in the counter.
+   * Brokers with cross-currency accounts (a Trading212 EUR account trading USD instruments) charge
+   * in the account currency, and venues that bill out of the credited asset depend on the side —
+   * Alpaca takes a crypto BUY fee in the base asset and a SELL fee in the counter.
    */
-  protected async getFeeAsset(pair: TradingPair, _side: OrderSide) {
+  async getFeeAsset(pair: TradingPair, _side: OrderSide) {
     return pair.counter;
   }
 

--- a/packages/exchange/src/broker/alpaca/AlpacaBroker.test.ts
+++ b/packages/exchange/src/broker/alpaca/AlpacaBroker.test.ts
@@ -162,6 +162,70 @@ describe('AlpacaBroker', {concurrent: false}, () => {
       expect(fills[0]?.order_id).toBe('order-1');
       expect(fills[0]?.price).toBe('53.05');
       expect(fills[0]?.side).toBe(OrderSide.BUY);
+      expect(fills[0]?.fee, 'stock trades are commission-free on Alpaca').toBe('0');
+      expect(fills[0]?.feeAsset).toBe('USD');
+    });
+
+    it('derives the crypto commission the order payload does not carry', async () => {
+      mockMethods.getCryptoBarsLatest.mockResolvedValue({bars: {'USDT/USD': {c: 1}}});
+      mockMethods.getOrders.mockResolvedValue([
+        {
+          asset_class: AlpacaAssetClass.CRYPTO,
+          created_at: '2023-09-23T10:21:09.000000Z',
+          filled_avg_price: '0.99912',
+          filled_qty: '56.7732',
+          id: 'crypto-sell',
+          side: AlpacaOrderSide.SELL,
+          status: AlpacaOrderStatus.FILLED,
+          type: AlpacaOrderType.MARKET,
+        },
+      ]);
+
+      const fills = await exchange.getFills(new TradingPair('USDT', 'USD'));
+
+      expect(fills[0]?.fee, 'matches the CFEE activity Alpaca charged for this exact fill').toBe('0.15');
+      expect(fills[0]?.feeAsset, 'a SELL is credited in the counter asset').toBe('USD');
+    });
+
+    it('bills a crypto BUY in the base asset', async () => {
+      mockMethods.getCryptoBarsLatest.mockResolvedValue({bars: {'BTC/USD': {c: 1}}});
+      mockMethods.getOrders.mockResolvedValue([
+        {
+          asset_class: AlpacaAssetClass.CRYPTO,
+          created_at: '2024-05-06T09:00:00.000001Z',
+          filled_avg_price: '61234.5',
+          filled_qty: '2.5',
+          id: 'crypto-buy',
+          side: AlpacaOrderSide.BUY,
+          status: AlpacaOrderStatus.FILLED,
+          type: AlpacaOrderType.MARKET,
+        },
+      ]);
+
+      const fills = await exchange.getFills(new TradingPair('BTC', 'USD'));
+
+      expect(fills[0]?.fee, '2.5 BTC * 0.0025 taker rate').toBe('0.00625');
+      expect(fills[0]?.feeAsset, 'a BUY is credited in the base asset').toBe('BTC');
+    });
+
+    it('keeps a zero fee when the order has no average fill price', async () => {
+      mockMethods.getCryptoBarsLatest.mockResolvedValue({bars: {'BTC/USD': {c: 1}}});
+      mockMethods.getOrders.mockResolvedValue([
+        {
+          asset_class: AlpacaAssetClass.CRYPTO,
+          created_at: '2024-05-06T09:00:00.000001Z',
+          filled_avg_price: null,
+          filled_qty: '2.5',
+          id: 'crypto-no-price',
+          side: AlpacaOrderSide.BUY,
+          status: AlpacaOrderStatus.FILLED,
+          type: AlpacaOrderType.MARKET,
+        },
+      ]);
+
+      const fills = await exchange.getFills(new TradingPair('BTC', 'USD'));
+
+      expect(fills[0]?.fee, 'without a notional there is no rate to apply').toBe('0');
     });
   });
 

--- a/packages/exchange/src/broker/alpaca/AlpacaBroker.test.ts
+++ b/packages/exchange/src/broker/alpaca/AlpacaBroker.test.ts
@@ -63,11 +63,7 @@ const {AlpacaBroker} = await import('./AlpacaBroker.js');
 const {AlpacaMarketData} = await import('./AlpacaMarketData.js');
 const {SimplifiedHttpError} = await import('../../util/SimplifiedHttpError.js');
 
-/*
- * Typed builders for the API payloads. The shared mocks carry their real `AlpacaAPI` signatures,
- * so a fixture has to satisfy the whole schema; these supply the fields a test does not care about
- * and keep each case down to the handful that matter.
- */
+// The mocks carry real AlpacaAPI signatures, so fixtures must satisfy the whole schema.
 function anOrder(overrides: Partial<Order> = {}): Order {
   return {
     asset_class: AlpacaAssetClass.US_EQUITY,
@@ -678,10 +674,6 @@ describe('AlpacaBroker', {concurrent: false}, () => {
     });
 
     it('derives the crypto fee on a streamed fill', async () => {
-      /*
-       * The other stream cases use a US equity, where this path and a bare `toFilledOrder` both
-       * produce a zero fee — so neither would notice if the fee derivation were dropped here.
-       */
       const topicId = await exchange.watchOrders();
       const fillHandler = vi.fn();
       exchange.on(topicId, fillHandler);

--- a/packages/exchange/src/broker/alpaca/AlpacaBroker.test.ts
+++ b/packages/exchange/src/broker/alpaca/AlpacaBroker.test.ts
@@ -7,21 +7,26 @@ import {AlpacaAssetClass, AlpacaOrderSide, AlpacaOrderStatus, AlpacaOrderType} f
 import {PositionSide} from './api/schema/PositionSchema.js';
 import {TradeUpdateEvent} from './api/schema/TradingStreamSchema.js';
 import type {AlpacaAPI} from './api/AlpacaAPI.js';
+import type {Account} from './api/schema/AccountSchema.js';
+import type {Asset} from './api/schema/AssetSchema.js';
+import type {Bar} from './api/schema/BarSchema.js';
+import type {Order} from './api/schema/OrderSchema.js';
+import type {Position} from './api/schema/PositionSchema.js';
 import type {alpacaTradingWebSocket} from './AlpacaTradingWebSocket.js';
 
 // Shared mock references
 const mockMethods = {
-  deleteOrder: vi.fn(),
-  getAccount: vi.fn(),
-  getAssets: vi.fn(),
-  getClock: vi.fn(),
-  getCryptoBars: vi.fn(),
-  getCryptoBarsLatest: vi.fn().mockResolvedValue({bars: {}}),
-  getOrders: vi.fn(),
-  getPositions: vi.fn(),
-  getStockBars: vi.fn(),
-  getStockBarsLatest: vi.fn(),
-  postOrder: vi.fn(),
+  deleteOrder: vi.fn<AlpacaAPI['deleteOrder']>(),
+  getAccount: vi.fn<AlpacaAPI['getAccount']>(),
+  getAssets: vi.fn<AlpacaAPI['getAssets']>(),
+  getClock: vi.fn<AlpacaAPI['getClock']>(),
+  getCryptoBars: vi.fn<AlpacaAPI['getCryptoBars']>(),
+  getCryptoBarsLatest: vi.fn<AlpacaAPI['getCryptoBarsLatest']>().mockResolvedValue({bars: {}}),
+  getOrders: vi.fn<AlpacaAPI['getOrders']>(),
+  getPositions: vi.fn<AlpacaAPI['getPositions']>(),
+  getStockBars: vi.fn<AlpacaAPI['getStockBars']>(),
+  getStockBarsLatest: vi.fn<AlpacaAPI['getStockBarsLatest']>(),
+  postOrder: vi.fn<AlpacaAPI['postOrder']>(),
 };
 
 vi.mock(import('./api/AlpacaAPI.js'), () => ({
@@ -58,6 +63,115 @@ const {AlpacaBroker} = await import('./AlpacaBroker.js');
 const {AlpacaMarketData} = await import('./AlpacaMarketData.js');
 const {SimplifiedHttpError} = await import('../../util/SimplifiedHttpError.js');
 
+/*
+ * Typed builders for the API payloads. The shared mocks carry their real `AlpacaAPI` signatures,
+ * so a fixture has to satisfy the whole schema; these supply the fields a test does not care about
+ * and keep each case down to the handful that matter.
+ */
+function anOrder(overrides: Partial<Order> = {}): Order {
+  return {
+    asset_class: AlpacaAssetClass.US_EQUITY,
+    asset_id: 'asset-1',
+    canceled_at: null,
+    client_order_id: 'client-1',
+    created_at: '2023-08-21T15:57:26.195019Z',
+    expired_at: null,
+    extended_hours: false,
+    failed_at: null,
+    filled_at: '2023-08-21T15:57:27.000000Z',
+    filled_avg_price: '53.05',
+    filled_qty: '3',
+    id: 'order-1',
+    legs: null,
+    limit_price: null,
+    notional: null,
+    qty: '3',
+    replaced_at: null,
+    replaced_by: null,
+    replaces: null,
+    side: AlpacaOrderSide.BUY,
+    status: AlpacaOrderStatus.FILLED,
+    stop_price: null,
+    submitted_at: '2023-08-21T15:57:26.000000Z',
+    symbol: 'SHOP',
+    time_in_force: 'day',
+    type: AlpacaOrderType.MARKET,
+    updated_at: '2023-08-21T15:57:27.000000Z',
+    ...overrides,
+  };
+}
+
+function aPosition(overrides: Partial<Position> = {}): Position {
+  return {
+    asset_class: AlpacaAssetClass.US_EQUITY,
+    asset_id: 'asset-1',
+    avg_entry_price: '50',
+    change_today: '0',
+    cost_basis: '150',
+    current_price: '53',
+    lastday_price: '52',
+    market_value: '159',
+    qty: '3',
+    qty_available: '3',
+    side: PositionSide.LONG,
+    symbol: 'SHOP',
+    unrealized_intraday_pl: '0',
+    unrealized_intraday_plpc: '0',
+    unrealized_pl: '9',
+    unrealized_plpc: '0.06',
+    ...overrides,
+  };
+}
+
+function anAccount(overrides: Partial<Account> = {}): Account {
+  return {
+    account_blocked: false,
+    account_number: '123456789',
+    buying_power: '1000',
+    cash: '1000',
+    created_at: '2023-01-01T00:00:00Z',
+    currency: 'USD',
+    daytrade_count: 0,
+    equity: '1000',
+    id: 'account-1',
+    initial_margin: '0',
+    last_equity: '30000',
+    long_market_value: '0',
+    maintenance_margin: '0',
+    multiplier: '1',
+    pattern_day_trader: false,
+    portfolio_value: '1000',
+    short_market_value: '0',
+    shorting_enabled: false,
+    status: 'ACTIVE',
+    trade_suspended_by_user: false,
+    trading_blocked: false,
+    transfers_blocked: false,
+    ...overrides,
+  };
+}
+
+function anAsset(overrides: Partial<Asset> = {}): Asset {
+  return {
+    class: 'us_equity',
+    easy_to_borrow: false,
+    exchange: 'NASDAQ',
+    fractionable: true,
+    id: 'asset-1',
+    marginable: false,
+    name: 'Test Asset',
+    shortable: false,
+    status: 'active',
+    symbol: 'SHOP',
+    tradable: true,
+    ...overrides,
+  };
+}
+
+function aBar(close: number): Bar {
+  return {c: close, h: close, l: close, n: 1, o: close, t: '2024-01-01T00:00:00Z', v: 1, vw: close};
+}
+
 describe('AlpacaBroker', {concurrent: false}, () => {
   let exchange: InstanceType<typeof AlpacaBroker>;
 
@@ -82,9 +196,9 @@ describe('AlpacaBroker', {concurrent: false}, () => {
   describe('listBalances', () => {
     it('returns positions and account cash', async () => {
       mockMethods.getPositions.mockResolvedValue([
-        {asset_class: 'us_equity', qty: '3', side: PositionSide.LONG, symbol: 'SHOP'},
+        aPosition({asset_class: 'us_equity', qty: '3', side: PositionSide.LONG, symbol: 'SHOP'}),
       ]);
-      mockMethods.getAccount.mockResolvedValue({cash: '500.50', currency: 'USD', last_equity: '30000'});
+      mockMethods.getAccount.mockResolvedValue(anAccount({cash: '500.50', currency: 'USD', last_equity: '30000'}));
 
       const balances = await exchange.listBalances();
 
@@ -100,9 +214,9 @@ describe('AlpacaBroker', {concurrent: false}, () => {
 
     it('trims crypto USD suffix from symbol', async () => {
       mockMethods.getPositions.mockResolvedValue([
-        {asset_class: 'crypto', qty: '100', side: PositionSide.LONG, symbol: 'USDTUSD'},
+        aPosition({asset_class: 'crypto', qty: '100', side: PositionSide.LONG, symbol: 'USDTUSD'}),
       ]);
-      mockMethods.getAccount.mockResolvedValue({cash: '0', currency: 'USD', last_equity: '30000'});
+      mockMethods.getAccount.mockResolvedValue(anAccount({cash: '0', currency: 'USD', last_equity: '30000'}));
 
       const balances = await exchange.listBalances();
       expect(balances[0]?.currency).toBe('USDT');
@@ -110,9 +224,9 @@ describe('AlpacaBroker', {concurrent: false}, () => {
 
     it('uses absolute values for SHORT positions', async () => {
       mockMethods.getPositions.mockResolvedValue([
-        {asset_class: 'us_equity', qty: '-3', side: PositionSide.SHORT, symbol: 'TSLA'},
+        aPosition({asset_class: 'us_equity', qty: '-3', side: PositionSide.SHORT, symbol: 'TSLA'}),
       ]);
-      mockMethods.getAccount.mockResolvedValue({cash: '0', currency: 'USD', last_equity: '30000'});
+      mockMethods.getAccount.mockResolvedValue(anAccount({cash: '0', currency: 'USD', last_equity: '30000'}));
 
       const balances = await exchange.listBalances();
       expect(balances[0]).toEqual({
@@ -125,9 +239,15 @@ describe('AlpacaBroker', {concurrent: false}, () => {
 
     it('throws an error when Alpaca returns an unknown position side', async () => {
       mockMethods.getPositions.mockResolvedValue([
-        {asset_class: 'us_equity', qty: '3', side: 'unknown', symbol: 'SHOP'},
+        aPosition({
+          asset_class: 'us_equity',
+          qty: '3',
+          // Deliberately invalid: this test exists to prove the broker rejects a side it cannot map.
+          side: 'unknown' as PositionSide,
+          symbol: 'SHOP',
+        }),
       ]);
-      mockMethods.getAccount.mockResolvedValue({cash: '0', currency: 'USD', last_equity: '30000'});
+      mockMethods.getAccount.mockResolvedValue(anAccount({cash: '0', currency: 'USD', last_equity: '30000'}));
 
       await expect(exchange.listBalances()).rejects.toThrow();
     });
@@ -135,7 +255,7 @@ describe('AlpacaBroker', {concurrent: false}, () => {
 
   describe('getFills', () => {
     it('returns only filled orders mapped to Fill', async () => {
-      const filledOrder = {
+      const filledOrder = anOrder({
         asset_class: AlpacaAssetClass.US_EQUITY,
         created_at: '2023-08-21T15:57:26.195019Z',
         filled_avg_price: '53.05',
@@ -143,15 +263,15 @@ describe('AlpacaBroker', {concurrent: false}, () => {
         id: 'order-1',
         side: AlpacaOrderSide.BUY,
         status: AlpacaOrderStatus.FILLED,
-      };
+      });
 
-      const canceledOrder = {
+      const canceledOrder = anOrder({
         ...filledOrder,
         filled_avg_price: null,
         filled_qty: '0',
         id: 'order-2',
         status: AlpacaOrderStatus.CANCELED,
-      };
+      });
 
       mockMethods.getOrders.mockResolvedValue([filledOrder, canceledOrder]);
 
@@ -167,9 +287,9 @@ describe('AlpacaBroker', {concurrent: false}, () => {
     });
 
     it('derives the crypto commission the order payload does not carry', async () => {
-      mockMethods.getCryptoBarsLatest.mockResolvedValue({bars: {'USDT/USD': {c: 1}}});
+      mockMethods.getCryptoBarsLatest.mockResolvedValue({bars: {'USDT/USD': aBar(1)}});
       mockMethods.getOrders.mockResolvedValue([
-        {
+        anOrder({
           asset_class: AlpacaAssetClass.CRYPTO,
           created_at: '2023-09-23T10:21:09.000000Z',
           filled_avg_price: '0.99912',
@@ -178,7 +298,7 @@ describe('AlpacaBroker', {concurrent: false}, () => {
           side: AlpacaOrderSide.SELL,
           status: AlpacaOrderStatus.FILLED,
           type: AlpacaOrderType.MARKET,
-        },
+        }),
       ]);
 
       const fills = await exchange.getFills(new TradingPair('USDT', 'USD'));
@@ -188,9 +308,9 @@ describe('AlpacaBroker', {concurrent: false}, () => {
     });
 
     it('bills a crypto BUY in the base asset', async () => {
-      mockMethods.getCryptoBarsLatest.mockResolvedValue({bars: {'BTC/USD': {c: 1}}});
+      mockMethods.getCryptoBarsLatest.mockResolvedValue({bars: {'BTC/USD': aBar(1)}});
       mockMethods.getOrders.mockResolvedValue([
-        {
+        anOrder({
           asset_class: AlpacaAssetClass.CRYPTO,
           created_at: '2024-05-06T09:00:00.000001Z',
           filled_avg_price: '61234.5',
@@ -199,7 +319,7 @@ describe('AlpacaBroker', {concurrent: false}, () => {
           side: AlpacaOrderSide.BUY,
           status: AlpacaOrderStatus.FILLED,
           type: AlpacaOrderType.MARKET,
-        },
+        }),
       ]);
 
       const fills = await exchange.getFills(new TradingPair('BTC', 'USD'));
@@ -208,10 +328,10 @@ describe('AlpacaBroker', {concurrent: false}, () => {
       expect(fills[0]?.feeAsset, 'a BUY is credited in the base asset').toBe('BTC');
     });
 
-    it('keeps a zero fee when the order has no average fill price', async () => {
-      mockMethods.getCryptoBarsLatest.mockResolvedValue({bars: {'BTC/USD': {c: 1}}});
+    it('rejects a filled order that has no average fill price', async () => {
+      mockMethods.getCryptoBarsLatest.mockResolvedValue({bars: {'BTC/USD': aBar(1)}});
       mockMethods.getOrders.mockResolvedValue([
-        {
+        anOrder({
           asset_class: AlpacaAssetClass.CRYPTO,
           created_at: '2024-05-06T09:00:00.000001Z',
           filled_avg_price: null,
@@ -220,12 +340,13 @@ describe('AlpacaBroker', {concurrent: false}, () => {
           side: AlpacaOrderSide.BUY,
           status: AlpacaOrderStatus.FILLED,
           type: AlpacaOrderType.MARKET,
-        },
+        }),
       ]);
 
-      const fills = await exchange.getFills(new TradingPair('BTC', 'USD'));
-
-      expect(fills[0]?.fee, 'without a notional there is no rate to apply').toBe('0');
+      await expect(
+        exchange.getFills(new TradingPair('BTC', 'USD')),
+        'a Fill priced "null" would throw later inside new Big(fill.price)'
+      ).rejects.toThrowError(/no average fill price/);
     });
   });
 
@@ -242,16 +363,16 @@ describe('AlpacaBroker', {concurrent: false}, () => {
   describe('getTradingRules', () => {
     it('returns crypto trading rules with exchange-provided values', async () => {
       mockMethods.getCryptoBarsLatest.mockResolvedValue({
-        bars: {'BTC/USD': {c: 1, h: 1, l: 1, n: 1, o: 1, t: '', v: 1, vw: 1}},
+        bars: {'BTC/USD': aBar(1)},
       });
       mockMethods.getAssets.mockResolvedValue([
-        {
+        anAsset({
           class: 'crypto',
           min_order_size: '0.0001',
           min_trade_increment: '0.0001',
           price_increment: '0.01',
           symbol: 'BTC/USD',
-        },
+        }),
       ]);
 
       const pair = new TradingPair('BTC', 'USD');
@@ -264,7 +385,7 @@ describe('AlpacaBroker', {concurrent: false}, () => {
     });
 
     it('returns stock trading rules with hardcoded defaults', async () => {
-      mockMethods.getAssets.mockResolvedValue([{class: 'us_equity', symbol: 'SHOP'}]);
+      mockMethods.getAssets.mockResolvedValue([anAsset({class: 'us_equity', symbol: 'SHOP'})]);
 
       const pair = new TradingPair('SHOP', 'USD');
       const rules = await exchange.getTradingRules(pair);
@@ -289,13 +410,15 @@ describe('AlpacaBroker', {concurrent: false}, () => {
     const uuidMatcher: unknown = expect.toSatisfy(isUuid);
 
     it('places a stock MARKET BUY order with notional amount', async () => {
-      mockMethods.postOrder.mockResolvedValue({
-        id: 'order-123',
-        notional: '200',
-        qty: null,
-        side: AlpacaOrderSide.BUY,
-        type: AlpacaOrderType.MARKET,
-      });
+      mockMethods.postOrder.mockResolvedValue(
+        anOrder({
+          id: 'order-123',
+          notional: '200',
+          qty: null,
+          side: AlpacaOrderSide.BUY,
+          type: AlpacaOrderType.MARKET,
+        })
+      );
 
       const pair = new TradingPair('SHOP', 'USD');
       const order = await exchange.placeMarketOrder(pair, {
@@ -318,14 +441,16 @@ describe('AlpacaBroker', {concurrent: false}, () => {
     });
 
     it('places a stock LIMIT SELL order with gtc for whole shares', async () => {
-      mockMethods.postOrder.mockResolvedValue({
-        id: 'order-456',
-        limit_price: '100',
-        notional: null,
-        qty: '5',
-        side: AlpacaOrderSide.SELL,
-        type: AlpacaOrderType.LIMIT,
-      });
+      mockMethods.postOrder.mockResolvedValue(
+        anOrder({
+          id: 'order-456',
+          limit_price: '100',
+          notional: null,
+          qty: '5',
+          side: AlpacaOrderSide.SELL,
+          type: AlpacaOrderType.LIMIT,
+        })
+      );
 
       const pair = new TradingPair('SHOP', 'USD');
       const order = await exchange.placeLimitOrder(pair, {
@@ -348,14 +473,16 @@ describe('AlpacaBroker', {concurrent: false}, () => {
     });
 
     it('places a stock LIMIT SELL order with day and extended hours for fractional shares', async () => {
-      mockMethods.postOrder.mockResolvedValue({
-        id: 'order-frac',
-        limit_price: '100',
-        notional: null,
-        qty: '5.5',
-        side: AlpacaOrderSide.SELL,
-        type: AlpacaOrderType.LIMIT,
-      });
+      mockMethods.postOrder.mockResolvedValue(
+        anOrder({
+          id: 'order-frac',
+          limit_price: '100',
+          notional: null,
+          qty: '5.5',
+          side: AlpacaOrderSide.SELL,
+          type: AlpacaOrderType.LIMIT,
+        })
+      );
 
       const pair = new TradingPair('SHOP', 'USD');
       const order = await exchange.placeLimitOrder(pair, {
@@ -380,15 +507,17 @@ describe('AlpacaBroker', {concurrent: false}, () => {
 
     it('uses gtc time_in_force for crypto orders', async () => {
       mockMethods.getCryptoBarsLatest.mockResolvedValue({
-        bars: {'BTC/USD': {c: 1, h: 1, l: 1, n: 1, o: 1, t: '', v: 1, vw: 1}},
+        bars: {'BTC/USD': aBar(1)},
       });
-      mockMethods.postOrder.mockResolvedValue({
-        id: 'order-789',
-        notional: '100',
-        qty: null,
-        side: AlpacaOrderSide.BUY,
-        type: AlpacaOrderType.MARKET,
-      });
+      mockMethods.postOrder.mockResolvedValue(
+        anOrder({
+          id: 'order-789',
+          notional: '100',
+          qty: null,
+          side: AlpacaOrderSide.BUY,
+          type: AlpacaOrderType.MARKET,
+        })
+      );
 
       const pair = new TradingPair('BTC', 'USD');
       await exchange.placeMarketOrder(pair, {
@@ -408,13 +537,15 @@ describe('AlpacaBroker', {concurrent: false}, () => {
     });
 
     it('sends a fresh client_order_id (UUID) with every placement so operators can reconcile failed submissions', async () => {
-      mockMethods.postOrder.mockResolvedValue({
-        id: 'order-123',
-        notional: '200',
-        qty: null,
-        side: AlpacaOrderSide.BUY,
-        type: AlpacaOrderType.MARKET,
-      });
+      mockMethods.postOrder.mockResolvedValue(
+        anOrder({
+          id: 'order-123',
+          notional: '200',
+          qty: null,
+          side: AlpacaOrderSide.BUY,
+          type: AlpacaOrderType.MARKET,
+        })
+      );
 
       const pair = new TradingPair('SHOP', 'USD');
       const options = {side: OrderSide.BUY, size: '200', sizeInCounter: true} as const;
@@ -422,7 +553,7 @@ describe('AlpacaBroker', {concurrent: false}, () => {
       await exchange.placeMarketOrder(pair, options);
 
       const clientOrderIds = mockMethods.postOrder.mock.calls.map(call => {
-        const [params] = call as Parameters<AlpacaAPI['postOrder']>;
+        const [params] = call;
         return params.client_order_id;
       });
       expect(clientOrderIds).toHaveLength(2);
@@ -435,7 +566,7 @@ describe('AlpacaBroker', {concurrent: false}, () => {
 
   describe('cancelOpenOrders', () => {
     it('cancels all open orders for a pair', async () => {
-      mockMethods.getOrders.mockResolvedValue([{id: 'open-1'}, {id: 'open-2'}]);
+      mockMethods.getOrders.mockResolvedValue([anOrder({id: 'open-1'}), anOrder({id: 'open-2'})]);
       mockMethods.deleteOrder.mockResolvedValue(undefined);
 
       const pair = new TradingPair('SHOP', 'USD');
@@ -448,7 +579,7 @@ describe('AlpacaBroker', {concurrent: false}, () => {
     });
 
     it('ignores orders that filled between fetching and canceling them', async () => {
-      mockMethods.getOrders.mockResolvedValue([{id: 'open-1'}]);
+      mockMethods.getOrders.mockResolvedValue([anOrder({id: 'open-1'})]);
       mockMethods.deleteOrder.mockRejectedValue(
         new SimplifiedHttpError({
           data: {code: 42210000, message: 'order is already in "filled" state'},
@@ -463,7 +594,7 @@ describe('AlpacaBroker', {concurrent: false}, () => {
     });
 
     it('rethrows unexpected cancellation errors', async () => {
-      mockMethods.getOrders.mockResolvedValue([{id: 'open-1'}]);
+      mockMethods.getOrders.mockResolvedValue([anOrder({id: 'open-1'})]);
       mockMethods.deleteOrder.mockRejectedValue(
         new SimplifiedHttpError({data: {message: 'internal server error'}, status: 500})
       );
@@ -543,6 +674,37 @@ describe('AlpacaBroker', {concurrent: false}, () => {
           side: OrderSide.BUY,
           size: '10',
         })
+      );
+    });
+
+    it('derives the crypto fee on a streamed fill', async () => {
+      /*
+       * The other stream cases use a US equity, where this path and a bare `toFilledOrder` both
+       * produce a zero fee — so neither would notice if the fee derivation were dropped here.
+       */
+      const topicId = await exchange.watchOrders();
+      const fillHandler = vi.fn();
+      exchange.on(topicId, fillHandler);
+
+      const registeredCb = mockTradingWebSocket.onTradeUpdate.mock.calls[0]?.[1];
+      registeredCb?.({
+        event: TradeUpdateEvent.FILL,
+        order: anOrder({
+          asset_class: AlpacaAssetClass.CRYPTO,
+          filled_avg_price: '61234.5',
+          filled_qty: '2.5',
+          id: 'crypto-stream-buy',
+          side: AlpacaOrderSide.BUY,
+          symbol: 'BTC/USD',
+          type: AlpacaOrderType.MARKET,
+        }),
+        price: '61234.5',
+        qty: '2.5',
+        timestamp: '2024-05-06T09:00:00.600000Z',
+      });
+
+      expect(fillHandler).toHaveBeenCalledWith(
+        expect.objectContaining({fee: '0.00625', feeAsset: 'BTC', order_id: 'crypto-stream-buy'})
       );
     });
 

--- a/packages/exchange/src/broker/alpaca/AlpacaBroker.ts
+++ b/packages/exchange/src/broker/alpaca/AlpacaBroker.ts
@@ -8,6 +8,7 @@ import {
   type Balance,
   type Candle,
   type CandleImportRequest,
+  type FeeEstimateRequest,
   type FeeRate,
   type Fill,
   type LimitOrderOptions,
@@ -331,22 +332,16 @@ export class AlpacaBroker extends Broker implements MarketDataSource {
   /**
    * Maps a filled order and fills in the fee the wire payload does not carry.
    *
-   * The fee is derived, not reported: see `AlpacaFees` for what that costs in accuracy. Orders
-   * without an average fill price keep the mapper's neutral zero fee, since there is no notional
-   * to apply a rate to.
+   * The fee is derived, not reported: see `AlpacaFees` for what that costs in accuracy.
    */
   #toFillWithFee(order: Order, pair: TradingPair, rates: FeeRate): Fill {
     const fill = AlpacaBrokerMapper.toFilledOrder(order, pair);
-
-    if (order.filled_avg_price === null) {
-      return fill;
-    }
 
     const {fee, feeAsset} = getTradeCost({
       isCrypto: order.asset_class === AlpacaAssetClass.CRYPTO,
       orderType: order.type === AlpacaOrderType.LIMIT ? OrderType.LIMIT : OrderType.MARKET,
       pair,
-      price: order.filled_avg_price,
+      price: fill.price,
       quantity: order.filled_qty,
       rates,
       side: fill.side,
@@ -410,9 +405,36 @@ export class AlpacaBroker extends Broker implements MarketDataSource {
    * Alpaca deducts a crypto fee from the asset you are credited with, so a BUY is billed in the
    * base asset and a SELL in the counter. Stocks settle in the counter currency either way.
    */
-  protected override async getFeeAsset(pair: TradingPair, side: OrderSide) {
+  override async getFeeAsset(pair: TradingPair, side: OrderSide) {
     const isCrypto = await isAlpacaCryptoSymbol(this.#alpacaAPI, pair);
     return getCreditedAsset(pair, side, isCrypto);
+  }
+
+  /**
+   * Routes through the same calculator the realised `Fill` fee uses, so a pre-trade estimate and
+   * the fee that comes back after execution cannot disagree.
+   *
+   * The base `Broker` implementation would apply `getFeeRates` to everything, and Alpaca's rates
+   * are the *crypto* schedule — charging a commission on commission-free equities.
+   */
+  override async estimateFee(pair: TradingPair, request: FeeEstimateRequest) {
+    const isCrypto = await isAlpacaCryptoSymbol(this.#alpacaAPI, pair);
+    const cost = getTradeCost({
+      isCrypto,
+      orderType: request.orderType,
+      pair,
+      price: request.price,
+      quantity: request.quantity,
+      rates: await this.getFeeRates(pair),
+      side: request.side,
+    });
+
+    return {
+      commission: cost.feeInCounter,
+      currencyConversion: new Big(0),
+      feeAsset: pair.counter,
+      total: cost.feeInCounter,
+    };
   }
 
   /**

--- a/packages/exchange/src/broker/alpaca/AlpacaBroker.ts
+++ b/packages/exchange/src/broker/alpaca/AlpacaBroker.ts
@@ -24,7 +24,8 @@ import {
 import type {MarketDataSource} from '../MarketDataSource.js';
 import type {TradingPair} from '../TradingPair.js';
 import {createAlpacaSymbol, isAlpacaCryptoSymbol} from './alpacaSymbol.js';
-import {AlpacaOrderStatus} from './api/schema/OrderSchema.js';
+import {getCreditedAsset, getTradeCost} from './AlpacaFees.js';
+import {AlpacaAssetClass, AlpacaOrderStatus, AlpacaOrderType, type Order} from './api/schema/OrderSchema.js';
 import {AlpacaAPI} from './api/AlpacaAPI.js';
 import {PositionSide} from './api/schema/PositionSchema.js';
 import {alpacaTradingWebSocket, type AlpacaTradingConnection} from './AlpacaTradingWebSocket.js';
@@ -188,7 +189,12 @@ export class AlpacaBroker extends Broker implements MarketDataSource {
     const cb = (message: TradeUpdateMessage) => {
       if (message.event === TradeUpdateEvent.FILL) {
         const pair = AlpacaBrokerMapper.symbolToPair(message.order.symbol, message.order.asset_class);
-        const fill = AlpacaBrokerMapper.toFilledOrder(message.order, pair);
+        /*
+         * The stream is account-wide, so there is no single pair to query rates for. The default
+         * schedule is what `getFeeRates` returns today anyway, and using it keeps the hot path
+         * free of an HTTP round trip per fill.
+         */
+        const fill = this.#toFillWithFee(message.order, pair, AlpacaBroker.DEFAULT_FEE_RATES);
         this.emit(topicId, fill);
       }
     };
@@ -318,7 +324,35 @@ export class AlpacaBroker extends Broker implements MarketDataSource {
     const symbol = await this.#createReliableSymbol(pair);
     const orders = await this.#alpacaAPI.getOrders({status: 'closed', symbols: symbol});
     const filledOrders = orders.filter(order => order.status === AlpacaOrderStatus.FILLED);
-    return filledOrders.map(order => AlpacaBrokerMapper.toFilledOrder(order, pair));
+    const rates = await this.getFeeRates(pair);
+    return filledOrders.map(order => this.#toFillWithFee(order, pair, rates));
+  }
+
+  /**
+   * Maps a filled order and fills in the fee the wire payload does not carry.
+   *
+   * The fee is derived, not reported: see `AlpacaFees` for what that costs in accuracy. Orders
+   * without an average fill price keep the mapper's neutral zero fee, since there is no notional
+   * to apply a rate to.
+   */
+  #toFillWithFee(order: Order, pair: TradingPair, rates: FeeRate): Fill {
+    const fill = AlpacaBrokerMapper.toFilledOrder(order, pair);
+
+    if (order.filled_avg_price === null) {
+      return fill;
+    }
+
+    const {fee, feeAsset} = getTradeCost({
+      isCrypto: order.asset_class === AlpacaAssetClass.CRYPTO,
+      orderType: order.type === AlpacaOrderType.LIMIT ? OrderType.LIMIT : OrderType.MARKET,
+      pair,
+      price: order.filled_avg_price,
+      quantity: order.filled_qty,
+      rates,
+      side: fill.side,
+    });
+
+    return {...fill, fee: fee.toFixed(), feeAsset};
   }
 
   async getFillByOrderId(pair: TradingPair, orderId: string): Promise<Fill | undefined> {
@@ -370,6 +404,15 @@ export class AlpacaBroker extends Broker implements MarketDataSource {
   async getFeeRates(_pair: TradingPair): Promise<FeeRate> {
     // TODO: Refine according to "30-Day Crypto Volume (USD)" and make fee rate dependant on crypto or stocks
     return AlpacaBroker.DEFAULT_FEE_RATES;
+  }
+
+  /**
+   * Alpaca deducts a crypto fee from the asset you are credited with, so a BUY is billed in the
+   * base asset and a SELL in the counter. Stocks settle in the counter currency either way.
+   */
+  protected override async getFeeAsset(pair: TradingPair, side: OrderSide) {
+    const isCrypto = await isAlpacaCryptoSymbol(this.#alpacaAPI, pair);
+    return getCreditedAsset(pair, side, isCrypto);
   }
 
   /**

--- a/packages/exchange/src/broker/alpaca/AlpacaBroker.ts
+++ b/packages/exchange/src/broker/alpaca/AlpacaBroker.ts
@@ -189,11 +189,7 @@ export class AlpacaBroker extends Broker implements MarketDataSource {
     const cb = (message: TradeUpdateMessage) => {
       if (message.event === TradeUpdateEvent.FILL) {
         const pair = AlpacaBrokerMapper.symbolToPair(message.order.symbol, message.order.asset_class);
-        /*
-         * The stream is account-wide, so there is no single pair to query rates for. The default
-         * schedule is what `getFeeRates` returns today anyway, and using it keeps the hot path
-         * free of an HTTP round trip per fill.
-         */
+        // Account-wide stream: no single pair to query rates for, and no round trip per fill.
         const fill = this.#toFillWithFee(message.order, pair, AlpacaBroker.DEFAULT_FEE_RATES);
         this.emit(topicId, fill);
       }
@@ -328,11 +324,6 @@ export class AlpacaBroker extends Broker implements MarketDataSource {
     return filledOrders.map(order => this.#toFillWithFee(order, pair, rates));
   }
 
-  /**
-   * Maps a filled order and fills in the fee the wire payload does not carry.
-   *
-   * The fee is derived, not reported: see `AlpacaFees` for what that costs in accuracy.
-   */
   #toFillWithFee(order: Order, pair: TradingPair, rates: FeeRate): Fill {
     const fill = AlpacaBrokerMapper.toFilledOrder(order, pair);
 

--- a/packages/exchange/src/broker/alpaca/AlpacaBroker.ts
+++ b/packages/exchange/src/broker/alpaca/AlpacaBroker.ts
@@ -8,7 +8,6 @@ import {
   type Balance,
   type Candle,
   type CandleImportRequest,
-  type FeeEstimateRequest,
   type FeeRate,
   type Fill,
   type LimitOrderOptions,
@@ -25,7 +24,7 @@ import {
 import type {MarketDataSource} from '../MarketDataSource.js';
 import type {TradingPair} from '../TradingPair.js';
 import {createAlpacaSymbol, isAlpacaCryptoSymbol} from './alpacaSymbol.js';
-import {getCreditedAsset, getTradeCost} from './AlpacaFees.js';
+import {getTradeCost} from './AlpacaFees.js';
 import {AlpacaAssetClass, AlpacaOrderStatus, AlpacaOrderType, type Order} from './api/schema/OrderSchema.js';
 import {AlpacaAPI} from './api/AlpacaAPI.js';
 import {PositionSide} from './api/schema/PositionSchema.js';
@@ -399,42 +398,6 @@ export class AlpacaBroker extends Broker implements MarketDataSource {
   async getFeeRates(_pair: TradingPair): Promise<FeeRate> {
     // TODO: Refine according to "30-Day Crypto Volume (USD)" and make fee rate dependant on crypto or stocks
     return AlpacaBroker.DEFAULT_FEE_RATES;
-  }
-
-  /**
-   * Alpaca deducts a crypto fee from the asset you are credited with, so a BUY is billed in the
-   * base asset and a SELL in the counter. Stocks settle in the counter currency either way.
-   */
-  override async getFeeAsset(pair: TradingPair, side: OrderSide) {
-    const isCrypto = await isAlpacaCryptoSymbol(this.#alpacaAPI, pair);
-    return getCreditedAsset(pair, side, isCrypto);
-  }
-
-  /**
-   * Routes through the same calculator the realised `Fill` fee uses, so a pre-trade estimate and
-   * the fee that comes back after execution cannot disagree.
-   *
-   * The base `Broker` implementation would apply `getFeeRates` to everything, and Alpaca's rates
-   * are the *crypto* schedule — charging a commission on commission-free equities.
-   */
-  override async estimateFee(pair: TradingPair, request: FeeEstimateRequest) {
-    const isCrypto = await isAlpacaCryptoSymbol(this.#alpacaAPI, pair);
-    const cost = getTradeCost({
-      isCrypto,
-      orderType: request.orderType,
-      pair,
-      price: request.price,
-      quantity: request.quantity,
-      rates: await this.getFeeRates(pair),
-      side: request.side,
-    });
-
-    return {
-      commission: cost.feeInCounter,
-      currencyConversion: new Big(0),
-      feeAsset: pair.counter,
-      total: cost.feeInCounter,
-    };
   }
 
   /**

--- a/packages/exchange/src/broker/alpaca/AlpacaBrokerMapper.ts
+++ b/packages/exchange/src/broker/alpaca/AlpacaBrokerMapper.ts
@@ -100,7 +100,11 @@ export class AlpacaBrokerMapper {
 
     return {
       created_at: `${order.created_at}`,
-      /** Alpaca does not charge a commission (except for crypto) for trades: https://files.alpaca.markets/disclosures/library/BrokFeeSched.pdf */
+      /**
+       * Alpaca's order payload carries no fee field, so there is nothing to map here. Crypto fills
+       * do cost a commission; `AlpacaBroker` derives it (see `AlpacaFees`) and overwrites these two
+       * values on the way out.
+       */
       fee: '0',
       feeAsset: pair.counter,
       order_id: `${order.id}`,

--- a/packages/exchange/src/broker/alpaca/AlpacaBrokerMapper.ts
+++ b/packages/exchange/src/broker/alpaca/AlpacaBrokerMapper.ts
@@ -98,22 +98,14 @@ export class AlpacaBrokerMapper {
       throw new Error(`Order ID "${order.id}" is not filled.`);
     }
 
-    /*
-     * Interpolating a null here would hand downstream a Fill whose price is the string "null",
-     * which survives every type check and then throws inside `new Big(fill.price)` far away from
-     * the payload that caused it.
-     */
+    // Interpolating null yields the string "null", which type-checks and throws far downstream.
     if (order.filled_avg_price === null) {
       throw new Error(`Order ID "${order.id}" is filled but has no average fill price.`);
     }
 
     return {
       created_at: `${order.created_at}`,
-      /**
-       * Alpaca's order payload carries no fee field, so there is nothing to map here. Crypto fills
-       * do cost a commission; `AlpacaBroker` derives it (see `AlpacaFees`) and overwrites these two
-       * values on the way out.
-       */
+      /** No fee on the wire; `AlpacaBroker` derives it and overwrites both fields. */
       fee: '0',
       feeAsset: pair.counter,
       order_id: `${order.id}`,

--- a/packages/exchange/src/broker/alpaca/AlpacaBrokerMapper.ts
+++ b/packages/exchange/src/broker/alpaca/AlpacaBrokerMapper.ts
@@ -98,6 +98,15 @@ export class AlpacaBrokerMapper {
       throw new Error(`Order ID "${order.id}" is not filled.`);
     }
 
+    /*
+     * Interpolating a null here would hand downstream a Fill whose price is the string "null",
+     * which survives every type check and then throws inside `new Big(fill.price)` far away from
+     * the payload that caused it.
+     */
+    if (order.filled_avg_price === null) {
+      throw new Error(`Order ID "${order.id}" is filled but has no average fill price.`);
+    }
+
     return {
       created_at: `${order.created_at}`,
       /**
@@ -111,7 +120,7 @@ export class AlpacaBrokerMapper {
       pair,
       /** @see https://forum.alpaca.markets/t/13480 */
       position: OrderPosition.LONG,
-      price: `${order.filled_avg_price}`,
+      price: order.filled_avg_price,
       side: order.side === 'buy' ? OrderSide.BUY : OrderSide.SELL,
       size: `${order.filled_qty}`,
     };

--- a/packages/exchange/src/broker/alpaca/AlpacaFees.test.ts
+++ b/packages/exchange/src/broker/alpaca/AlpacaFees.test.ts
@@ -75,11 +75,6 @@ describe('AlpacaFees', () => {
     });
 
     it('rounds a fiat fee up to the penny, the way Alpaca bills it', () => {
-      /*
-       * Taken from a live account: a USDT/USD market SELL of 56.7732 @ 0.99912 has a notional of
-       * 56.723239584 USD, which at the 0.25% taker rate computes to 0.14180809896 USD. Alpaca
-       * billed a CFEE activity of 0.15 USD for it.
-       */
       const cost = getTradeCost({
         isCrypto: true,
         orderType: OrderType.MARKET,

--- a/packages/exchange/src/broker/alpaca/AlpacaFees.test.ts
+++ b/packages/exchange/src/broker/alpaca/AlpacaFees.test.ts
@@ -1,0 +1,127 @@
+import Big from 'big.js';
+import {describe, expect, it} from 'vitest';
+import {OrderSide, OrderType, type FeeRate} from '../Broker.js';
+import {TradingPair} from '../TradingPair.js';
+import {getCreditedAsset, getTradeCost} from './AlpacaFees.js';
+
+const RATES: FeeRate = {
+  [OrderType.LIMIT]: new Big(0.0015),
+  [OrderType.MARKET]: new Big(0.0025),
+};
+
+const BTC_USD = new TradingPair('BTC', 'USD');
+
+describe('AlpacaFees', () => {
+  describe('getCreditedAsset', () => {
+    it('credits the base asset on a crypto BUY', () => {
+      expect(getCreditedAsset(BTC_USD, OrderSide.BUY, true)).toBe('BTC');
+    });
+
+    it('credits the counter asset on a crypto SELL', () => {
+      expect(getCreditedAsset(BTC_USD, OrderSide.SELL, true)).toBe('USD');
+    });
+
+    it('credits the counter asset for stocks on both sides', () => {
+      const pair = new TradingPair('SHOP', 'USD');
+      expect(getCreditedAsset(pair, OrderSide.BUY, false)).toBe('USD');
+      expect(getCreditedAsset(pair, OrderSide.SELL, false)).toBe('USD');
+    });
+  });
+
+  describe('getTradeCost', () => {
+    it('charges no commission on stocks', () => {
+      const cost = getTradeCost({
+        isCrypto: false,
+        orderType: OrderType.MARKET,
+        pair: new TradingPair('SHOP', 'USD'),
+        price: '53.05',
+        quantity: '3',
+        rates: RATES,
+        side: OrderSide.BUY,
+      });
+
+      expect(cost.fee.toFixed(), 'stocks and ETFs are commission-free on Alpaca').toBe('0');
+      expect(cost.feeAsset).toBe('USD');
+    });
+
+    it('charges a crypto BUY in the base asset at the taker rate', () => {
+      const cost = getTradeCost({
+        isCrypto: true,
+        orderType: OrderType.MARKET,
+        pair: BTC_USD,
+        price: '61234.5',
+        quantity: '2.5',
+        rates: RATES,
+        side: OrderSide.BUY,
+      });
+
+      expect(cost.fee.toFixed(), '2.5 BTC * 0.0025 taker rate').toBe('0.00625');
+      expect(cost.feeAsset).toBe('BTC');
+    });
+
+    it('charges a crypto SELL in the counter asset at the maker rate for limit orders', () => {
+      const cost = getTradeCost({
+        isCrypto: true,
+        orderType: OrderType.LIMIT,
+        pair: BTC_USD,
+        price: '61234.5',
+        quantity: '0.4',
+        rates: RATES,
+        side: OrderSide.SELL,
+      });
+
+      expect(cost.fee.toFixed(), '0.4 * 61234.5 USD * 0.0015 maker rate').toBe('36.75');
+      expect(cost.feeAsset).toBe('USD');
+    });
+
+    it('rounds a fiat fee up to the penny, the way Alpaca bills it', () => {
+      /*
+       * Taken from a live account: a USDT/USD market SELL of 56.7732 @ 0.99912 has a notional of
+       * 56.723239584 USD, which at the 0.25% taker rate computes to 0.14180809896 USD. Alpaca
+       * billed a CFEE activity of 0.15 USD for it.
+       */
+      const cost = getTradeCost({
+        isCrypto: true,
+        orderType: OrderType.MARKET,
+        pair: new TradingPair('USDT', 'USD'),
+        price: '0.99912',
+        quantity: '56.7732',
+        rates: RATES,
+        side: OrderSide.SELL,
+      });
+
+      expect(cost.fee.toFixed(), 'matches the CFEE activity Alpaca actually charged').toBe('0.15');
+      expect(cost.feeAsset).toBe('USD');
+    });
+
+    it('reports the counter-currency equivalent of a base-denominated fee', () => {
+      const cost = getTradeCost({
+        isCrypto: true,
+        orderType: OrderType.MARKET,
+        pair: BTC_USD,
+        price: '61234.5',
+        quantity: '2.5',
+        rates: RATES,
+        side: OrderSide.BUY,
+      });
+
+      expect(cost.fee.toFixed(), 'debited in BTC').toBe('0.00625');
+      expect(cost.feeInCounter.toFixed(), '2.5 * 61234.5 USD * 0.0025, rounded up to the penny').toBe('382.72');
+      expect(
+        cost.fee.times('61234.5').round(2, Big.roundUp).toFixed(),
+        'both denominations describe the same fee at the fill price'
+      ).toBe(cost.feeInCounter.toFixed());
+    });
+
+    it('bills BUY and SELL at the same fraction of the notional', () => {
+      const shared = {isCrypto: true, orderType: OrderType.MARKET, pair: BTC_USD, price: '61234.5', rates: RATES};
+
+      const buy = getTradeCost({...shared, quantity: '2.5', side: OrderSide.BUY});
+      const sell = getTradeCost({...shared, quantity: '2.5', side: OrderSide.SELL});
+
+      expect(buy.feeInCounter.toFixed(), 'only the denomination differs between sides, not the rate').toBe(
+        sell.feeInCounter.toFixed()
+      );
+    });
+  });
+});

--- a/packages/exchange/src/broker/alpaca/AlpacaFees.test.ts
+++ b/packages/exchange/src/broker/alpaca/AlpacaFees.test.ts
@@ -93,35 +93,5 @@ describe('AlpacaFees', () => {
       expect(cost.fee.toFixed(), 'matches the CFEE activity Alpaca actually charged').toBe('0.15');
       expect(cost.feeAsset).toBe('USD');
     });
-
-    it('reports the counter-currency equivalent of a base-denominated fee', () => {
-      const cost = getTradeCost({
-        isCrypto: true,
-        orderType: OrderType.MARKET,
-        pair: BTC_USD,
-        price: '61234.5',
-        quantity: '2.5',
-        rates: RATES,
-        side: OrderSide.BUY,
-      });
-
-      expect(cost.fee.toFixed(), 'debited in BTC').toBe('0.00625');
-      expect(cost.feeInCounter.toFixed(), '2.5 * 61234.5 USD * 0.0025, rounded up to the penny').toBe('382.72');
-      expect(
-        cost.fee.times('61234.5').round(2, Big.roundUp).toFixed(),
-        'both denominations describe the same fee at the fill price'
-      ).toBe(cost.feeInCounter.toFixed());
-    });
-
-    it('bills BUY and SELL at the same fraction of the notional', () => {
-      const shared = {isCrypto: true, orderType: OrderType.MARKET, pair: BTC_USD, price: '61234.5', rates: RATES};
-
-      const buy = getTradeCost({...shared, quantity: '2.5', side: OrderSide.BUY});
-      const sell = getTradeCost({...shared, quantity: '2.5', side: OrderSide.SELL});
-
-      expect(buy.feeInCounter.toFixed(), 'only the denomination differs between sides, not the rate').toBe(
-        sell.feeInCounter.toFixed()
-      );
-    });
   });
 });

--- a/packages/exchange/src/broker/alpaca/AlpacaFees.ts
+++ b/packages/exchange/src/broker/alpaca/AlpacaFees.ts
@@ -1,0 +1,104 @@
+import Big from 'big.js';
+import {OrderSide, type FeeRate, type OrderType} from '../Broker.js';
+import type {TradingPair} from '../TradingPair.js';
+
+/**
+ * Alpaca's order payload carries no fee field, and the authoritative `CFEE` account activity is a
+ * daily aggregate without an order reference, so a per-fill fee has to be derived. Everything in
+ * this module is therefore an *estimate* — reconcile against account activities when exact figures
+ * matter.
+ *
+ * @see https://docs.alpaca.markets/docs/crypto-fees
+ * @see https://files.alpaca.markets/disclosures/library/BrokFeeSched.pdf
+ */
+
+/**
+ * Alpaca rounds fiat fees *up* to the penny, both for crypto commissions and for regulatory
+ * pass-through fees.
+ *
+ * This is deliberately not `TradingRules.counter_increment`: that is the pair's *price* increment,
+ * which for BTC/USD is `0.000000001`. Price precision and billing precision are different things.
+ *
+ * @see https://alpaca.markets/support/regulatory-fees
+ */
+const FIAT_FEE_DECIMAL_PLACES = 2;
+
+export interface AlpacaTradeCost {
+  /** Fee amount, denominated in `feeAsset`. */
+  fee: Big;
+  /** Asset the fee is debited in. */
+  feeAsset: string;
+  /**
+   * The same fee expressed in `pair.counter`, so callers can compare costs across trades without
+   * caring which asset was debited. Equal to `fee` whenever `feeAsset` is the counter.
+   */
+  feeInCounter: Big;
+}
+
+export interface AlpacaTradeCostRequest {
+  /** `false` for stocks and ETFs, which pay no commission. */
+  isCrypto: boolean;
+  orderType: OrderType;
+  pair: TradingPair;
+  /** Execution price, in counter units per base unit. */
+  price: Big.BigSource;
+  /** Executed quantity, in base units. */
+  quantity: Big.BigSource;
+  rates: FeeRate;
+  side: OrderSide;
+}
+
+/**
+ * The asset Alpaca debits a fee from.
+ *
+ * Crypto fees are taken out of the *credited* asset — what you receive — so a BUY pays in the base
+ * asset and a SELL pays in the counter. Everything else settles in the counter currency.
+ */
+export function getCreditedAsset(pair: TradingPair, side: OrderSide, isCrypto: boolean): string {
+  if (isCrypto && side === OrderSide.BUY) {
+    return pair.base;
+  }
+  return pair.counter;
+}
+
+/**
+ * Derives the fee for a single Alpaca execution.
+ *
+ * The commission is `notional × rate` regardless of side; only the denomination changes. A BUY
+ * billed in the base asset works out to `quantity × rate`, a SELL billed in the counter to
+ * `quantity × price × rate`.
+ *
+ * Limit orders are billed at the maker rate and everything else at the taker rate. That is the best
+ * available signal, not the truth: a marketable limit order executes as a taker, but the order
+ * payload does not say whether the fill added or removed liquidity.
+ *
+ * Stocks and ETFs return a zero fee. Alpaca charges no commission on them, and the regulatory
+ * pass-through fees it does charge (SEC/REG, FINRA TAF, CAT) arrive as separate day-aggregated
+ * `FEE` activities that cannot be attributed to an order.
+ *
+ * @see https://alpaca.markets/support/regulatory-fees
+ */
+export function getTradeCost(request: AlpacaTradeCostRequest): AlpacaTradeCost {
+  const {isCrypto, orderType, pair, price, quantity, rates, side} = request;
+
+  const feeAsset = getCreditedAsset(pair, side, isCrypto);
+
+  if (!isCrypto) {
+    return {fee: new Big(0), feeAsset, feeInCounter: new Big(0)};
+  }
+
+  const rate = rates[orderType];
+  const notional = new Big(quantity).times(price);
+  const feeInCounter = notional.times(rate).round(FIAT_FEE_DECIMAL_PLACES, Big.roundUp);
+
+  if (feeAsset === pair.base) {
+    /*
+     * Base-denominated fees are left exact. The penny rounding observed on fiat fees has no
+     * documented equivalent for crypto quantities, and BTC/USD's trade increment (0.000000001) is
+     * fine enough that inventing one would distort the number more than leaving it alone.
+     */
+    return {fee: new Big(quantity).times(rate), feeAsset, feeInCounter};
+  }
+
+  return {fee: feeInCounter, feeAsset, feeInCounter};
+}

--- a/packages/exchange/src/broker/alpaca/AlpacaFees.ts
+++ b/packages/exchange/src/broker/alpaca/AlpacaFees.ts
@@ -3,35 +3,23 @@ import {OrderSide, type FeeRate, type OrderType} from '../Broker.js';
 import type {TradingPair} from '../TradingPair.js';
 
 /**
- * Alpaca's order payload carries no fee field, and the authoritative `CFEE` account activity is a
- * daily aggregate without an order reference, so a per-fill fee has to be derived. Everything in
- * this module is therefore an *estimate* — reconcile against account activities when exact figures
- * matter.
+ * Alpaca's order payload carries no fee field, so every figure here is derived rather than reported.
  *
  * @see https://docs.alpaca.markets/docs/crypto-fees
- * @see https://files.alpaca.markets/disclosures/library/BrokFeeSched.pdf
  */
 
 /**
- * Alpaca rounds fiat fees *up* to the penny, both for crypto commissions and for regulatory
- * pass-through fees.
- *
- * This is deliberately not `TradingRules.counter_increment`: that is the pair's *price* increment,
- * which for BTC/USD is `0.000000001`. Price precision and billing precision are different things.
- *
- * @see https://alpaca.markets/support/regulatory-fees
+ * Alpaca rounds fiat fees up to the penny. Deliberately not `TradingRules.counter_increment`, which
+ * is the pair's *price* increment — `0.000000001` for BTC/USD.
  */
 const FIAT_FEE_DECIMAL_PLACES = 2;
 
 export interface AlpacaTradeCost {
-  /** Fee amount, denominated in `feeAsset`. */
   fee: Big;
-  /** Asset the fee is debited in. */
   feeAsset: string;
 }
 
 export interface AlpacaTradeCostRequest {
-  /** `false` for stocks and ETFs, which pay no commission. */
   isCrypto: boolean;
   orderType: OrderType;
   pair: TradingPair;
@@ -44,10 +32,8 @@ export interface AlpacaTradeCostRequest {
 }
 
 /**
- * The asset Alpaca debits a fee from.
- *
- * Crypto fees are taken out of the *credited* asset — what you receive — so a BUY pays in the base
- * asset and a SELL pays in the counter. Everything else settles in the counter currency.
+ * Crypto fees come out of the asset you are credited with, so a BUY pays in the base asset and a
+ * SELL in the counter. Everything else settles in the counter.
  */
 export function getCreditedAsset(pair: TradingPair, side: OrderSide, isCrypto: boolean): string {
   if (isCrypto && side === OrderSide.BUY) {
@@ -57,21 +43,9 @@ export function getCreditedAsset(pair: TradingPair, side: OrderSide, isCrypto: b
 }
 
 /**
- * Derives the fee for a single Alpaca execution.
- *
- * The commission is `notional × rate` regardless of side; only the denomination changes. A BUY
- * billed in the base asset works out to `quantity × rate`, a SELL billed in the counter to
- * `quantity × price × rate`.
- *
  * Limit orders are billed at the maker rate and everything else at the taker rate. That is the best
- * available signal, not the truth: a marketable limit order executes as a taker, but the order
- * payload does not say whether the fill added or removed liquidity.
- *
- * Stocks and ETFs return a zero fee. Alpaca charges no commission on them, and the regulatory
- * pass-through fees it does charge (SEC/REG, FINRA TAF, CAT) arrive as separate day-aggregated
- * `FEE` activities that cannot be attributed to an order.
- *
- * @see https://alpaca.markets/support/regulatory-fees
+ * available signal, not the truth: a marketable limit order pays taker, and the payload does not
+ * say whether the fill added or removed liquidity.
  */
 export function getTradeCost(request: AlpacaTradeCostRequest): AlpacaTradeCost {
   const {isCrypto, orderType, pair, price, quantity, rates, side} = request;
@@ -86,11 +60,7 @@ export function getTradeCost(request: AlpacaTradeCostRequest): AlpacaTradeCost {
   const notional = new Big(quantity).times(price);
 
   if (feeAsset === pair.base) {
-    /*
-     * Base-denominated fees are left exact. The penny rounding observed on fiat fees has no
-     * documented equivalent for crypto quantities, and BTC/USD's trade increment (0.000000001) is
-     * fine enough that inventing one would distort the number more than leaving it alone.
-     */
+    // Left exact: the penny rounding seen on fiat fees has no documented crypto equivalent.
     return {fee: new Big(quantity).times(rate), feeAsset};
   }
 

--- a/packages/exchange/src/broker/alpaca/AlpacaFees.ts
+++ b/packages/exchange/src/broker/alpaca/AlpacaFees.ts
@@ -28,11 +28,6 @@ export interface AlpacaTradeCost {
   fee: Big;
   /** Asset the fee is debited in. */
   feeAsset: string;
-  /**
-   * The same fee expressed in `pair.counter`, so callers can compare costs across trades without
-   * caring which asset was debited. Equal to `fee` whenever `feeAsset` is the counter.
-   */
-  feeInCounter: Big;
 }
 
 export interface AlpacaTradeCostRequest {
@@ -84,12 +79,11 @@ export function getTradeCost(request: AlpacaTradeCostRequest): AlpacaTradeCost {
   const feeAsset = getCreditedAsset(pair, side, isCrypto);
 
   if (!isCrypto) {
-    return {fee: new Big(0), feeAsset, feeInCounter: new Big(0)};
+    return {fee: new Big(0), feeAsset};
   }
 
   const rate = rates[orderType];
   const notional = new Big(quantity).times(price);
-  const feeInCounter = notional.times(rate).round(FIAT_FEE_DECIMAL_PLACES, Big.roundUp);
 
   if (feeAsset === pair.base) {
     /*
@@ -97,8 +91,8 @@ export function getTradeCost(request: AlpacaTradeCostRequest): AlpacaTradeCost {
      * documented equivalent for crypto quantities, and BTC/USD's trade increment (0.000000001) is
      * fine enough that inventing one would distort the number more than leaving it alone.
      */
-    return {fee: new Big(quantity).times(rate), feeAsset, feeInCounter};
+    return {fee: new Big(quantity).times(rate), feeAsset};
   }
 
-  return {fee: feeInCounter, feeAsset, feeInCounter};
+  return {fee: notional.times(rate).round(FIAT_FEE_DECIMAL_PLACES, Big.roundUp), feeAsset};
 }

--- a/packages/exchange/src/broker/alpaca/AlpacaTradingWebSocket.ts
+++ b/packages/exchange/src/broker/alpaca/AlpacaTradingWebSocket.ts
@@ -76,10 +76,7 @@ class AlpacaTradingWebSocket {
             const listeners = this.#listeners.get(connectionId);
             if (listeners) {
               for (const cb of listeners) {
-                /*
-                 * Listeners are independent subscribers: one that throws on a malformed payload
-                 * must not stop the others in this loop from seeing the update.
-                 */
+                // One throwing listener must not stop the others in this loop.
                 try {
                   cb(parsed.data);
                 } catch (error) {

--- a/packages/exchange/src/broker/alpaca/AlpacaTradingWebSocket.ts
+++ b/packages/exchange/src/broker/alpaca/AlpacaTradingWebSocket.ts
@@ -76,7 +76,15 @@ class AlpacaTradingWebSocket {
             const listeners = this.#listeners.get(connectionId);
             if (listeners) {
               for (const cb of listeners) {
-                cb(parsed.data);
+                /*
+                 * Listeners are independent subscribers: one that throws on a malformed payload
+                 * must not stop the others in this loop from seeing the update.
+                 */
+                try {
+                  cb(parsed.data);
+                } catch (error) {
+                  console.error(`Trade update listener failed for connection "${connectionId}".`, error);
+                }
               }
             }
           } else {

--- a/packages/exchange/src/broker/alpaca/index.ts
+++ b/packages/exchange/src/broker/alpaca/index.ts
@@ -1,6 +1,7 @@
 export * from './AlpacaBroker.js';
 export * from './AlpacaBrokerMapper.js';
 export * from './AlpacaBrokerMock.js';
+export * from './AlpacaFees.js';
 export * from './AlpacaMarketData.js';
 export * from './getAlpacaClient.js';
 export * from './getAlpacaMarketData.js';

--- a/packages/exchange/src/broker/trading212/Trading212Broker.ts
+++ b/packages/exchange/src/broker/trading212/Trading212Broker.ts
@@ -371,7 +371,7 @@ export class Trading212Broker extends Broker implements MarketDataSource {
    * Trading212 debits all fees in the account currency, not the instrument currency.
    * Strategies on a EUR account trading USD stocks see fees in EUR.
    */
-  protected override async getFeeAsset(_pair: TradingPair, _side: OrderSide) {
+  override async getFeeAsset(_pair: TradingPair, _side: OrderSide) {
     const accountInfo = await this.#api.getAccountInfo();
     return accountInfo.currencyCode;
   }

--- a/packages/exchange/src/broker/trading212/Trading212Broker.ts
+++ b/packages/exchange/src/broker/trading212/Trading212Broker.ts
@@ -371,7 +371,7 @@ export class Trading212Broker extends Broker implements MarketDataSource {
    * Trading212 debits all fees in the account currency, not the instrument currency.
    * Strategies on a EUR account trading USD stocks see fees in EUR.
    */
-  protected override async getFeeAsset(_pair: TradingPair) {
+  protected override async getFeeAsset(_pair: TradingPair, _side: OrderSide) {
     const accountInfo = await this.#api.getAccountInfo();
     return accountInfo.currencyCode;
   }

--- a/packages/exchange/src/broker/trading212/Trading212Broker.ts
+++ b/packages/exchange/src/broker/trading212/Trading212Broker.ts
@@ -367,15 +367,6 @@ export class Trading212Broker extends Broker implements MarketDataSource {
     };
   }
 
-  /**
-   * Trading212 debits all fees in the account currency, not the instrument currency.
-   * Strategies on a EUR account trading USD stocks see fees in EUR.
-   */
-  override async getFeeAsset(_pair: TradingPair, _side: OrderSide) {
-    const accountInfo = await this.#api.getAccountInfo();
-    return accountInfo.currencyCode;
-  }
-
   protected override async placeOrder(pair: TradingPair, options: LimitOrderOptions): Promise<PendingLimitOrder>;
   protected override async placeOrder(pair: TradingPair, options: MarketOrderOptions): Promise<PendingMarketOrder>;
   protected override async placeOrder(pair: TradingPair, options: OrderOptions): Promise<PendingOrder> {


### PR DESCRIPTION
`AlpacaBrokerMapper.toFilledOrder` hardcoded `fee: '0'` on every fill, so realized P&L for crypto silently ignored Alpaca's commission.

Alpaca's order payload carries no fee field, and the authoritative `CFEE` account activity has no order reference on the historical records this was built against, so the fee has to be derived. `AlpacaFees` does that.

## What a plain `notional × rate` gets wrong

**The fee is not always denominated in the counter currency.** Alpaca deducts a crypto fee from the asset you are credited with, so a BUY is billed in the base asset and a SELL in the counter.

**Fiat fees round up to the penny.** Verified against a live account: a USDT/USD market SELL of 56.7732 @ 0.99912 has a notional of 56.723239584 USD, which at the taker rate computes to 0.14180809896 USD. Alpaca billed a `CFEE` of 0.15 USD. That fill is pinned as a test.

**The penny is not `TradingRules.counter_increment`.** That field is the pair's *price* increment, which for BTC/USD is `0.000000001`. Price precision and billing precision are different things.

## Also removes the fee-estimation API

`Broker.estimateFee` and `Broker.getFeeAsset` had no callers anywhere in the monorepo, and both had real defects: `estimateFee` labelled a counter-denominated amount with the base asset, and applied Alpaca's crypto rate schedule to commission-free equities. Fixing an interface with no consumers is worse than removing it, so they are gone along with Trading212's `getFeeAsset` override.

This is a breaking change to `@typedtrader/exchange`'s public surface. Anything that later needs a pre-trade cost can call `getTradeCost`, which is the calculator the realised `Fill` fee already uses, so there is one model rather than two to keep in agreement.

## Other fixes

A filled order without an average fill price is rejected rather than mapped to a `Fill` whose price is the string `"null"`, which passed every type check and then threw inside `new Big(fill.price)` far from the payload that caused it. The listener fan-out in `AlpacaTradingWebSocket` is wrapped so throwing there cannot stop other subscribers from receiving the update.

The shared API mocks carry their real `AlpacaAPI` signatures per `.claude/rules/testing.md`, with typed builders supplying the fields a case does not care about. The streamed-fill path gained a crypto case: the previous stream tests used a US equity, where the fee derivation and a bare `toFilledOrder` both return zero, so replacing one with the other survived.

Stocks and ETFs stay at a zero fee here; a follow-up estimates the regulatory fees Alpaca passes through.

Supersedes #1177.