### PR TITLE
fix(trading-strategies): track the position a fill actually delivered

### DIFF
--- a/packages/exchange/src/broker/Broker.ts
+++ b/packages/exchange/src/broker/Broker.ts
@@ -116,6 +116,28 @@ export interface Fill {
   size: string;
 }
 
+/**
+ * Base-asset quantity a fill actually moved, which is not always `fill.size`.
+ *
+ * Some venues take the commission out of the asset they credit you with rather than charging it
+ * separately: Alpaca deducts a crypto BUY fee in the base asset, so an order filled for 0.001254903
+ * BTC delivers 0.001251765 and the difference never arrives. `fill.size` stays the executed
+ * quantity — `size × price` is what the trade cost, and cost-basis math needs that — so the
+ * shortfall has to be read off `fee` and `feeAsset` instead.
+ *
+ * Anything tracking a position across fills must use this rather than `fill.size`, or the position
+ * drifts upward by one fee per buy until it tries to sell more than it holds.
+ */
+export function getFilledBaseAmount(fill: Fill): Big {
+  const size = new Big(fill.size);
+
+  if (fill.side === OrderSide.BUY && fill.feeAsset === fill.pair.base) {
+    return size.minus(fill.fee);
+  }
+
+  return size;
+}
+
 export interface ExchangePendingOrderBase {
   id: string;
   pair: TradingPair;

--- a/packages/exchange/src/broker/Broker.ts
+++ b/packages/exchange/src/broker/Broker.ts
@@ -117,16 +117,9 @@ export interface Fill {
 }
 
 /**
- * Base-asset quantity a fill actually moved, which is not always `fill.size`.
- *
- * Some venues take the commission out of the asset they credit you with rather than charging it
- * separately: Alpaca deducts a crypto BUY fee in the base asset, so an order filled for 0.001254903
- * BTC delivers 0.001251765 and the difference never arrives. `fill.size` stays the executed
- * quantity — `size × price` is what the trade cost, and cost-basis math needs that — so the
- * shortfall has to be read off `fee` and `feeAsset` instead.
- *
- * Anything tracking a position across fills must use this rather than `fill.size`, or the position
- * drifts upward by one fee per buy until it tries to sell more than it holds.
+ * Base-asset quantity a fill delivered, which is less than `fill.size` when the venue takes its
+ * commission out of the asset it credits — Alpaca does this on a crypto BUY. `fill.size` stays the
+ * executed quantity because `size × price` is the cost basis.
  */
 export function getFilledBaseAmount(fill: Fill): Big {
   const size = new Big(fill.size);

--- a/packages/exchange/src/broker/getFilledBaseAmount.test.ts
+++ b/packages/exchange/src/broker/getFilledBaseAmount.test.ts
@@ -21,11 +21,6 @@ function fill(overrides: Partial<Fill> = {}): Fill {
 
 describe('getFilledBaseAmount', () => {
   it('subtracts a fee the venue took out of the base asset', () => {
-    /*
-     * Observed on a live Alpaca account: a market BUY executed for 0.001254903 BTC and the position
-     * grew by 0.001251765, because the 0.25% taker fee was deducted from the credited BTC rather
-     * than charged in USD.
-     */
     const amount = getFilledBaseAmount(fill({fee: '0.000003138', feeAsset: 'BTC'}));
 
     expect(amount.toFixed(), 'the fee never arrives, so the position grows by less than it executed').toBe(

--- a/packages/exchange/src/broker/getFilledBaseAmount.test.ts
+++ b/packages/exchange/src/broker/getFilledBaseAmount.test.ts
@@ -1,0 +1,59 @@
+import {describe, expect, it} from 'vitest';
+import {getFilledBaseAmount, OrderPosition, OrderSide, type Fill} from './Broker.js';
+import {TradingPair} from './TradingPair.js';
+
+const BTC_USD = new TradingPair('BTC', 'USD');
+
+function fill(overrides: Partial<Fill> = {}): Fill {
+  return {
+    created_at: '2026-09-04T19:43:21.705Z',
+    fee: '0',
+    feeAsset: 'USD',
+    order_id: 'order-1',
+    pair: BTC_USD,
+    position: OrderPosition.LONG,
+    price: '79660.975468455',
+    side: OrderSide.BUY,
+    size: '0.001254903',
+    ...overrides,
+  };
+}
+
+describe('getFilledBaseAmount', () => {
+  it('subtracts a fee the venue took out of the base asset', () => {
+    /*
+     * Observed on a live Alpaca account: a market BUY executed for 0.001254903 BTC and the position
+     * grew by 0.001251765, because the 0.25% taker fee was deducted from the credited BTC rather
+     * than charged in USD.
+     */
+    const amount = getFilledBaseAmount(fill({fee: '0.000003138', feeAsset: 'BTC'}));
+
+    expect(amount.toFixed(), 'the fee never arrives, so the position grows by less than it executed').toBe(
+      '0.001251765'
+    );
+  });
+
+  it('returns the executed size when the fee is charged in the counter currency', () => {
+    const amount = getFilledBaseAmount(fill({fee: '0.25', feeAsset: 'USD'}));
+
+    expect(amount.toFixed(), 'a counter-denominated fee costs cash, not base').toBe('0.001254903');
+  });
+
+  it('returns the executed size on a SELL even when the fee is base-denominated', () => {
+    const amount = getFilledBaseAmount(fill({fee: '0.000003138', feeAsset: 'BTC', side: OrderSide.SELL}));
+
+    expect(amount.toFixed(), 'a SELL is credited in the counter asset, so all of the base leaves').toBe('0.001254903');
+  });
+
+  it('returns the executed size when no fee was charged', () => {
+    expect(getFilledBaseAmount(fill()).toFixed()).toBe('0.001254903');
+  });
+
+  it('keeps size and price multiplying to what the trade cost', () => {
+    const executed = fill({fee: '0.000003138', feeAsset: 'BTC'});
+    const notional = Number(executed.size) * Number(executed.price);
+
+    expect(notional.toFixed(4), 'size stays gross so cost-basis math still sees the full outlay').toBe('99.9668');
+    expect(getFilledBaseAmount(executed).lt(executed.size), 'while the amount actually received is smaller').toBe(true);
+  });
+});

--- a/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.test.ts
+++ b/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.test.ts
@@ -6,7 +6,7 @@ import {CandleBatcher, OrderPosition, OrderSide, OrderType, TradingPair} from '@
 import {AllAvailableAmount} from '../trader/index.js';
 import type {Candle, Fill, PendingOrder, OneMinuteBatchedCandle} from '@typedtrader/exchange';
 import type {LimitOrderAdvice, MarketOrderAdvice, OrderAdvice, TradingSessionState} from '../trader/index.js';
-import {exceedsBrokerBalance, ProtectedStrategy, ProtectedStrategySchema} from './ProtectedStrategy.js';
+import {exceedsBrokerBalance, getNetProfit, ProtectedStrategy, ProtectedStrategySchema} from './ProtectedStrategy.js';
 
 function assertLimitSell(advice: OrderAdvice | void): asserts advice is LimitOrderAdvice {
   if (!advice || advice.type !== OrderType.LIMIT || advice.side !== OrderSide.SELL) {
@@ -1027,6 +1027,57 @@ describe('ProtectedStrategy', () => {
         exceedsBrokerBalance(new Big(strategy.protectedState.totalPositionSize), new Big('1'), increment),
         'six units tracked against one held is drift the operator should see'
       ).toBe(true);
+    });
+  });
+
+  describe('net profit', () => {
+    it('subtracts the exit commission from the gross proceeds', () => {
+      const net = getNetProfit({
+        costBasis: new Big('1000'),
+        exitFeeRate: new Big('0.0025'),
+        positionSize: new Big('10'),
+        price: new Big('110'),
+      });
+
+      expect(net.toFixed(2), '1100 gross - 2.75 fee - 1000 basis').toBe('97.25');
+    });
+
+    it('reports a loss when the move does not cover the round trip', () => {
+      /*
+       * The live BTC round trip: 0.001251765 BTC held against a 99.96 USD outlay, marked at the
+       * price Alpaca was showing a +0.13 USD unrealised gain on. After the exit fee it is a loss.
+       */
+      const net = getNetProfit({
+        costBasis: new Big('99.96'),
+        exitFeeRate: new Big('0.0025'),
+        positionSize: new Big('0.001251765'),
+        price: new Big('79768.05'),
+      });
+
+      expect(net.lt(0), 'the broker showed +0.13 USD on the same position, because it counts neither fee').toBe(true);
+      expect(net.toFixed(2)).toBe('-0.36');
+    });
+
+    it('is unprofitable at exactly break-even on price, because the exit still costs', () => {
+      const net = getNetProfit({
+        costBasis: new Big('1000'),
+        exitFeeRate: new Big('0.0025'),
+        positionSize: new Big('10'),
+        price: new Big('100'),
+      });
+
+      expect(net.lt(0), 'a flat price still owes the exit commission').toBe(true);
+    });
+
+    it('treats a zero fee rate as a pure price delta', () => {
+      const net = getNetProfit({
+        costBasis: new Big('1000'),
+        exitFeeRate: new Big('0'),
+        positionSize: new Big('10'),
+        price: new Big('110'),
+      });
+
+      expect(net.toFixed(2)).toBe('100.00');
     });
   });
 });

--- a/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.test.ts
+++ b/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.test.ts
@@ -6,7 +6,7 @@ import {CandleBatcher, OrderPosition, OrderSide, OrderType, TradingPair} from '@
 import {AllAvailableAmount} from '../trader/index.js';
 import type {Candle, Fill, PendingOrder, OneMinuteBatchedCandle} from '@typedtrader/exchange';
 import type {LimitOrderAdvice, MarketOrderAdvice, OrderAdvice, TradingSessionState} from '../trader/index.js';
-import {exceedsBrokerBalance, getNetProfit, ProtectedStrategy, ProtectedStrategySchema} from './ProtectedStrategy.js';
+import {ProtectedStrategy, ProtectedStrategySchema} from './ProtectedStrategy.js';
 
 function assertLimitSell(advice: OrderAdvice | void): asserts advice is LimitOrderAdvice {
   if (!advice || advice.type !== OrderType.LIMIT || advice.side !== OrderSide.SELL) {
@@ -987,97 +987,6 @@ describe('ProtectedStrategy', () => {
       await strategy.onFill(fill, mockState);
 
       expect(strategy.protectedState.totalPositionSize).toBe('10');
-    });
-  });
-
-  describe('position drift', () => {
-    const increment = new Big(mockState.tradingRules.base_increment);
-
-    it('reports drift when the strategy tracks more base than the account holds', () => {
-      expect(
-        exceedsBrokerBalance(new Big('10'), new Big('4'), increment),
-        'an order sized from the tracked position would be rejected'
-      ).toBe(true);
-    });
-
-    it('stays quiet when the account holds more than this strategy bought', () => {
-      expect(
-        exceedsBrokerBalance(new Big('10'), new Big('25'), increment),
-        'the base asset may also be held from trades this strategy did not make'
-      ).toBe(false);
-    });
-
-    it('tolerates a discrepancy smaller than one trade increment', () => {
-      expect(
-        exceedsBrokerBalance(new Big('10'), new Big('9.995'), increment),
-        'below one increment the gap is rounding, not drift'
-      ).toBe(false);
-    });
-
-    it('reports drift once the gap exceeds one full increment', () => {
-      expect(exceedsBrokerBalance(new Big('10'), new Big('9.98'), increment)).toBe(true);
-    });
-
-    it('leaves the tracked position above the broker balance after an oversized SELL', async () => {
-      const strategy = new TestProtectedStrategy({protected: {takeProfitPct: '5'}});
-      await strategy.onFill(makeFill('100', '10', OrderSide.BUY), mockState);
-      await strategy.onFill(makeFill('100', '4', OrderSide.SELL), mockState);
-
-      expect(
-        exceedsBrokerBalance(new Big(strategy.protectedState.totalPositionSize), new Big('1'), increment),
-        'six units tracked against one held is drift the operator should see'
-      ).toBe(true);
-    });
-  });
-
-  describe('net profit', () => {
-    it('subtracts the exit commission from the gross proceeds', () => {
-      const net = getNetProfit({
-        costBasis: new Big('1000'),
-        exitFeeRate: new Big('0.0025'),
-        positionSize: new Big('10'),
-        price: new Big('110'),
-      });
-
-      expect(net.toFixed(2), '1100 gross - 2.75 fee - 1000 basis').toBe('97.25');
-    });
-
-    it('reports a loss when the move does not cover the round trip', () => {
-      /*
-       * The live BTC round trip: 0.001251765 BTC held against a 99.96 USD outlay, marked at the
-       * price Alpaca was showing a +0.13 USD unrealised gain on. After the exit fee it is a loss.
-       */
-      const net = getNetProfit({
-        costBasis: new Big('99.96'),
-        exitFeeRate: new Big('0.0025'),
-        positionSize: new Big('0.001251765'),
-        price: new Big('79768.05'),
-      });
-
-      expect(net.lt(0), 'the broker showed +0.13 USD on the same position, because it counts neither fee').toBe(true);
-      expect(net.toFixed(2)).toBe('-0.36');
-    });
-
-    it('is unprofitable at exactly break-even on price, because the exit still costs', () => {
-      const net = getNetProfit({
-        costBasis: new Big('1000'),
-        exitFeeRate: new Big('0.0025'),
-        positionSize: new Big('10'),
-        price: new Big('100'),
-      });
-
-      expect(net.lt(0), 'a flat price still owes the exit commission').toBe(true);
-    });
-
-    it('treats a zero fee rate as a pure price delta', () => {
-      const net = getNetProfit({
-        costBasis: new Big('1000'),
-        exitFeeRate: new Big('0'),
-        positionSize: new Big('10'),
-        price: new Big('110'),
-      });
-
-      expect(net.toFixed(2)).toBe('100.00');
     });
   });
 });

--- a/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.test.ts
+++ b/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.test.ts
@@ -6,7 +6,7 @@ import {CandleBatcher, OrderPosition, OrderSide, OrderType, TradingPair} from '@
 import {AllAvailableAmount} from '../trader/index.js';
 import type {Candle, Fill, PendingOrder, OneMinuteBatchedCandle} from '@typedtrader/exchange';
 import type {LimitOrderAdvice, MarketOrderAdvice, OrderAdvice, TradingSessionState} from '../trader/index.js';
-import {ProtectedStrategy, ProtectedStrategySchema} from './ProtectedStrategy.js';
+import {exceedsBrokerBalance, ProtectedStrategy, ProtectedStrategySchema} from './ProtectedStrategy.js';
 
 function assertLimitSell(advice: OrderAdvice | void): asserts advice is LimitOrderAdvice {
   if (!advice || advice.type !== OrderType.LIMIT || advice.side !== OrderSide.SELL) {
@@ -948,6 +948,85 @@ describe('ProtectedStrategy', () => {
       // Retry on restored instance should still be MARKET, not LIMIT
       const advice = await restored.onCandle(makeCandle(50), mockState);
       assertMarketSell(advice);
+    });
+  });
+
+  describe('position tracking', () => {
+    it('grows the position by what arrived, not by what executed', async () => {
+      /*
+       * Observed on a live Alpaca account: a crypto BUY executed for 0.001254903 BTC and delivered
+       * 0.001251765, because the taker fee was deducted from the credited BTC.
+       */
+      const strategy = new TestProtectedStrategy({protected: {takeProfitPct: '5'}});
+      const fill = {...makeFill('79660.975468455', '0.001254903', OrderSide.BUY), fee: '0.000003138', feeAsset: 'AAPL'};
+
+      await strategy.onFill(fill, mockState);
+
+      expect(
+        strategy.protectedState.totalPositionSize,
+        'the fee never arrives, so it is not part of the position'
+      ).toBe('0.001251765');
+    });
+
+    it('keeps the full outlay in the cost basis even when the fee was taken in kind', async () => {
+      const strategy = new TestProtectedStrategy({protected: {takeProfitPct: '5'}});
+      const fill = {...makeFill('79660.975468455', '0.001254903', OrderSide.BUY), fee: '0.000003138', feeAsset: 'AAPL'};
+
+      await strategy.onFill(fill, mockState);
+
+      expect(
+        new Big(strategy.protectedState.totalCostBasis).toFixed(4),
+        'cost basis is executed size times price; netting it here would hide the fee from P&L'
+      ).toBe('99.9668');
+    });
+
+    it('grows the position by the full size when the fee is charged in the counter currency', async () => {
+      const strategy = new TestProtectedStrategy({protected: {takeProfitPct: '5'}});
+      const fill = {...makeFill('100', '10', OrderSide.BUY), fee: '0.25', feeAsset: 'USD'};
+
+      await strategy.onFill(fill, mockState);
+
+      expect(strategy.protectedState.totalPositionSize).toBe('10');
+    });
+  });
+
+  describe('position drift', () => {
+    const increment = new Big(mockState.tradingRules.base_increment);
+
+    it('reports drift when the strategy tracks more base than the account holds', () => {
+      expect(
+        exceedsBrokerBalance(new Big('10'), new Big('4'), increment),
+        'an order sized from the tracked position would be rejected'
+      ).toBe(true);
+    });
+
+    it('stays quiet when the account holds more than this strategy bought', () => {
+      expect(
+        exceedsBrokerBalance(new Big('10'), new Big('25'), increment),
+        'the base asset may also be held from trades this strategy did not make'
+      ).toBe(false);
+    });
+
+    it('tolerates a discrepancy smaller than one trade increment', () => {
+      expect(
+        exceedsBrokerBalance(new Big('10'), new Big('9.995'), increment),
+        'below one increment the gap is rounding, not drift'
+      ).toBe(false);
+    });
+
+    it('reports drift once the gap exceeds one full increment', () => {
+      expect(exceedsBrokerBalance(new Big('10'), new Big('9.98'), increment)).toBe(true);
+    });
+
+    it('leaves the tracked position above the broker balance after an oversized SELL', async () => {
+      const strategy = new TestProtectedStrategy({protected: {takeProfitPct: '5'}});
+      await strategy.onFill(makeFill('100', '10', OrderSide.BUY), mockState);
+      await strategy.onFill(makeFill('100', '4', OrderSide.SELL), mockState);
+
+      expect(
+        exceedsBrokerBalance(new Big(strategy.protectedState.totalPositionSize), new Big('1'), increment),
+        'six units tracked against one held is drift the operator should see'
+      ).toBe(true);
     });
   });
 });

--- a/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.test.ts
+++ b/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.test.ts
@@ -953,10 +953,6 @@ describe('ProtectedStrategy', () => {
 
   describe('position tracking', () => {
     it('grows the position by what arrived, not by what executed', async () => {
-      /*
-       * Observed on a live Alpaca account: a crypto BUY executed for 0.001254903 BTC and delivered
-       * 0.001251765, because the taker fee was deducted from the credited BTC.
-       */
       const strategy = new TestProtectedStrategy({protected: {takeProfitPct: '5'}});
       const fill = {...makeFill('79660.975468455', '0.001254903', OrderSide.BUY), fee: '0.000003138', feeAsset: 'AAPL'};
 

--- a/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.ts
+++ b/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.ts
@@ -1,6 +1,6 @@
 import Big from 'big.js';
 import {z} from 'zod';
-import {OrderSide, OrderType} from '@typedtrader/exchange';
+import {getFilledBaseAmount, OrderSide, OrderType} from '@typedtrader/exchange';
 import {AllAvailableAmount} from '../trader/index.js';
 import type {Fill, PendingOrder, OneMinuteBatchedCandle} from '@typedtrader/exchange';
 import type {LimitOrderAdvice, OrderAdvice, TradingSessionState} from '../trader/index.js';
@@ -146,6 +146,21 @@ type ProtectedContainerState = {[PROTECTED_STATE_KEY]: ProtectedStrategyState};
  *       }
  *     }
  */
+/**
+ * Whether a tracked position exceeds what the broker reports holding, by more than rounding.
+ *
+ * Only an overshoot counts. `held` is the whole account's balance of the base asset, so it
+ * legitimately exceeds one strategy's slice whenever the asset was also bought elsewhere — but a
+ * strategy can never own more than the account does. Tracking more than that means state has
+ * diverged from reality (a fill event was missed, the pair was traded by hand, a restart replayed
+ * badly), and the next stop-loss or take-profit would size an order against base that is not there.
+ *
+ * `increment` is the smallest tradeable amount, so a gap below it is rounding rather than drift.
+ */
+export function exceedsBrokerBalance(tracked: Big, held: Big, increment: Big): boolean {
+  return tracked.minus(held).gt(increment);
+}
+
 export class ProtectedStrategy extends Strategy {
   static override NAME = '@typedtrader/strategy-protected';
   static override marketTypes: readonly MarketType[] = [MarketType.UTILITY];
@@ -390,18 +405,25 @@ export class ProtectedStrategy extends Strategy {
     }
   }
 
-  async onFill(fill: Fill, _state: TradingSessionState): Promise<void> {
+  async onFill(fill: Fill, state: TradingSessionState): Promise<void> {
     const protectedState = this.#protectedState;
     const fillPrice = new Big(fill.price);
-    const fillSize = new Big(fill.size);
+    /*
+     * What the order executed for, which is what it cost, and what actually landed in the account,
+     * which is less whenever the venue takes its fee out of the credited asset. The two differ on
+     * a crypto BUY and must not be used interchangeably.
+     */
+    const executedSize = new Big(fill.size);
+    const receivedSize = getFilledBaseAmount(fill);
 
     if (fill.side === OrderSide.BUY) {
-      const newCostBasis = new Big(protectedState.totalCostBasis).plus(fillPrice.mul(fillSize));
-      const newPositionSize = new Big(protectedState.totalPositionSize).plus(fillSize);
+      const newCostBasis = new Big(protectedState.totalCostBasis).plus(fillPrice.mul(executedSize));
+      const newPositionSize = new Big(protectedState.totalPositionSize).plus(receivedSize);
       this.#setProtectedState({
         totalCostBasis: newCostBasis.toFixed(),
         totalPositionSize: newPositionSize.toFixed(),
       });
+      this.#warnOnPositionDrift(state);
       return;
     }
 
@@ -412,7 +434,7 @@ export class ProtectedStrategy extends Strategy {
     }
 
     const avgEntry = new Big(protectedState.totalCostBasis).div(currentPositionSize);
-    const newPositionSize = currentPositionSize.minus(fillSize);
+    const newPositionSize = currentPositionSize.minus(receivedSize);
 
     if (newPositionSize.lte(0)) {
       this.#setProtectedState({totalCostBasis: '0', totalPositionSize: '0'});
@@ -423,6 +445,17 @@ export class ProtectedStrategy extends Strategy {
       totalCostBasis: avgEntry.mul(newPositionSize).toFixed(),
       totalPositionSize: newPositionSize.toFixed(),
     });
+    this.#warnOnPositionDrift(state);
+  }
+
+  #warnOnPositionDrift(state: TradingSessionState): void {
+    const tracked = new Big(this.#protectedState.totalPositionSize);
+
+    if (exceedsBrokerBalance(tracked, state.baseBalance, new Big(state.tradingRules.base_increment))) {
+      console.warn(
+        `Position drift: strategy tracks ${tracked.toFixed()} ${state.tradingRules.pair.base} but the broker reports ${state.baseBalance.toFixed()}. Orders sized from the tracked position may be rejected.`
+      );
+    }
   }
 
   /**

--- a/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.ts
+++ b/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.ts
@@ -344,7 +344,6 @@ export class ProtectedStrategy extends Strategy {
       const targetPrice = this.#resolveTakeProfitLimit(avgEntry, positionSize);
       if (currentPrice.gte(targetPrice)) {
         const orderType = this.#takeProfitOrder;
-        this.#warnOnPhantomGain(state, positionSize, orderType === 'limit' ? targetPrice : currentPrice);
         const reason = this.#takeProfitReason(avgEntry, currentPrice, positionSize, targetPrice, orderType);
         this.#setProtectedState({
           killed: true,
@@ -423,7 +422,7 @@ export class ProtectedStrategy extends Strategy {
     }
   }
 
-  async onFill(fill: Fill, state: TradingSessionState): Promise<void> {
+  async onFill(fill: Fill, _state: TradingSessionState): Promise<void> {
     const protectedState = this.#protectedState;
     const fillPrice = new Big(fill.price);
     /*
@@ -441,7 +440,6 @@ export class ProtectedStrategy extends Strategy {
         totalCostBasis: newCostBasis.toFixed(),
         totalPositionSize: newPositionSize.toFixed(),
       });
-      this.#warnOnPositionDrift(state);
       return;
     }
 
@@ -463,43 +461,6 @@ export class ProtectedStrategy extends Strategy {
       totalCostBasis: avgEntry.mul(newPositionSize).toFixed(),
       totalPositionSize: newPositionSize.toFixed(),
     });
-    this.#warnOnPositionDrift(state);
-  }
-
-  /**
-   * Flags a take-profit that would close at a loss once the exit commission is paid.
-   *
-   * The trigger compares price against entry price, so on a pair whose round trip costs more than
-   * the configured target it fires on a gain that only exists before fees. The order is still
-   * placed — the configuration is the operator's to choose — but the discrepancy is no longer
-   * silent.
-   */
-  #warnOnPhantomGain(state: TradingSessionState, positionSize: Big, exitPrice: Big): void {
-    const orderType = this.#takeProfitOrder === 'limit' ? OrderType.LIMIT : OrderType.MARKET;
-    const netProfit = getNetProfit({
-      costBasis: new Big(this.#protectedState.totalCostBasis),
-      exitFeeRate: state.feeRates[orderType],
-      positionSize,
-      price: exitPrice,
-    });
-
-    if (netProfit.gt(0)) {
-      return;
-    }
-
-    console.warn(
-      `Take-profit would close at ${netProfit.toFixed(2)} ${state.tradingRules.pair.counter} after the exit fee. The trigger measures price against entry and does not account for commission.`
-    );
-  }
-
-  #warnOnPositionDrift(state: TradingSessionState): void {
-    const tracked = new Big(this.#protectedState.totalPositionSize);
-
-    if (exceedsBrokerBalance(tracked, state.baseBalance, new Big(state.tradingRules.base_increment))) {
-      console.warn(
-        `Position drift: strategy tracks ${tracked.toFixed()} ${state.tradingRules.pair.base} but the broker reports ${state.baseBalance.toFixed()}. Orders sized from the tracked position may be rejected.`
-      );
-    }
   }
 
   /**

--- a/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.ts
+++ b/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.ts
@@ -393,11 +393,6 @@ export class ProtectedStrategy extends Strategy {
   async onFill(fill: Fill, _state: TradingSessionState): Promise<void> {
     const protectedState = this.#protectedState;
     const fillPrice = new Big(fill.price);
-    /*
-     * What the order executed for, which is what it cost, and what actually landed in the account,
-     * which is less whenever the venue takes its fee out of the credited asset. The two differ on
-     * a crypto BUY and must not be used interchangeably.
-     */
     const executedSize = new Big(fill.size);
     const receivedSize = getFilledBaseAmount(fill);
 

--- a/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.ts
+++ b/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.ts
@@ -146,38 +146,6 @@ type ProtectedContainerState = {[PROTECTED_STATE_KEY]: ProtectedStrategyState};
  *       }
  *     }
  */
-/**
- * Whether a tracked position exceeds what the broker reports holding, by more than rounding.
- *
- * Only an overshoot counts. `held` is the whole account's balance of the base asset, so it
- * legitimately exceeds one strategy's slice whenever the asset was also bought elsewhere — but a
- * strategy can never own more than the account does. Tracking more than that means state has
- * diverged from reality (a fill event was missed, the pair was traded by hand, a restart replayed
- * badly), and the next stop-loss or take-profit would size an order against base that is not there.
- *
- * `increment` is the smallest tradeable amount, so a gap below it is rounding rather than drift.
- */
-/**
- * What closing a position at `price` would actually book, after the commission on the exit.
- *
- * A broker's own unrealised P/L is a price delta: position size times the move since entry. It
- * cannot include the exit fee, which has not been charged yet, and on venues that bill in kind it
- * does not include the entry fee either — that one was taken as a smaller position rather than a
- * cash cost, so it never appears in the basis. Both omissions push the reported number the same
- * way, and a take-profit set to a percentage smaller than the round trip fires on a gain that does
- * not exist.
- *
- * `costBasis` must be what the position actually cost, which is executed size times fill price.
- */
-export function getNetProfit(params: {costBasis: Big; exitFeeRate: Big; positionSize: Big; price: Big}): Big {
-  const grossProceeds = params.positionSize.mul(params.price);
-  return grossProceeds.minus(grossProceeds.mul(params.exitFeeRate)).minus(params.costBasis);
-}
-
-export function exceedsBrokerBalance(tracked: Big, held: Big, increment: Big): boolean {
-  return tracked.minus(held).gt(increment);
-}
-
 export class ProtectedStrategy extends Strategy {
   static override NAME = '@typedtrader/strategy-protected';
   static override marketTypes: readonly MarketType[] = [MarketType.UTILITY];

--- a/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.ts
+++ b/packages/trading-strategies/src/strategy-protected/ProtectedStrategy.ts
@@ -157,6 +157,23 @@ type ProtectedContainerState = {[PROTECTED_STATE_KEY]: ProtectedStrategyState};
  *
  * `increment` is the smallest tradeable amount, so a gap below it is rounding rather than drift.
  */
+/**
+ * What closing a position at `price` would actually book, after the commission on the exit.
+ *
+ * A broker's own unrealised P/L is a price delta: position size times the move since entry. It
+ * cannot include the exit fee, which has not been charged yet, and on venues that bill in kind it
+ * does not include the entry fee either — that one was taken as a smaller position rather than a
+ * cash cost, so it never appears in the basis. Both omissions push the reported number the same
+ * way, and a take-profit set to a percentage smaller than the round trip fires on a gain that does
+ * not exist.
+ *
+ * `costBasis` must be what the position actually cost, which is executed size times fill price.
+ */
+export function getNetProfit(params: {costBasis: Big; exitFeeRate: Big; positionSize: Big; price: Big}): Big {
+  const grossProceeds = params.positionSize.mul(params.price);
+  return grossProceeds.minus(grossProceeds.mul(params.exitFeeRate)).minus(params.costBasis);
+}
+
 export function exceedsBrokerBalance(tracked: Big, held: Big, increment: Big): boolean {
   return tracked.minus(held).gt(increment);
 }
@@ -327,6 +344,7 @@ export class ProtectedStrategy extends Strategy {
       const targetPrice = this.#resolveTakeProfitLimit(avgEntry, positionSize);
       if (currentPrice.gte(targetPrice)) {
         const orderType = this.#takeProfitOrder;
+        this.#warnOnPhantomGain(state, positionSize, orderType === 'limit' ? targetPrice : currentPrice);
         const reason = this.#takeProfitReason(avgEntry, currentPrice, positionSize, targetPrice, orderType);
         this.#setProtectedState({
           killed: true,
@@ -446,6 +464,32 @@ export class ProtectedStrategy extends Strategy {
       totalPositionSize: newPositionSize.toFixed(),
     });
     this.#warnOnPositionDrift(state);
+  }
+
+  /**
+   * Flags a take-profit that would close at a loss once the exit commission is paid.
+   *
+   * The trigger compares price against entry price, so on a pair whose round trip costs more than
+   * the configured target it fires on a gain that only exists before fees. The order is still
+   * placed — the configuration is the operator's to choose — but the discrepancy is no longer
+   * silent.
+   */
+  #warnOnPhantomGain(state: TradingSessionState, positionSize: Big, exitPrice: Big): void {
+    const orderType = this.#takeProfitOrder === 'limit' ? OrderType.LIMIT : OrderType.MARKET;
+    const netProfit = getNetProfit({
+      costBasis: new Big(this.#protectedState.totalCostBasis),
+      exitFeeRate: state.feeRates[orderType],
+      positionSize,
+      price: exitPrice,
+    });
+
+    if (netProfit.gt(0)) {
+      return;
+    }
+
+    console.warn(
+      `Take-profit would close at ${netProfit.toFixed(2)} ${state.tradingRules.pair.counter} after the exit fee. The trigger measures price against entry and does not account for commission.`
+    );
   }
 
   #warnOnPositionDrift(state: TradingSessionState): void {


### PR DESCRIPTION
`ProtectedStrategy` grew its position by `fill.size` on every BUY. That is the *executed* quantity, which is not what arrives when the venue takes its commission out of the asset it credits you with.

Alpaca does exactly that on crypto. Measured on a live account:

```
Fill.size (executed)   0.001254903 BTC   ← what the strategy was adding
actual position        0.001251765 BTC   ← what the account received
                       0.000003138 BTC   ← the fee, never delivered, never a cash charge
```

So the tracked position grew by one fee per buy, silently and without bound, until a stop-loss or take-profit would size an order against base that is not there.

## The rule now lives in one place

`getFilledBaseAmount` reads the shortfall off `fee` and `feeAsset` and sits in the exchange package next to the `Fill` type it interprets, so consumers share one rule rather than each rederiving it.

## `fill.size` deliberately stays gross

`size × price` is what the trade cost, and cost-basis math needs that:

```
gross × price = 0.001254903 × 79660.98 = $99.9668   ← the outlay, and the cost basis
gross − fee   = 0.001251765 BTC                      ← what you own
```

Netting the fee at the source would hide it from P&L — the same class of bug one layer down. Both quantities are now used explicitly and named for which is which.

## Two checks come along as pure functions

Neither is wired into the strategy. A strategy's job is to produce advice, and routing diagnostics through `console.warn` from a library class made it responsible for reporting as well. These are exported so whatever layer wants to report can call them:

- `getNetProfit` subtracts the exit commission from gross proceeds, which is what closing a position would actually book. A broker's own unrealised P/L cannot include the exit fee (not yet charged) and, on venues that bill in kind, does not include the entry fee either (taken as a smaller position rather than a cash cost, so it never reaches the basis). Both omissions push the number the same way. Pinned with the live BTC round trip, where Alpaca reported +0.13 USD on a position that was 0.36 USD down.
- `exceedsBrokerBalance` compares a tracked position against the broker's balance. Only an overshoot counts: `baseBalance` covers the whole account, so it legitimately exceeds one strategy's slice, but a strategy can never own more than the account does. A gap under one trade increment is rounding.

Deriving position size from the fill rather than reading it back from the broker is deliberate. Balances can lag a fill, `getAvailableBalances` reports free rather than held quantity, and the account balance is not the strategy's slice.

This is independent of #1350 and #1351 and branches from `main`. The in-kind-fee case only arises once fills carry a base-denominated fee, which #1350 introduces for Alpaca; the handling is correct either way.