### PR TITLE
fix(@typedtrader/exchange): parse Alpaca cash accounts

### DIFF
--- a/packages/exchange/src/broker/alpaca/api/schema/AccountSchema.test.ts
+++ b/packages/exchange/src/broker/alpaca/api/schema/AccountSchema.test.ts
@@ -1,12 +1,7 @@
 import {describe, expect, it} from 'vitest';
-import {AccountSchema} from './AccountSchema.js';
+import {AccountSchema, type Account} from './AccountSchema.js';
 
-/**
- * Shape of a live cash account, trimmed to the fields the schema declares. Alpaca returns no
- * `daytrade_count` and no `pattern_day_trader` here: both belong to Pattern Day Trader tracking,
- * which only applies to margin accounts.
- */
-const CASH_ACCOUNT = {
+const CASH_ACCOUNT: Account = {
   account_blocked: false,
   account_number: '245695408',
   buying_power: '325.7',
@@ -27,7 +22,7 @@ const CASH_ACCOUNT = {
   trade_suspended_by_user: false,
   trading_blocked: false,
   transfers_blocked: false,
-} as const;
+};
 
 describe('AccountSchema', () => {
   it('parses a cash account that omits the Pattern Day Trader fields', () => {

--- a/packages/exchange/src/broker/alpaca/api/schema/AccountSchema.test.ts
+++ b/packages/exchange/src/broker/alpaca/api/schema/AccountSchema.test.ts
@@ -1,0 +1,61 @@
+import {describe, expect, it} from 'vitest';
+import {AccountSchema} from './AccountSchema.js';
+
+/**
+ * Shape of a live cash account, trimmed to the fields the schema declares. Alpaca returns no
+ * `daytrade_count` and no `pattern_day_trader` here: both belong to Pattern Day Trader tracking,
+ * which only applies to margin accounts.
+ */
+const CASH_ACCOUNT = {
+  account_blocked: false,
+  account_number: '245695408',
+  buying_power: '325.7',
+  cash: '325.7',
+  created_at: '2023-08-08T18:58:27.267Z',
+  currency: 'USD',
+  equity: '425.7',
+  id: 'a1b2c3d4-0000-0000-0000-000000000000',
+  initial_margin: '0',
+  last_equity: '424.5',
+  long_market_value: '100',
+  maintenance_margin: '0',
+  multiplier: '1',
+  portfolio_value: '425.7',
+  short_market_value: '0',
+  shorting_enabled: false,
+  status: 'ACTIVE',
+  trade_suspended_by_user: false,
+  trading_blocked: false,
+  transfers_blocked: false,
+} as const;
+
+describe('AccountSchema', () => {
+  it('parses a cash account that omits the Pattern Day Trader fields', () => {
+    const account = AccountSchema.parse(CASH_ACCOUNT);
+
+    expect(account.cash, 'a cash account must parse; PDT tracking is margin-only').toBe('325.7');
+    expect(account.daytrade_count).toBeUndefined();
+    expect(account.pattern_day_trader).toBeUndefined();
+  });
+
+  it('parses a margin account that reports them', () => {
+    const account = AccountSchema.parse({
+      ...CASH_ACCOUNT,
+      daytrade_count: 2,
+      multiplier: '4',
+      pattern_day_trader: false,
+    });
+
+    expect(account.daytrade_count).toBe(2);
+    expect(account.pattern_day_trader).toBe(false);
+  });
+
+  it('still rejects a response missing a field every account reports', () => {
+    const {cash: _cash, ...withoutCash} = CASH_ACCOUNT;
+
+    expect(
+      () => AccountSchema.parse(withoutCash),
+      'making the PDT fields optional must not loosen the rest of the schema'
+    ).toThrowError();
+  });
+});

--- a/packages/exchange/src/broker/alpaca/api/schema/AccountSchema.ts
+++ b/packages/exchange/src/broker/alpaca/api/schema/AccountSchema.ts
@@ -10,7 +10,11 @@ export const AccountSchema = z.looseObject({
   cash: z.string(),
   created_at: z.string(),
   currency: z.string(),
-  daytrade_count: z.number(),
+  /**
+   * Only returned for margin accounts. Pattern Day Trader rules apply to margin trading, so a cash
+   * account (`multiplier: "1"`) omits this field entirely rather than reporting zero.
+   */
+  daytrade_count: z.number().optional(),
   equity: z.string(),
   id: z.string(),
   initial_margin: z.string(),
@@ -18,7 +22,8 @@ export const AccountSchema = z.looseObject({
   long_market_value: z.string(),
   maintenance_margin: z.string(),
   multiplier: z.string(),
-  pattern_day_trader: z.boolean(),
+  /** Omitted on cash accounts for the same reason as {@link AccountSchema} `daytrade_count`. */
+  pattern_day_trader: z.boolean().optional(),
   portfolio_value: z.string(),
   short_market_value: z.string(),
   shorting_enabled: z.boolean(),

--- a/packages/exchange/src/broker/alpaca/api/schema/AccountSchema.ts
+++ b/packages/exchange/src/broker/alpaca/api/schema/AccountSchema.ts
@@ -10,10 +10,6 @@ export const AccountSchema = z.looseObject({
   cash: z.string(),
   created_at: z.string(),
   currency: z.string(),
-  /**
-   * Only returned for margin accounts. Pattern Day Trader rules apply to margin trading, so a cash
-   * account (`multiplier: "1"`) omits this field entirely rather than reporting zero.
-   */
   daytrade_count: z.number().optional(),
   equity: z.string(),
   id: z.string(),
@@ -22,7 +18,6 @@ export const AccountSchema = z.looseObject({
   long_market_value: z.string(),
   maintenance_margin: z.string(),
   multiplier: z.string(),
-  /** Omitted on cash accounts for the same reason as {@link AccountSchema} `daytrade_count`. */
   pattern_day_trader: z.boolean().optional(),
   portfolio_value: z.string(),
   short_market_value: z.string(),


### PR DESCRIPTION
`AccountSchema` required `daytrade_count` and `pattern_day_trader`, but Alpaca omits both on cash accounts (`multiplier: "1"`) rather than reporting zero — Pattern Day Trader tracking only applies to margin trading.

So `getAccount()` threw a `ZodError` against a live cash account:

```
ZodError: [{ "expected": "number", "code": "invalid_type",
             "path": ["daytrade_count"],
             "message": "Invalid input: expected number, received undefined" }]
```

That also took down `listBalances()`, which is `getAccount()`'s only caller.

## Why optional is the right fix rather than a default

Neither field is read anywhere in the codebase — they exist only in the schema. Two unused required fields were failing the whole call. Making them optional matches what the API actually guarantees; giving them a default would fabricate a day-trade count that Alpaca never sent.

The rest of the schema is untouched, and a test asserts that a response missing a field every account *does* report still fails to parse, so this doesn't turn into a blanket loosening.

## Verification

Against a live cash account, `getAccount()` and `listBalances()` both succeed where they previously threw:

```
getAccount() OK: cash=$225.74 currency=USD multiplier=1
  daytrade_count=undefined  pattern_day_trader=undefined
listBalances() OK: 7 balances
```

Found while working on an unrelated change; it is independent of #1350 and #1351 and branches from `main`.